### PR TITLE
test: round out import-existing flag + path-derivation coverage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2606,6 +2606,140 @@ mod tests {
         }
     }
 
+    // ── import-existing path-derivation flags ──────────────────────────
+    //
+    // Each flag here changes how `expected_paths_for` derives the on-disk
+    // path. A regression in the clap value_parser (e.g. mapping `medium` to
+    // `Original`) is silent unless the parsed variant is asserted -- a
+    // `--help`-driven smoke test catches "spelling vanished" but not
+    // "spelling reaches the wrong variant". These tests pin the
+    // CLI-string -> enum mapping for every accepted value.
+
+    fn parse_import(extra: &[&str]) -> ImportArgs {
+        let mut args = vec!["kei", "import-existing", "--download-dir", "/tmp"];
+        args.extend(extra.iter().copied());
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Command::ImportExisting(a)) => a,
+            _ => panic!("Expected ImportExisting command"),
+        }
+    }
+
+    #[test]
+    fn import_existing_size_flag_parses_to_correct_variant() {
+        for (input, expected) in [
+            ("original", VersionSize::Original),
+            ("medium", VersionSize::Medium),
+            ("thumb", VersionSize::Thumb),
+            ("adjusted", VersionSize::Adjusted),
+            ("alternative", VersionSize::Alternative),
+        ] {
+            let args = parse_import(&["--size", input]);
+            assert_eq!(args.size, Some(expected), "size={input}");
+        }
+    }
+
+    #[test]
+    fn import_existing_live_photo_mode_parses_to_correct_variant() {
+        for (input, expected) in [
+            ("both", LivePhotoMode::Both),
+            ("image-only", LivePhotoMode::ImageOnly),
+            ("video-only", LivePhotoMode::VideoOnly),
+            ("skip", LivePhotoMode::Skip),
+        ] {
+            let args = parse_import(&["--live-photo-mode", input]);
+            assert_eq!(args.live_photo_mode, Some(expected), "mode={input}");
+        }
+    }
+
+    #[test]
+    fn import_existing_live_photo_size_parses_to_correct_variant() {
+        for (input, expected) in [
+            ("original", LivePhotoSize::Original),
+            ("medium", LivePhotoSize::Medium),
+            ("thumb", LivePhotoSize::Thumb),
+            ("adjusted", LivePhotoSize::Adjusted),
+        ] {
+            let args = parse_import(&["--live-photo-size", input]);
+            assert_eq!(args.live_photo_size, Some(expected), "size={input}");
+        }
+    }
+
+    #[test]
+    fn import_existing_live_photo_mov_filename_policy_parses_to_correct_variant() {
+        for (input, expected) in [
+            ("suffix", LivePhotoMovFilenamePolicy::Suffix),
+            ("original", LivePhotoMovFilenamePolicy::Original),
+        ] {
+            let args = parse_import(&["--live-photo-mov-filename-policy", input]);
+            assert_eq!(
+                args.live_photo_mov_filename_policy,
+                Some(expected),
+                "policy={input}"
+            );
+        }
+    }
+
+    #[test]
+    fn import_existing_align_raw_parses_to_correct_variant() {
+        for (input, expected) in [
+            ("as-is", RawTreatmentPolicy::Unchanged),
+            ("original", RawTreatmentPolicy::PreferOriginal),
+            ("alternative", RawTreatmentPolicy::PreferAlternative),
+        ] {
+            let args = parse_import(&["--align-raw", input]);
+            assert_eq!(args.align_raw, Some(expected), "policy={input}");
+        }
+    }
+
+    #[test]
+    fn import_existing_force_size_flag_parses_to_true() {
+        let args = parse_import(&["--force-size"]);
+        assert_eq!(args.force_size, Some(true));
+    }
+
+    #[test]
+    fn import_existing_keep_unicode_flag_parses_to_true() {
+        let args = parse_import(&["--keep-unicode-in-filenames"]);
+        assert_eq!(args.keep_unicode_in_filenames, Some(true));
+    }
+
+    #[test]
+    fn import_existing_keep_unicode_env_var_parses_to_true() {
+        let _guard = scrub_auth_env();
+        // SAFETY: scrub_auth_env serializes against any other test that
+        // mutates these env vars; KEI_KEEP_UNICODE_IN_FILENAMES is read
+        // synchronously by clap during parse below.
+        unsafe {
+            std::env::set_var("KEI_KEEP_UNICODE_IN_FILENAMES", "true");
+        }
+        let cli =
+            Cli::try_parse_from(["kei", "import-existing", "--download-dir", "/tmp"]).unwrap();
+        unsafe {
+            std::env::remove_var("KEI_KEEP_UNICODE_IN_FILENAMES");
+        }
+        match cli.command {
+            Some(Command::ImportExisting(args)) => {
+                assert_eq!(args.keep_unicode_in_filenames, Some(true));
+            }
+            _ => panic!("Expected ImportExisting command"),
+        }
+    }
+
+    #[test]
+    fn import_existing_file_match_policy_parses_to_correct_variant() {
+        for (input, expected) in [
+            (
+                "name-size-dedup-with-suffix",
+                FileMatchPolicy::NameSizeDedupWithSuffix,
+            ),
+            ("name-id7", FileMatchPolicy::NameId7),
+        ] {
+            let args = parse_import(&["--file-match-policy", input]);
+            assert_eq!(args.file_match_policy, Some(expected), "policy={input}");
+        }
+    }
+
     #[test]
     fn test_list_albums_library_flag() {
         let cli = Cli::try_parse_from(["kei", "list", "--library", "all", "albums"]).unwrap();

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1968,3 +1968,269 @@ mod wiremock_tests {
     // baseline against accidental layout divergence.
     mod icloudpd_compat;
 }
+
+#[cfg(test)]
+mod build_config_tests {
+    //! Unit tests for [`build_import_download_config`] -- the
+    //! CLI > TOML > default resolution chain for import-existing's
+    //! path-derivation flags. Each new flag added to import-existing
+    //! needs a row in this test mod or the precedence is unverified.
+    //!
+    //! Construction of `ImportArgs` happens through `Cli::try_parse_from`
+    //! (rather than struct literals) so a regression that reorders
+    //! `or_else` arms or flips a default reaches us through the same
+    //! parse path that production uses.
+    use super::build_import_download_config;
+    use crate::cli::{Cli, Command};
+    use crate::config::{TomlConfig, TomlPhotos};
+    use crate::types::{
+        AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
+        LivePhotoSize, RawTreatmentPolicy, VersionSize,
+    };
+    use clap::Parser;
+
+    fn parse_import_args(extra: &[&str]) -> crate::cli::ImportArgs {
+        let mut argv = vec!["kei", "import-existing", "--download-dir", "/photos"];
+        argv.extend(extra.iter().copied());
+        let cli = Cli::try_parse_from(argv).expect("clap parse");
+        match cli.command {
+            Some(Command::ImportExisting(a)) => a,
+            _ => panic!("expected ImportExisting"),
+        }
+    }
+
+    fn empty_toml() -> TomlConfig {
+        TomlConfig {
+            data_dir: None,
+            log_level: None,
+            auth: None,
+            download: None,
+            filters: None,
+            photos: None,
+            watch: None,
+            notifications: None,
+            metrics: None,
+            server: None,
+            report: None,
+        }
+    }
+
+    fn toml_with_photos(p: TomlPhotos) -> TomlConfig {
+        let mut t = empty_toml();
+        t.photos = Some(p);
+        t
+    }
+
+    fn empty_photos() -> TomlPhotos {
+        TomlPhotos {
+            size: None,
+            live_photo_size: None,
+            live_photo_mode: None,
+            live_photo_mov_filename_policy: None,
+            align_raw: None,
+            file_match_policy: None,
+            force_size: None,
+            keep_unicode_in_filenames: None,
+        }
+    }
+
+    /// CG-1 / AT-3: CLI value beats TOML value across every photos field.
+    /// Each row plants a different value at each layer; if the resolver
+    /// reverses precedence on any field, exactly that row fails.
+    #[test]
+    fn build_import_download_config_cli_overrides_toml() {
+        // size: CLI=Medium, TOML=Thumb -> Medium
+        let args = parse_import_args(&["--size", "medium"]);
+        let toml = toml_with_photos(TomlPhotos {
+            size: Some(VersionSize::Thumb),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(cfg.size, AssetVersionSize::Medium, "size: CLI must win");
+
+        // file_match_policy: CLI=NameId7, TOML=NameSizeDedupWithSuffix -> NameId7
+        let args = parse_import_args(&["--file-match-policy", "name-id7"]);
+        let toml = toml_with_photos(TomlPhotos {
+            file_match_policy: Some(FileMatchPolicy::NameSizeDedupWithSuffix),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(
+            cfg.file_match_policy,
+            FileMatchPolicy::NameId7,
+            "file_match_policy: CLI must win"
+        );
+
+        // live_photo_mode: CLI=VideoOnly, TOML=ImageOnly -> VideoOnly
+        let args = parse_import_args(&["--live-photo-mode", "video-only"]);
+        let toml = toml_with_photos(TomlPhotos {
+            live_photo_mode: Some(LivePhotoMode::ImageOnly),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(
+            cfg.live_photo_mode,
+            LivePhotoMode::VideoOnly,
+            "live_photo_mode: CLI must win"
+        );
+
+        // live_photo_size: CLI=Medium, TOML=Thumb -> LiveMedium
+        let args = parse_import_args(&["--live-photo-size", "medium"]);
+        let toml = toml_with_photos(TomlPhotos {
+            live_photo_size: Some(LivePhotoSize::Thumb),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(
+            cfg.live_photo_size,
+            AssetVersionSize::LiveMedium,
+            "live_photo_size: CLI must win"
+        );
+
+        // live_photo_mov_filename_policy: CLI=Original, TOML=Suffix -> Original
+        let args = parse_import_args(&["--live-photo-mov-filename-policy", "original"]);
+        let toml = toml_with_photos(TomlPhotos {
+            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Suffix),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(
+            cfg.live_photo_mov_filename_policy,
+            LivePhotoMovFilenamePolicy::Original,
+            "live_photo_mov_filename_policy: CLI must win"
+        );
+
+        // align_raw: CLI=PreferOriginal, TOML=PreferAlternative -> PreferOriginal
+        let args = parse_import_args(&["--align-raw", "original"]);
+        let toml = toml_with_photos(TomlPhotos {
+            align_raw: Some(RawTreatmentPolicy::PreferAlternative),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(
+            cfg.align_raw,
+            RawTreatmentPolicy::PreferOriginal,
+            "align_raw: CLI must win"
+        );
+
+        // force_size: CLI=true, TOML=false -> true
+        let args = parse_import_args(&["--force-size"]);
+        let toml = toml_with_photos(TomlPhotos {
+            force_size: Some(false),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert!(
+            cfg.force_size,
+            "force_size: CLI true must win over TOML false"
+        );
+
+        // keep_unicode_in_filenames: CLI=true, TOML=false -> true
+        let args = parse_import_args(&["--keep-unicode-in-filenames"]);
+        let toml = toml_with_photos(TomlPhotos {
+            keep_unicode_in_filenames: Some(false),
+            ..empty_photos()
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert!(
+            cfg.keep_unicode_in_filenames,
+            "keep_unicode_in_filenames: CLI true must win over TOML false"
+        );
+    }
+
+    /// CG-1: TOML value beats default when CLI absent.
+    #[test]
+    fn build_import_download_config_uses_toml_when_cli_absent() {
+        let args = parse_import_args(&[]);
+        let toml = toml_with_photos(TomlPhotos {
+            size: Some(VersionSize::Medium),
+            file_match_policy: Some(FileMatchPolicy::NameId7),
+            live_photo_mode: Some(LivePhotoMode::VideoOnly),
+            live_photo_size: Some(LivePhotoSize::Thumb),
+            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
+            align_raw: Some(RawTreatmentPolicy::PreferOriginal),
+            force_size: Some(true),
+            keep_unicode_in_filenames: Some(true),
+        });
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        assert_eq!(cfg.size, AssetVersionSize::Medium);
+        assert_eq!(cfg.file_match_policy, FileMatchPolicy::NameId7);
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::VideoOnly);
+        assert_eq!(cfg.live_photo_size, AssetVersionSize::LiveThumb);
+        assert_eq!(
+            cfg.live_photo_mov_filename_policy,
+            LivePhotoMovFilenamePolicy::Original
+        );
+        assert_eq!(cfg.align_raw, RawTreatmentPolicy::PreferOriginal);
+        assert!(cfg.force_size);
+        assert!(cfg.keep_unicode_in_filenames);
+    }
+
+    /// CG-1: documented defaults when neither CLI nor TOML set the field.
+    /// Pinning the *documented* default protects against silent default
+    /// drift (per memory `feedback_default_value_change_test`).
+    #[test]
+    fn build_import_download_config_falls_through_to_default() {
+        let args = parse_import_args(&[]);
+        let cfg = build_import_download_config(&args, None).unwrap();
+        assert_eq!(cfg.size, AssetVersionSize::Original);
+        assert_eq!(
+            cfg.file_match_policy,
+            FileMatchPolicy::NameSizeDedupWithSuffix
+        );
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Both);
+        assert_eq!(cfg.live_photo_size, AssetVersionSize::LiveOriginal);
+        assert_eq!(
+            cfg.live_photo_mov_filename_policy,
+            LivePhotoMovFilenamePolicy::Suffix
+        );
+        assert_eq!(cfg.align_raw, RawTreatmentPolicy::Unchanged);
+        assert!(!cfg.force_size);
+        assert!(!cfg.keep_unicode_in_filenames);
+        assert_eq!(cfg.folder_structure, "%Y/%m/%d");
+    }
+
+    /// CG-9: empty `directory` after TOML resolve produces the documented
+    /// "is required" error rather than a confusing downstream failure.
+    #[test]
+    fn build_import_download_config_empty_directory_bails() {
+        // No --download-dir on the CLI, no TOML directory either: bails.
+        let cli = Cli::try_parse_from([
+            "kei",
+            "import-existing",
+            // explicitly absent --download-dir
+        ])
+        .unwrap();
+        let args = match cli.command {
+            Some(Command::ImportExisting(a)) => a,
+            _ => panic!("expected ImportExisting"),
+        };
+        let err =
+            build_import_download_config(&args, None).expect_err("empty directory should bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--download-dir is required"),
+            "error must name the missing flag, got: {msg}"
+        );
+    }
+
+    /// CG-10: setting both `--directory` (deprecated) and `--download-dir`
+    /// at once fails fast rather than letting one silently win. The
+    /// deprecation warning users rely on requires this guard to stay
+    /// strict.
+    #[test]
+    fn build_import_download_config_both_directory_flags_bails() {
+        let args = parse_import_args(&["--directory", "/old/photos"]);
+        // parse_import_args already set --download-dir=/photos, so both
+        // are present.
+        assert!(args.download_dir.is_some());
+        assert!(args.directory.is_some());
+        let err = build_import_download_config(&args, None)
+            .expect_err("both directory flags should bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--directory") && (msg.contains("deprecated") || msg.contains("pick one")),
+            "error must name the deprecation conflict, got: {msg}"
+        );
+    }
+}

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1438,6 +1438,336 @@ mod tests {
         );
     }
 
+    // ── size / live_photo_size matrix on present versions ───────────────
+    //
+    // The matrix expansion below pins behaviour for the import-existing
+    // CLI flags `--size` and `--live-photo-size` when the requested
+    // version *is* published. The pre-existing `expected_paths_size_*`
+    // tests cover the fallback (size missing) and force_size branches;
+    // these cover the "actually use the requested size" branch and the
+    // independence between primary and live-photo sizing.
+
+    /// Builds a primary photo with original + medium + thumb JPEG
+    /// resolutions. Mirrors `multi_size_photo_asset` (defined later in
+    /// this mod) but is independent so test reordering can't break it.
+    fn primary_multi_size_asset(record: &str, filename: &str) -> PhotoAsset {
+        PhotoAsset::new(
+            json!({"recordName": record, "fields": {
+                "filenameEnc": {"value": filename, "type": "STRING"},
+                "itemType": {"value": "public.jpeg"},
+                "resOriginalRes": {"value": {
+                    "size": 5000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/orig",
+                    "fileChecksum": "orig_ck"
+                }},
+                "resOriginalFileType": {"value": "public.jpeg"},
+                "resJPEGMedRes": {"value": {
+                    "size": 2000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/med",
+                    "fileChecksum": "med_ck"
+                }},
+                "resJPEGMedFileType": {"value": "public.jpeg"},
+                "resJPEGThumbRes": {"value": {
+                    "size": 500_u64,
+                    "downloadURL": "https://p01.icloud-content.com/thumb",
+                    "fileChecksum": "thumb_ck"
+                }},
+                "resJPEGThumbFileType": {"value": "public.jpeg"}
+            }}),
+            json!({"fields": {"assetDate": {"value": 1_736_899_200_000.0_f64}}}),
+        )
+    }
+
+    /// Live-photo HEIC primary with both LiveOriginal and LiveMedium MOV
+    /// companions. Covers the live_photo_size=Medium path.
+    fn live_photo_multi_size_asset(record: &str) -> PhotoAsset {
+        PhotoAsset::new(
+            json!({"recordName": record, "fields": {
+                "filenameEnc": {"value": "IMG_LIVE.HEIC", "type": "STRING"},
+                "itemType": {"value": "public.heic"},
+                "resOriginalRes": {"value": {
+                    "size": 4000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/heic_orig",
+                    "fileChecksum": "heic_ck"
+                }},
+                "resOriginalFileType": {"value": "public.heic"},
+                "resOriginalVidComplRes": {"value": {
+                    "size": 3000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_orig",
+                    "fileChecksum": "live_orig_ck"
+                }},
+                "resOriginalVidComplFileType": {"value": "com.apple.quicktime-movie"},
+                "resVidMedRes": {"value": {
+                    "size": 1500_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_med",
+                    "fileChecksum": "live_med_ck"
+                }},
+                "resVidMedFileType": {"value": "com.apple.quicktime-movie"},
+            }}),
+            json!({"fields": {"assetDate": {"value": 1_736_899_200_000.0_f64}}}),
+        )
+    }
+
+    /// CG-2: regression-guards `--size medium` actually-published path.
+    /// A bug in the size-suffix branch of `expected_paths_for` would emit
+    /// an unsuffixed path; sync would write `IMG-medium.JPG` while
+    /// import-existing scans for `IMG.JPG` (silent miss).
+    #[test]
+    fn expected_paths_size_medium_present_emits_medium_suffix() {
+        let asset = primary_multi_size_asset("MED_PRESENT", "IMG_6001.JPG");
+        let mut config = test_config();
+        config.size = AssetVersionSize::Medium;
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].version_size, VersionSizeKey::Medium);
+        assert_eq!(paths[0].size, 2000);
+        let name = paths[0].path.file_name().unwrap().to_string_lossy();
+        assert!(
+            name.contains("-medium"),
+            "size=Medium present should carry '-medium' suffix, got {name}"
+        );
+    }
+
+    /// CG-2 parity: when Medium is published and `--size medium` is set,
+    /// sync's path and import's path agree.
+    #[test]
+    fn expected_paths_parity_size_medium_present() {
+        let asset = primary_multi_size_asset("PAR_MED", "IMG_6002.JPG");
+        let mut config = test_config();
+        config.size = AssetVersionSize::Medium;
+        assert_path_parity(&asset, &config, VersionSizeKey::Medium, "Medium present");
+    }
+
+    /// CG-3: regression-guards `--size thumb` actually-published path.
+    #[test]
+    fn expected_paths_size_thumb_present_emits_thumb_suffix() {
+        let asset = primary_multi_size_asset("THUMB_PRESENT", "IMG_6003.JPG");
+        let mut config = test_config();
+        config.size = AssetVersionSize::Thumb;
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].version_size, VersionSizeKey::Thumb);
+        assert_eq!(paths[0].size, 500);
+        let name = paths[0].path.file_name().unwrap().to_string_lossy();
+        assert!(
+            name.contains("-thumb"),
+            "size=Thumb present should carry '-thumb' suffix, got {name}"
+        );
+    }
+
+    /// CG-3 parity.
+    #[test]
+    fn expected_paths_parity_size_thumb_present() {
+        let asset = primary_multi_size_asset("PAR_THUMB", "IMG_6004.JPG");
+        let mut config = test_config();
+        config.size = AssetVersionSize::Thumb;
+        assert_path_parity(&asset, &config, VersionSizeKey::Thumb, "Thumb present");
+    }
+
+    /// CG-4: regression-guards `--live-photo-size medium`. A bug in the
+    /// `version_with_fallback` call inside the live branch would silently
+    /// land the LiveOriginal MOV at the LiveMedium config, producing the
+    /// wrong path.
+    #[test]
+    fn expected_paths_live_photo_size_medium_emits_live_medium_path() {
+        let asset = live_photo_multi_size_asset("LIVE_MED_1");
+        let mut config = test_config();
+        config.live_photo_size = AssetVersionSize::LiveMedium;
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 2, "expected primary + MOV companion");
+        let mov = paths
+            .iter()
+            .find(|p| matches!(p.version_size, VersionSizeKey::LiveMedium))
+            .expect("LiveMedium MOV path missing");
+        assert_eq!(mov.size, 1500);
+        assert_eq!(&*mov.checksum, "live_med_ck");
+        // The primary stays at Original and unaffected by live_photo_size.
+        let primary = paths
+            .iter()
+            .find(|p| matches!(p.version_size, VersionSizeKey::Original))
+            .expect("primary path missing");
+        assert_eq!(primary.version_size, VersionSizeKey::Original);
+        assert_eq!(primary.size, 4000);
+    }
+
+    /// CG-5: `--size` and `--live-photo-size` are independent. A
+    /// regression that couples them (e.g. live branch reading
+    /// `config.size` instead of `config.live_photo_size`) lands silently
+    /// without this assertion.
+    #[test]
+    fn expected_paths_size_medium_with_live_photo_size_thumb_independent() {
+        // Build a HEIC primary with original + medium res, and a live MOV
+        // companion at LiveOriginal + LiveMedium. We don't have a
+        // LiveThumb resolution to point to, so we use LiveMedium for the
+        // live size and Medium for the primary -- different non-default
+        // values across the two flags.
+        let asset = PhotoAsset::new(
+            json!({"recordName": "INDEP_1", "fields": {
+                "filenameEnc": {"value": "IMG_INDEP.HEIC", "type": "STRING"},
+                "itemType": {"value": "public.heic"},
+                "resOriginalRes": {"value": {
+                    "size": 4000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/heic_orig",
+                    "fileChecksum": "heic_ck"
+                }},
+                "resOriginalFileType": {"value": "public.heic"},
+                "resJPEGMedRes": {"value": {
+                    "size": 1800_u64,
+                    "downloadURL": "https://p01.icloud-content.com/heic_med",
+                    "fileChecksum": "heic_med_ck"
+                }},
+                "resJPEGMedFileType": {"value": "public.jpeg"},
+                "resOriginalVidComplRes": {"value": {
+                    "size": 3000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_orig",
+                    "fileChecksum": "live_orig_ck"
+                }},
+                "resOriginalVidComplFileType": {"value": "com.apple.quicktime-movie"},
+                "resVidMedRes": {"value": {
+                    "size": 1500_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_med",
+                    "fileChecksum": "live_med_ck"
+                }},
+                "resVidMedFileType": {"value": "com.apple.quicktime-movie"},
+            }}),
+            json!({"fields": {"assetDate": {"value": 1_736_899_200_000.0_f64}}}),
+        );
+        let mut config = test_config();
+        config.size = AssetVersionSize::Medium;
+        config.live_photo_size = AssetVersionSize::LiveMedium;
+
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 2);
+        let primary = paths
+            .iter()
+            .find(|p| matches!(p.version_size, VersionSizeKey::Medium))
+            .expect("primary at Medium missing");
+        assert_eq!(primary.size, 1800);
+        let mov = paths
+            .iter()
+            .find(|p| matches!(p.version_size, VersionSizeKey::LiveMedium))
+            .expect("MOV at LiveMedium missing");
+        assert_eq!(mov.size, 1500);
+        // Crucially: primary did not key off live_photo_size, MOV did
+        // not key off size. (If the two flags were coupled, both would
+        // share one variant.)
+        assert_ne!(primary.version_size, VersionSizeKey::LiveMedium);
+        assert_ne!(mov.version_size, VersionSizeKey::Medium);
+    }
+
+    /// CG-6: `--align-raw original` + `--size medium`. apply_raw_policy
+    /// runs before size selection; this pins that the swap doesn't
+    /// silently re-key the size lookup off the wrong version.
+    #[test]
+    fn expected_paths_align_raw_prefer_original_with_size_medium_keys_correctly() {
+        // RAW + JPEG pair where the alt is the JPEG. With
+        // align_raw=PreferOriginal we want Original to remain the JPEG
+        // (the "user-visible" original) per the existing `align_raw_*`
+        // tests; the question here is whether `--size medium` then keys
+        // off the Medium version of that JPEG (the test's primary has no
+        // medium published, so we expect fallback to Original size with
+        // force_size=false).
+        let asset = TestPhotoAsset::new("ALIGN_MED")
+            .filename("IMG_RAW_MED.DNG")
+            .item_type("public.camera-raw-image")
+            .orig_file_type("public.camera-raw-image")
+            .alt_version(
+                "https://p01.icloud-content.com/jpeg",
+                "jpeg_ck",
+                2500,
+                "public.jpeg",
+            )
+            .build();
+        let mut config = test_config();
+        config.align_raw = RawTreatmentPolicy::PreferOriginal;
+        config.size = AssetVersionSize::Medium;
+        config.force_size = false;
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 1);
+        // No medium published in the swapped Original (which is the
+        // JPEG alt promoted to Original under PreferOriginal); the
+        // fallback should land on Original-without-suffix.
+        assert_eq!(paths[0].version_size, VersionSizeKey::Original);
+        let name = paths[0].path.file_name().unwrap().to_string_lossy();
+        assert!(
+            !name.contains("-medium"),
+            "fallback to Original under align_raw must drop the medium suffix, got {name}"
+        );
+    }
+
+    /// CG-7: `--force-size` applied to the live-photo companion. With
+    /// force_size=true and live_photo_size=LiveMedium but only LiveOriginal
+    /// published, the MOV companion should drop entirely (not silently
+    /// land at LiveOriginal).
+    #[test]
+    fn expected_paths_force_size_drops_live_companion_when_live_size_missing() {
+        let asset = TestPhotoAsset::new("FORCE_LIVE")
+            .filename("IMG_FL.HEIC")
+            .item_type("public.heic")
+            .orig_file_type("public.heic")
+            .live_photo("https://p01.icloud-content.com/live_orig", "live_ck", 3000)
+            .build();
+        let mut config = test_config();
+        config.live_photo_size = AssetVersionSize::LiveMedium;
+        config.force_size = true;
+        let paths = expected_paths_for(&asset, &config);
+        // Primary HEIC is still Original and kept (force_size applies to
+        // the requested primary `size` and to the requested
+        // `live_photo_size`; primary `size` is Original which is
+        // present).
+        assert!(
+            paths
+                .iter()
+                .any(|p| matches!(p.version_size, VersionSizeKey::Original)),
+            "primary should remain present when its requested size is published"
+        );
+        // The MOV companion should drop because LiveMedium is missing
+        // and force_size=true forbids fallback.
+        assert!(
+            !paths.iter().any(|p| matches!(
+                p.version_size,
+                VersionSizeKey::LiveOriginal | VersionSizeKey::LiveMedium
+            )),
+            "force_size + missing LiveMedium should drop the MOV companion entirely, got {paths:?}"
+        );
+    }
+
+    /// CG-8: `--live-photo-mov-filename-policy original` + `name-id7`.
+    /// The Original-policy branch must still apply the name-id7 suffix
+    /// to the MOV (otherwise id7 users on the non-default MOV policy
+    /// silently break).
+    #[test]
+    fn expected_paths_mov_policy_original_with_name_id7_carries_suffix() {
+        let asset = TestPhotoAsset::new("MOV_ID7_ORIG")
+            .filename("IMG_8001.HEIC")
+            .item_type("public.heic")
+            .orig_file_type("public.heic")
+            .live_photo("https://p01.icloud-content.com/mov", "mov_ck", 3000)
+            .build();
+        let mut config = test_config();
+        config.file_match_policy = FileMatchPolicy::NameId7;
+        config.live_photo_mov_filename_policy = LivePhotoMovFilenamePolicy::Original;
+        let paths = expected_paths_for(&asset, &config);
+        assert_eq!(paths.len(), 2);
+        let mov = paths
+            .iter()
+            .find(|p| matches!(p.version_size, VersionSizeKey::LiveOriginal))
+            .expect("MOV companion missing");
+        let mov_name = mov.path.file_name().unwrap().to_string_lossy();
+        // Under Original policy the MOV reuses the primary's stem (no
+        // _HEVC suffix); under NameId7 the stem itself carries the id7
+        // marker, so the MOV path must carry it too. The HEIC->MOV
+        // extension map happens regardless of policy.
+        assert!(
+            mov_name.starts_with("IMG_8001_") && mov_name.ends_with(".MOV"),
+            "MOV under Original policy + id7 should be IMG_8001_<id7>.MOV, got {mov_name}"
+        );
+        assert!(
+            !mov_name.contains("_HEVC"),
+            "Original MOV policy should NOT add _HEVC suffix, got {mov_name}"
+        );
+    }
+
     // ── expected_paths_for negative-space coverage ───────────────────────
     //
     // The 11 happy-path expected_paths_* tests above leave a lot of input

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -813,25 +813,19 @@ fn import_existing_accepts_no_progress_bar() {
 
 // ── import-existing path-derivation flags ───────────────────────────────
 //
-// import-existing must accept every flag that affects sync's output paths,
-// or files synced under those settings will silently fail to match. Each of
-// these mirrors a sync flag and was added to close that gap.
+// The CLI-string -> enum mapping for each flag (--size, --live-photo-mode,
+// --live-photo-size, --live-photo-mov-filename-policy, --align-raw,
+// --force-size, --keep-unicode-in-filenames, --file-match-policy) is pinned
+// by `Cli::try_parse_from`-driven unit tests in src/cli.rs (search for
+// `import_existing_*_parses_to_correct_variant`). Those assert on parsed
+// variants -- which `--help`-driven subprocess tests cannot.
+//
+// The subprocess-level test below stays because it exercises one thing the
+// unit tests can't: that clap's value rejection produces a non-zero subprocess
+// exit code (the contract Docker / systemd consumers rely on).
 
 #[test]
-fn import_existing_file_match_policy_flag() {
-    for input in ["name-size-dedup-with-suffix", "name-id7"] {
-        common::cmd()
-            .args([
-                "import-existing",
-                "--download-dir",
-                "/tmp",
-                "--file-match-policy",
-                input,
-                "--help",
-            ])
-            .assert()
-            .success();
-    }
+fn import_existing_file_match_policy_rejects_bogus_value() {
     common::cmd()
         .args([
             "import-existing",
@@ -843,72 +837,6 @@ fn import_existing_file_match_policy_flag() {
         ])
         .assert()
         .failure();
-}
-
-#[test]
-fn import_existing_size_flag() {
-    for input in ["original", "medium", "thumb", "adjusted", "alternative"] {
-        common::cmd()
-            .args([
-                "import-existing",
-                "--download-dir",
-                "/tmp",
-                "--size",
-                input,
-                "--help",
-            ])
-            .assert()
-            .success();
-    }
-}
-
-#[test]
-fn import_existing_live_photo_flags() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--live-photo-mode",
-            "video-only",
-            "--live-photo-size",
-            "medium",
-            "--live-photo-mov-filename-policy",
-            "original",
-            "--help",
-        ])
-        .assert()
-        .success();
-}
-
-#[test]
-fn import_existing_align_raw_and_force_size_flags() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--align-raw",
-            "original",
-            "--force-size",
-            "--help",
-        ])
-        .assert()
-        .success();
-}
-
-#[test]
-fn import_existing_keep_unicode_flag_takes_env() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--keep-unicode-in-filenames",
-            "--help",
-        ])
-        .assert()
-        .success();
 }
 
 // ── exit codes ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace 5 weak `--help`-driven CLI tests with 9 strong-assertion parser tests that pin every accepted value to its parsed enum variant (`VersionSize`, `LivePhotoMode`, `LivePhotoSize`, `LivePhotoMovFilenamePolicy`, `RawTreatmentPolicy`, `FileMatchPolicy`, plus boolean flags / env vars).
- Add 9 new `expected_paths_for` tests in `src/download/filter.rs` covering `--size medium` / `--size thumb` (CG-2/CG-3), non-Original `--live-photo-size` (CG-4), concurrent primary + live size (CG-5), `--align-raw` × `--size` (CG-6), `--force-size` live-companion drop (CG-7), `--live-photo-mov-filename-policy original` × name-id7 (CG-8), plus 2 parity tests against `filter_asset_to_tasks`.
- Add 5 `build_import_download_config` tests in `src/commands/import.rs` pinning the CLI > TOML > default chain across all 8 photos fields (CG-1), plus empty-directory bail (CG-9) and conflicting `--directory`/`--download-dir` bail (CG-10).
- Net: +23 lib tests, −4 cli tests, **2103 fast tests total**. No production code changed.

Documented in `.scratch/2026-04-29_TEST_REVIEW.md`.

## Test plan

- [x] `just gate` green (fmt + clippy + tests + audit + docs + roundtrip)
- [x] `cargo test` parallel: PASS (2103 tests)
- [x] `cargo test -- --test-threads=1`: PASS (no isolation drift)