### PR TITLE
heif: walk top-level boxes by header to skip non-meta parsers

### DIFF
--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -14,8 +14,8 @@ use std::io::Write;
 use std::path::Path;
 
 use mp4_atom::{
-    Any, DecodeMaybe, Encode, FourCC, Iinf, Iloc, ItemInfoEntry, ItemLocation, ItemLocationExtent,
-    Mdat, Meta,
+    Any, Atom, Buf, DecodeMaybe, Encode, FourCC, Header, Iinf, Iloc, ItemInfoEntry, ItemLocation,
+    ItemLocationExtent, Mdat, Meta,
 };
 
 /// Typed failures from the HEIC writer. Each variant names the precise mode
@@ -109,37 +109,102 @@ pub(crate) fn is_heif_content(bytes: &[u8]) -> bool {
 /// raw RDF/XML payload referenced by the first `mime`-type item with
 /// content_type `"application/rdf+xml"`. Used by the write path to preserve
 /// existing XMP on rewrite (symmetric with xmp_toolkit's `file.xmp()`).
+///
+/// Walks top-level boxes by header only and descends into `meta` directly,
+/// rather than using `Any::decode_maybe` which dispatches into mp4-atom's
+/// full type table on every box kind. That dispatch is unsafe for
+/// kei: parsers like `Dfla::decode_body` (`flac.rs::parse_vorbis_comment`)
+/// and `Avcc::decode_body` allocate from attacker-controlled length fields
+/// without a `min(..)` cap, so a malformed sub-100-byte HEIC turns into a
+/// 20+ GiB allocation. Filed upstream as kixelated/mp4-atom#154; this
+/// function avoids the problem regardless of when that lands by only
+/// invoking the iinf / iloc decoders we actually need.
 pub(crate) fn extract_xmp_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
     let mut cursor: &[u8] = bytes;
-    while let Ok(Some(atom)) = Any::decode_maybe(&mut cursor) {
-        let Any::Meta(meta) = atom else { continue };
-        let iinf = meta.get::<Iinf>()?;
-        let iloc = meta.get::<Iloc>()?;
-        let xmp_entry = iinf.item_infos.iter().find(|e| {
-            e.item_type == Some(FourCC::new(b"mime"))
-                && e.content_type.as_deref() == Some("application/rdf+xml")
-        })?;
-        let loc = iloc
-            .item_locations
-            .iter()
-            .find(|l| l.item_id == xmp_entry.item_id)?;
-        if loc.construction_method != 0 {
+    while cursor.has_remaining() {
+        let header = Header::decode_maybe(&mut cursor).ok().flatten()?;
+        let body_size = header.size.unwrap_or(cursor.remaining());
+        if body_size > cursor.remaining() {
             return None;
         }
-        let extent = loc.extents.first()?;
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "HEIC file byte offsets/lengths fit in usize on 64-bit; kei targets 64-bit platforms"
-        )]
-        let start = loc.base_offset.saturating_add(extent.offset) as usize;
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "HEIC extent length fits in usize on 64-bit"
-        )]
-        let end = start.checked_add(extent.length as usize)?;
-        return bytes.get(start..end).map(<[u8]>::to_vec);
+        if header.kind == FourCC::new(b"meta") {
+            // HEIC has at most one top-level `meta` box; stop either way.
+            return extract_xmp_from_meta(bytes, cursor.get(..body_size)?);
+        }
+        cursor.advance(body_size);
     }
     None
+}
+
+/// Pull the iinf + iloc out of a `meta` box body and resolve the XMP extent
+/// against the original file bytes. Walks the meta sub-boxes by header only
+/// and decodes only `iinf` and `iloc`, so a hostile sub-atom (e.g. a nested
+/// `dfLa`) can't reach the unbounded-allocation parsers either.
+fn extract_xmp_from_meta(file_bytes: &[u8], meta_body: &[u8]) -> Option<Vec<u8>> {
+    let mut cursor: &[u8] = meta_body;
+
+    // Two on-the-wire formats for `meta`:
+    //   - ISO/IEC 14496-12: 4-byte version+flags, then sub-boxes (first is hdlr).
+    //   - Apple QuickTime: starts with hdlr directly, no version+flags.
+    // Detect by peeking offset 4..8 for "hdlr"; same heuristic as
+    // mp4_atom::Meta::decode_body.
+    if cursor.len() >= 8 && cursor.get(4..8) != Some(b"hdlr".as_slice()) {
+        if cursor.len() < 4 {
+            return None;
+        }
+        cursor.advance(4);
+    }
+
+    // Skip hdlr; we don't need its contents.
+    let hdlr = Header::decode_maybe(&mut cursor).ok().flatten()?;
+    let hdlr_size = hdlr.size.unwrap_or(cursor.remaining());
+    if hdlr_size > cursor.remaining() {
+        return None;
+    }
+    cursor.advance(hdlr_size);
+
+    let mut iinf: Option<Iinf> = None;
+    let mut iloc: Option<Iloc> = None;
+    while cursor.has_remaining() {
+        let h = Header::decode_maybe(&mut cursor).ok().flatten()?;
+        let sz = h.size.unwrap_or(cursor.remaining());
+        if sz > cursor.remaining() {
+            return None;
+        }
+        let body = cursor.get(..sz)?;
+        if h.kind == FourCC::new(b"iinf") {
+            iinf = Iinf::decode_body(&mut &body[..]).ok();
+        } else if h.kind == FourCC::new(b"iloc") {
+            iloc = Iloc::decode_body(&mut &body[..]).ok();
+        }
+        cursor.advance(sz);
+    }
+
+    let iinf = iinf?;
+    let iloc = iloc?;
+    let xmp_entry = iinf.item_infos.iter().find(|e| {
+        e.item_type == Some(FourCC::new(b"mime"))
+            && e.content_type.as_deref() == Some("application/rdf+xml")
+    })?;
+    let loc = iloc
+        .item_locations
+        .iter()
+        .find(|l| l.item_id == xmp_entry.item_id)?;
+    if loc.construction_method != 0 {
+        return None;
+    }
+    let extent = loc.extents.first()?;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "HEIC file byte offsets/lengths fit in usize on 64-bit; kei targets 64-bit platforms"
+    )]
+    let start = loc.base_offset.saturating_add(extent.offset) as usize;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "HEIC extent length fits in usize on 64-bit"
+    )]
+    let end = start.checked_add(extent.length as usize)?;
+    file_bytes.get(start..end).map(<[u8]>::to_vec)
 }
 
 /// Surgically insert (or replace) the XMP `mime` item inside a HEIC file,
@@ -648,6 +713,76 @@ mod tests {
         bytes.extend_from_slice(b"meta");
         bytes.extend_from_slice(&[0; 16]); // payload tail (will be cut short)
         assert!(extract_xmp_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_top_level_dfla_does_not_oom() {
+        // Regression: this 110-byte input was the first OOM repro from the
+        // libfuzzer harness (`fuzz/seeds/heif_atoms/regression-iloc-oom`).
+        // Pre-fix, `Any::decode_maybe` saw a top-level `dfLa` FourCC,
+        // dispatched to `Dfla::decode_body` -> `parse_vorbis_comment`, and
+        // tried to `Vec::with_capacity(~876_000_000)` for a `Vec<String>`
+        // (~21 GiB) - upstream kixelated/mp4-atom#154. The kei-side fix is
+        // to walk top-level boxes by header and only descend into `meta`,
+        // so this input must return None promptly without allocating.
+        const REPRO: &[u8] = &[
+            0x00, 0x00, 0x00, 0x08, 0x00, 0x1d, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00, 0x64, 0x66,
+            0x4c, 0x61, 0x00, 0x00, 0x00, 0xf6, 0x6a, 0x00, 0x00, 0x10, 0x0d, 0xaa, 0x6b, 0x9d,
+            0xbb, 0xff, 0xff, 0x00, 0x00, 0x00, 0x0c, 0x0c, 0x0c, 0x0c, 0x1b, 0x00, 0x04, 0x00,
+            0x00, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x66, 0x6c, 0x36, 0x34, 0x00, 0x32, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4f, 0xe0,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x22, 0x00, 0x00, 0x00,
+            0x64, 0x66, 0x4c, 0x61, 0x00, 0x00, 0x00, 0xf6, 0x6a, 0x00, 0x00, 0x10, 0x0d, 0xaa,
+            0x6b, 0x9d, 0xbb, 0xff, 0xff, 0x00, 0x00, 0x00, 0x0c, 0x0c, 0x00, 0x00,
+        ];
+        assert_eq!(REPRO.len(), 110);
+        assert!(extract_xmp_bytes(REPRO).is_none());
+    }
+
+    #[test]
+    fn extract_xmp_bytes_meta_with_nested_dfla_is_safe() {
+        // The same upstream OOM is reachable from a `meta` box that contains
+        // a nested `dfLa` sub-atom, because mp4_atom::Meta::decode_body uses
+        // `Any::decode_maybe` internally on every item. The kei-side fix
+        // also walks meta sub-boxes by header so only `iinf`/`iloc` decoders
+        // run; an attacker-supplied `dfLa` inside `meta` is skipped.
+        //
+        // Layout: <meta box header> <version+flags> <hdlr box> <dfLa box>.
+        // The dfLa body declares 0xFFFF_FFFF Vorbis comment fields; pre-fix
+        // (or with a future Meta::decode_body-using rewrite) this would
+        // allocate ~103 GiB.
+        let mut hdlr: Vec<u8> = Vec::new();
+        hdlr.extend_from_slice(&0x21_u32.to_be_bytes()); // size = header(8) + body(25) = 33
+        hdlr.extend_from_slice(b"hdlr");
+        hdlr.extend_from_slice(&[0; 4]); // version+flags
+        hdlr.extend_from_slice(&[0; 4]); // pre_defined
+        hdlr.extend_from_slice(b"pict"); // handler_type
+        hdlr.extend_from_slice(&[0; 12]); // reserved
+        hdlr.push(0); // empty name (null-terminated)
+
+        let mut dfla: Vec<u8> = Vec::new();
+        dfla.extend_from_slice(&0x18_u32.to_be_bytes()); // size = 24
+        dfla.extend_from_slice(b"dfLa");
+        dfla.extend_from_slice(&[0; 4]); // version+flags
+                                         // metadata block header: last_block=1, type=4 (vorbis_comment), length=8
+        dfla.extend_from_slice(&[0x84, 0x00, 0x00, 0x08]);
+        // vorbis comment body: vendor_string_length=0, number_of_fields=0xFFFF_FFFF
+        dfla.extend_from_slice(&0_u32.to_le_bytes());
+        dfla.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let mut meta_body: Vec<u8> = Vec::new();
+        meta_body.extend_from_slice(&[0; 4]); // version+flags
+        meta_body.extend_from_slice(&hdlr);
+        meta_body.extend_from_slice(&dfla);
+
+        let mut meta_box: Vec<u8> = Vec::new();
+        let total = (8 + meta_body.len()) as u32;
+        meta_box.extend_from_slice(&total.to_be_bytes());
+        meta_box.extend_from_slice(b"meta");
+        meta_box.extend_from_slice(&meta_body);
+
+        // Must return None instead of allocating gigabytes.
+        assert!(extract_xmp_bytes(&meta_box).is_none());
     }
 
     // ── insert_xmp: typed errors per failure mode ──


### PR DESCRIPTION
## Why

`extract_xmp_bytes` walked top-level boxes via `Any::decode_maybe`, which dispatches into mp4-atom's full FourCC type table on every kind. Two of those parsers (`Dfla::decode_body -> parse_vorbis_comment` and `Avcc::decode_body`) call `Vec::with_capacity` on a `u32` read straight from input with no `min(...)` cap. Found via fuzzing: a 110-byte input with a top-level `dfLa` FourCC asks for ~21 GiB up front and aborts under any OOM budget. A `meta`-wrapped nested `dfLa` triggers the same parsers because `Meta::decode_body` uses `Any::decode_maybe` internally too.

Filed upstream as [kixelated/mp4-atom#154](https://github.com/kixelated/mp4-atom/issues/154). This PR doesn't depend on that landing.

## What

Replace the `Any::decode_maybe` walk with a manual header walk. At the top level, only descend into `meta`. Inside `meta`, only decode `iinf` and `iloc` - everything else is skipped by header offset. The set of mp4-atom parsers reachable from kei shrinks from "every type the crate knows about" to "iinf and iloc only", which is the strict subset `extract_xmp_bytes` actually consumes.

Behavior on legitimate HEIC inputs is unchanged. The four pre-existing malformed-input tests still pass.

## Test plan

- [x] `cargo test --bin kei -- 'download::heif'` - 16 / 16 pass, including:
  - `extract_xmp_bytes_top_level_dfla_does_not_oom` - the 110-byte fuzz repro returns `None`
  - `extract_xmp_bytes_meta_with_nested_dfla_is_safe` - synthesized `meta`-wrapped `dfLa` with `number_of_fields = u32::MAX` returns `None` instead of allocating ~103 GiB
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual sync against a real HEIC after merge to confirm the legitimate path still extracts XMP. Unit tests cover synthesis and malformed inputs but no real fixture round-trips through here today.