### PR TITLE
deps: bump transitive rand 0.9.3 + drop unused hmac/pbkdf2-simple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,12 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,7 +1413,6 @@ dependencies = [
  "fs4",
  "futures-util",
  "glob",
- "hmac",
  "http",
  "indicatif",
  "keyring",
@@ -1790,17 +1783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,8 +1796,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2082,9 +2082,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ toml = "1"
 
 # Crypto (SRP auth)
 sha2 = "0.10"
-pbkdf2 = { version = "0.12", features = ["simple"] }
-hmac = "0.12"
+pbkdf2 = "0.12"
 num-bigint = "0.4"
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary
Closes Dependabot [#12](https://github.com/rhoopr/kei/security/dependabot/12) (`GHSA-cq8v-f236-94qc`: rand is unsound with a custom logger using `rand::rng()`) and cleans up two genuinely-unused crypto deps while I'm here.

### Changes
- **`Cargo.lock`: rand 0.9.2 → 0.9.3** — advisory was rescoped on 2026-04-22 to cover `>= 0.9.0, < 0.9.3`, re-flagging our transitive `rand 0.9.2` (carried via `reqwest → quinn → quinn-proto`). `cargo update -p rand@0.9.2 --precise 0.9.3`. We don't enable reqwest's `http3` feature so quinn isn't in the real dep graph (`cargo tree` confirms), but the lockfile entry is enough for Dependabot to alert.
- **Drop `hmac = "0.12"` from `Cargo.toml`** — declared but has zero references in `src/` or `tests/`. `pbkdf2` pulls its own hmac internally so the transitive stays; only the direct declaration is removed.
- **Drop `features = ["simple"]` from `pbkdf2`** — `simple` adds the PHC-string password-hashing convenience API (`password_hash::PasswordHasher`). Our SRP code only uses the low-level `pbkdf2_hmac::<Sha256>` function (`src/auth/srp.rs:122,124`), so the feature is dead weight. Removes `base64ct` and `password-hash` from the lockfile.

### Why not prune the stale quinn entries?
`quinn`, `quinn-proto`, `quinn-udp` are declared `optional = true` in reqwest's manifest. Cargo always resolves optional deps into `Cargo.lock`, regardless of feature selection. Kicking them out of the lockfile would require a reqwest change we don't own. The rand bump closes the alert anyway.

### Follow-ups (not in this PR)
Captured in `.scratch/deps-followups.md`:
- Switch reqwest to `default-features = false` + rustls to drop OpenSSL/aws-lc-rs (four of the last ten Dependabot alerts were in that stack).
- Full `cargo update` to re-resolve the dep graph to latest compatible versions — standalone PR, disciplined test plan including live-auth.
- Smaller: explicit audit of reqwest's default feature set (bundle with the TLS PR).

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo fmt --check`, `cargo clippy -D warnings` clean
- [x] `cargo test --release --all-features -- --test-threads=1` — 1793 passed, 0 failed, 60 ignored (auth-gated)
- [ ] CI green on PR