### PR TITLE
icloud: skip CMM share-link zones; backport v0.12.1 hotfix to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,12 @@ on:
       - Cargo.toml
       - Cargo.lock
       - Dockerfile
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Tag, branch, or SHA to build (e.g. v0.12.1)
+        required: true
+        type: string
 
 jobs:
   docker:
@@ -20,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.1] - 2026-04-29
+
+### Fixed
+
+- **`CMM-{UUID}` share-link zones are no longer treated as Shared Photo Libraries.** Accounts that have ever received an iCloud share link surface one or more `CMM-{UUID}` zones in the shared CloudKit database. These are "Cloud Master Moment Share Asset" containers, not iCloud Shared Photo Libraries (which use the `SharedSync-{UUID}` zone naming). kei previously enumerated them alongside real shared libraries and ran a `CheckIndexingState` probe per zone, which produced spurious `ERROR ... Failed to load library zone zone=CMM-...` lines whenever Apple's CloudKit gateway transiently 502'd, and inflated the "Detected N iCloud shared libraries" notice. CMM zones are now skipped entirely with a debug-level log; only `SharedSync-*` zones count as shared libraries. No download behavior changes — primary-library syncs were never affected. (#289)
+
+---
+
 ## [0.12.0] - 2026-04-26
 
 ### Added

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -204,6 +204,19 @@ impl PhotosService {
                 continue;
             }
             let zone_name = zone.zone_id.zone_name.clone();
+            // CMM-{UUID} zones are iCloud share-link bundles ("Cloud Master
+            // Moment Share Assets"), not Shared Photo Libraries. They use a
+            // different record schema and don't answer `CheckIndexingState`,
+            // so probing them produces noisy errors and they can't be
+            // enumerated through the library/album path anyway. Skip them
+            // entirely; they're not meaningful as a sync target today.
+            if zone_name.starts_with("CMM-") {
+                tracing::debug!(
+                    zone = %zone_name,
+                    "Skipping CMM share-link zone (not a Shared Photo Library)"
+                );
+                continue;
+            }
             let zone_id = Arc::new(serde_json::to_value(&zone.zone_id)?);
             let ep = self.get_service_endpoint(library_type);
             let lib_session = self.session.clone_box();
@@ -591,6 +604,34 @@ mod tests {
         assert_eq!(libs.len(), 1);
         assert!(libs.contains_key("LiveZone"));
         assert!(!libs.contains_key("GoneZone"));
+    }
+
+    /// CMM-{UUID} share-link zones are filtered out of the library map.
+    /// They use a different record schema and aren't Shared Photo Libraries,
+    /// so probing them produces noisy errors and they can't be synced.
+    #[tokio::test]
+    async fn test_fetch_libraries_skips_cmm_share_link_zones() {
+        let session = CloneableSession {
+            response: json!({
+                "zones": [
+                    {"zoneID": {"zoneName": "PrimarySync"}, "syncToken": "t"},
+                    {
+                        "zoneID": {"zoneName": "CMM-657AE284-D1E0-4C7F-9B4D-987888651AC6"},
+                        "syncToken": "t2",
+                    },
+                    {"zoneID": {"zoneName": "SharedSync-ABCD"}, "syncToken": "t3"}
+                ]
+            }),
+        };
+        let mut svc = make_service(Box::new(session), HashMap::new());
+        let libs = svc.fetch_private_libraries().await.unwrap();
+        assert!(libs.contains_key("PrimarySync"));
+        assert!(libs.contains_key("SharedSync-ABCD"));
+        assert!(
+            !libs.contains_key("CMM-657AE284-D1E0-4C7F-9B4D-987888651AC6"),
+            "CMM zones must be skipped: {:?}",
+            libs.keys().collect::<Vec<_>>()
+        );
     }
 
     /// Second call to fetch_private_libraries reuses the cached map


### PR DESCRIPTION
## Summary

Cherry-picks the substantive changes from the [v0.12.1 hotfix](https://github.com/rhoopr/kei/releases/tag/v0.12.1) (tagged off v0.12.0) back onto main so the v0.13 release line carries the CMM-zone fix and the workflow improvements that shipped on the tag.

## What's in this PR

- `src/icloud/photos/mod.rs` (+ test): `fetch_libraries` skips zones whose name starts with `CMM-` before running `CheckIndexingState`. CMM-`{UUID}` zones are Cloud Master Moment Share Asset containers (iCloud share-link bundles), not Shared Photo Libraries. They have a different record schema and don't answer the indexing-state query, which produced spurious `ERROR ... Failed to load library zone zone=CMM-...` lines whenever Apple's CloudKit gateway transiently 502'd. New unit test covers a mixed zone list (PrimarySync + CMM + SharedSync-).
- `.github/workflows/release.yml`: build matrix now checks out `${{ github.ref_name }}` instead of the hardcoded `main` ref, so future hotfixes off old tags ship the right binaries.
- `.github/workflows/docker.yml`: adds a `workflow_dispatch` trigger with a `ref` input, plus the corresponding `ref` honored in checkout. Lets us trigger manual hotfix images without piggybacking on a release event.
- `CHANGELOG.md`: inserts the `[0.12.1]` section between `[Unreleased]` and `[0.12.0]`, matching what the tag shipped.

## What's deliberately not here

- Cargo.toml / Cargo.lock version bump. Main is already on `0.12.1-dev` for the next release line; the v0.12.1 tag carries its own bump.

## Test plan

- [x] `just gate` passes (1874 lib + 131 cli + 102 behavioral, clippy/typos/roundtrip clean)
- [ ] CI green
- [ ] Spot-check that the CMM zone test fails without the production change (sanity)
- [ ] Confirm no clippy regressions on the new test