### PR TITLE
import-existing: probe AM/PM whitespace siblings before unmatched

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -11,6 +11,7 @@ use crate::cli;
 use crate::config;
 use crate::download;
 use crate::download::filter::{expected_paths_for, is_asset_filtered, ExpectedAssetPath};
+use crate::download::paths::DirCache;
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
@@ -48,16 +49,21 @@ impl std::ops::AddAssign for ImportStats {
     }
 }
 
-/// Find the on-disk path that satisfies the expected size, trying the
-/// primary path first and -- for `NameSizeDedupWithSuffix` policy -- the
-/// `<stem>-<size><ext>` collision shape as a fallback.
+/// Find the on-disk path that satisfies the expected size, trying in
+/// order:
+/// 1. the primary path,
+/// 2. the `<stem>-<size><ext>` dedup-collision shape (only under
+///    `NameSizeDedupWithSuffix`), and
+/// 3. an AM/PM whitespace sibling (for filenames containing AM/PM —
+///    macOS screenshots use NBSP `\u{202F}`, but a tree synced through
+///    a different tool may have a regular space, and vice versa).
 ///
-/// Returns `(path, metadata)` for the matching file, or `None` if neither
-/// candidate exists with size `expected_size`.
+/// Returns `(path, metadata)` for the matching file, or `None`.
 async fn resolve_match_path(
     primary: &Path,
     expected_size: u64,
     policy: FileMatchPolicy,
+    dir_cache: &mut DirCache,
 ) -> Option<(std::path::PathBuf, std::fs::Metadata)> {
     if let Ok(m) = tokio::fs::metadata(primary).await {
         if m.len() == expected_size {
@@ -78,6 +84,21 @@ async fn resolve_match_path(
         if let Ok(m) = tokio::fs::metadata(&suffixed).await {
             if m.len() == expected_size {
                 return Some((suffixed, m));
+            }
+        }
+    }
+    if let Some(parent) = primary.parent() {
+        dir_cache.ensure_dir_async(parent).await;
+        if let Some(variant) = dir_cache.find_ampm_variant(primary) {
+            if let Ok(m) = tokio::fs::metadata(&variant).await {
+                if m.len() == expected_size {
+                    tracing::info!(
+                        primary = %primary.display(),
+                        variant = %variant.display(),
+                        "Matched AM/PM whitespace variant on disk",
+                    );
+                    return Some((variant, m));
+                }
             }
         }
     }
@@ -112,6 +133,10 @@ where
 
     tokio::pin!(stream);
     let mut stats = ImportStats::default();
+    // One cache per library scan. Each parent directory is read_dir'd
+    // exactly once; the AM/PM variant probe (and any future sibling
+    // probes) reuse it.
+    let mut dir_cache = DirCache::new();
 
     while let Some(result) = stream.next().await {
         let asset: PhotoAsset = match result {
@@ -180,6 +205,7 @@ where
                 &primary_path,
                 expected_size,
                 download_config.file_match_policy,
+                &mut dir_cache,
             )
             .await
             {
@@ -2105,6 +2131,105 @@ mod wiremock_tests {
             downloaded.is_empty(),
             "no downloaded rows expected after bail, got {n}",
             n = downloaded.len(),
+        );
+    }
+
+    // ── AM/PM whitespace variant probe ────────────────────────────────
+    //
+    // macOS uses NARROW NO-BREAK SPACE (U+202F) before AM/PM in default
+    // screenshot filenames since macOS 13. A user whose tree was synced
+    // via a third-party tool that normalized the filename to a regular
+    // space (or the other way around) would otherwise see every such
+    // photo come up unmatched on import. The DirCache-backed AM/PM probe
+    // bridges both directions.
+
+    #[tokio::test]
+    async fn ampm_variant_with_regular_space_on_disk_matches_nbsp_from_icloud() {
+        let server = MockServer::start().await;
+        // iCloud filename uses NARROW NO-BREAK SPACE (U+202F). The probe
+        // only kicks in when the on-disk filename is being compared
+        // against an AM/PM-bearing iCloud filename — keep_unicode is on
+        // so the U+202F survives path-derivation.
+        let icloud_filename = "Screenshot 2025-01-14 at 1.40.01\u{202F}PM.PNG";
+        let asset = WiremockAsset::new("AMPM_NBSP", icloud_filename, "public.png").orig(
+            4096,
+            "ck_ampm_nbsp",
+            "public.png",
+        );
+
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let mut config = base_config(&dl);
+        config.keep_unicode_in_filenames = true;
+
+        // Stage on disk under the regular-space variant (what a tree
+        // normalized by a third-party tool would have).
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        assert_eq!(expected.len(), 1);
+        let icloud_path = expected[0].path.clone();
+        let parent = icloud_path.parent().unwrap();
+        let regular_space_filename = "Screenshot 2025-01-14 at 1.40.01 PM.PNG";
+        let on_disk = parent.join(regular_space_filename);
+        stage_file(&on_disk, expected[0].size);
+
+        let db = open_db(&tmp).await;
+        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+
+        assert_eq!(stats.total, 1);
+        assert_eq!(
+            stats.matched, 1,
+            "AM/PM variant on disk must match the iCloud NBSP form",
+        );
+        assert_eq!(stats.unmatched, 0);
+        let rows = all_downloaded(db.as_ref()).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].local_path.as_deref().map(StdPath::new),
+            Some(on_disk.as_path()),
+            "DB must record the variant path that was actually adopted",
+        );
+    }
+
+    #[tokio::test]
+    async fn ampm_variant_with_nbsp_on_disk_matches_regular_space_from_icloud() {
+        let server = MockServer::start().await;
+        // iCloud filename uses a regular space.
+        let icloud_filename = "Screenshot 2025-01-14 at 1.40.02 PM.PNG";
+        let asset = WiremockAsset::new("AMPM_REG", icloud_filename, "public.png").orig(
+            8192,
+            "ck_ampm_reg",
+            "public.png",
+        );
+
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let mut config = base_config(&dl);
+        config.keep_unicode_in_filenames = true;
+
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        assert_eq!(expected.len(), 1);
+        let icloud_path = expected[0].path.clone();
+        let parent = icloud_path.parent().unwrap();
+        let nbsp_filename = "Screenshot 2025-01-14 at 1.40.02\u{202F}PM.PNG";
+        let on_disk = parent.join(nbsp_filename);
+        stage_file(&on_disk, expected[0].size);
+
+        let db = open_db(&tmp).await;
+        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+
+        assert_eq!(stats.total, 1);
+        assert_eq!(
+            stats.matched, 1,
+            "NBSP variant on disk must match the iCloud regular-space form",
+        );
+        assert_eq!(stats.unmatched, 0);
+        let rows = all_downloaded(db.as_ref()).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].local_path.as_deref().map(StdPath::new),
+            Some(on_disk.as_path()),
         );
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -11,7 +11,7 @@ use crate::cli;
 use crate::config;
 use crate::download;
 use crate::download::filter::{expected_paths_for, is_asset_filtered, ExpectedAssetPath};
-use crate::download::paths::DirCache;
+use crate::download::paths::{normalize_ampm, DirCache};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
@@ -49,16 +49,11 @@ impl std::ops::AddAssign for ImportStats {
     }
 }
 
-/// Find the on-disk path that satisfies the expected size, trying in
-/// order:
-/// 1. the primary path,
-/// 2. the `<stem>-<size><ext>` dedup-collision shape (only under
-///    `NameSizeDedupWithSuffix`), and
-/// 3. an AM/PM whitespace sibling (for filenames containing AM/PM —
-///    macOS screenshots use NBSP `\u{202F}`, but a tree synced through
-///    a different tool may have a regular space, and vice versa).
-///
-/// Returns `(path, metadata)` for the matching file, or `None`.
+/// Find the on-disk path that satisfies the expected size: primary, then
+/// the dedup-collision shape under `NameSizeDedupWithSuffix`, then an
+/// AM/PM whitespace sibling. macOS screenshots use NARROW NO-BREAK SPACE
+/// (`\u{202F}`) before AM/PM; trees synced through other tools may have
+/// normalized to a regular space (or vice versa).
 async fn resolve_match_path(
     primary: &Path,
     expected_size: u64,
@@ -87,22 +82,30 @@ async fn resolve_match_path(
             }
         }
     }
-    if let Some(parent) = primary.parent() {
-        dir_cache.ensure_dir_async(parent).await;
-        if let Some(variant) = dir_cache.find_ampm_variant(primary) {
-            if let Ok(m) = tokio::fs::metadata(&variant).await {
-                if m.len() == expected_size {
-                    tracing::info!(
-                        primary = %primary.display(),
-                        variant = %variant.display(),
-                        "Matched AM/PM whitespace variant on disk",
-                    );
-                    return Some((variant, m));
-                }
-            }
-        }
+    // Cheap pre-check: only pay for the dir read if the filename actually
+    // has an AM/PM whitespace token to vary. `normalize_ampm` is idempotent
+    // on filenames that have no such token, so the inequality below is the
+    // exact condition under which `find_ampm_variant` could return Some.
+    let needs_probe = primary
+        .file_name()
+        .and_then(|f| f.to_str())
+        .is_some_and(|f| normalize_ampm(f) != f);
+    if !needs_probe {
+        return None;
     }
-    None
+    let parent = primary.parent()?;
+    dir_cache.ensure_dir_async(parent).await;
+    let variant = dir_cache.find_ampm_variant(primary)?;
+    if dir_cache.file_size(&variant) != Some(expected_size) {
+        return None;
+    }
+    let m = tokio::fs::metadata(&variant).await.ok()?;
+    tracing::info!(
+        primary = %primary.display(),
+        variant = %variant.display(),
+        "Matched AM/PM whitespace variant on disk",
+    );
+    Some((variant, m))
 }
 
 /// Run the import-existing matching loop over a stream of `PhotoAsset`s.
@@ -133,9 +136,8 @@ where
 
     tokio::pin!(stream);
     let mut stats = ImportStats::default();
-    // One cache per library scan. Each parent directory is read_dir'd
-    // exactly once; the AM/PM variant probe (and any future sibling
-    // probes) reuse it.
+    // One cache per library scan: each parent directory is read_dir'd at
+    // most once across all sibling probes.
     let mut dir_cache = DirCache::new();
 
     while let Some(result) = stream.next().await {
@@ -2143,17 +2145,16 @@ mod wiremock_tests {
     // photo come up unmatched on import. The DirCache-backed AM/PM probe
     // bridges both directions.
 
-    #[tokio::test]
-    async fn ampm_variant_with_regular_space_on_disk_matches_nbsp_from_icloud() {
+    /// Run an end-to-end import where the iCloud filename is `icloud`
+    /// and the file actually staged is named `on_disk_filename` in the
+    /// same parent directory. `keep_unicode_in_filenames=true` keeps
+    /// the U+202F in the expected path; otherwise `remove_unicode_chars`
+    /// would strip it before the AM/PM probe could fire.
+    async fn assert_ampm_variant_adopted(icloud: &str, on_disk_filename: &str) {
         let server = MockServer::start().await;
-        // iCloud filename uses NARROW NO-BREAK SPACE (U+202F). The probe
-        // only kicks in when the on-disk filename is being compared
-        // against an AM/PM-bearing iCloud filename — keep_unicode is on
-        // so the U+202F survives path-derivation.
-        let icloud_filename = "Screenshot 2025-01-14 at 1.40.01\u{202F}PM.PNG";
-        let asset = WiremockAsset::new("AMPM_NBSP", icloud_filename, "public.png").orig(
+        let asset = WiremockAsset::new("AMPM_TEST", icloud, "public.png").orig(
             4096,
-            "ck_ampm_nbsp",
+            "ck_ampm_test",
             "public.png",
         );
 
@@ -2163,14 +2164,17 @@ mod wiremock_tests {
         let mut config = base_config(&dl);
         config.keep_unicode_in_filenames = true;
 
-        // Stage on disk under the regular-space variant (what a tree
-        // normalized by a third-party tool would have).
         let expected = expected_paths_for(&asset.to_photo_asset(), &config);
-        assert_eq!(expected.len(), 1);
-        let icloud_path = expected[0].path.clone();
-        let parent = icloud_path.parent().unwrap();
-        let regular_space_filename = "Screenshot 2025-01-14 at 1.40.01 PM.PNG";
-        let on_disk = parent.join(regular_space_filename);
+        assert_eq!(
+            expected.len(),
+            1,
+            "single-version asset must yield one path"
+        );
+        let parent = expected[0]
+            .path
+            .parent()
+            .expect("expected path always has a parent");
+        let on_disk = parent.join(on_disk_filename);
         stage_file(&on_disk, expected[0].size);
 
         let db = open_db(&tmp).await;
@@ -2179,9 +2183,8 @@ mod wiremock_tests {
         assert_eq!(stats.total, 1);
         assert_eq!(
             stats.matched, 1,
-            "AM/PM variant on disk must match the iCloud NBSP form",
+            "AM/PM probe must adopt the on-disk variant",
         );
-        assert_eq!(stats.unmatched, 0);
         let rows = all_downloaded(db.as_ref()).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(
@@ -2192,45 +2195,21 @@ mod wiremock_tests {
     }
 
     #[tokio::test]
+    async fn ampm_variant_with_regular_space_on_disk_matches_nbsp_from_icloud() {
+        assert_ampm_variant_adopted(
+            "Screenshot 2025-01-14 at 1.40.01\u{202F}PM.PNG",
+            "Screenshot 2025-01-14 at 1.40.01 PM.PNG",
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn ampm_variant_with_nbsp_on_disk_matches_regular_space_from_icloud() {
-        let server = MockServer::start().await;
-        // iCloud filename uses a regular space.
-        let icloud_filename = "Screenshot 2025-01-14 at 1.40.02 PM.PNG";
-        let asset = WiremockAsset::new("AMPM_REG", icloud_filename, "public.png").orig(
-            8192,
-            "ck_ampm_reg",
-            "public.png",
-        );
-
-        let tmp = TempDir::new().unwrap();
-        let dl = tmp.path().join("photos");
-        std::fs::create_dir_all(&dl).unwrap();
-        let mut config = base_config(&dl);
-        config.keep_unicode_in_filenames = true;
-
-        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
-        assert_eq!(expected.len(), 1);
-        let icloud_path = expected[0].path.clone();
-        let parent = icloud_path.parent().unwrap();
-        let nbsp_filename = "Screenshot 2025-01-14 at 1.40.02\u{202F}PM.PNG";
-        let on_disk = parent.join(nbsp_filename);
-        stage_file(&on_disk, expected[0].size);
-
-        let db = open_db(&tmp).await;
-        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
-
-        assert_eq!(stats.total, 1);
-        assert_eq!(
-            stats.matched, 1,
-            "NBSP variant on disk must match the iCloud regular-space form",
-        );
-        assert_eq!(stats.unmatched, 0);
-        let rows = all_downloaded(db.as_ref()).await;
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].local_path.as_deref().map(StdPath::new),
-            Some(on_disk.as_path()),
-        );
+        assert_ampm_variant_adopted(
+            "Screenshot 2025-01-14 at 1.40.02 PM.PNG",
+            "Screenshot 2025-01-14 at 1.40.02\u{202F}PM.PNG",
+        )
+        .await;
     }
 
     // ── icloudpd compat baseline ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- iCloud filenames with AM/PM tokens use a NARROW NO-BREAK SPACE (U+202F) on macOS 13+. A tree previously synced via a tool that normalized to a regular space - or vice versa - would otherwise see every such file come up unmatched.
- After the existing primary + dedup-suffix probes miss, `resolve_match_path` now consults `DirCache::find_ampm_variant` to find a sibling that differs only in the AM/PM whitespace character. A match is logged at `INFO` naming the primary and variant paths.
- One `DirCache` is created per `import_assets` call so each parent dir is `read_dir`-ed at most once across all sibling probes.
- Closes robustness CF-1 (tactical fix; PR-7's path-derivation refactor will fold this check into the shared layer).

## Notes

The probe fires when the iCloud-derived expected path retains an AM/PM whitespace token - which is the case when `keep_unicode_in_filenames = true` (NBSP survives) or when the iCloud filename uses a regular space (always preserved). With the default `keep_unicode_in_filenames = false`, the importer strips NBSP from the expected path; the no-whitespace canonical form is short-circuited by `find_ampm_variant`'s contract. PR-7 will normalize across all three forms.

## Test plan

- [x] `ampm_variant_with_regular_space_on_disk_matches_nbsp_from_icloud`: stages a regular-space sibling, asserts matched=1 and DB records the variant path.
- [x] `ampm_variant_with_nbsp_on_disk_matches_regular_space_from_icloud`: reverse direction.
- [x] `just gate` green