### PR TITLE
Fix import-existing silently ignoring file_match_policy = name-id7

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -494,6 +494,10 @@ pub struct ImportArgs {
     #[arg(long)]
     pub keep_unicode_in_filenames: Option<bool>,
 
+    /// File matching and dedup policy (must match what was used during sync)
+    #[arg(long, env = "KEI_FILE_MATCH_POLICY", value_enum)]
+    pub file_match_policy: Option<FileMatchPolicy>,
+
     /// Number of recent photos to check (`--recent 100`). The `--recent Nd`
     /// days form is only supported in `sync`; import-existing errors on use.
     #[arg(long, value_parser = parse_recent_limit)]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -67,10 +67,12 @@ pub(crate) async fn run_import_existing(
         .or_else(|| toml_photos.and_then(|p| p.keep_unicode_in_filenames))
         .unwrap_or(false);
 
-    // Resolve file_match_policy from TOML (default: NameSizeDedupWithSuffix to
-    // match sync's default).
-    let file_match_policy = toml_photos
-        .and_then(|p| p.file_match_policy)
+    // Resolve file_match_policy as CLI > env > TOML > default (matching sync).
+    // Same silent-failure class as the original bug: with KEI_FILE_MATCH_POLICY
+    // set but no TOML, the import would still report 0 matched.
+    let file_match_policy = args
+        .file_match_policy
+        .or_else(|| toml_photos.and_then(|p| p.file_match_policy))
         .unwrap_or(FileMatchPolicy::NameSizeDedupWithSuffix);
 
     // import-existing walks files on disk, not iCloud creation dates, so the

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -12,7 +12,7 @@ use crate::download;
 use crate::retry;
 use crate::state;
 use crate::state::StateDb;
-use crate::types::AssetVersionSize;
+use crate::types::{AssetVersionSize, FileMatchPolicy};
 
 use super::service::{init_photos_service, resolve_libraries};
 
@@ -66,6 +66,12 @@ pub(crate) async fn run_import_existing(
         .keep_unicode_in_filenames
         .or_else(|| toml_photos.and_then(|p| p.keep_unicode_in_filenames))
         .unwrap_or(false);
+
+    // Resolve file_match_policy from TOML (default: NameSizeDedupWithSuffix to
+    // match sync's default).
+    let file_match_policy = toml_photos
+        .and_then(|p| p.file_match_policy)
+        .unwrap_or(FileMatchPolicy::NameSizeDedupWithSuffix);
 
     // import-existing walks files on disk, not iCloud creation dates, so the
     // `--recent Nd` form has no meaning here. Count form only.
@@ -175,8 +181,18 @@ pub(crate) async fn run_import_existing(
             let Some(version) = asset.get_version(AssetVersionSize::Original) else {
                 continue;
             };
-            let filename =
+            let filename_mapped =
                 download::paths::map_filename_extension(&base_filename, &version.asset_type);
+            // Apply file_match_policy — name-id7 bakes the asset ID suffix into
+            // the filename (e.g. IMG_4726.HEIC → IMG_4726_QVNKc1d.HEIC) so the
+            // matcher can find files that were originally downloaded by icloudpd
+            // or by kei sync with the same policy.
+            let filename = match file_match_policy {
+                FileMatchPolicy::NameId7 => {
+                    download::paths::apply_name_id7(&filename_mapped, asset.id())
+                }
+                FileMatchPolicy::NameSizeDedupWithSuffix => filename_mapped,
+            };
             let expected_path = download::paths::local_download_path(
                 &directory,
                 &folder_structure,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -560,6 +560,47 @@ fn import_existing_recent_flag() {
         .success();
 }
 
+#[test]
+fn import_existing_file_match_policy_all_variants() {
+    for variant in ["name-size-dedup-with-suffix", "name-id7"] {
+        common::cmd()
+            .args([
+                "import-existing",
+                "--download-dir",
+                "/tmp",
+                "--file-match-policy",
+                variant,
+                "--help",
+            ])
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn import_existing_file_match_policy_rejects_invalid() {
+    common::cmd()
+        .args([
+            "import-existing",
+            "--download-dir",
+            "/tmp",
+            "--file-match-policy",
+            "bogus",
+            "--help",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn import_existing_file_match_policy_from_env() {
+    common::cmd()
+        .env("KEI_FILE_MATCH_POLICY", "name-id7")
+        .args(["import-existing", "--download-dir", "/tmp", "--help"])
+        .assert()
+        .success();
+}
+
 // ── Env var credential passthrough ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

`import-existing` ignores the `file_match_policy` setting from TOML config (and has no CLI flag for it). It always computes the expected local path using the base filename from `map_filename_extension`, regardless of which policy the user has configured for sync.

For users migrating from `icloudpd` with `--file-match-policy name-id7`, this means every single file is reported as unmatched, because their files on disk have the `_<id7>` suffix baked in (e.g. `IMG_4726_QVNKc1d.HEIC`) while `import-existing`is looking for `IMG_4726.HEIC`.

The matching utility itself (`paths::apply_name_id7`) exists and is used correctly by the sync flow in `download/filter.rs` — it just isn't called from `commands/import.rs`.

## Test plan

Config:
```toml
[photos]
file_match_policy = "name-id7"
```

Run `kei import-existing` against a directory previously populated by `icloudpd --file-match-policy name-id7`. Result:

```
Total assets scanned: 48981
Files matched:        0
Unmatched versions:   48981
```

## Checklist

- [ ] ~`cargo fmt -- --check` passes~ (error?)
- [ ] ~`cargo clippy --all-targets --all-features -- -D warnings` passes~ (error?)
- [x] `cargo test --bin kei --test cli --test behavioral` passes

## Verification

Tested against a live library of 48981 assets with ~58k local files downloaded by `icloudpd` with `name-id7`:

| Before patch | After patch |
| --- | --- |
| 0 matched / 48981 | 48872 matched / 48981 (99.78%) |

The remaining 109 unmatched are expected (likely a mix of EXIF-rewrite size drift and live-photo MOVs, which `import-existing` doesn't enumerate separately).

## Notes / open questions

- I defaulted to `NameSizeDedupWithSuffix` to preserve current behaviour for users who don't set the policy explicitly. Happy to change if you'd prefer reading from a CLI flag too (mirroring sync's `--file-match-policy`).
- Didn't add tests in this PR. Let me know if you'd like me to add coverage in `tests/behavioral.rs` and I'll push a follow-up commit.
- The filesize-only match (line ~209) is unchanged in scope here, but worth noting that EXIF rewrites by other tools can cause small (~29-58 byte) drift that this PR does not address.
