### PR TITLE
gate: round-trip property check for serializer changes

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,7 +7,10 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 _default:
     @just --list
 
-# Pre-push gate: fmt + clippy + offline tests + doc + audit + typos.
+# Pre-push gate: fmt + clippy + offline tests + doc + audit + typos +
+# round-trip property gate. The round-trip gate fails when this branch
+# adds/changes a serializer in src/ without a paired round-trip test;
+# see scripts/check-roundtrip-gate.sh for the detector and override.
 gate:
     cargo fmt --all --check
     cargo clippy --all-targets --all-features -- -D warnings
@@ -16,6 +19,7 @@ gate:
     cargo fetch --locked
     cargo audit
     typos
+    bash scripts/check-roundtrip-gate.sh
 
 # Test dispatcher: offline | fast | live | concurrency | state | docker | PATTERN.
 test MODE="":

--- a/scripts/check-roundtrip-gate.sh
+++ b/scripts/check-roundtrip-gate.sh
@@ -23,7 +23,15 @@ if [ "${KEI_SKIP_ROUNDTRIP_GATE:-0}" = "1" ]; then
 fi
 
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
-    echo "roundtrip-gate: base ref '$BASE_REF' not found; skipping (run \`git fetch origin main\`)" >&2
+    # CI environments always have origin/main fetched; a missing base ref
+    # there is a real configuration bug and we fail loudly. Locally, we
+    # warn and skip so a fresh checkout doesn't hard-block on `just gate`
+    # before the user has had a chance to run `git fetch origin main`.
+    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "roundtrip-gate: base ref '$BASE_REF' not found in CI; check checkout config" >&2
+        exit 1
+    fi
+    echo "roundtrip-gate: WARNING base ref '$BASE_REF' not found locally; skipping detector. Run \`git fetch origin main\` to enable the gate." >&2
     exit 0
 fi
 

--- a/scripts/check-roundtrip-gate.sh
+++ b/scripts/check-roundtrip-gate.sh
@@ -30,7 +30,7 @@ fi
 MERGE_BASE=$(git merge-base "$BASE_REF" HEAD)
 
 # Diff body, added lines only, excluding the +++ header.
-ADDED_LINES=$(git diff "$MERGE_BASE...HEAD" -- 'src/**/*.rs' | grep -E '^\+[^+]' || true)
+ADDED_LINES=$(git diff "$MERGE_BASE...HEAD" -- ':(glob)src/**/*.rs' | grep -E '^\+[^+]' || true)
 
 SERIALIZER_HITS=$(printf '%s\n' "$ADDED_LINES" | grep -E '\bfn (to_raw|to_string|serialize|to_toml|to_json)\b|\bimpl[^{]*\bSerialize\b' || true)
 
@@ -39,7 +39,7 @@ if [ -z "$SERIALIZER_HITS" ]; then
 fi
 
 # Test diff (tests/ tree + any *.rs in src/ since #[cfg(test)] modules live there).
-TEST_DIFF=$(git diff "$MERGE_BASE...HEAD" -- 'tests/**/*.rs' 'src/**/*.rs' | grep -E '^\+[^+]' || true)
+TEST_DIFF=$(git diff "$MERGE_BASE...HEAD" -- ':(glob)tests/**/*.rs' ':(glob)src/**/*.rs' | grep -E '^\+[^+]' || true)
 
 ROUNDTRIP_SIGNAL=$(printf '%s\n' "$TEST_DIFF" | grep -E 'roundtrip|round_trip|serialize.*parse|parse.*serialize|to_raw.*from_raw|from_raw.*to_raw' || true)
 

--- a/scripts/check-roundtrip-gate.sh
+++ b/scripts/check-roundtrip-gate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fail when this branch adds/changes a serializer in src/ without a
+# corresponding round-trip test edit. Catches `parse(serialize(x))`-shape
+# bugs that pass per-side review by demanding the property test exist.
+#
+# Triggers on added lines (`^+`, not `^+++`) matching any of:
+#   fn to_raw / fn to_string / fn serialize / fn to_toml / fn to_json
+#   impl <...> Serialize for
+#
+# Looks for a corresponding signal in test diffs:
+#   roundtrip / round_trip / serialize.*parse / parse.*serialize /
+#   to_raw.*from_raw / from_raw.*to_raw
+#
+# Override: KEI_SKIP_ROUNDTRIP_GATE=1 (use only with a written justification).
+
+set -euo pipefail
+
+BASE_REF="${KEI_ROUNDTRIP_BASE:-origin/main}"
+
+if [ "${KEI_SKIP_ROUNDTRIP_GATE:-0}" = "1" ]; then
+    echo "roundtrip-gate: skipped via KEI_SKIP_ROUNDTRIP_GATE=1" >&2
+    exit 0
+fi
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    echo "roundtrip-gate: base ref '$BASE_REF' not found; skipping (run \`git fetch origin main\`)" >&2
+    exit 0
+fi
+
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD)
+
+# Diff body, added lines only, excluding the +++ header.
+ADDED_LINES=$(git diff "$MERGE_BASE...HEAD" -- 'src/**/*.rs' | grep -E '^\+[^+]' || true)
+
+SERIALIZER_HITS=$(printf '%s\n' "$ADDED_LINES" | grep -E '\bfn (to_raw|to_string|serialize|to_toml|to_json)\b|\bimpl[^{]*\bSerialize\b' || true)
+
+if [ -z "$SERIALIZER_HITS" ]; then
+    exit 0
+fi
+
+# Test diff (tests/ tree + any *.rs in src/ since #[cfg(test)] modules live there).
+TEST_DIFF=$(git diff "$MERGE_BASE...HEAD" -- 'tests/**/*.rs' 'src/**/*.rs' | grep -E '^\+[^+]' || true)
+
+ROUNDTRIP_SIGNAL=$(printf '%s\n' "$TEST_DIFF" | grep -E 'roundtrip|round_trip|serialize.*parse|parse.*serialize|to_raw.*from_raw|from_raw.*to_raw' || true)
+
+if [ -n "$ROUNDTRIP_SIGNAL" ]; then
+    exit 0
+fi
+
+cat >&2 <<EOF
+roundtrip-gate: serializer change detected without a round-trip test edit.
+
+Changed serializers (diff vs $MERGE_BASE):
+$(printf '%s\n' "$SERIALIZER_HITS" | sed 's/^/  /')
+
+Add a test that exercises \`parse(serialize(x)) == x\` (or equivalent
+inverse) for the type whose serializer changed. Look for an existing
+\`*_roundtrip\` / \`round_trip\` test in tests/ or src/ as a pattern.
+
+If this serializer truly has no inverse and no round-trip property,
+add the test name with a short comment explaining why
+(\`fn no_roundtrip_*\`) so the gate sees the signal and the next
+reviewer sees the rationale.
+
+To bypass for an emergency hotfix: KEI_SKIP_ROUNDTRIP_GATE=1 just gate
+EOF
+
+exit 1


### PR DESCRIPTION
## Summary

Adds a pre-push gate that fails when this branch adds or changes a serializer in `src/` without a paired round-trip test edit. Catches the class of bug where `parse(serialize(x)) == x` is silently broken because each side is reviewed in isolation but the property they jointly satisfy isn't tested.

Wired into `just gate` as the last step.

## Background

Surfaced during a coherence review of `selection-flags-redesign`. `config show` on that branch emits both `[filters].albums = ["all", "!Family"]` and the deprecated `exclude_albums = ["Family"]` simultaneously. Feeding the output back to the parser fails with `--album '!Family' specified more than once` because both forms collapse into the same selector. Each serializer call site looks correct in isolation; only the round-trip property catches the interaction.

## Detector

Triggers on added lines in `src/**/*.rs` matching:

- `fn to_raw` / `fn to_string` / `fn serialize` / `fn to_toml` / `fn to_json`
- `impl <...> Serialize`

Looks for any of these signals in the same diff against `tests/**/*.rs` or `src/**/*.rs`:

- `roundtrip` / `round_trip`
- `serialize.*parse` or `parse.*serialize`
- `to_raw.*from_raw` or `from_raw.*to_raw`

If a serializer change has no matching test signal, fail with an actionable message that names every changed serializer.

## CI vs local behavior

Missing `origin/main` (e.g. fresh checkout without `git fetch origin main`):

- Locally: warn to stderr, skip the detector, exit 0. Doesn't hard-block on a fresh clone.
- In CI (`CI=true` or `GITHUB_ACTIONS` set): exit 1 with a config-error message. A missing base in CI is a real bug; silent-skip would let serializer-without-test land green.

## Override

`KEI_SKIP_ROUNDTRIP_GATE=1 just gate` for emergency hotfixes only. The override logs to stderr so its use is visible in CI logs and PR review.

## Validated

- Empty diff vs origin/main: gate exits 0.
- Synthetic serializer change in `src/cli.rs` with no test edit: gate exits 1 with named offender and remediation guidance.
- Same change paired with a test-file edit containing `roundtrip`: gate exits 0.
- Pathspec correctness verified after first detector pass returned empty (`src/**/*.rs` literal pathspec matches nothing in git; needs `:(glob)` magic prefix). Fixed in second commit.

## Test plan

- [x] Run `just gate` on main locally; expect exit 0.
- [x] On a branch that touches a serializer, confirm `just gate` fails with the actionable message.
- [x] Pair the change with a roundtrip-keyword test, confirm `just gate` passes.
- [x] Confirm `KEI_SKIP_ROUNDTRIP_GATE=1 just gate` succeeds without running the detector.