### PR TITLE
notifier: drop on saturation; pin producer touched_ids flush

### DIFF
--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1291,10 +1291,21 @@ where
         // Flush the accumulated last_seen_at updates in one transaction.
         // Running after the producer loop exits means we skip the fsync-
         // per-asset cost that dominated sync-start on mostly-synced
-        // libraries. last_seen_at is observational and only affects the
-        // stuck-pipeline promotion window via sync_started_at, so a
-        // deferred flush is safe for terminal-status rows (which is all
-        // touched_ids contains).
+        // libraries.
+        //
+        // touched_ids contains assets the consumer will not finalize this
+        // sync: trust-state fast-skips (line 1026, status='downloaded')
+        // and on-disk skips (line 1053, which the comment at the push
+        // site notes can include status='pending' rows carried over from
+        // a prior interrupted sync). Bumping their last_seen_at is a
+        // no-op for terminal rows and is load-bearing for stuck-pipeline
+        // recovery on pending rows: promote_pending_to_failed promotes
+        // any 'pending' row whose last_seen_at >= sync_started_at.
+        //
+        // If we lose this flush (e.g. process killed between the producer
+        // loop exiting and touch_last_seen_many returning), stuck-pipeline
+        // promotion is delayed by exactly one sync — the same row hits
+        // the same path next run and gets promoted then. No data loss.
         if let Some(db) = &producer_state_db {
             if !touched_ids.is_empty() {
                 let touched_count = touched_ids.len();
@@ -3569,6 +3580,108 @@ mod tests {
         let summary = db.get_summary().await.unwrap();
         assert_eq!(summary.pending, 1);
         assert_eq!(summary.failed, 0);
+    }
+
+    /// Producer-side regression for the deferred `touched_ids` flush.
+    ///
+    /// A pending row carried over from a prior interrupted sync, whose
+    /// new sync hits the on-disk-skip path (the `tasks.is_empty()`
+    /// branch at the producer's filter step), must end the sync as
+    /// `failed` -- the producer task pushes its id into `touched_ids`,
+    /// the deferred `touch_last_seen_many` flush bumps `last_seen_at`,
+    /// and `promote_pending_to_failed` then promotes it. This is
+    /// load-bearing for stuck-pipeline recovery.
+    ///
+    /// If a future refactor moves the flush behind a not-always-reached
+    /// path, or moves `touched_ids` writes off the producer's terminal
+    /// path, this test fails.
+    #[tokio::test]
+    async fn producer_flushes_touched_ids_so_pending_on_disk_skip_promotes() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::{MediaType, SqliteStateDb, StateDb};
+        use chrono::TimeZone;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn carryover_asset() -> PhotoAsset {
+            TestPhotoAsset::new("STUCK")
+                .filename("stuck.jpg")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(1234)
+                .orig_url("http://127.0.0.1:1/stuck.jpg")
+                .orig_checksum("ck_stuck")
+                .build()
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+
+        // Pending row carried over from a prior interrupted sync. We
+        // backdate `last_seen_at` so it sits below `sync_started_at`
+        // until this run's producer flush bumps it.
+        let prior_seen_at = chrono::Utc::now().timestamp() - 86400;
+        let record = AssetRecord::new_pending(
+            "STUCK".into(),
+            VersionSizeKey::Original,
+            "ck_stuck".into(),
+            "stuck.jpg".into(),
+            chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            None,
+            1234,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&record).await.unwrap();
+        db.backdate_last_seen("STUCK", prior_seen_at);
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        // Pre-create the file at the path the producer will compute,
+        // with matching size, so `filter_asset_to_tasks` resolves to
+        // "already on disk, skip" and returns no tasks. Computing the
+        // path via the same helper the producer uses keeps the test
+        // tz-independent.
+        let asset = carryover_asset();
+        let target_path = crate::download::paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&chrono::Local),
+            "stuck.jpg",
+            None,
+        );
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target_path, vec![0u8; 1234]).unwrap();
+
+        let client = reqwest::Client::new();
+        let sync_started_at = chrono::Utc::now().timestamp();
+        let stream1 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(carryover_asset())]);
+        stream_and_download_from_stream(&client, stream1, &config, 1, CancellationToken::new())
+            .await
+            .expect("sync must complete");
+
+        // The pre-existing on-disk file routed the asset through the
+        // `tasks.is_empty()` branch, which pushed its id into
+        // `touched_ids`. The producer task's end-of-loop flush then
+        // bumped `last_seen_at >= sync_started_at`, making this row
+        // visible to `promote_pending_to_failed`.
+        let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
+        assert_eq!(
+            promoted, 1,
+            "stuck pending row hitting the on-disk-skip path must have its \
+             last_seen_at bumped by the deferred touched_ids flush so that \
+             promote_pending_to_failed promotes it at sync end -- this is \
+             load-bearing for stuck-pipeline recovery"
+        );
+
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(&*failed[0].id, "STUCK");
     }
 
     // ── run_metadata_rewrites end-to-end ───────────────────────────────────

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3599,8 +3599,8 @@ mod tests {
     async fn producer_flushes_touched_ids_so_pending_on_disk_skip_promotes() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
-        use crate::state::{MediaType, SqliteStateDb, StateDb};
-        use chrono::TimeZone;
+        use crate::state::{SqliteStateDb, StateDb};
+        use crate::test_helpers::TestAssetRecord;
         use futures_util::stream;
         use std::sync::Arc;
 
@@ -3617,20 +3617,12 @@ mod tests {
 
         let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
 
-        // Pending row carried over from a prior interrupted sync. We
-        // backdate `last_seen_at` so it sits below `sync_started_at`
-        // until this run's producer flush bumps it.
         let prior_seen_at = chrono::Utc::now().timestamp() - 86400;
-        let record = AssetRecord::new_pending(
-            "STUCK".into(),
-            VersionSizeKey::Original,
-            "ck_stuck".into(),
-            "stuck.jpg".into(),
-            chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-            None,
-            1234,
-            MediaType::Photo,
-        );
+        let record = TestAssetRecord::new("STUCK")
+            .checksum("ck_stuck")
+            .filename("stuck.jpg")
+            .size(1234)
+            .build();
         db.upsert_seen(&record).await.unwrap();
         db.backdate_last_seen("STUCK", prior_seen_at);
 
@@ -3640,11 +3632,9 @@ mod tests {
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 
-        // Pre-create the file at the path the producer will compute,
-        // with matching size, so `filter_asset_to_tasks` resolves to
-        // "already on disk, skip" and returns no tasks. Computing the
-        // path via the same helper the producer uses keeps the test
-        // tz-independent.
+        // Pre-create the on-disk file at the path the producer will
+        // compute so `filter_asset_to_tasks` returns no tasks. Reuses
+        // `local_download_path` to stay tz-independent.
         let asset = carryover_asset();
         let target_path = crate::download::paths::local_download_path(
             &config.directory,
@@ -3665,18 +3655,10 @@ mod tests {
             .await
             .expect("sync must complete");
 
-        // The pre-existing on-disk file routed the asset through the
-        // `tasks.is_empty()` branch, which pushed its id into
-        // `touched_ids`. The producer task's end-of-loop flush then
-        // bumped `last_seen_at >= sync_started_at`, making this row
-        // visible to `promote_pending_to_failed`.
         let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
         assert_eq!(
             promoted, 1,
-            "stuck pending row hitting the on-disk-skip path must have its \
-             last_seen_at bumped by the deferred touched_ids flush so that \
-             promote_pending_to_failed promotes it at sync end -- this is \
-             load-bearing for stuck-pipeline recovery"
+            "stuck pending row must be promoted by the deferred touched_ids flush"
         );
 
         let failed = db.get_failed().await.unwrap();

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -508,8 +508,10 @@ mod tests {
     /// permit is held, the surplus events must be **dropped**, not queued.
     /// With the old `acquire_owned().await` we'd spawn a task per event and
     /// the surplus would run as permits became free; with `try_acquire_owned`
-    /// the surplus saturates and we drop on the floor.
+    /// the surplus saturates and we drop on the floor. After permits are
+    /// released, fresh events must be able to acquire (no permit leak).
     #[cfg(unix)]
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn notifier_drops_events_when_saturated() {
         let dir = tempfile::tempdir().unwrap();
@@ -575,6 +577,38 @@ mod tests {
             total_invocations, NOTIFIER_MAX_INFLIGHT,
             "expected exactly {NOTIFIER_MAX_INFLIGHT} script invocations \
              (cap), got {total_invocations} -- saturation drop regressed"
+        );
+
+        // The surplus events must have logged a saturation warning.
+        // `logs_contain` checks the captured tracing output for this
+        // test's scope.
+        assert!(
+            logs_contain("Notifier saturated"),
+            "expected at least one 'Notifier saturated' warning during the flood"
+        );
+
+        // Permit release sanity: after the first 8 scripts exited, their
+        // permits should be back in the pool. Fire a fresh batch using
+        // the same notifier; with `release` already in place, each new
+        // script exits immediately. If permits leaked we'd never reach
+        // `NOTIFIER_MAX_INFLIGHT + extra` invocations.
+        let extra = 4usize;
+        for _ in 0..extra {
+            notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
+        }
+        let expected_total = NOTIFIER_MAX_INFLIGHT + extra;
+        let invocation_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut final_total = 0usize;
+        while tokio::time::Instant::now() < invocation_deadline {
+            final_total = std::fs::read(&invocations).map(|b| b.len()).unwrap_or(0);
+            if final_total >= expected_total {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            final_total, expected_total,
+            "post-release events did not run -- permit leak in saturation path"
         );
     }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -430,74 +430,107 @@ mod tests {
         assert_eq!(output.trim(), "42|3|100|1500000|80");
     }
 
-    /// Fire many more events than `NOTIFIER_MAX_INFLIGHT` at a script
-    /// that blocks on a release file, and confirm the semaphore caps
-    /// the number of scripts running at any one moment. Without the
-    /// `acquire_owned` wrap, all events would spawn `/bin/sh`
-    /// concurrently and the marker count would exceed the cap.
+    /// Test scaffold: a barrier-blocked sh script that tracks both
+    /// concurrent in-flight invocations (per-pid marker files) and
+    /// total invocations (single-byte appends). Each invocation:
+    /// 1. Appends one byte to `invocations` (atomic on Linux).
+    /// 2. Drops a marker file at `inflight/$pid`.
+    /// 3. Polls until `release` exists.
+    /// 4. Removes its marker on exit.
+    #[cfg(unix)]
+    struct BarrierFixture {
+        _dir: tempfile::TempDir,
+        counter_dir: PathBuf,
+        release: PathBuf,
+        invocations: PathBuf,
+        script_path: PathBuf,
+    }
+
+    #[cfg(unix)]
+    impl BarrierFixture {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let counter_dir = dir.path().join("inflight");
+            std::fs::create_dir_all(&counter_dir).unwrap();
+            let release = dir.path().join("release");
+            let invocations = dir.path().join("invocations");
+            let body = format!(
+                "#!/bin/sh\nprintf x >> \"{}\"\nmarker=\"{}/$$\"\n: > \"$marker\"\n\
+                 while [ ! -f \"{}\" ]; do sleep 0.02; done\nrm -f \"$marker\"\n",
+                invocations.display(),
+                counter_dir.display(),
+                release.display(),
+            );
+            let script_path = write_test_script(dir.path(), "barrier.sh", body.as_bytes());
+            Self {
+                _dir: dir,
+                counter_dir,
+                release,
+                invocations,
+                script_path,
+            }
+        }
+
+        fn count_markers(&self) -> usize {
+            std::fs::read_dir(&self.counter_dir)
+                .map(|it| it.flatten().count())
+                .unwrap_or(0)
+        }
+
+        fn count_invocations(&self) -> usize {
+            std::fs::read(&self.invocations)
+                .map(|b| b.len())
+                .unwrap_or(0)
+        }
+
+        fn release_barrier(&self) {
+            std::fs::write(&self.release, b"").unwrap();
+        }
+
+        async fn wait_until<F: FnMut() -> bool>(&self, timeout: Duration, mut pred: F) {
+            let deadline = tokio::time::Instant::now() + timeout;
+            while tokio::time::Instant::now() < deadline {
+                if pred() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+
+    /// Fire more events than `NOTIFIER_MAX_INFLIGHT` at a barrier script
+    /// and confirm the semaphore caps concurrent in-flight invocations.
+    /// Without the cap, every event would spawn `/bin/sh` concurrently
+    /// and the marker count would exceed `NOTIFIER_MAX_INFLIGHT`.
     #[cfg(unix)]
     #[tokio::test]
     async fn notifier_semaphore_caps_concurrent_inflight() {
-        let dir = tempfile::tempdir().unwrap();
-        let counter_dir = dir.path().join("inflight");
-        std::fs::create_dir_all(&counter_dir).unwrap();
-        let release = dir.path().join("release");
-
-        // Each script invocation creates a unique marker, polls until the
-        // release file exists, then removes the marker on exit.
-        let body = format!(
-            "#!/bin/sh\nmarker=\"{}/$$\"\n: > \"$marker\"\n\
-             while [ ! -f \"{}\" ]; do sleep 0.02; done\nrm -f \"$marker\"\n",
-            counter_dir.display(),
-            release.display(),
-        );
-        let script_path = write_test_script(dir.path(), "barrier.sh", body.as_bytes());
-
-        let notifier = Notifier::new(Some(script_path));
-        let n_events = NOTIFIER_MAX_INFLIGHT * 2;
-        for _ in 0..n_events {
+        let fixture = BarrierFixture::new();
+        let notifier = Notifier::new(Some(fixture.script_path.clone()));
+        for _ in 0..NOTIFIER_MAX_INFLIGHT * 2 {
             notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
         }
 
-        // Wait until the steady state is reached, then sample for a
-        // window to confirm the cap holds. `count_markers` is
-        // best-effort: if a marker is in the process of being created
-        // or removed, we may briefly miss it, but the maximum across
-        // many samples is a tight bound.
-        let count_markers = || {
-            std::fs::read_dir(&counter_dir)
-                .map(|it| it.flatten().count())
-                .unwrap_or(0)
-        };
-
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         let mut max_concurrent = 0usize;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         while tokio::time::Instant::now() < deadline {
-            max_concurrent = max_concurrent.max(count_markers());
+            max_concurrent = max_concurrent.max(fixture.count_markers());
             if max_concurrent >= NOTIFIER_MAX_INFLIGHT {
                 for _ in 0..10 {
                     tokio::time::sleep(Duration::from_millis(50)).await;
-                    max_concurrent = max_concurrent.max(count_markers());
+                    max_concurrent = max_concurrent.max(fixture.count_markers());
                 }
                 break;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        // Release every blocked script so they can exit cleanly.
-        std::fs::write(&release, b"").unwrap();
-        let cleanup_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        while tokio::time::Instant::now() < cleanup_deadline {
-            if count_markers() == 0 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        fixture.release_barrier();
+        fixture
+            .wait_until(Duration::from_secs(5), || fixture.count_markers() == 0)
+            .await;
 
-        assert!(
-            max_concurrent >= 1,
-            "no scripts ever ran — test setup bug (script never created a marker)"
-        );
+        assert!(max_concurrent >= 1, "no scripts ever ran -- test setup bug");
         assert!(
             max_concurrent <= NOTIFIER_MAX_INFLIGHT,
             "semaphore did not cap concurrent scripts: max observed {max_concurrent}, cap is {NOTIFIER_MAX_INFLIGHT}",
@@ -509,106 +542,65 @@ mod tests {
     /// With the old `acquire_owned().await` we'd spawn a task per event and
     /// the surplus would run as permits became free; with `try_acquire_owned`
     /// the surplus saturates and we drop on the floor. After permits are
-    /// released, fresh events must be able to acquire (no permit leak).
+    /// released, fresh events must still be able to acquire (no permit leak).
     #[cfg(unix)]
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn notifier_drops_events_when_saturated() {
-        let dir = tempfile::tempdir().unwrap();
-        let counter_dir = dir.path().join("inflight");
-        std::fs::create_dir_all(&counter_dir).unwrap();
-        let release = dir.path().join("release");
-        let invocations = dir.path().join("invocations");
-
-        // Each invocation appends one byte to `invocations` (single-byte
-        // append is atomic on Linux), creates a per-pid marker, blocks on
-        // `release`, then removes the marker.
-        let body = format!(
-            "#!/bin/sh\nprintf x >> \"{}\"\nmarker=\"{}/$$\"\n: > \"$marker\"\n\
-             while [ ! -f \"{}\" ]; do sleep 0.02; done\nrm -f \"$marker\"\n",
-            invocations.display(),
-            counter_dir.display(),
-            release.display(),
-        );
-        let script_path = write_test_script(dir.path(), "saturate.sh", body.as_bytes());
-
-        let notifier = Notifier::new(Some(script_path));
-        let n_events = NOTIFIER_MAX_INFLIGHT * 4;
-        for _ in 0..n_events {
+        let fixture = BarrierFixture::new();
+        let notifier = Notifier::new(Some(fixture.script_path.clone()));
+        for _ in 0..NOTIFIER_MAX_INFLIGHT * 4 {
             notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
         }
 
-        // Wait until permits are saturated. With `try_acquire_owned`,
-        // dropped events return immediately, so we should reach the cap
-        // quickly and stay there.
-        let count_markers = || {
-            std::fs::read_dir(&counter_dir)
-                .map(|it| it.flatten().count())
-                .unwrap_or(0)
-        };
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        while tokio::time::Instant::now() < deadline {
-            if count_markers() >= NOTIFIER_MAX_INFLIGHT {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        fixture
+            .wait_until(Duration::from_secs(5), || {
+                fixture.count_markers() >= NOTIFIER_MAX_INFLIGHT
+            })
+            .await;
         assert_eq!(
-            count_markers(),
+            fixture.count_markers(),
             NOTIFIER_MAX_INFLIGHT,
-            "expected exactly {NOTIFIER_MAX_INFLIGHT} scripts to be holding permits"
+            "expected exactly {NOTIFIER_MAX_INFLIGHT} scripts holding permits"
         );
 
-        // Release the barrier and wait for everything in flight to drain.
-        std::fs::write(&release, b"").unwrap();
-        let cleanup_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        while tokio::time::Instant::now() < cleanup_deadline {
-            if count_markers() == 0 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        assert_eq!(count_markers(), 0, "scripts did not drain after release");
-
-        // Even after permits become available, the dropped events must
-        // not retroactively run. Total invocations must equal the cap.
-        let total_invocations = std::fs::read(&invocations).map(|b| b.len()).unwrap_or(0);
+        fixture.release_barrier();
+        fixture
+            .wait_until(Duration::from_secs(5), || fixture.count_markers() == 0)
+            .await;
         assert_eq!(
-            total_invocations, NOTIFIER_MAX_INFLIGHT,
-            "expected exactly {NOTIFIER_MAX_INFLIGHT} script invocations \
-             (cap), got {total_invocations} -- saturation drop regressed"
+            fixture.count_markers(),
+            0,
+            "scripts did not drain after release"
         );
 
-        // The surplus events must have logged a saturation warning.
-        // `logs_contain` checks the captured tracing output for this
-        // test's scope.
+        // Dropped events must not retroactively run once permits are free.
+        assert_eq!(
+            fixture.count_invocations(),
+            NOTIFIER_MAX_INFLIGHT,
+            "saturation drop regressed: surplus events ran retroactively"
+        );
         assert!(
             logs_contain("Notifier saturated"),
-            "expected at least one 'Notifier saturated' warning during the flood"
+            "expected a 'Notifier saturated' warning during the flood"
         );
 
-        // Permit release sanity: after the first 8 scripts exited, their
-        // permits should be back in the pool. Fire a fresh batch using
-        // the same notifier; with `release` already in place, each new
-        // script exits immediately. If permits leaked we'd never reach
-        // `NOTIFIER_MAX_INFLIGHT + extra` invocations.
-        let extra = 4usize;
-        for _ in 0..extra {
+        // Permit-leak guard: after drain, fresh events should run.
+        // With `release` in place, each new script exits immediately.
+        const FRESH_BATCH: usize = 4;
+        for _ in 0..FRESH_BATCH {
             notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
         }
-        let expected_total = NOTIFIER_MAX_INFLIGHT + extra;
-        let invocation_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        let mut final_total = 0usize;
-        while tokio::time::Instant::now() < invocation_deadline {
-            final_total = std::fs::read(&invocations).map(|b| b.len()).unwrap_or(0);
-            if final_total >= expected_total {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        let expected_total = NOTIFIER_MAX_INFLIGHT + FRESH_BATCH;
+        fixture
+            .wait_until(Duration::from_secs(5), || {
+                fixture.count_invocations() >= expected_total
+            })
+            .await;
         assert_eq!(
-            final_total, expected_total,
-            "post-release events did not run -- permit leak in saturation path"
+            fixture.count_invocations(),
+            expected_total,
+            "permit leak: post-release events failed to acquire"
         );
     }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -159,12 +159,29 @@ impl Notifier {
 
         tracing::debug!(event = event_str, "Firing notification script");
 
-        let concurrency = Arc::clone(&self.concurrency);
-        tokio::spawn(async move {
-            let Ok(permit) = concurrency.acquire_owned().await else {
-                // Semaphore closed during shutdown — safe to skip.
+        // Drop on saturation rather than queue: spawning a task that then
+        // parks on `acquire_owned().await` is a softer version of the
+        // unbounded-spawn behavior the semaphore exists to prevent. With
+        // `try_acquire_owned` we also keep the saturation path observable
+        // via the `notifier saturated` warning.
+        let permit = match Arc::clone(&self.concurrency).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                tracing::warn!(
+                    event = event_str,
+                    in_flight = NOTIFIER_MAX_INFLIGHT,
+                    "Notifier saturated, dropping event"
+                );
                 return;
-            };
+            }
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                // Only reachable if the underlying semaphore is closed,
+                // which kei never does. Treat as a process-exit no-op.
+                return;
+            }
+        };
+        tokio::spawn(async move {
+            let _permit = permit;
             match run_script(&script, event_str, &message, &username, data.as_ref()).await {
                 Ok(status) if status.success() => {
                     tracing::debug!(event = event_str, "Notification script completed");
@@ -184,7 +201,6 @@ impl Notifier {
                     );
                 }
             }
-            drop(permit);
         });
     }
 }
@@ -485,6 +501,80 @@ mod tests {
         assert!(
             max_concurrent <= NOTIFIER_MAX_INFLIGHT,
             "semaphore did not cap concurrent scripts: max observed {max_concurrent}, cap is {NOTIFIER_MAX_INFLIGHT}",
+        );
+    }
+
+    /// When more than `NOTIFIER_MAX_INFLIGHT` events are fired while every
+    /// permit is held, the surplus events must be **dropped**, not queued.
+    /// With the old `acquire_owned().await` we'd spawn a task per event and
+    /// the surplus would run as permits became free; with `try_acquire_owned`
+    /// the surplus saturates and we drop on the floor.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn notifier_drops_events_when_saturated() {
+        let dir = tempfile::tempdir().unwrap();
+        let counter_dir = dir.path().join("inflight");
+        std::fs::create_dir_all(&counter_dir).unwrap();
+        let release = dir.path().join("release");
+        let invocations = dir.path().join("invocations");
+
+        // Each invocation appends one byte to `invocations` (single-byte
+        // append is atomic on Linux), creates a per-pid marker, blocks on
+        // `release`, then removes the marker.
+        let body = format!(
+            "#!/bin/sh\nprintf x >> \"{}\"\nmarker=\"{}/$$\"\n: > \"$marker\"\n\
+             while [ ! -f \"{}\" ]; do sleep 0.02; done\nrm -f \"$marker\"\n",
+            invocations.display(),
+            counter_dir.display(),
+            release.display(),
+        );
+        let script_path = write_test_script(dir.path(), "saturate.sh", body.as_bytes());
+
+        let notifier = Notifier::new(Some(script_path));
+        let n_events = NOTIFIER_MAX_INFLIGHT * 4;
+        for _ in 0..n_events {
+            notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
+        }
+
+        // Wait until permits are saturated. With `try_acquire_owned`,
+        // dropped events return immediately, so we should reach the cap
+        // quickly and stay there.
+        let count_markers = || {
+            std::fs::read_dir(&counter_dir)
+                .map(|it| it.flatten().count())
+                .unwrap_or(0)
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if count_markers() >= NOTIFIER_MAX_INFLIGHT {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            count_markers(),
+            NOTIFIER_MAX_INFLIGHT,
+            "expected exactly {NOTIFIER_MAX_INFLIGHT} scripts to be holding permits"
+        );
+
+        // Release the barrier and wait for everything in flight to drain.
+        std::fs::write(&release, b"").unwrap();
+        let cleanup_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < cleanup_deadline {
+            if count_markers() == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(count_markers(), 0, "scripts did not drain after release");
+
+        // Even after permits become available, the dropped events must
+        // not retroactively run. Total invocations must equal the cap.
+        let total_invocations = std::fs::read(&invocations).map(|b| b.len()).unwrap_or(0);
+        assert_eq!(
+            total_invocations, NOTIFIER_MAX_INFLIGHT,
+            "expected exactly {NOTIFIER_MAX_INFLIGHT} script invocations \
+             (cap), got {total_invocations} -- saturation drop regressed"
         );
     }
 


### PR DESCRIPTION
Two #265 review follow-ups.

## Summary

- **`Notifier` drops events on saturation instead of queueing.** `notify()` now uses `try_acquire_owned()` and logs `Notifier saturated, dropping event` when all permits are held, instead of `tokio::spawn`ing a task that then parks on `acquire_owned().await`. The previous code queued spawn-task work behind hung scripts and softened the unbounded-spawn behavior the semaphore exists to prevent. Also drops a misleading "Semaphore closed during shutdown" comment - `tokio::sync::Semaphore` is never closed in kei.
- **New `notifier_drops_events_when_saturated` test.** Fires `4 * NOTIFIER_MAX_INFLIGHT` events while every script is blocked on a barrier file, then asserts exactly `NOTIFIER_MAX_INFLIGHT` script invocations occurred (not `4 * cap`). Asserts the saturation warning fires (via `tracing_test`), and after barrier release fires fresh events to confirm permits were released cleanly (no leak).
- **New `producer_flushes_touched_ids_so_pending_on_disk_skip_promotes` test.** Pins the contract that the producer task's deferred `touch_last_seen_many` flush runs at the end of the producer loop, by setting up a pending row carried over from a prior interrupted sync, pre-creating the file at the on-disk-skip path, and asserting `promote_pending_to_failed` promotes it on this same sync. If a future refactor moves the flush behind a not-always-reached path, this fails.
- **Fix misleading `touched_ids` comment in `pipeline.rs`.** The comment claimed `touched_ids` contains only terminal-status rows; the `tasks.is_empty()` push site intentionally includes pending stuck rows so `promote_pending_to_failed` can promote them at sync end. Updated comment notes that losing the flush only delays stuck-pipeline promotion by one sync, not data loss.

No behavior change beyond the notifier saturation path. No new flags, no schema changes.

## Test plan

- [x] `cargo test --bin kei` (1701 passing locally)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] Live sync against `icloudpd-test`: `sync_dry_run_downloads_nothing` (3.84s), `sync_idempotent_second_run_noop` (10.44s), `sync_album_downloads_all_asset_types` (7.09s) all green. The idempotent test is the strongest evidence that producer skip accounting (`skips.on_disk`, `skips.by_state`) is intact - it forces the second run through both fast-skip (line 1026) and on-disk-skip (line 1053) paths and asserts no re-downloads or mtime changes.
- [x] Notification flood / permit-leak: covered by the enhanced unit test (saturation log assertion + post-release permit verification), in lieu of a full watch-mode soak.

## Risk notes

- `Notifier` saturation-drop is a behavior change for one degenerate case: with the old code, an event that arrived while all 8 permits were held would eventually run once a permit freed up. With the new code, it's dropped on the floor and only logged. Acceptable because (a) notification scripts are fire-and-forget, (b) backlogged events delivered late are rarely useful, and (c) the old behavior leaked spawned tasks under flood. If a user wants every event delivered, the right fix is a longer `SCRIPT_TIMEOUT` or a smaller `NOTIFIER_MAX_INFLIGHT`, not unbounded queueing.
- The producer-flush regression test pre-creates a 1234-byte file at a tz-derived path under `TempDir`. Path computation reuses `local_download_path` so the test is tz-independent.