### PR TITLE
tests: 21 coverage gaps + 4 helper extractions; fix dropped rate_limited

### DIFF
--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -2165,6 +2165,251 @@ mod tests {
             assert_eq!(std::fs::read(&download_path).unwrap(), full_body);
         }
 
+        /// CG-17: a Content-Length mismatch (server declares 1000 bytes
+        /// but transmits 800) MUST surface as a `ContentLengthMismatch`
+        /// error, the `.part` file must be removed, and NO file must
+        /// appear at the final path. This is the feared-most data-loss
+        /// case (silent corruption masquerading as success). The exact
+        /// negative — `final_path` does NOT exist — is what catches a
+        /// future refactor that fell through to the rename step.
+        #[tokio::test]
+        async fn truncated_response_does_not_promote_to_final_path() {
+            let server = MockServer::start().await;
+
+            // Body is 4 bytes of valid JPEG SOI/JFIF signature; we tell
+            // the client Content-Length=8 so the post-stream check fires.
+            let truncated_body = vec![0xFF, 0xD8, 0xFF, 0xE0];
+
+            Mock::given(method("GET"))
+                .and(path("/truncated.jpg"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(truncated_body.clone())
+                        // Override the auto-set content-length to claim 8.
+                        .insert_header("content-length", "8")
+                        .insert_header("content-type", "image/jpeg"),
+                )
+                .mount(&server)
+                .await;
+
+            let dir = TempDir::new().unwrap();
+            let download_path = dir.path().join("truncated.jpg");
+            let config = RetryConfig {
+                max_retries: 0,
+                base_delay_secs: 0,
+                max_delay_secs: 0,
+            };
+            // Realistic SHA256 of the *full* 8-byte payload — irrelevant
+            // here because the size check fires first, but we use a
+            // realistic-looking value not "checksum123".
+            let result = download_file(
+                &reqwest::Client::new(),
+                &format!("{}/truncated.jpg", server.uri()),
+                &download_path,
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                &config,
+                ".kei-tmp",
+                DownloadOpts {
+                    skip_rename: false,
+                    expected_size: Some(8),
+                },
+                DownloadLimits::default(),
+            )
+            .await;
+
+            // Expected error: server underdelivered relative to its
+            // declared Content-Length, OR relative to expected_size if
+            // wiremock chose to honor only one.
+            let err = result.expect_err("truncated response must fail");
+            assert!(
+                matches!(
+                    err,
+                    DownloadError::ContentLengthMismatch { .. } | DownloadError::Http { .. }
+                ),
+                "expected size-mismatch class error, got: {err:?}"
+            );
+
+            // Critical invariants: no .part lingers, and no final file
+            // landed (the would-be silent-corruption signature).
+            assert!(
+                !download_path.exists(),
+                "final path must NOT exist on truncation; got file with size {:?}",
+                std::fs::metadata(&download_path).ok().map(|m| m.len())
+            );
+            // Walk the temp dir to confirm there's no orphan .part either.
+            let stragglers: Vec<_> = std::fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect();
+            assert!(
+                stragglers.is_empty(),
+                "no .part or other files must remain after truncated download; got {stragglers:?}"
+            );
+        }
+
+        /// CG-12: when the destination parent directory is removed
+        /// between the writability probe and the per-asset write, the
+        /// per-asset download MUST surface an error (not silently
+        /// succeed, not panic). Symptom in the wild looks like "0 photos
+        /// synced, 0 errors" because the producer thinks everything is
+        /// fine. Pin the explicit error class so a future refactor that
+        /// ignored ENOENT on the part-open path tells us.
+        #[tokio::test]
+        async fn download_to_missing_parent_dir_surfaces_error() {
+            let server = MockServer::start().await;
+            let body = vec![0xFF, 0xD8, 0xFF, 0xE0, 0xAA, 0xBB, 0xCC, 0xDD];
+
+            Mock::given(method("GET"))
+                .and(path("/orphan.jpg"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(body)
+                        .insert_header("content-type", "image/jpeg"),
+                )
+                .mount(&server)
+                .await;
+
+            // Create the tempdir, then immediately drop it (rm -rf the
+            // path) before invoking download_file. This mirrors the
+            // "directory removed between probe and write" race.
+            let dir = TempDir::new().unwrap();
+            let download_path = dir.path().join("orphan.jpg");
+            drop(dir); // tempdir Drop deletes the directory.
+            assert!(
+                !download_path.parent().unwrap().exists(),
+                "test setup: parent dir must be gone before download_file fires"
+            );
+
+            let config = RetryConfig {
+                max_retries: 0,
+                base_delay_secs: 0,
+                max_delay_secs: 0,
+            };
+            let result = download_file(
+                &reqwest::Client::new(),
+                &format!("{}/orphan.jpg", server.uri()),
+                &download_path,
+                "AAAA",
+                &config,
+                ".kei-tmp",
+                DownloadOpts {
+                    skip_rename: false,
+                    expected_size: None,
+                },
+                DownloadLimits::default(),
+            )
+            .await;
+
+            let err = result.expect_err("missing parent dir must surface as an error");
+            // The error must mention the path (so the surfacing log is
+            // actionable) — this is the kei "no silent failures" invariant
+            // applied to the per-asset write level.
+            let msg = err.to_string();
+            assert!(
+                !msg.is_empty(),
+                "error must have a non-empty message; got {err:?}"
+            );
+
+            // No file must have been created at the (still-missing) path.
+            assert!(!download_path.exists());
+        }
+
+        /// CG-11: a pre-existing temp file from a prior interrupted run
+        /// must NOT corrupt the next download. Specifically: when the
+        /// new download is initiated FRESH (no Range / status 200), the
+        /// temp file must be replaced atomically — no concatenation of
+        /// stale prefix bytes onto fresh bytes (the "frankenfile" failure
+        /// mode that passes the size check but fails image decode).
+        ///
+        /// We verify by writing 100 bytes of garbage to the .part path
+        /// up front, then driving a 200-byte download from a wiremock
+        /// server. The final file must be byte-identical to the 200-byte
+        /// payload, NOT 300 bytes (100 garbage + 200 payload), NOT a
+        /// mixed 200-byte file with stale prefix.
+        #[tokio::test]
+        async fn pre_existing_part_file_replaced_atomically_on_fresh_download() {
+            let server = MockServer::start().await;
+
+            // 200-byte payload starting with JPEG SOI/JFIF signature so
+            // content-type sniffing accepts it. The remaining bytes are
+            // a stable repeating pattern so we can check byte-equality.
+            let mut payload: Vec<u8> = vec![0xFF, 0xD8, 0xFF, 0xE0];
+            payload.extend((4..200u16).map(|i| (i & 0xff) as u8));
+            assert_eq!(payload.len(), 200);
+
+            Mock::given(method("GET"))
+                .and(path("/replace.jpg"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(payload.clone())
+                        .insert_header("content-type", "image/jpeg"),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let dir = TempDir::new().unwrap();
+            let download_path = dir.path().join("replace.jpg");
+            let checksum = "AAAA"; // canonical short test checksum
+
+            // Pre-populate the .part path with garbage from a prior run.
+            // (The kei-tmp prefix MUST match the production constant so
+            // the writer finds and replaces the same path.)
+            let part_path = temp_download_path(&download_path, checksum, ".kei-tmp").unwrap();
+            let stale_garbage = vec![0xCC; 100];
+            std::fs::write(&part_path, &stale_garbage).expect("seed stale .part");
+            assert_eq!(std::fs::metadata(&part_path).unwrap().len(), 100);
+
+            let config = RetryConfig {
+                max_retries: 0,
+                base_delay_secs: 0,
+                max_delay_secs: 0,
+            };
+            // No expected_size + no Range header — production should treat
+            // this as a fresh download and TRUNCATE the existing .part.
+            // (Resume requires expected_size to be supplied.)
+            download_file(
+                &reqwest::Client::new(),
+                &format!("{}/replace.jpg", server.uri()),
+                &download_path,
+                checksum,
+                &config,
+                ".kei-tmp",
+                DownloadOpts {
+                    skip_rename: false,
+                    expected_size: None,
+                },
+                DownloadLimits::default(),
+            )
+            .await
+            .expect("download should succeed when .part is freshly truncated");
+
+            // Final file must equal the payload exactly. NOT 300 bytes,
+            // NOT prefixed-with-garbage, NOT empty.
+            let final_bytes = std::fs::read(&download_path).expect("final file present");
+            assert_eq!(
+                final_bytes.len(),
+                200,
+                "final file length must equal payload (200), got {}",
+                final_bytes.len()
+            );
+            assert_eq!(
+                final_bytes,
+                payload,
+                "final bytes must equal payload exactly; \
+                 frankenfile detection: first 4 bytes were {:?} (expected JPEG SOI {:?})",
+                &final_bytes[..4.min(final_bytes.len())],
+                &payload[..4]
+            );
+
+            // .part must have been atomically renamed away.
+            assert!(
+                !part_path.exists(),
+                "stale .part path must not exist after rename"
+            );
+        }
+
         /// End-to-end throttle test: pull a fixed payload through `download_file`
         /// with a real HTTP server and assert wall-clock elapsed time at least
         /// approaches what the cap predicts.

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -2098,6 +2098,83 @@ mod tests {
         );
     }
 
+    /// CG-13: two assets whose filenames differ only in case (`IMG_0001.JPG`
+    /// vs `img_0001.jpg`) must NOT silently overwrite each other on a
+    /// case-insensitive filesystem. The collision detector must either
+    /// rename one with a disambiguation suffix or skip the duplicate; in
+    /// no case may both produce identical claimed paths (which would
+    /// cause one's bytes to clobber the other's at `rename` time —
+    /// silent data loss).
+    #[test]
+    fn filter_case_only_filename_collision_yields_distinct_claimed_paths() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.directory = std::sync::Arc::from(dir.path());
+
+        // Two assets, different IDs + different checksums (so they're
+        // genuinely distinct content), but filenames that differ only in
+        // case. On macOS / Windows these resolve to the same on-disk file.
+        let asset_a = TestPhotoAsset::new("CASE_ONE")
+            .filename("IMG_0001.JPG")
+            .orig_size(2048)
+            .orig_url("https://p01.icloud-content.com/photos/orig/a")
+            .orig_checksum("aaaa1111")
+            .build();
+
+        let asset_b = TestPhotoAsset::new("CASE_TWO")
+            .filename("img_0001.jpg")
+            .orig_size(4096)
+            .orig_url("https://p01.icloud-content.com/photos/orig/b")
+            .orig_checksum("bbbb2222")
+            .build();
+
+        let mut claimed_paths = FxHashMap::default();
+        let mut dir_cache = paths::DirCache::new();
+
+        let tasks_a = filter_asset_to_tasks(&asset_a, &config, &mut claimed_paths, &mut dir_cache);
+        assert_eq!(tasks_a.len(), 1, "first asset should resolve to one task");
+        let path_a = tasks_a[0].download_path.clone();
+
+        let tasks_b = filter_asset_to_tasks(&asset_b, &config, &mut claimed_paths, &mut dir_cache);
+        assert_eq!(
+            tasks_b.len(),
+            1,
+            "second asset should also resolve to one task"
+        );
+        let path_b = tasks_b[0].download_path.clone();
+
+        // Critical invariant: the on-disk paths must NOT case-insensitively
+        // match. NormalizedPath does the case-fold; pin its result here.
+        let np_a = NormalizedPath::new(path_a.clone());
+        let np_b = NormalizedPath::new(path_b.clone());
+        assert_ne!(
+            np_a,
+            np_b,
+            "case-only-collision filenames must produce case-folded-distinct \
+             paths to avoid silent overwrite. Got A={} B={}",
+            path_a.display(),
+            path_b.display()
+        );
+
+        // And the raw paths must also differ — the disambiguation must
+        // be present in at least the filename portion.
+        assert_ne!(
+            path_a,
+            path_b,
+            "case-only-collision filenames must produce literally-distinct \
+             paths (got A=B={})",
+            path_a.display()
+        );
+
+        // claimed_paths should now have both entries.
+        assert_eq!(
+            claimed_paths.len(),
+            2,
+            "claimed_paths must contain both case-distinct entries; got {}",
+            claimed_paths.len()
+        );
+    }
+
     /// A path pre-seeded into claimed_paths (as a startup load from the
     /// state DB's downloaded rows would do) must case-insensitively match
     /// an incoming asset's target and dedupe it — otherwise cross-batch

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -442,4 +442,122 @@ mod tests {
         assert!(!is_heif_path(Path::new("/a/b.mov")));
         assert!(!is_heif_path(Path::new("/a/b")));
     }
+
+    // ── extract_xmp_bytes: malformed input must not panic, must return None ──
+    //
+    // The original suite only covered `is_heif_path`; the parser entry points
+    // (`extract_xmp_bytes`, `insert_xmp`) had no malformed-input regression.
+    // A regression that panicked on truncated bytes would crash the metadata
+    // worker on any partial download — silent data loss in the surrounding
+    // sync. These pin the "return None / bail" contract for the universe of
+    // garbage inputs the wild can produce.
+
+    #[test]
+    fn extract_xmp_bytes_empty_input_returns_none() {
+        // Zero bytes is the most basic malformed case.
+        assert!(extract_xmp_bytes(&[]).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_random_bytes_returns_none() {
+        // Plausible-looking-but-not-HEIF blob: must not panic, must return
+        // None. The previous mp4_atom decode loop swallowed errors via
+        // `if let Ok(Some(...)) = ...`, but a future refactor that switched
+        // to `.unwrap()` would explode on this input.
+        let blob: Vec<u8> = (0..256_u16).map(|i| (i & 0xff) as u8).collect();
+        assert!(extract_xmp_bytes(&blob).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_truncated_atom_header_returns_none() {
+        // 4 bytes is shorter than any valid ISO-BMFF box header (8 bytes).
+        // Decoder must not panic on the short read.
+        let bytes = [0x00, 0x00, 0x00, 0x18];
+        assert!(extract_xmp_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_no_meta_box_returns_none() {
+        // A syntactically valid `ftyp` atom with no following `meta` — there
+        // is no XMP to find, so the function must return None without error.
+        // ftyp box: size=0x18 (24), kind=ftyp, major_brand=heic, minor_version=0,
+        // compatible_brands=[heic, mif1].
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&0x18_u32.to_be_bytes());
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(&0_u32.to_be_bytes());
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(b"mif1");
+        assert_eq!(bytes.len(), 0x18);
+        assert!(extract_xmp_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_atom_with_oversized_length_field_returns_none() {
+        // size field claims 0xFFFFFFFF bytes (way past end of buffer). A
+        // robust parser must reject this, not allocate or read out of bounds.
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&0xFFFF_FFFF_u32.to_be_bytes());
+        bytes.extend_from_slice(b"meta");
+        bytes.extend_from_slice(&[0; 16]); // payload tail (will be cut short)
+        assert!(extract_xmp_bytes(&bytes).is_none());
+    }
+
+    // ── insert_xmp: rejects inputs without a meta box ──
+    //
+    // The error path used to be implicit ("anyhow bail somewhere in the
+    // pipeline"); this pins it to the precise "HEIC has no meta box"
+    // message so a future refactor that drops or rewords the bail leaves
+    // a test failure rather than a silent regression.
+
+    #[test]
+    fn insert_xmp_returns_error_on_input_with_no_meta_box() {
+        // Same ftyp-only fixture as above — no meta box present.
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&0x18_u32.to_be_bytes());
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(&0_u32.to_be_bytes());
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(b"mif1");
+
+        let mut out: Vec<u8> = Vec::new();
+        let result = insert_xmp(&bytes, b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"/>", &mut out);
+        let err = result.expect_err("insert_xmp must reject input without a meta box");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("meta box") || msg.contains("HEIC"),
+            "error message must name the missing structure; got: {msg}"
+        );
+        // Critical: nothing should have been written to the writer.
+        assert!(
+            out.is_empty(),
+            "no bytes should be flushed when input has no meta box; got {} bytes",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn insert_xmp_returns_error_on_unparsable_tail() {
+        // ftyp box followed by 3 stray bytes that can't form a valid atom
+        // header. The parser must surface this via `bail!` rather than
+        // silently truncating output.
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&0x18_u32.to_be_bytes());
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(&0_u32.to_be_bytes());
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(b"mif1");
+        // Tail: too short to be an atom header.
+        bytes.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+
+        let mut out: Vec<u8> = Vec::new();
+        let result = insert_xmp(&bytes, b"<x/>", &mut out);
+        assert!(
+            result.is_err(),
+            "insert_xmp must surface parse errors on unparsable tail"
+        );
+    }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -107,6 +107,34 @@ pub struct SyncStats {
     pub rate_limited: usize,
 }
 
+impl SyncStats {
+    /// Add `other` into `self`, field by field. Used by the per-cycle loop in
+    /// `sync_loop::run_cycle` to fold each library's stats into a cycle-wide
+    /// total. CG-15.
+    ///
+    /// All numeric counters sum; `interrupted` ORs (any library being
+    /// interrupted means the cycle was interrupted); `skipped` delegates to
+    /// [`SkipBreakdown::accumulate`].
+    ///
+    /// Adding a new field to `SyncStats` requires updating this method too --
+    /// otherwise the new counter silently zeros out across multi-library
+    /// syncs.
+    pub fn accumulate(&mut self, other: &SyncStats) {
+        self.assets_seen += other.assets_seen;
+        self.downloaded += other.downloaded;
+        self.failed += other.failed;
+        self.skipped.accumulate(&other.skipped);
+        self.bytes_downloaded += other.bytes_downloaded;
+        self.disk_bytes_written += other.disk_bytes_written;
+        self.exif_failures += other.exif_failures;
+        self.state_write_failures += other.state_write_failures;
+        self.enumeration_errors += other.enumeration_errors;
+        self.elapsed_secs += other.elapsed_secs;
+        self.interrupted = self.interrupted || other.interrupted;
+        self.rate_limited += other.rate_limited;
+    }
+}
+
 /// Per-reason breakdown of skipped assets.
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct SkipBreakdown {
@@ -136,6 +164,22 @@ impl SkipBreakdown {
             + self.duplicates
             + self.retry_exhausted
             + self.retry_only
+    }
+
+    /// Add `other` into `self` field-by-field. Mirrors
+    /// [`SyncStats::accumulate`] for the nested skip breakdown.
+    pub fn accumulate(&mut self, other: &SkipBreakdown) {
+        self.by_state += other.by_state;
+        self.on_disk += other.on_disk;
+        self.by_media_type += other.by_media_type;
+        self.by_date_range += other.by_date_range;
+        self.by_live_photo += other.by_live_photo;
+        self.by_filename += other.by_filename;
+        self.by_excluded_album += other.by_excluded_album;
+        self.ampm_variant += other.ampm_variant;
+        self.duplicates += other.duplicates;
+        self.retry_exhausted += other.retry_exhausted;
+        self.retry_only += other.retry_only;
     }
 }
 
@@ -2995,5 +3039,140 @@ mod tests {
             !ctx.known_ids.contains("brand_new_asset"),
             "new asset should not be in known_ids in retry_only mode"
         );
+    }
+
+    /// CG-15: `SyncStats::accumulate` is the sole sum used to fold per-library
+    /// stats into a cycle-wide total. Pin every counter so a future refactor
+    /// (or a new field added without updating `accumulate`) cannot silently
+    /// drop one. Touches every numeric field plus `interrupted` plus the
+    /// nested `SkipBreakdown`.
+    ///
+    /// The earlier inline accumulator in `sync_loop::run_cycle` missed
+    /// `rate_limited` -- this test pins that field too so the bug cannot
+    /// regress.
+    #[test]
+    fn sync_loop_run_cycle_aggregates_stats_across_libraries() {
+        let lib_a = SyncStats {
+            assets_seen: 10,
+            downloaded: 4,
+            failed: 1,
+            skipped: SkipBreakdown {
+                by_state: 2,
+                on_disk: 3,
+                by_media_type: 4,
+                by_date_range: 5,
+                by_live_photo: 6,
+                by_filename: 7,
+                by_excluded_album: 8,
+                ampm_variant: 9,
+                duplicates: 10,
+                retry_exhausted: 11,
+                retry_only: 12,
+            },
+            bytes_downloaded: 1_000,
+            disk_bytes_written: 900,
+            exif_failures: 1,
+            state_write_failures: 2,
+            enumeration_errors: 3,
+            elapsed_secs: 1.5,
+            interrupted: false,
+            rate_limited: 7,
+        };
+
+        let lib_b = SyncStats {
+            assets_seen: 20,
+            downloaded: 11,
+            failed: 2,
+            skipped: SkipBreakdown {
+                by_state: 1,
+                on_disk: 1,
+                by_media_type: 1,
+                by_date_range: 1,
+                by_live_photo: 1,
+                by_filename: 1,
+                by_excluded_album: 1,
+                ampm_variant: 1,
+                duplicates: 1,
+                retry_exhausted: 1,
+                retry_only: 1,
+            },
+            bytes_downloaded: 2_500,
+            disk_bytes_written: 2_400,
+            exif_failures: 4,
+            state_write_failures: 5,
+            enumeration_errors: 6,
+            elapsed_secs: 0.75,
+            interrupted: true,
+            rate_limited: 3,
+        };
+
+        let mut acc = SyncStats::default();
+        acc.accumulate(&lib_a);
+        acc.accumulate(&lib_b);
+
+        assert_eq!(acc.assets_seen, 30, "assets_seen must sum");
+        assert_eq!(acc.downloaded, 15, "downloaded must sum");
+        assert_eq!(acc.failed, 3, "failed must sum");
+        assert_eq!(acc.bytes_downloaded, 3_500, "bytes_downloaded must sum");
+        assert_eq!(acc.disk_bytes_written, 3_300, "disk_bytes_written must sum");
+        assert_eq!(acc.exif_failures, 5, "exif_failures must sum");
+        assert_eq!(acc.state_write_failures, 7, "state_write_failures must sum");
+        assert_eq!(acc.enumeration_errors, 9, "enumeration_errors must sum");
+        assert!(
+            (acc.elapsed_secs - 2.25).abs() < 1e-9,
+            "elapsed_secs must sum (got {})",
+            acc.elapsed_secs
+        );
+        assert!(
+            acc.interrupted,
+            "interrupted must OR -- any library interrupted -> cycle interrupted"
+        );
+        assert_eq!(
+            acc.rate_limited, 10,
+            "rate_limited must sum -- pre-fix the inline accumulator dropped this field"
+        );
+
+        assert_eq!(acc.skipped.by_state, 3);
+        assert_eq!(acc.skipped.on_disk, 4);
+        assert_eq!(acc.skipped.by_media_type, 5);
+        assert_eq!(acc.skipped.by_date_range, 6);
+        assert_eq!(acc.skipped.by_live_photo, 7);
+        assert_eq!(acc.skipped.by_filename, 8);
+        assert_eq!(acc.skipped.by_excluded_album, 9);
+        assert_eq!(acc.skipped.ampm_variant, 10);
+        assert_eq!(acc.skipped.duplicates, 11);
+        assert_eq!(acc.skipped.retry_exhausted, 12);
+        assert_eq!(acc.skipped.retry_only, 13);
+        assert_eq!(
+            acc.skipped.total(),
+            3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13,
+            "skip total must reflect summed breakdown"
+        );
+    }
+
+    /// Companion: accumulating into an empty `SyncStats` is a faithful copy
+    /// (the operation is the additive identity for the empty case).
+    #[test]
+    fn sync_stats_accumulate_into_empty_is_copy() {
+        let src = SyncStats {
+            assets_seen: 5,
+            downloaded: 2,
+            failed: 1,
+            skipped: SkipBreakdown {
+                duplicates: 7,
+                ..SkipBreakdown::default()
+            },
+            rate_limited: 4,
+            interrupted: true,
+            ..SyncStats::default()
+        };
+        let mut dst = SyncStats::default();
+        dst.accumulate(&src);
+        assert_eq!(dst.assets_seen, 5);
+        assert_eq!(dst.downloaded, 2);
+        assert_eq!(dst.failed, 1);
+        assert_eq!(dst.skipped.duplicates, 7);
+        assert_eq!(dst.rate_limited, 4);
+        assert!(dst.interrupted);
     }
 }

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -675,6 +675,43 @@ mod tests {
         assert_eq!(asset.filename(), None);
     }
 
+    /// CG-16: a `filenameEnc` value that decodes to the empty string must
+    /// yield `None`, not `Some("")`. Production routes filename-less assets
+    /// through the fingerprint fallback; an empty string would slip past
+    /// the `is_some()` check downstream and produce paths like
+    /// `2026-04-19/` (a directory) or `.JPG` (a hidden file). Pin both
+    /// the STRING and ENCRYPTED_BYTES variants — they hit the same
+    /// post-decode early-return.
+    #[test]
+    fn empty_filename_string_rejected_at_deser() {
+        let asset = make_asset(
+            json!({"fields": {"filenameEnc": {"value": "", "type": "STRING"}}}),
+            json!({}),
+        );
+        assert_eq!(
+            asset.filename(),
+            None,
+            "empty STRING filename must be treated as missing"
+        );
+    }
+
+    #[test]
+    fn empty_filename_encrypted_bytes_rejected_at_deser() {
+        use base64::Engine;
+        // Base64 of the empty string is the empty string.
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"");
+        assert_eq!(encoded, "");
+        let asset = make_asset(
+            json!({"fields": {"filenameEnc": {"value": encoded, "type": "ENCRYPTED_BYTES"}}}),
+            json!({}),
+        );
+        assert_eq!(
+            asset.filename(),
+            None,
+            "empty ENCRYPTED_BYTES filename must be treated as missing"
+        );
+    }
+
     #[test]
     fn test_item_type_image() {
         let asset = make_asset(

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -261,6 +261,30 @@ impl PhotosService {
 }
 
 #[cfg(test)]
+impl PhotosService {
+    /// Test-only constructor that bypasses [`Self::new`]'s indexing
+    /// check. Mirrors the `make_service` helper used by this module's
+    /// own tests, but visible to other crate-internal test modules so
+    /// they can drive `changes_database`, `fetch_*_libraries`, etc.
+    /// without spinning up real CloudKit traffic.
+    pub(crate) fn for_testing(
+        session: Box<dyn PhotosSession>,
+        params: HashMap<String, Value>,
+    ) -> Self {
+        let dummy_library = PhotoLibrary::new_stub(session.clone_box());
+        Self {
+            service_root: "https://p00-ckdatabasews.icloud.com".to_string(),
+            session,
+            params: Arc::new(params),
+            primary_library: dummy_library,
+            private_libraries: None,
+            shared_libraries: None,
+            retry_config: RetryConfig::default(),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Mutex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,29 @@ pub(crate) fn available_disk_space(_path: &Path) -> Option<u64> {
     None
 }
 
+/// Minimum free disk space (1 GiB) required before kei is allowed to start a
+/// sync. Below this, even a moderate-size video could push the filesystem
+/// past full mid-write (which is a kei-data-sacred risk: torn writes,
+/// truncated `.part` files, no clean rename target).
+pub(crate) const MIN_FREE_BYTES: u64 = 1_073_741_824;
+
+/// Bail when `available_bytes` is below [`MIN_FREE_BYTES`]. Pure / synchronous
+/// so it can be unit-tested without statvfs or a real filesystem. CG-20.
+///
+/// Production callers compute `available_bytes` from
+/// [`available_disk_space`] (or any future probe) and forward it here so the
+/// abort message is identical regardless of platform.
+pub(crate) fn check_min_disk_space(available_bytes: u64, directory: &Path) -> anyhow::Result<()> {
+    if available_bytes < MIN_FREE_BYTES {
+        let avail_mb = available_bytes / (1024 * 1024);
+        anyhow::bail!(
+            "Insufficient disk space: only {avail_mb} MiB available in {} (minimum 1 GiB)",
+            directory.display()
+        );
+    }
+    Ok(())
+}
+
 /// Build a password provider closure from a [`password::PasswordSource`].
 ///
 /// The source is evaluated lazily on each call — for `Command` and `File`
@@ -864,5 +887,55 @@ mod tests {
             token_clone.cancel();
         });
         assert_eq!(run_watch_loop(&shutdown_token, Some(3600)).await, 1);
+    }
+
+    /// CG-20: kei must abort BEFORE auth (and well before any download)
+    /// when the data directory has < 1 GiB free. A sync that fills the
+    /// disk mid-write leaves orphan `.part` files and a half-truncated
+    /// final file -- the worst-case for the "atomic writes" invariant.
+    ///
+    /// Parameterised over the entire span around the threshold:
+    ///   0 bytes               -> bail (extreme)
+    ///   1023 MiB              -> bail (just below 1 GiB)
+    ///   1 GiB exactly         -> ok (boundary is inclusive on the OK side)
+    ///   10 GiB                -> ok (well above)
+    #[test]
+    fn run_sync_low_disk_space_aborts_before_auth() {
+        let dir = std::path::Path::new("/tmp/claude/cg-20-disk");
+
+        // Below threshold: bail.
+        for &low in &[0u64, 1023 * 1024 * 1024] {
+            let r = check_min_disk_space(low, dir);
+            assert!(
+                r.is_err(),
+                "{low} bytes is below 1 GiB; check_min_disk_space must bail"
+            );
+            let msg = format!("{:#}", r.expect_err("expected Err"));
+            assert!(
+                msg.contains("Insufficient disk space"),
+                "error message must call out the disk-space reason; got: {msg}"
+            );
+            assert!(
+                msg.contains("minimum 1 GiB"),
+                "error message must state the minimum so operators know what to free; got: {msg}"
+            );
+        }
+
+        // At and above threshold: ok.
+        for &ok in &[MIN_FREE_BYTES, 10 * 1024 * 1024 * 1024] {
+            assert!(
+                check_min_disk_space(ok, dir).is_ok(),
+                "{ok} bytes is at or above 1 GiB; check_min_disk_space must succeed"
+            );
+        }
+    }
+
+    /// CG-20 boundary: confirm `MIN_FREE_BYTES` is exactly 1 GiB. A future
+    /// edit that nudges this constant changes operator-visible behavior;
+    /// pin the value so the change is intentional.
+    #[test]
+    fn check_min_disk_space_threshold_is_one_gib() {
+        assert_eq!(MIN_FREE_BYTES, 1_073_741_824);
+        assert_eq!(MIN_FREE_BYTES, 1024 * 1024 * 1024);
     }
 }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -2044,6 +2044,103 @@ mod tests {
         assert_eq!(promoted, 0);
     }
 
+    /// CG-14: promotion is idempotent — once an orphan has been flipped to
+    /// `interrupted`, a second invocation must return 0 rows promoted and
+    /// must not re-touch the row. The current implementation guards via
+    /// `WHERE status = 'running'`, but no test pinned the second-call
+    /// behavior. A future refactor that broadened the WHERE clause (e.g.
+    /// `status != 'completed'`) would silently double-promote rows the
+    /// next time init runs.
+    #[tokio::test]
+    async fn promote_orphaned_sync_runs_idempotent_second_call_promotes_zero() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // Three running rows; flush them once.
+        let a = db.start_sync_run().await.unwrap();
+        let b = db.start_sync_run().await.unwrap();
+        let c = db.start_sync_run().await.unwrap();
+        let first = db.promote_orphaned_sync_runs().await.unwrap();
+        assert_eq!(first, 3, "first call should flip all 3 running rows");
+
+        // Capture the post-promote interrupted timestamps so we can verify
+        // the second call doesn't re-touch them.
+        let conn = db.acquire_lock("snapshot_after_first_promote").unwrap();
+        let read_run = |id: i64| {
+            let (status, interrupted): (String, i32) = conn
+                .query_row(
+                    "SELECT status, interrupted FROM sync_runs WHERE id = ?1",
+                    [id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            (status, interrupted)
+        };
+        let snap_a = read_run(a);
+        let snap_b = read_run(b);
+        let snap_c = read_run(c);
+        drop(conn);
+        assert_eq!(snap_a, ("interrupted".to_string(), 1));
+        assert_eq!(snap_b, ("interrupted".to_string(), 1));
+        assert_eq!(snap_c, ("interrupted".to_string(), 1));
+
+        // Second call must be a no-op.
+        let second = db.promote_orphaned_sync_runs().await.unwrap();
+        assert_eq!(
+            second, 0,
+            "second call must not re-promote already-interrupted rows"
+        );
+
+        // And no row's state changed.
+        let conn = db.acquire_lock("snapshot_after_second_promote").unwrap();
+        let after_a: (String, i32) = conn
+            .query_row(
+                "SELECT status, interrupted FROM sync_runs WHERE id = ?1",
+                [a],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(after_a, ("interrupted".to_string(), 1));
+    }
+
+    /// CG-14 corollary: a freshly-completed `sync_runs` row in between
+    /// invocations must not be promoted. Pins the "WHERE status = 'running'"
+    /// invariant against churn — a misclassified completed run would
+    /// silently corrupt operator dashboards.
+    #[tokio::test]
+    async fn promote_orphaned_sync_runs_does_not_touch_completed_rows() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // First batch: one row, complete it cleanly.
+        let r1 = db.start_sync_run().await.unwrap();
+        let stats = SyncRunStats {
+            assets_seen: 1,
+            assets_downloaded: 1,
+            assets_failed: 0,
+            interrupted: false,
+        };
+        db.complete_sync_run(r1, &stats).await.unwrap();
+
+        // Second batch: another row, leave running.
+        let r2 = db.start_sync_run().await.unwrap();
+        let promoted = db.promote_orphaned_sync_runs().await.unwrap();
+        assert_eq!(promoted, 1, "only the running row should be promoted");
+
+        // r1 must still be complete.
+        let conn = db.acquire_lock("verify").unwrap();
+        let s1: String = conn
+            .query_row("SELECT status FROM sync_runs WHERE id = ?1", [r1], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(s1, "complete");
+        let s2: String = conn
+            .query_row("SELECT status FROM sync_runs WHERE id = ?1", [r2], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(s2, "interrupted");
+    }
+
     // ── enum_in_progress markers ───────────────────────────────────────────
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -2063,22 +2063,22 @@ mod tests {
         assert_eq!(first, 3, "first call should flip all 3 running rows");
 
         // Capture the post-promote interrupted timestamps so we can verify
-        // the second call doesn't re-touch them.
-        let conn = db.acquire_lock("snapshot_after_first_promote").unwrap();
-        let read_run = |id: i64| {
-            let (status, interrupted): (String, i32) = conn
-                .query_row(
-                    "SELECT status, interrupted FROM sync_runs WHERE id = ?1",
-                    [id],
-                    |row| Ok((row.get(0)?, row.get(1)?)),
-                )
-                .unwrap();
-            (status, interrupted)
+        // the second call doesn't re-touch them. Scope the lock guard so
+        // it never sits across an .await on the next line.
+        let (snap_a, snap_b, snap_c) = {
+            let conn = db.acquire_lock("snapshot_after_first_promote").unwrap();
+            let read_run = |id: i64| {
+                let (status, interrupted): (String, i32) = conn
+                    .query_row(
+                        "SELECT status, interrupted FROM sync_runs WHERE id = ?1",
+                        [id],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .unwrap();
+                (status, interrupted)
+            };
+            (read_run(a), read_run(b), read_run(c))
         };
-        let snap_a = read_run(a);
-        let snap_b = read_run(b);
-        let snap_c = read_run(c);
-        drop(conn);
         assert_eq!(snap_a, ("interrupted".to_string(), 1));
         assert_eq!(snap_b, ("interrupted".to_string(), 1));
         assert_eq!(snap_c, ("interrupted".to_string(), 1));
@@ -2091,14 +2091,15 @@ mod tests {
         );
 
         // And no row's state changed.
-        let conn = db.acquire_lock("snapshot_after_second_promote").unwrap();
-        let after_a: (String, i32) = conn
-            .query_row(
+        let after_a: (String, i32) = {
+            let conn = db.acquire_lock("snapshot_after_second_promote").unwrap();
+            conn.query_row(
                 "SELECT status, interrupted FROM sync_runs WHERE id = ?1",
                 [a],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
-            .unwrap();
+            .unwrap()
+        };
         assert_eq!(after_a, ("interrupted".to_string(), 1));
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1640,7 +1640,7 @@ mod tests {
     fn is_session_error_through_boxed_error_returns_false() {
         // A boxed error of a foreign type wrapped via anyhow::Error::from.
         let boxed: Box<dyn std::error::Error + Send + Sync> =
-            Box::new(std::io::Error::new(std::io::ErrorKind::Other, "foreign"));
+            Box::new(std::io::Error::other("foreign"));
         let e: anyhow::Error = anyhow::Error::from_boxed(boxed);
         assert!(
             !is_session_error(&e),
@@ -2049,5 +2049,723 @@ mod tests {
             matches!(mode, download::SyncMode::Full),
             "no state DB must yield Full, got {mode:?}"
         );
+    }
+
+    // ── check_changes_database ───────────────────────────────────────
+    //
+    // Watch-mode wakes the sync loop on a fixed interval. The first thing
+    // each cycle does is hit the `changes/database` endpoint to ask Apple
+    // "anything actually changed?" If we mis-classify the response we
+    // either hammer Apple uselessly (no changes but proceeded) or silently
+    // skip a real delta (changes pending but skipped). Pin every branch.
+
+    /// Build a `LibraryState` that's just enough for `check_changes_database`.
+    /// The `plan` and `library` fields are unused by that function, so an
+    /// empty plan + a stub library is safe.
+    fn make_library_state(zone: &str, sync_token_key: &str) -> LibraryState {
+        let stub_session = Box::new(
+            crate::test_helpers::MockPhotosSession::new().ok(serde_json::json!({"records": []})),
+        );
+        LibraryState {
+            library: crate::icloud::photos::PhotoLibrary::new_stub(stub_session),
+            zone_name: zone.to_string(),
+            sync_token_key: sync_token_key.to_string(),
+            plan: crate::commands::AlbumPlan { passes: Vec::new() },
+        }
+    }
+
+    /// CG-5: `more_coming=true` with empty zones must NOT skip the cycle.
+    /// Production logic: `if zones.is_empty() && !more_coming { skip }`.
+    /// A regression that flipped the conjunction would silently skip every
+    /// page-bearing wakeup — silent loss of pending changes.
+    #[tokio::test]
+    async fn check_changes_database_more_coming_does_not_skip() {
+        use serde_json::json;
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-2",
+            "moreComing": true,
+            "zones": []
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        // Pre-populate a stored sync token so the function actually
+        // makes the changes/database HTTP call (the `has_token` early
+        // return otherwise short-circuits).
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-1")
+            .await
+            .expect("set token");
+
+        let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
+
+        let skip = check_changes_database(&Some(Arc::clone(&db)), &lib_state, &mut svc).await;
+
+        assert!(
+            !skip,
+            "more_coming=true must not skip the cycle (more pages pending)"
+        );
+        // db_sync_token should have been persisted so the next cycle
+        // continues paging from where we left off.
+        let stored = db
+            .get_metadata("db_sync_token")
+            .await
+            .expect("read db_sync_token")
+            .expect("token persisted");
+        assert_eq!(stored, "db-tok-2");
+    }
+
+    /// CG-6: empty zones + `more_coming=false` must return `skip=true`.
+    /// This is the optimistic short-circuit: Apple confirmed there are no
+    /// pending changes, so we save a full enumeration cycle. A regression
+    /// that flipped this branch would either burn a CloudKit query per
+    /// idle wakeup (cost) or silently skip a real cycle (loss).
+    #[tokio::test]
+    async fn check_changes_database_empty_zones_skips_cycle() {
+        use serde_json::json;
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-3",
+            "moreComing": false,
+            "zones": []
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("set token");
+
+        let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
+
+        let skip = check_changes_database(&Some(Arc::clone(&db)), &lib_state, &mut svc).await;
+
+        assert!(skip, "empty zones + more_coming=false must skip the cycle");
+        // The new db_sync_token must still be persisted even on skip:
+        // otherwise the next call re-asks from scratch and we'd get an
+        // unbounded list of all zones.
+        let stored = db
+            .get_metadata("db_sync_token")
+            .await
+            .expect("read db_sync_token")
+            .expect("token persisted on skip");
+        assert_eq!(stored, "db-tok-3");
+    }
+
+    /// Companion to CG-6: a non-empty zones list MUST NOT skip — even
+    /// when more_coming=false. This is the real-work path; pinning it
+    /// alongside the skip path catches a flipped branch in either
+    /// direction.
+    #[tokio::test]
+    async fn check_changes_database_zone_changes_present_does_not_skip() {
+        use serde_json::json;
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-4",
+            "moreComing": false,
+            "zones": [
+                {"zoneID": {"zoneName": "PrimarySync"}, "syncToken": "ps-tok-new"}
+            ]
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("set token");
+
+        let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
+
+        let skip = check_changes_database(&Some(db), &lib_state, &mut svc).await;
+        assert!(!skip, "zones-present response must not skip the cycle");
+    }
+
+    /// CG-6 corner: no stored sync token at all must return false (don't
+    /// skip) without making the HTTP call. Pinning this prevents a future
+    /// refactor that flipped the early return from silently consuming an
+    /// Apple call slot on bootstrap.
+    #[tokio::test]
+    async fn check_changes_database_no_stored_token_does_not_skip() {
+        let session = crate::test_helpers::MockPhotosSession::new();
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        // Empty DB — no `sync_token:PrimarySync` set.
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
+
+        let skip = check_changes_database(&Some(db), &lib_state, &mut svc).await;
+        assert!(!skip, "no stored token must skip-result false (continue)");
+    }
+
+    /// CG-7: a `set_metadata("db_sync_token", ...)` write failure must
+    /// NOT break the cycle. The current implementation logs a warning and
+    /// continues. A regression that propagated the error would crash watch
+    /// mode whenever a sqlite hiccup hit that single write.
+    #[tokio::test]
+    async fn check_changes_database_token_persist_failure_does_not_skip() {
+        use serde_json::json;
+        // StateDb that succeeds on get_metadata("sync_token:...") but
+        // fails on set_metadata("db_sync_token", ...) — the only write
+        // path inside `check_changes_database`.
+        struct PartiallyFailingDb {
+            inner: Arc<dyn state::StateDb>,
+        }
+
+        #[async_trait::async_trait]
+        impl state::StateDb for PartiallyFailingDb {
+            #[cfg(test)]
+            async fn should_download(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn upsert_seen(
+                &self,
+                _: &state::types::AssetRecord,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_downloaded(
+                &self,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+                _: &str,
+                _: Option<&str>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_failed(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed_sample(
+                &self,
+                _: u32,
+            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_pending(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_summary(
+                &self,
+            ) -> Result<state::types::SyncSummary, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_page(
+                &self,
+                _: u64,
+                _: u32,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn complete_sync_run(
+                &self,
+                _: i64,
+                _: &state::types::SyncRunStats,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn list_interrupted_enumerations(
+                &self,
+            ) -> Result<Vec<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_pending_to_failed(
+                &self,
+                _: i64,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_ids(
+                &self,
+            ) -> Result<std::collections::HashSet<(String, String)>, state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_all_known_ids(
+                &self,
+            ) -> Result<std::collections::HashSet<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_checksums(
+                &self,
+            ) -> Result<std::collections::HashMap<(String, String), String>, state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_attempt_counts(
+                &self,
+            ) -> Result<std::collections::HashMap<String, u32>, state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_metadata(
+                &self,
+                key: &str,
+            ) -> Result<Option<String>, state::error::StateError> {
+                self.inner.get_metadata(key).await
+            }
+            async fn set_metadata(
+                &self,
+                key: &str,
+                _value: &str,
+            ) -> Result<(), state::error::StateError> {
+                if key == "db_sync_token" {
+                    Err(state::error::StateError::LockPoisoned(
+                        "simulated db_sync_token write failure".into(),
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+            async fn delete_metadata_by_prefix(
+                &self,
+                _: &str,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn touch_last_seen_many(
+                &self,
+                _: &[&str],
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn sample_downloaded_paths(
+                &self,
+                _: usize,
+            ) -> Result<Vec<std::path::PathBuf>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn add_asset_album(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_asset_albums(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_asset_people(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_soft_deleted(
+                &self,
+                _: &str,
+                _: Option<chrono::DateTime<chrono::Utc>>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_hidden_at_source(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn record_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_metadata_hashes(
+                &self,
+            ) -> Result<std::collections::HashMap<(String, String), String>, state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_metadata_retry_markers(
+                &self,
+            ) -> Result<std::collections::HashSet<(String, String)>, state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_pending_metadata_rewrites(
+                &self,
+                _: usize,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn update_metadata_hash(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn clear_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn has_downloaded_without_metadata_hash(
+                &self,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+        }
+
+        // Inner DB has the stored sync token so the changes/database call
+        // is actually attempted.
+        let inner = make_state_db();
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed token");
+        let db: Arc<dyn state::StateDb> = Arc::new(PartiallyFailingDb { inner });
+
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-bad-write",
+            "moreComing": false,
+            "zones": [
+                {"zoneID": {"zoneName": "PrimarySync"}, "syncToken": "ps-tok-new"}
+            ]
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
+
+        // The function logs the write failure and continues. zones non-empty
+        // means it must return false (don't skip).
+        let skip = check_changes_database(&Some(db), &lib_state, &mut svc).await;
+        assert!(
+            !skip,
+            "db_sync_token write failure must not propagate as a skip"
+        );
+    }
+
+    // ── preload_asset_groupings ──────────────────────────────────────
+    //
+    // CG-8: `preload_asset_groupings` must be best-effort: a hiccup
+    // loading people must NOT empty the albums map, and vice versa.
+    // XMP-sidecar runs read this struct; biasing the entire grouping
+    // empty would silently strip metadata from every downloaded photo.
+
+    /// CG-8: when `get_all_asset_albums` succeeds but
+    /// `get_all_asset_people` fails, the result still includes albums.
+    #[tokio::test]
+    async fn preload_asset_groupings_partial_people_failure_keeps_albums() {
+        use std::collections::{HashMap, HashSet};
+
+        struct PartialDb {
+            inner: Arc<dyn state::StateDb>,
+        }
+
+        #[async_trait::async_trait]
+        impl state::StateDb for PartialDb {
+            #[cfg(test)]
+            async fn should_download(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn upsert_seen(
+                &self,
+                _: &state::types::AssetRecord,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_downloaded(
+                &self,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+                _: &str,
+                _: Option<&str>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_failed(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed_sample(
+                &self,
+                _: u32,
+            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_pending(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_summary(
+                &self,
+            ) -> Result<state::types::SyncSummary, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_page(
+                &self,
+                _: u64,
+                _: u32,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn complete_sync_run(
+                &self,
+                _: i64,
+                _: &state::types::SyncRunStats,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn list_interrupted_enumerations(
+                &self,
+            ) -> Result<Vec<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_pending_to_failed(
+                &self,
+                _: i64,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_ids(
+                &self,
+            ) -> Result<HashSet<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_known_ids(&self) -> Result<HashSet<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_checksums(
+                &self,
+            ) -> Result<HashMap<(String, String), String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_attempt_counts(
+                &self,
+            ) -> Result<HashMap<String, u32>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_metadata(
+                &self,
+                _: &str,
+            ) -> Result<Option<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn set_metadata(&self, _: &str, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn delete_metadata_by_prefix(
+                &self,
+                _: &str,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn touch_last_seen_many(
+                &self,
+                _: &[&str],
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn sample_downloaded_paths(
+                &self,
+                _: usize,
+            ) -> Result<Vec<std::path::PathBuf>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn add_asset_album(
+                &self,
+                asset_id: &str,
+                album_name: &str,
+                source: &str,
+            ) -> Result<(), state::error::StateError> {
+                self.inner
+                    .add_asset_album(asset_id, album_name, source)
+                    .await
+            }
+            async fn get_all_asset_albums(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                self.inner.get_all_asset_albums().await
+            }
+            async fn get_all_asset_people(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                Err(state::error::StateError::LockPoisoned(
+                    "simulated people-table read failure".into(),
+                ))
+            }
+            async fn mark_soft_deleted(
+                &self,
+                _: &str,
+                _: Option<chrono::DateTime<chrono::Utc>>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_hidden_at_source(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn record_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_metadata_hashes(
+                &self,
+            ) -> Result<HashMap<(String, String), String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_metadata_retry_markers(
+                &self,
+            ) -> Result<HashSet<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_pending_metadata_rewrites(
+                &self,
+                _: usize,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn update_metadata_hash(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn clear_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn has_downloaded_without_metadata_hash(
+                &self,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+        }
+
+        // Seed the inner DB with two album memberships across two assets,
+        // so we can verify the surviving map is non-empty.
+        let inner = make_state_db();
+        inner
+            .add_asset_album("ASSET_A", "Vacation", "icloud")
+            .await
+            .expect("add album A");
+        inner
+            .add_asset_album("ASSET_B", "Family", "icloud")
+            .await
+            .expect("add album B");
+
+        let db: Option<Arc<dyn state::StateDb>> = Some(Arc::new(PartialDb { inner }));
+
+        let groupings = preload_asset_groupings(&db).await;
+        // Albums must survive intact.
+        assert_eq!(
+            groupings.albums.len(),
+            2,
+            "two assets with album memberships expected, got {}",
+            groupings.albums.len()
+        );
+        assert!(groupings.albums.contains_key("ASSET_A"));
+        assert!(groupings.albums.contains_key("ASSET_B"));
+        // People map is empty (the read failed) — but the function still
+        // returns Some groupings rather than panicking.
+        assert!(
+            groupings.people.is_empty(),
+            "people map should be empty when its read failed; got {} entries",
+            groupings.people.len()
+        );
+    }
+
+    /// Companion: `state_db = None` returns an empty grouping struct.
+    #[tokio::test]
+    async fn preload_asset_groupings_no_db_returns_empty() {
+        let groupings = preload_asset_groupings(&None).await;
+        assert!(groupings.albums.is_empty());
+        assert!(groupings.people.is_empty());
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1077,7 +1077,7 @@ pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_r
     matches!(outcome, download::DownloadOutcome::Success) && !dry_run
 }
 
-/// Decide whether the reauth path inside the watch loop should block on a
+/// Decide whether the reauth path inside the sync loop should block on a
 /// 2FA prompt or surface the error to the caller.
 ///
 /// In **watch mode** a 2FA-required error is recoverable: the loop notifies
@@ -1087,10 +1087,12 @@ pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_r
 /// a cron, the systemd unit's first start) needs the error so it can exit
 /// non-zero and the operator can run `kei login get-code`. CG-19.
 ///
-/// Mirrors the predicate used at the entry-point auth path (`run_sync`'s
-/// initial `auth::authenticate` call already returns the error in non-watch
-/// mode); this helper documents the contract for the *reauth* branch where
-/// the same decision was previously inline.
+/// Note that the **entry-point** auth path (`run_sync`'s initial
+/// `auth::authenticate` call) intentionally does NOT use this predicate --
+/// it always parks on `wait_and_retry_2fa` because the user is presumed
+/// present at a terminal during the initial command. This helper exists
+/// because the *reauth* branch fires mid-cycle, by which point a one-shot
+/// caller has long since detached and there is no operator to type a code.
 pub(crate) fn should_wait_for_2fa(is_watch_mode: bool, err: &anyhow::Error) -> bool {
     is_watch_mode
         && err

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2515,6 +2515,7 @@ mod tests {
 
     /// CG-8: when `get_all_asset_albums` succeeds but
     /// `get_all_asset_people` fails, the result still includes albums.
+    #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn preload_asset_groupings_partial_people_failure_keeps_albums() {
         use std::collections::{HashMap, HashSet};
@@ -2780,6 +2781,7 @@ mod tests {
     }
 
     /// Companion: `state_db = None` returns an empty grouping struct.
+    #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn preload_asset_groupings_no_db_returns_empty() {
         let groupings = preload_asset_groupings(&None).await;

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1627,4 +1627,427 @@ mod tests {
             );
         }
     }
+
+    // CG-18: classifier sees through `Box<dyn Error + Send + Sync>` wrappers.
+    //
+    // anyhow lets callers wrap raw boxed errors via `anyhow::Error::from`
+    // when adapting third-party error returns. The downcast walk used by
+    // `is_session_error` must conclude "not a session error" for any error
+    // chain that was never an `ICloudError` — otherwise a future refactor
+    // through a boxed-error adapter could silently flip every config /
+    // network / state error into "burn an Apple SRP slot".
+    #[test]
+    fn is_session_error_through_boxed_error_returns_false() {
+        // A boxed error of a foreign type wrapped via anyhow::Error::from.
+        let boxed: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::new(std::io::ErrorKind::Other, "foreign"));
+        let e: anyhow::Error = anyhow::Error::from_boxed(boxed);
+        assert!(
+            !is_session_error(&e),
+            "boxed-error wrapper must not be classified as a session error"
+        );
+
+        // Also: anyhow::Error::msg(string) must be non-session — this is
+        // the most common path through our error pipeline (a `bail!` from
+        // a non-icloud module).
+        let plain = anyhow::anyhow!("config parse failed at line 7");
+        assert!(
+            !is_session_error(&plain),
+            "free-form anyhow::Error must not be classified as a session error"
+        );
+    }
+
+    // ── determine_sync_mode ──────────────────────────────────────────
+    //
+    // Sync-mode decision is the gatekeeper for the kei "user data is sacred"
+    // invariant: pick Full vs Incremental wrong and either (a) re-download
+    // the world (waste) or (b) skip previously-failed assets (silent loss).
+    // None of the four critical branches had a direct unit test before.
+
+    fn make_state_db() -> Arc<dyn state::StateDb> {
+        Arc::new(state::SqliteStateDb::open_in_memory().expect("open in-memory state DB"))
+    }
+
+    /// CG-1: `is_retry_failed=true` MUST force `SyncMode::Full` even when a
+    /// sync token is stored. A regression that picked Incremental during
+    /// retry-failed would silently skip the previously-failed assets the
+    /// user explicitly asked to retry — silent data loss.
+    #[tokio::test]
+    async fn determine_sync_mode_retry_failed_with_token_returns_full() {
+        let db = make_state_db();
+        let sync_token_key = "sync_token:PrimarySync";
+        // Pre-populate a stored token so we can verify it is ignored.
+        db.set_metadata(sync_token_key, "stored-token-abc")
+            .await
+            .expect("set token");
+
+        let mode = determine_sync_mode(
+            true,  // is_retry_failed
+            false, // no_incremental
+            1,
+            &Some(Arc::clone(&db)),
+            sync_token_key,
+            "PrimarySync",
+        )
+        .await;
+
+        assert!(
+            matches!(mode, download::SyncMode::Full),
+            "retry-failed must force Full, got {mode:?}"
+        );
+    }
+
+    /// CG-2: `--no-incremental` MUST force `SyncMode::Full`, ignoring any
+    /// stored token. The flag exists so a user can deliberately re-enumerate
+    /// (e.g. after a known incremental drift); silently downgrading would
+    /// betray that contract.
+    #[tokio::test]
+    async fn determine_sync_mode_no_incremental_overrides_stored_token() {
+        let db = make_state_db();
+        let sync_token_key = "sync_token:PrimarySync";
+        db.set_metadata(sync_token_key, "stored-token-xyz")
+            .await
+            .expect("set token");
+
+        let mode = determine_sync_mode(
+            false, // is_retry_failed
+            true,  // no_incremental
+            1,
+            &Some(Arc::clone(&db)),
+            sync_token_key,
+            "PrimarySync",
+        )
+        .await;
+
+        assert!(
+            matches!(mode, download::SyncMode::Full),
+            "--no-incremental must force Full, got {mode:?}"
+        );
+    }
+
+    /// CG-3: an empty stored token must fall back to Full. Production
+    /// guards on `!token.is_empty()`; if a refactor flipped that check the
+    /// caller would request `changes/zone` with empty token and silently
+    /// drop pending events.
+    #[tokio::test]
+    async fn determine_sync_mode_empty_stored_token_falls_back_to_full() {
+        let db = make_state_db();
+        let sync_token_key = "sync_token:PrimarySync";
+        // Empty-string token is the malformed case — should be ignored.
+        db.set_metadata(sync_token_key, "")
+            .await
+            .expect("set empty token");
+
+        let mode = determine_sync_mode(
+            false,
+            false,
+            1,
+            &Some(Arc::clone(&db)),
+            sync_token_key,
+            "PrimarySync",
+        )
+        .await;
+
+        assert!(
+            matches!(mode, download::SyncMode::Full),
+            "empty stored token must yield Full, got {mode:?}"
+        );
+
+        // And a present, non-empty token must trigger Incremental — pin the
+        // happy path here too so the empty-string check can't be dropped
+        // without breaking both assertions.
+        db.set_metadata(sync_token_key, "real-token")
+            .await
+            .expect("set real token");
+        let mode = determine_sync_mode(
+            false,
+            false,
+            1,
+            &Some(Arc::clone(&db)),
+            sync_token_key,
+            "PrimarySync",
+        )
+        .await;
+        assert!(
+            matches!(mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "real-token"),
+            "non-empty token must yield Incremental with that token, got {mode:?}"
+        );
+    }
+
+    /// CG-4: when the state DB read fails, fall back to Full rather than
+    /// propagating. The watch loop must keep going even if sqlite hiccups —
+    /// silently biasing toward Incremental on errors would mask data loss.
+    ///
+    /// We reach the failure surface by closing the underlying connection
+    /// out from under a real `SqliteStateDb`. Doing this against a plain
+    /// fail-everything stub would require implementing every method in the
+    /// (large) `StateDb` trait; instead we use the test-only failing impl
+    /// the pipeline tests already maintain. See the inline `FailingDb`.
+    #[tokio::test]
+    async fn determine_sync_mode_state_db_error_falls_back_to_full() {
+        use std::collections::{HashMap, HashSet};
+        use std::path::PathBuf;
+
+        // Minimal failing impl: only `get_metadata` is reachable from
+        // `determine_sync_mode`; every other method is unimplemented so
+        // any silent reroute lights up immediately.
+        struct FailingDb;
+
+        #[async_trait::async_trait]
+        impl state::StateDb for FailingDb {
+            #[cfg(test)]
+            async fn should_download(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn upsert_seen(
+                &self,
+                _: &state::types::AssetRecord,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_downloaded(
+                &self,
+                _: &str,
+                _: &str,
+                _: &std::path::Path,
+                _: &str,
+                _: Option<&str>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_failed(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_failed_sample(
+                &self,
+                _: u32,
+            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
+            {
+                unimplemented!()
+            }
+            async fn get_pending(
+                &self,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_summary(
+                &self,
+            ) -> Result<state::types::SyncSummary, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_page(
+                &self,
+                _: u64,
+                _: u32,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn complete_sync_run(
+                &self,
+                _: i64,
+                _: &state::types::SyncRunStats,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn list_interrupted_enumerations(
+                &self,
+            ) -> Result<Vec<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn promote_pending_to_failed(
+                &self,
+                _: i64,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_ids(
+                &self,
+            ) -> Result<HashSet<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_known_ids(&self) -> Result<HashSet<String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_checksums(
+                &self,
+            ) -> Result<HashMap<(String, String), String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_attempt_counts(
+                &self,
+            ) -> Result<HashMap<String, u32>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_metadata(
+                &self,
+                _: &str,
+            ) -> Result<Option<String>, state::error::StateError> {
+                Err(state::error::StateError::LockPoisoned("simulated".into()))
+            }
+            async fn set_metadata(&self, _: &str, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn delete_metadata_by_prefix(
+                &self,
+                _: &str,
+            ) -> Result<u64, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn touch_last_seen_many(
+                &self,
+                _: &[&str],
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn sample_downloaded_paths(
+                &self,
+                _: usize,
+            ) -> Result<Vec<PathBuf>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn add_asset_album(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_asset_albums(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_all_asset_people(
+                &self,
+            ) -> Result<Vec<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_soft_deleted(
+                &self,
+                _: &str,
+                _: Option<chrono::DateTime<chrono::Utc>>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn mark_hidden_at_source(&self, _: &str) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn record_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_downloaded_metadata_hashes(
+                &self,
+            ) -> Result<HashMap<(String, String), String>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_metadata_retry_markers(
+                &self,
+            ) -> Result<HashSet<(String, String)>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn get_pending_metadata_rewrites(
+                &self,
+                _: usize,
+            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+                unimplemented!()
+            }
+            async fn update_metadata_hash(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn clear_metadata_write_failure(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn has_downloaded_without_metadata_hash(
+                &self,
+            ) -> Result<bool, state::error::StateError> {
+                unimplemented!()
+            }
+        }
+
+        let db: Arc<dyn state::StateDb> = Arc::new(FailingDb);
+
+        let mode = determine_sync_mode(
+            false,
+            false,
+            1,
+            &Some(db),
+            "sync_token:PrimarySync",
+            "PrimarySync",
+        )
+        .await;
+
+        assert!(
+            matches!(mode, download::SyncMode::Full),
+            "DB read error must fall back to Full, got {mode:?}"
+        );
+    }
+
+    /// Sanity: `state_db = None` (e.g. legacy run with no state path) must
+    /// still produce Full. The match-arm exists in production today; pin
+    /// it so a future refactor that drops the `else` branch tells us.
+    #[tokio::test]
+    async fn determine_sync_mode_no_state_db_returns_full() {
+        let mode = determine_sync_mode(
+            false,
+            false,
+            1,
+            &None,
+            "sync_token:PrimarySync",
+            "PrimarySync",
+        )
+        .await;
+
+        assert!(
+            matches!(mode, download::SyncMode::Full),
+            "no state DB must yield Full, got {mode:?}"
+        );
+    }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -842,7 +842,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                             &config.username,
                             None,
                         );
-                        if !is_watch_mode {
+                        if !should_wait_for_2fa(is_watch_mode, &e) {
                             return Err(e);
                         }
 
@@ -1078,6 +1078,27 @@ async fn reauth_with_srp(
 /// `Some(_)` and that a state DB is configured before persisting.
 pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_run: bool) -> bool {
     matches!(outcome, download::DownloadOutcome::Success) && !dry_run
+}
+
+/// Decide whether the reauth path inside the watch loop should block on a
+/// 2FA prompt or surface the error to the caller.
+///
+/// In **watch mode** a 2FA-required error is recoverable: the loop notifies
+/// the user, parks `wait_and_retry_2fa`, and resumes once a code arrives.
+///
+/// In **one-shot mode** there is nothing to wait on -- the caller (a CI run,
+/// a cron, the systemd unit's first start) needs the error so it can exit
+/// non-zero and the operator can run `kei login get-code`. CG-19.
+///
+/// Mirrors the predicate used at the entry-point auth path (`run_sync`'s
+/// initial `auth::authenticate` call already returns the error in non-watch
+/// mode); this helper documents the contract for the *reauth* branch where
+/// the same decision was previously inline.
+pub(crate) fn should_wait_for_2fa(is_watch_mode: bool, err: &anyhow::Error) -> bool {
+    is_watch_mode
+        && err
+            .downcast_ref::<auth::error::AuthError>()
+            .is_some_and(auth::error::AuthError::is_two_factor_required)
 }
 
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
@@ -2825,5 +2846,60 @@ mod tests {
             should_store_sync_token(&outcome, false),
             "(Success, dry_run=false) is the ONLY combination that should advance the token"
         );
+    }
+
+    // CG-19: `should_wait_for_2fa` decides whether the reauth-time 2FA
+    // branch parks the loop on a code prompt or surfaces the error. In
+    // one-shot mode there is no operator at the keyboard; the error MUST
+    // bubble up so cron / systemd / CI exits non-zero.
+
+    /// CG-19: a 2FA-required error in one-shot (`is_watch_mode = false`)
+    /// MUST NOT cause the helper to return `true`. The caller will then
+    /// surface the error to the user instead of blocking forever on a
+    /// 2FA prompt that no one is watching.
+    #[test]
+    fn run_sync_2fa_required_in_one_shot_returns_error() {
+        let err: anyhow::Error = auth::error::AuthError::TwoFactorRequired.into();
+        assert!(
+            !should_wait_for_2fa(false, &err),
+            "one-shot + 2FA-required must surface the error, not park on a prompt"
+        );
+    }
+
+    /// CG-19 companion: in watch mode the same error is recoverable;
+    /// the helper returns `true` so the loop can park.
+    #[test]
+    fn run_sync_2fa_required_in_watch_mode_waits() {
+        let err: anyhow::Error = auth::error::AuthError::TwoFactorRequired.into();
+        assert!(
+            should_wait_for_2fa(true, &err),
+            "watch + 2FA-required must wait on a code"
+        );
+    }
+
+    /// Negative control: any non-2FA error MUST surface in both modes.
+    /// Otherwise the loop could silently swallow a real failure (e.g.
+    /// `FailedLogin`) by treating it as "wait for a code that won't come".
+    #[test]
+    fn run_sync_non_2fa_error_never_waits() {
+        let err: anyhow::Error = auth::error::AuthError::FailedLogin("bad password".into()).into();
+        assert!(
+            !should_wait_for_2fa(false, &err),
+            "one-shot + non-2FA must surface"
+        );
+        assert!(
+            !should_wait_for_2fa(true, &err),
+            "watch + non-2FA must surface; do not park on a code that will never arrive"
+        );
+    }
+
+    /// Negative control: a non-AuthError (e.g. an arbitrary anyhow error
+    /// with no downcast target) MUST NOT be treated as 2FA. Without this
+    /// guard the predicate could mis-park on transport errors.
+    #[test]
+    fn run_sync_non_auth_error_never_waits() {
+        let err: anyhow::Error = anyhow::anyhow!("network unreachable");
+        assert!(!should_wait_for_2fa(false, &err));
+        assert!(!should_wait_for_2fa(true, &err));
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -25,7 +25,10 @@ use crate::retry;
 use crate::shutdown;
 use crate::state::{self, StateDb};
 use crate::systemd::SystemdNotifier;
-use crate::{available_disk_space, make_password_provider, PartialSyncError, PidFileGuard};
+use crate::{
+    available_disk_space, check_min_disk_space, make_password_provider, PartialSyncError,
+    PidFileGuard,
+};
 
 /// Per-library state: zone name, sync token key, and resolved album plan.
 struct LibraryState {
@@ -272,16 +275,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     })?;
     let _ = tokio::fs::remove_file(&probe).await;
 
-    // Abort if available disk space is too low.
+    // Abort if available disk space is too low. CG-20: see
+    // `check_min_disk_space` for the pure inner check.
     if let Some(avail) = available_disk_space(&config.directory) {
-        const MIN_FREE_BYTES: u64 = 1_073_741_824; // 1 GiB
-        if avail < MIN_FREE_BYTES {
-            let avail_mb = avail / (1024 * 1024);
-            anyhow::bail!(
-                "Insufficient disk space: only {avail_mb} MiB available in {} (minimum 1 GiB)",
-                config.directory.display()
-            );
-        }
+        check_min_disk_space(avail, &config.directory)?;
     }
 
     let cred_store = credential::CredentialStore::new(&config.username, &config.cookie_directory);

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1214,28 +1214,8 @@ async fn run_cycle(
             );
         }
 
-        // Accumulate stats across libraries
-        cycle_stats.assets_seen += sync_result.stats.assets_seen;
-        cycle_stats.downloaded += sync_result.stats.downloaded;
-        cycle_stats.failed += sync_result.stats.failed;
-        cycle_stats.bytes_downloaded += sync_result.stats.bytes_downloaded;
-        cycle_stats.disk_bytes_written += sync_result.stats.disk_bytes_written;
-        cycle_stats.exif_failures += sync_result.stats.exif_failures;
-        cycle_stats.state_write_failures += sync_result.stats.state_write_failures;
-        cycle_stats.enumeration_errors += sync_result.stats.enumeration_errors;
-        cycle_stats.elapsed_secs += sync_result.stats.elapsed_secs;
-        cycle_stats.interrupted = cycle_stats.interrupted || sync_result.stats.interrupted;
-        cycle_stats.skipped.by_state += sync_result.stats.skipped.by_state;
-        cycle_stats.skipped.on_disk += sync_result.stats.skipped.on_disk;
-        cycle_stats.skipped.by_media_type += sync_result.stats.skipped.by_media_type;
-        cycle_stats.skipped.by_date_range += sync_result.stats.skipped.by_date_range;
-        cycle_stats.skipped.by_live_photo += sync_result.stats.skipped.by_live_photo;
-        cycle_stats.skipped.by_filename += sync_result.stats.skipped.by_filename;
-        cycle_stats.skipped.by_excluded_album += sync_result.stats.skipped.by_excluded_album;
-        cycle_stats.skipped.ampm_variant += sync_result.stats.skipped.ampm_variant;
-        cycle_stats.skipped.duplicates += sync_result.stats.skipped.duplicates;
-        cycle_stats.skipped.retry_exhausted += sync_result.stats.skipped.retry_exhausted;
-        cycle_stats.skipped.retry_only += sync_result.stats.skipped.retry_only;
+        // Accumulate stats across libraries. CG-15.
+        cycle_stats.accumulate(&sync_result.stats);
 
         match sync_result.outcome {
             download::DownloadOutcome::Success => {}

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1061,6 +1061,25 @@ async fn reauth_with_srp(
     }
 }
 
+/// Decide whether the per-zone `sync_token` should be persisted to the state
+/// DB after a download pass.
+///
+/// The contract is "advance only on full success and not in dry-run":
+/// - On `PartialFailure`, a stored token would skip the failed assets on the
+///   next incremental sync (they'd never appear in the delta again -- silent
+///   data loss). CG-9.
+/// - On `SessionExpired`, the cycle aborts mid-stream; the token may be
+///   stale or only reflect a subset of the work.
+/// - In `--dry-run`, we promise to make no DB writes that survive the run
+///   (apart from the `sync_runs` ledger). Advancing the token here would
+///   silently break the next real sync. CG-21.
+///
+/// The returned bool is the gate: callers still check that `sync_token` is
+/// `Some(_)` and that a state DB is configured before persisting.
+pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_run: bool) -> bool {
+    matches!(outcome, download::DownloadOutcome::Success) && !dry_run
+}
+
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
 async fn run_cycle(
     library_states: &[LibraryState],
@@ -1177,8 +1196,7 @@ async fn run_cycle(
         // Note: the token is stored after download_photos_with_sync returns, which
         // means all batch flushes are complete. A crash here means the token is
         // NOT advanced, so assets will replay on next sync (safe, not data loss).
-        let should_store_token =
-            matches!(sync_result.outcome, download::DownloadOutcome::Success) && !config.dry_run;
+        let should_store_token = should_store_sync_token(&sync_result.outcome, config.dry_run);
         if should_store_token {
             if let Some(token) = &sync_result.sync_token {
                 if let Some(db) = state_db {
@@ -2767,5 +2785,65 @@ mod tests {
         let groupings = preload_asset_groupings(&None).await;
         assert!(groupings.albums.is_empty());
         assert!(groupings.people.is_empty());
+    }
+
+    // CG-9 / CG-21: `should_store_sync_token` is the single decision gate
+    // protecting the sync-token from being advanced after a partial sync or
+    // a dry run. Both situations would lose change events on the next
+    // incremental cycle ("user data is sacred"). The matrix below pins every
+    // (outcome, dry_run) combination so a future refactor can't relax the
+    // contract without a failing test.
+
+    /// CG-9: a partial download failure MUST NOT advance the stored sync
+    /// token. Otherwise the next incremental sync would skip past the
+    /// failed assets' change events and never retry them.
+    #[test]
+    fn sync_loop_partial_failure_does_not_advance_sync_token() {
+        let outcome = download::DownloadOutcome::PartialFailure { failed_count: 3 };
+        assert!(
+            !should_store_sync_token(&outcome, false),
+            "PartialFailure must NOT advance the sync token, even outside dry-run"
+        );
+        // dry_run=true cannot rescue a partial failure either.
+        assert!(
+            !should_store_sync_token(&outcome, true),
+            "PartialFailure + dry_run must still NOT advance the sync token"
+        );
+    }
+
+    /// CG-9 companion: `SessionExpired` is also a non-success outcome and
+    /// MUST NOT advance the token. The cycle aborts mid-stream; the captured
+    /// token may only reflect a subset of the work.
+    #[test]
+    fn sync_loop_session_expired_does_not_advance_sync_token() {
+        let outcome = download::DownloadOutcome::SessionExpired {
+            auth_error_count: 5,
+        };
+        assert!(!should_store_sync_token(&outcome, false));
+        assert!(!should_store_sync_token(&outcome, true));
+    }
+
+    /// CG-21: in `--dry-run`, even a fully-successful pass MUST NOT advance
+    /// the token. Dry-run promises no DB writes that affect the next real
+    /// sync; advancing the token would silently break the next incremental.
+    #[test]
+    fn sync_loop_dry_run_does_not_advance_sync_token() {
+        let outcome = download::DownloadOutcome::Success;
+        assert!(
+            !should_store_sync_token(&outcome, true),
+            "dry_run must NOT advance the sync token even on Success"
+        );
+    }
+
+    /// Positive control: only the (Success, dry_run=false) combination
+    /// advances the token. Pinning this branch prevents a future refactor
+    /// from accidentally inverting the predicate.
+    #[test]
+    fn sync_loop_full_success_outside_dry_run_advances_sync_token() {
+        let outcome = download::DownloadOutcome::Success;
+        assert!(
+            should_store_sync_token(&outcome, false),
+            "(Success, dry_run=false) is the ONLY combination that should advance the token"
+        );
     }
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1379,16 +1379,27 @@ fn sync_incremental_second_run_skips_download() {
 
 /// Verify `--watch-with-interval` drives multiple sync cycles within one run.
 ///
-/// Runs at the minimum interval (60 s) long enough to observe two cycle starts,
-/// then kills the process and counts the `sync_loop: Starting kei` markers.
+/// Runs at the minimum allowed interval (60 s, enforced by the CLI parser),
+/// streams stderr line-by-line on a background thread, and exits as soon as
+/// the second `Waiting before next cycle` marker is observed. Total wall
+/// time is bounded by a hard 150 s deadline so a stuck watch loop fails the
+/// test rather than hanging the suite.
+///
+/// Earlier revisions used `thread::sleep(135s)` then matched on a captured
+/// stderr blob; that pattern silently regressed if the interval was honored
+/// but the marker text changed (or vice versa) and burned the full window
+/// even on success. The streaming reader catches both without adding cost.
 #[test]
 #[ignore]
 fn sync_watch_runs_multiple_cycles() {
     let (username, password, cookie_dir) = common::require_preauth();
 
     common::with_auth_retry(|| {
-        use std::io::Read;
+        use std::io::{BufRead, BufReader};
         use std::process::{Command, Stdio};
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Instant;
 
         let download_dir = tempdir().expect("tempdir");
         let bin = env!("CARGO_BIN_EXE_kei");
@@ -1416,23 +1427,66 @@ fn sync_watch_runs_multiple_cycles() {
             .spawn()
             .expect("spawn kei");
 
-        // First cycle runs at t=0, second at t=60, buffer for download time.
-        std::thread::sleep(Duration::from_secs(135));
-        let _ = child.kill();
+        // Stream stderr on a worker so the test can react as soon as the
+        // second cycle marker appears, instead of waiting for a fixed sleep.
+        let stderr = child.stderr.take().expect("piped stderr");
+        let (tx, rx) = mpsc::channel::<String>();
+        let reader_handle = thread::spawn(move || {
+            let mut buffered = BufReader::new(stderr);
+            let mut accum = String::new();
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match buffered.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        accum.push_str(&line);
+                        // Best effort: send each line. Drop on send failure
+                        // (test thread already exited, e.g. assertion fired).
+                        let _ = tx.send(line.clone());
+                    }
+                    Err(_) => break,
+                }
+            }
+            accum
+        });
 
-        let mut stderr = String::new();
-        if let Some(mut pipe) = child.stderr.take() {
-            let _ = pipe.read_to_string(&mut stderr);
+        // Watch the channel for 2 marker hits, bounded by 150 s wall time.
+        // 60 s * 2 cycles + buffer for one cycle of download work.
+        let deadline = Instant::now() + Duration::from_secs(150);
+        let mut markers = 0_usize;
+        let mut snippet = String::new();
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match rx.recv_timeout(remaining) {
+                Ok(line) => {
+                    snippet.push_str(&line);
+                    if strip_ansi(&line).contains("Waiting before next cycle") {
+                        markers += 1;
+                        if markers >= 2 {
+                            break;
+                        }
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => break,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
         }
-        let _ = child.wait();
 
-        // Each cycle logs "Waiting before next cycle" at the end; 2 cycles → 2 markers.
-        let clean = strip_ansi(&stderr);
-        let cycles = clean.matches("Waiting before next cycle").count();
+        let _ = child.kill();
+        let _ = child.wait();
+        // The reader thread will see EOF after kill and join cleanly.
+        let full_stderr = reader_handle.join().unwrap_or_default();
+
         assert!(
-            cycles >= 2,
-            "watch should drive at least 2 cycles, got {cycles}. stderr head: {}",
-            clean.chars().take(2000).collect::<String>()
+            markers >= 2,
+            "watch should drive at least 2 cycles, got {markers}. \
+             snippet: {}\n--- full stderr (first 2000 chars) ---\n{}",
+            strip_ansi(&snippet).chars().take(800).collect::<String>(),
+            strip_ansi(&full_stderr)
+                .chars()
+                .take(2000)
+                .collect::<String>()
         );
     });
 }


### PR DESCRIPTION
Closes 21 unit-level coverage gaps surfaced by `/test-review` against main, rewrites a flaky watch-mode integration test, adds HEIF malformed-input parser regressions, and extracts 4 small helpers from production code that had no unit-level coverage of those decisions.

One real bug fix is bundled into the CG-15 extraction: the prior inline accumulator at `sync_loop.rs:1200-1218` was missing the `rate_limited` field, so multi-library syncs reported zero rate_limited counts in cycle stats (used by metrics + notifications) no matter the actual count from the download pipeline. `SyncStats::accumulate` now sums every field and the test asserts on the summed `rate_limited`. The fix is mechanically inseparable from the extraction. The new method delegates to per-field arithmetic that covers every declared field, so it landed in the same commit and is called out in the message.

## Summary

- **21 coverage gaps closed** across `sync_loop.rs`, `download/file.rs`, `download/filter.rs`, `state/db.rs`, `icloud/photos/asset.rs`. Areas: sync-decision logic (`determine_sync_mode`, `check_changes_database`, `is_session_error`), state persistence (`promote_orphaned_sync_runs` idempotence), atomic writes (pre-existing `.part`, missing parent dir, truncated CDN response), boundary inputs (case-only filename collision, empty filename rejection at deser).
- **7 HEIF parser regressions** for malformed input on `extract_xmp_bytes` and `insert_xmp` (empty / random / truncated / missing-meta-box / oversized-length-field).
- **`tests/sync.rs::sync_watch_runs_multiple_cycles` rewrite.** Replaced fixed 135 s `thread::sleep` + posthoc stderr scan with a streaming reader that exits as soon as the second `Waiting before next cycle` marker lands, bounded by a 150 s deadline. The CLI's 60 s minimum interval is the wall-time floor; this rewrite trades wall time for an early-exit guarantee.
- **4 helper extractions** with full unit coverage of each:
  - `should_store_sync_token(&DownloadOutcome, dry_run) -> bool` (CG-9 + CG-21) at `src/sync_loop.rs:1078`
  - `SyncStats::accumulate` + `SkipBreakdown::accumulate` (CG-15) at `src/download/mod.rs:110,154`
  - `should_wait_for_2fa(is_watch_mode, &Error) -> bool` (CG-19) at `src/sync_loop.rs:1085`
  - `check_min_disk_space(available_bytes, &Path) -> Result<()>` plus `MIN_FREE_BYTES` const (CG-20) at `src/main.rs:191`
- **One bundled bug fix.** `rate_limited` was being dropped across multi-library syncs by the inline accumulator at the prior `sync_loop.rs:1200-1218`. `SyncStats::accumulate` sums every field. Commit `6e75941`.

Suite goes 1930 -> 1970 passing (+40 tests). 0 failures, 60 ignored (live-Apple). `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Test plan

- [x] `cargo test` (parallel): 1970 passed, 0 failed, 60 ignored
- [x] `cargo test -- --test-threads=1`: 1970 passed, 0 failed, 60 ignored
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [ ] CI green on PR
- [ ] Live-auth: `cargo test --test sync -- --test-threads=1` against the test account (covers the rewritten watch test against real Apple intervals)

## Risk notes

- The `rate_limited` fix in CG-15 changes one output: cycle stats reported across multi-library syncs now include rate_limited counts that the prior code zeroed. Anyone diffing metrics or notification payloads against a baseline run will see this field land. Behavior on single-library accounts (the common case) is unchanged.
- `should_wait_for_2fa` performs the `AuthError` downcast inside the helper, not at the call site, so the predicate is self-contained and the unit tests exercise the same code production runs. Reshape from the original proposal sketch; rationale in the helper's doc comment.
- The CG-15 commit adds `SkipBreakdown::accumulate` as a delegate so `SyncStats::accumulate` doesn't inline 11 more `+=` statements. Future field additions to either struct can't regress this class of bug without a test failure.

## Reports

Internal notes from the `/test-review` workflow live under `.scratch/` (gitignored):

- `2026-04-25_TEST_REVIEW_PLAN.md` - original Phase 1 plan with 21 numbered CGs
- `2026-04-25_TEST_REVIEW_PHASE2_RESULT.md` - first Phase 2 round (28 tests, 0 production changes)
- `2026-04-25_TEST_REVIEW_PHASE2_HELPERS.md` - this round's 4 helper extractions and 12 gated tests