### PR TITLE
fix: create state DB parent dir on open (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`kei import-existing` no longer fails on a fresh install.** On a brand-new machine (no prior `kei sync` or `kei login` run), the command bailed out with `Failed to open database at ...: unable to open database file: Error code 14` because the `~/.config/kei/cookies/` parent directory didn't exist yet, and SQLite won't `mkdir -p` for you. `SqliteStateDb::open` now creates the parent directory before opening the DB, so `import-existing` works without the previously-required `kei login` workaround. (#264)
 - **`--file-match-policy name-id7` no longer risks producing a path separator inside a filename.** The 7-char asset-ID suffix baked into every filename was generated via standard base64, whose alphabet includes `/` and `+`. A CloudKit asset ID containing certain bytes (e.g. a `?` early in the ID) would produce `/` as the 4th base64 character, causing kei to drop that asset into a surprise subdirectory instead of the expected filename. kei now uses URL-safe base64 (`-` / `_`) for the suffix. Files that previously got the bug land at a new path on next sync and may re-download once. Added a fuzz test that walks every single-byte input and asserts the suffix only contains `[A-Za-z0-9_-]`.
 
 ### Security

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -339,8 +339,25 @@ impl std::fmt::Debug for SqliteStateDb {
 
 impl SqliteStateDb {
     /// Open or create a database at the given path.
+    ///
+    /// The parent directory is created if it doesn't exist. Several
+    /// subcommands (`import-existing`, `status`, `verify`, `reset`,
+    /// `reconcile`) open the DB before any auth flow runs, so on a fresh
+    /// install the cookie/data directory may not exist yet (issue #264).
     pub async fn open(path: &Path) -> Result<Self, StateError> {
         let path = path.to_path_buf();
+
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                tokio::fs::create_dir_all(parent).await.map_err(|source| {
+                    StateError::ParentDir {
+                        path: parent.to_path_buf(),
+                        source,
+                    }
+                })?;
+            }
+        }
+
         let path_clone = path.clone();
 
         let conn = tokio::task::spawn_blocking(move || {
@@ -3245,6 +3262,69 @@ mod tests {
 
         let result = SqliteStateDb::open(&path).await;
         assert!(result.is_err(), "opening a truncated DB should fail");
+    }
+
+    // Regression test for #264: on a fresh install the cookie/data directory
+    // doesn't exist yet for commands that open the DB before auth runs
+    // (import-existing, status, verify, reset, reconcile). SqliteStateDb::open
+    // must create the parent directory itself rather than letting SQLite fail
+    // with a generic "unable to open database file" (error code 14).
+    #[tokio::test]
+    async fn open_creates_missing_parent_directory() {
+        let dir = test_dir();
+        let nested = dir.path().join("does/not/exist/yet");
+        let path = nested.join("state.db");
+
+        assert!(!nested.exists(), "precondition: parent dir must be missing");
+
+        let db = SqliteStateDb::open(&path)
+            .await
+            .expect("open should create the missing parent directory");
+
+        assert!(nested.is_dir(), "parent directory should be created");
+        assert!(path.is_file(), "DB file should be created");
+
+        // Sanity: the DB is actually usable, not just opened then closed.
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.downloaded, 0);
+        assert_eq!(summary.pending, 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_returns_parent_dir_error_on_unwritable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Skip when running as root: 0o555 doesn't restrict root, so the
+        // mkdir would succeed and the assertion below would falsely fail.
+        // SAFETY: geteuid is always safe to call.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        let dir = test_dir();
+        let readonly = dir.path().join("readonly");
+        fs::create_dir(&readonly).unwrap();
+        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let path = readonly.join("nested/state.db");
+        let result = SqliteStateDb::open(&path).await;
+
+        // Restore writable permissions so TempDir cleanup can remove it.
+        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.expect_err("expected ParentDir error on read-only parent");
+        match &err {
+            StateError::ParentDir { path: p, .. } => {
+                assert!(
+                    p.starts_with(&readonly),
+                    "ParentDir path {} should be under {}",
+                    p.display(),
+                    readonly.display(),
+                );
+            }
+            other => panic!("expected StateError::ParentDir, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -345,6 +345,9 @@ impl SqliteStateDb {
     pub async fn open(path: &Path) -> Result<Self, StateError> {
         let path = path.to_path_buf();
 
+        // create_dir_all is idempotent on an existing directory, so concurrent
+        // opens on the same path don't race here. SQLite's own file locking
+        // handles the open() race that follows.
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -3293,21 +3296,27 @@ mod tests {
 
         // Skip when running as root: 0o555 doesn't restrict root, so the
         // mkdir would succeed and the assertion below would falsely fail.
-        // SAFETY: geteuid is always safe to call.
+        // SAFETY: libc::geteuid() is a stateless POSIX FFI call with no
+        // preconditions, no side effects, and a uid_t return value; it cannot
+        // violate Rust memory safety.
         if unsafe { libc::geteuid() } == 0 {
             return;
         }
 
         let dir = test_dir();
         let readonly = dir.path().join("readonly");
-        fs::create_dir(&readonly).unwrap();
-        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o555)).unwrap();
+        tokio::fs::create_dir(&readonly).await.unwrap();
+        tokio::fs::set_permissions(&readonly, fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
 
         let path = readonly.join("nested/state.db");
         let result = SqliteStateDb::open(&path).await;
 
         // Restore writable permissions so TempDir cleanup can remove it.
-        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o755)).unwrap();
+        tokio::fs::set_permissions(&readonly, fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
 
         let err = result.expect_err("expected ParentDir error on read-only parent");
         match &err {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -340,22 +340,18 @@ impl std::fmt::Debug for SqliteStateDb {
 impl SqliteStateDb {
     /// Open or create a database at the given path.
     ///
-    /// The parent directory is created if it doesn't exist. Several
-    /// subcommands (`import-existing`, `status`, `verify`, `reset`,
-    /// `reconcile`) open the DB before any auth flow runs, so on a fresh
-    /// install the cookie/data directory may not exist yet (issue #264).
+    /// Creates the parent directory if it doesn't exist; see
+    /// [`StateError::ParentDir`].
     pub async fn open(path: &Path) -> Result<Self, StateError> {
         let path = path.to_path_buf();
 
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                tokio::fs::create_dir_all(parent).await.map_err(|source| {
-                    StateError::ParentDir {
-                        path: parent.to_path_buf(),
-                        source,
-                    }
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|source| StateError::ParentDir {
+                    path: parent.to_path_buf(),
+                    source,
                 })?;
-            }
         }
 
         let path_clone = path.clone();

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -7,6 +7,21 @@ use thiserror::Error;
 /// Errors that can occur during state database operations.
 #[derive(Error, Debug)]
 pub enum StateError {
+    /// Failed to create the parent directory for the database file.
+    ///
+    /// On a fresh install the cookie/data directory may not exist yet
+    /// (commands like `import-existing`, `status`, `verify`, `reset`,
+    /// `reconcile` open the DB before any auth flow runs that would create
+    /// it). `SqliteStateDb::open` creates the parent directory so SQLite
+    /// doesn't fail with a generic "unable to open database file" — this
+    /// variant surfaces the underlying mkdir failure (e.g. permission
+    /// denied) distinctly from a SQLite open error.
+    #[error("Failed to create parent directory {path}: {source}")]
+    ParentDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
     /// Failed to open or create the database file.
     #[error("Failed to open database at {path}: {source}")]
     Open {
@@ -140,6 +155,27 @@ mod tests {
         assert!(
             display.starts_with("Failed to open database at"),
             "unexpected prefix: {display}"
+        );
+    }
+
+    #[test]
+    fn parent_dir_error_display_includes_path() {
+        let err = StateError::ParentDir {
+            path: PathBuf::from("/tmp/claude/missing/dir"),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+        };
+        let display = err.to_string();
+        assert!(
+            display.contains("/tmp/claude/missing/dir"),
+            "expected path in display, got: {display}"
+        );
+        assert!(
+            display.starts_with("Failed to create parent directory"),
+            "unexpected prefix: {display}"
+        );
+        assert!(
+            display.contains("denied"),
+            "expected source message in display, got: {display}"
         );
     }
 }

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -9,13 +9,11 @@ use thiserror::Error;
 pub enum StateError {
     /// Failed to create the parent directory for the database file.
     ///
-    /// On a fresh install the cookie/data directory may not exist yet
-    /// (commands like `import-existing`, `status`, `verify`, `reset`,
-    /// `reconcile` open the DB before any auth flow runs that would create
-    /// it). `SqliteStateDb::open` creates the parent directory so SQLite
-    /// doesn't fail with a generic "unable to open database file" — this
-    /// variant surfaces the underlying mkdir failure (e.g. permission
-    /// denied) distinctly from a SQLite open error.
+    /// `SqliteStateDb::open` creates the parent directory before opening
+    /// so SQLite doesn't fail with a generic "unable to open database
+    /// file" on a fresh install (issue #264). This variant surfaces the
+    /// underlying mkdir failure (e.g. permission denied) distinctly from
+    /// a SQLite-level open error.
     #[error("Failed to create parent directory {path}: {source}")]
     ParentDir {
         path: PathBuf,


### PR DESCRIPTION
## Summary

- Fixes #264: `kei import-existing` on a fresh install crashed with `unable to open database file: Error code 14` because the `~/.config/kei/cookies/` parent directory hadn't been created yet. `kei sync` and `kei login` ran `fs::create_dir_all` as a side effect of auth setup, but `import-existing` opens the state DB before authenticating, so the directory was missing.
- `SqliteStateDb::open` now calls `tokio::fs::create_dir_all` on the parent before opening the SQLite connection. mkdir failures (e.g. permission denied) surface as a new `StateError::ParentDir { path, source }` variant so they stay distinct from SQLite-level open errors.
- Defensive scope: only `import-existing` was user-visible; `status` / `verify` / `reset` / `reconcile` short-circuit with "no DB found" before opening, and `sync` auth already created the directory. The fix makes the DB layer self-sufficient regardless of caller.

## Test plan

- [x] `open_creates_missing_parent_directory` unit test - opens a DB at `tempdir/does/not/exist/yet/state.db` and asserts the parent dir + DB file get created and the DB is usable.
- [x] `open_returns_parent_dir_error_on_unwritable_parent` unit test (Unix only, skipped when euid is 0) - confirms `StateError::ParentDir` fires and carries the parent path when mkdir is denied.
- [x] `parent_dir_error_display_includes_path` unit test for the new `StateError` variant.
- [x] `just gate` passes (fmt, clippy, full test suite, docs, audit, typos).
- [x] Smoke test: `cargo run -- import-existing --username smoketest@example.com --password fake --data-dir /tmp/claude/kei-fresh-test/cookies --download-dir /tmp/claude/kei-fresh-photos` against a non-existent data dir now runs migrations cleanly and only fails at the auth step (expected with fake credentials). The DB and parent dir are created on disk.