### PR TITLE
state: mark_downloaded returns AssetRowMissing on zero rows

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -264,11 +264,9 @@ where
                 {
                     Ok(()) => {}
                     Err(e @ StateError::AssetRowMissing { .. }) => {
-                        // The row we just upsert_seen'd is gone. This is
-                        // an invariant violation (concurrent writer? DB
-                        // corruption?) that retry can't fix; bail so the
-                        // operator can investigate before more assets
-                        // are silently dropped.
+                        // Row vanished between upsert_seen and
+                        // mark_downloaded — retry can't fix this. Bail
+                        // before more assets are silently dropped.
                         anyhow::bail!("import scan aborted for library '{library_label}': {e}");
                     }
                     Err(e) => {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -15,7 +15,7 @@ use crate::download::paths::{normalize_ampm, DirCache};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
-use crate::state::StateDb;
+use crate::state::{StateDb, StateError};
 use crate::types::{
     AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize,
     RawTreatmentPolicy, VersionSize,
@@ -252,7 +252,7 @@ where
                     continue;
                 }
 
-                if let Err(e) = db
+                match db
                     .mark_downloaded(
                         asset.id(),
                         version_size.as_str(),
@@ -262,8 +262,19 @@ where
                     )
                     .await
                 {
-                    tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to mark as downloaded");
-                    continue;
+                    Ok(()) => {}
+                    Err(e @ StateError::AssetRowMissing { .. }) => {
+                        // The row we just upsert_seen'd is gone. This is
+                        // an invariant violation (concurrent writer? DB
+                        // corruption?) that retry can't fix; bail so the
+                        // operator can investigate before more assets
+                        // are silently dropped.
+                        anyhow::bail!("import scan aborted for library '{library_label}': {e}");
+                    }
+                    Err(e) => {
+                        tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to mark as downloaded");
+                        continue;
+                    }
                 }
             }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -3390,11 +3390,6 @@ mod tests {
             }
             other => panic!("expected AssetRowMissing, got {other:?}"),
         }
-
-        // Verify: the asset is NOT in the DB (it was never inserted).
-        let summary = db.get_summary().await.unwrap();
-        assert_eq!(summary.downloaded, 0);
-        assert_eq!(summary.total_assets, 0);
     }
 
     /// A regression that increases the rate of zero-row `mark_downloaded`

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -698,12 +698,11 @@ impl StateDb for SqliteStateDb {
                 .map_err(|e| StateError::query("mark_downloaded", e))?;
 
             if rows == 0 {
-                tracing::warn!(
-                    id = %id,
-                    version_size = %version_size,
-                    "mark_downloaded matched 0 rows — asset may not have been recorded via upsert_seen"
-                );
                 crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.inc();
+                return Err(StateError::AssetRowMissing {
+                    asset_id: id,
+                    version_size,
+                });
             }
 
             Ok(())
@@ -3365,13 +3364,13 @@ mod tests {
     // ── Gap: mark_downloaded on non-existent record (no upsert_seen) ──
 
     #[tokio::test]
-    async fn mark_downloaded_without_upsert_seen_succeeds_with_zero_rows() {
-        // mark_downloaded does an UPDATE, not an UPSERT. If the asset was
-        // never recorded via upsert_seen, it updates 0 rows and logs a
-        // warning. This should NOT return an error -- it's a graceful no-op.
+    async fn mark_downloaded_without_upsert_seen_returns_asset_row_missing() {
+        // The UPDATE matches zero rows when the asset wasn't recorded
+        // via upsert_seen. The caller must see this loudly so a missed
+        // dispatch step doesn't silently drop a downloaded file.
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        let result = db
+        let err = db
             .mark_downloaded(
                 "NEVER_SEEN",
                 "original",
@@ -3379,38 +3378,44 @@ mod tests {
                 "abc123",
                 None,
             )
-            .await;
-        assert!(
-            result.is_ok(),
-            "mark_downloaded on unknown asset should succeed (0-row update)"
-        );
+            .await
+            .expect_err("mark_downloaded on unknown asset must err");
+        match err {
+            StateError::AssetRowMissing {
+                asset_id,
+                version_size,
+            } => {
+                assert_eq!(asset_id, "NEVER_SEEN");
+                assert_eq!(version_size, "original");
+            }
+            other => panic!("expected AssetRowMissing, got {other:?}"),
+        }
 
-        // Verify: the asset is NOT in the DB (it was never inserted)
+        // Verify: the asset is NOT in the DB (it was never inserted).
         let summary = db.get_summary().await.unwrap();
         assert_eq!(summary.downloaded, 0);
         assert_eq!(summary.total_assets, 0);
     }
 
-    /// Robustness review NB-1 (2026-04-25): a `mark_downloaded` call
-    /// without a prior `upsert_seen` is self-healing in 1 cycle, but a
-    /// regression that increases the rate (producer-dispatch invariant
-    /// quietly broken) needs to be visible in /metrics rather than only
-    /// in logs. Pin the counter increment so the wiring can't be silently
-    /// dropped on a future refactor.
+    /// A regression that increases the rate of zero-row `mark_downloaded`
+    /// calls (e.g. a producer-dispatch invariant quietly broken) needs to
+    /// be visible in /metrics, not only in logs / per-asset errors. Pin
+    /// the counter increment so the wiring can't be silently dropped on
+    /// a future refactor.
     #[tokio::test]
     async fn mark_downloaded_zero_rows_increments_metric_counter() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
         let before = crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.get();
-        db.mark_downloaded(
-            "NEVER_SEEN_FOR_METRIC",
-            "original",
-            Path::new("/tmp/never_metric.jpg"),
-            "abc123",
-            None,
-        )
-        .await
-        .expect("mark_downloaded on unknown row should succeed");
+        let _ = db
+            .mark_downloaded(
+                "NEVER_SEEN_FOR_METRIC",
+                "original",
+                Path::new("/tmp/never_metric.jpg"),
+                "abc123",
+                None,
+            )
+            .await;
         let after = crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.get();
 
         assert!(

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -51,11 +51,9 @@ pub enum StateError {
     #[error("Database schema version {found} is newer than supported version {expected}")]
     UnsupportedSchemaVersion { found: i32, expected: i32 },
 
-    /// `mark_downloaded` matched zero rows. The asset row that should
-    /// have been upserted before this call is missing, indicating either
-    /// a missed upsert step or out-of-band row deletion. Callers must
-    /// not treat this as a clean write — the asset will silently fail
-    /// to record otherwise.
+    /// `mark_downloaded` matched zero rows. The asset row should have
+    /// been upserted before this call; its absence indicates a missed
+    /// upsert step or out-of-band row deletion.
     #[error("mark_downloaded: no row for asset {asset_id} version_size {version_size}")]
     AssetRowMissing {
         asset_id: String,

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -50,6 +50,17 @@ pub enum StateError {
     /// The database schema version is newer than supported.
     #[error("Database schema version {found} is newer than supported version {expected}")]
     UnsupportedSchemaVersion { found: i32, expected: i32 },
+
+    /// `mark_downloaded` matched zero rows. The asset row that should
+    /// have been upserted before this call is missing, indicating either
+    /// a missed upsert step or out-of-band row deletion. Callers must
+    /// not treat this as a clean write — the asset will silently fail
+    /// to record otherwise.
+    #[error("mark_downloaded: no row for asset {asset_id} version_size {version_size}")]
+    AssetRowMissing {
+        asset_id: String,
+        version_size: String,
+    },
 }
 
 impl StateError {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,4 +13,5 @@ pub mod schema;
 pub mod types;
 
 pub use db::{SqliteStateDb, StateDb};
+pub use error::StateError;
 pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};


### PR DESCRIPTION
## Summary

- New `StateError::AssetRowMissing { asset_id, version_size }` variant.
- `mark_downloaded` returns it instead of Ok when the UPDATE matches zero rows. The `MARK_DOWNLOADED_ZERO_ROWS` metric still ticks for ops visibility.
- import-existing's call site bails with the library label on `AssetRowMissing` (retry can't fix it; an operator should investigate before more assets are silently dropped). Other errors keep the warn-and-continue behavior.
- Sync's `mark_downloaded` retry path is out of scope - it currently retries any error and after `STATE_WRITE_MAX_RETRIES` surfaces via the existing failed-write log path, so AssetRowMissing flows through without regression.
- Closes robustness AD-1 from `.scratch/2026-04-29_FULL_REVIEW.md`.

## Why

A zero-row UPDATE means the row that should exist post-`upsert_seen` is gone. Treating it as success let a downloaded file land on disk that the state DB never tracked - exactly the silent-loss class kei is designed to surface loudly.

## Test plan

- [x] `mark_downloaded_without_upsert_seen_returns_asset_row_missing` pins the new Err variant.
- [x] `mark_downloaded_zero_rows_increments_metric_counter` still pins the metric.
- [x] Existing 60 import wiremock tests pass unchanged (the typed Err flows through the existing match arms).
- [x] `just gate` green