### PR TITLE
state: transactional import_adopt closes pending+NULL local_path window

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -15,7 +15,7 @@ use crate::download::paths::{normalize_ampm, DirCache};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
-use crate::state::{StateDb, StateError};
+use crate::state::StateDb;
 use crate::types::{
     AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize,
     RawTreatmentPolicy, VersionSize,
@@ -247,21 +247,12 @@ where
                     expected_size,
                     media_type,
                 );
-                match db
+                if let Err(e) = db
                     .import_adopt(&record, &expected_path, &local_checksum)
                     .await
                 {
-                    Ok(()) => {}
-                    Err(e @ StateError::AssetRowMissing { .. }) => {
-                        // Should be unreachable: the UPSERT and UPDATE run
-                        // in one transaction, so the UPDATE always matches.
-                        // Bail loudly rather than silently drop assets.
-                        anyhow::bail!("import scan aborted for library '{library_label}': {e}");
-                    }
-                    Err(e) => {
-                        tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to adopt asset");
-                        continue;
-                    }
+                    tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to adopt asset");
+                    continue;
                 }
             }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -247,30 +247,19 @@ where
                     expected_size,
                     media_type,
                 );
-                if let Err(e) = db.upsert_seen(&record).await {
-                    tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to record asset");
-                    continue;
-                }
-
                 match db
-                    .mark_downloaded(
-                        asset.id(),
-                        version_size.as_str(),
-                        &expected_path,
-                        &local_checksum,
-                        None,
-                    )
+                    .import_adopt(&record, &expected_path, &local_checksum)
                     .await
                 {
                     Ok(()) => {}
                     Err(e @ StateError::AssetRowMissing { .. }) => {
-                        // Row vanished between upsert_seen and
-                        // mark_downloaded — retry can't fix this. Bail
-                        // before more assets are silently dropped.
+                        // Should be unreachable: the UPSERT and UPDATE run
+                        // in one transaction, so the UPDATE always matches.
+                        // Bail loudly rather than silently drop assets.
                         anyhow::bail!("import scan aborted for library '{library_label}': {e}");
                     }
                     Err(e) => {
-                        tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to mark as downloaded");
+                        tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to adopt asset");
                         continue;
                     }
                 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3046,6 +3046,9 @@ mod tests {
                 Ok(())
             }
         }
+        async fn import_adopt(&self, _: &AssetRecord, _: &Path, _: &str) -> Result<(), StateError> {
+            unimplemented!()
+        }
         async fn mark_failed(&self, _: &str, _: &str, _: &str) -> Result<(), StateError> {
             unimplemented!()
         }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -78,10 +78,8 @@ pub trait StateDb: Send + Sync {
 
     /// Atomically upsert `record` and mark it downloaded in one transaction.
     ///
-    /// Used by `import-existing` so that an interrupted scan never leaves a
-    /// `pending` row with `local_path = NULL` on disk: either both writes
-    /// commit (asset is `downloaded`) or neither does (asset is absent and
-    /// the next run will re-adopt it).
+    /// Used by `import-existing` so an interrupted scan never leaves a
+    /// `pending` row with `local_path = NULL` for the next sync to redownload.
     async fn import_adopt(
         &self,
         record: &AssetRecord,
@@ -581,10 +579,8 @@ fn upsert_asset_row(
     Ok(())
 }
 
-/// Execute the `mark_downloaded` UPDATE on `conn`. Returns rows affected so
-/// the caller can decide whether zero rows is an error (mark_downloaded) or
-/// an internal bug (import_adopt — the prior UPSERT in the same transaction
-/// guarantees a row exists).
+/// Execute the `mark_downloaded` UPDATE on `conn`. Returns rows affected;
+/// callers decide what zero rows means in their context.
 fn update_status_to_downloaded(
     conn: &Connection,
     id: &str,
@@ -594,19 +590,21 @@ fn update_status_to_downloaded(
     download_checksum: Option<&str>,
     downloaded_at: i64,
 ) -> Result<usize, StateError> {
-    conn.execute(
-        "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
-         local_checksum = ?3, download_checksum = ?4, last_error = NULL \
-         WHERE id = ?5 AND version_size = ?6",
-        rusqlite::params![
-            downloaded_at,
-            local_path.to_string_lossy(),
-            local_checksum,
-            download_checksum,
-            id,
-            version_size
-        ],
-    )
+    let mut stmt = conn
+        .prepare_cached(
+            "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
+             local_checksum = ?3, download_checksum = ?4, last_error = NULL \
+             WHERE id = ?5 AND version_size = ?6",
+        )
+        .map_err(|e| StateError::query("mark_downloaded::prepare", e))?;
+    stmt.execute(rusqlite::params![
+        downloaded_at,
+        local_path.to_string_lossy(),
+        local_checksum,
+        download_checksum,
+        id,
+        version_size
+    ])
     .map_err(|e| StateError::query("mark_downloaded", e))
 }
 
@@ -781,17 +779,10 @@ impl StateDb for SqliteStateDb {
                 None,
                 now,
             )?;
-            // The UPSERT in the same transaction just inserted-or-updated
-            // this row, so the UPDATE must match. Zero rows here means our
-            // own SQL is wrong, not a missed dispatch — surface the same
-            // error variant so the call site can bail loudly.
-            if rows == 0 {
-                crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.inc();
-                return Err(StateError::AssetRowMissing {
-                    asset_id: record.id.to_string(),
-                    version_size: record.version_size.as_str().to_owned(),
-                });
-            }
+            debug_assert_eq!(
+                rows, 1,
+                "import_adopt UPDATE missed the row inserted by UPSERT in the same tx — SQL bug"
+            );
 
             tx.commit()
                 .map_err(|e| StateError::query("import_adopt::commit", e))?;

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -76,6 +76,19 @@ pub trait StateDb: Send + Sync {
         download_checksum: Option<&str>,
     ) -> Result<(), StateError>;
 
+    /// Atomically upsert `record` and mark it downloaded in one transaction.
+    ///
+    /// Used by `import-existing` so that an interrupted scan never leaves a
+    /// `pending` row with `local_path = NULL` on disk: either both writes
+    /// commit (asset is `downloaded`) or neither does (asset is absent and
+    /// the next run will re-adopt it).
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+    ) -> Result<(), StateError>;
+
     /// Mark an asset as failed with an error message.
     async fn mark_failed(
         &self,
@@ -459,6 +472,144 @@ impl SqliteStateDb {
     }
 }
 
+/// Execute the asset UPSERT on `conn` (works against either a `Connection`
+/// or a `Transaction`, since `Transaction: Deref<Target = Connection>`).
+/// Shared by `upsert_seen` and `import_adopt` so both write the same column
+/// set and conflict resolution.
+fn upsert_asset_row(
+    conn: &Connection,
+    record: &AssetRecord,
+    last_seen_at: i64,
+) -> Result<(), StateError> {
+    let meta = &record.metadata;
+    // Lazily compute metadata_hash if caller supplied metadata without one.
+    // Storing the hash alongside the metadata is what lets feature 5 detect
+    // metadata-only changes in O(1) during incremental sync. Computed only
+    // when missing (rare — extract() normally pre-populates it).
+    let computed_hash: Option<String> = if meta.metadata_hash.is_none() {
+        Some(meta.compute_hash())
+    } else {
+        None
+    };
+    let metadata_hash: Option<&str> = meta.metadata_hash.as_deref().or(computed_hash.as_deref());
+
+    let mut stmt = conn
+        .prepare_cached(
+            r"
+                INSERT INTO assets (
+                    id, version_size, checksum, filename, created_at, added_at,
+                    size_bytes, media_type, status, last_seen_at,
+                    source, is_favorite, rating, latitude, longitude, altitude,
+                    orientation, duration_secs, timezone_offset, width, height,
+                    title, keywords, description, media_subtype, burst_id,
+                    is_hidden, is_archived, modified_at, is_deleted, deleted_at,
+                    provider_data, metadata_hash
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9,
+                        ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+                        ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)
+                ON CONFLICT(id, version_size) DO UPDATE SET
+                    checksum = excluded.checksum,
+                    filename = excluded.filename,
+                    created_at = excluded.created_at,
+                    added_at = excluded.added_at,
+                    size_bytes = excluded.size_bytes,
+                    media_type = excluded.media_type,
+                    last_seen_at = excluded.last_seen_at,
+                    source = COALESCE(excluded.source, assets.source),
+                    is_favorite = excluded.is_favorite,
+                    rating = excluded.rating,
+                    latitude = excluded.latitude,
+                    longitude = excluded.longitude,
+                    altitude = excluded.altitude,
+                    orientation = excluded.orientation,
+                    duration_secs = excluded.duration_secs,
+                    timezone_offset = excluded.timezone_offset,
+                    width = excluded.width,
+                    height = excluded.height,
+                    title = excluded.title,
+                    keywords = excluded.keywords,
+                    description = excluded.description,
+                    media_subtype = excluded.media_subtype,
+                    burst_id = excluded.burst_id,
+                    is_hidden = excluded.is_hidden,
+                    is_archived = excluded.is_archived,
+                    modified_at = excluded.modified_at,
+                    is_deleted = excluded.is_deleted,
+                    deleted_at = excluded.deleted_at,
+                    provider_data = excluded.provider_data,
+                    metadata_hash = excluded.metadata_hash
+                ",
+        )
+        .map_err(|e| StateError::query("upsert_seen::prepare", e))?;
+    stmt.execute(rusqlite::params![
+        &record.id,
+        record.version_size.as_str(),
+        &record.checksum,
+        &record.filename,
+        record.created_at.timestamp(),
+        record.added_at.map(|dt| dt.timestamp()),
+        i64::try_from(record.size_bytes).unwrap_or(i64::MAX),
+        record.media_type.as_str(),
+        last_seen_at,
+        meta.source.as_deref().unwrap_or(DEFAULT_SOURCE),
+        i64::from(meta.is_favorite),
+        meta.rating.map(i64::from),
+        meta.latitude,
+        meta.longitude,
+        meta.altitude,
+        meta.orientation.map(i64::from),
+        meta.duration_secs,
+        meta.timezone_offset.map(i64::from),
+        meta.width.map(i64::from),
+        meta.height.map(i64::from),
+        meta.title.as_deref(),
+        meta.keywords.as_deref(),
+        meta.description.as_deref(),
+        meta.media_subtype.as_deref(),
+        meta.burst_id.as_deref(),
+        i64::from(meta.is_hidden),
+        i64::from(meta.is_archived),
+        meta.modified_at.map(|dt| dt.timestamp()),
+        i64::from(meta.is_deleted),
+        meta.deleted_at.map(|dt| dt.timestamp()),
+        meta.provider_data.as_deref(),
+        metadata_hash,
+    ])
+    .map_err(|e| StateError::query("upsert_seen", e))?;
+
+    Ok(())
+}
+
+/// Execute the `mark_downloaded` UPDATE on `conn`. Returns rows affected so
+/// the caller can decide whether zero rows is an error (mark_downloaded) or
+/// an internal bug (import_adopt — the prior UPSERT in the same transaction
+/// guarantees a row exists).
+fn update_status_to_downloaded(
+    conn: &Connection,
+    id: &str,
+    version_size: &str,
+    local_path: &Path,
+    local_checksum: &str,
+    download_checksum: Option<&str>,
+    downloaded_at: i64,
+) -> Result<usize, StateError> {
+    conn.execute(
+        "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
+         local_checksum = ?3, download_checksum = ?4, last_error = NULL \
+         WHERE id = ?5 AND version_size = ?6",
+        rusqlite::params![
+            downloaded_at,
+            local_path.to_string_lossy(),
+            local_checksum,
+            download_checksum,
+            id,
+            version_size
+        ],
+    )
+    .map_err(|e| StateError::query("mark_downloaded", e))
+}
+
 /// Drain a rusqlite row iterator into `Vec<T>`, dropping parse failures but
 /// logging each at `debug!` and summarising the drop count at `warn!` so a
 /// corrupted row never silently disappears from a bulk loader.
@@ -560,107 +711,7 @@ impl StateDb for SqliteStateDb {
     async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
         let record = record.clone();
         self.with_conn("upsert_seen", move |conn| {
-            let last_seen_at = Utc::now().timestamp();
-
-            let meta = &record.metadata;
-            // Lazily compute metadata_hash if caller supplied metadata without one.
-            // Storing the hash alongside the metadata is what lets feature 5 detect
-            // metadata-only changes in O(1) during incremental sync. Computed only
-            // when missing (rare — extract() normally pre-populates it).
-            let computed_hash: Option<String> = if meta.metadata_hash.is_none() {
-                Some(meta.compute_hash())
-            } else {
-                None
-            };
-            let metadata_hash: Option<&str> =
-                meta.metadata_hash.as_deref().or(computed_hash.as_deref());
-
-            let mut stmt = conn
-                .prepare_cached(
-                    r"
-                INSERT INTO assets (
-                    id, version_size, checksum, filename, created_at, added_at,
-                    size_bytes, media_type, status, last_seen_at,
-                    source, is_favorite, rating, latitude, longitude, altitude,
-                    orientation, duration_secs, timezone_offset, width, height,
-                    title, keywords, description, media_subtype, burst_id,
-                    is_hidden, is_archived, modified_at, is_deleted, deleted_at,
-                    provider_data, metadata_hash
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9,
-                        ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
-                        ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)
-                ON CONFLICT(id, version_size) DO UPDATE SET
-                    checksum = excluded.checksum,
-                    filename = excluded.filename,
-                    created_at = excluded.created_at,
-                    added_at = excluded.added_at,
-                    size_bytes = excluded.size_bytes,
-                    media_type = excluded.media_type,
-                    last_seen_at = excluded.last_seen_at,
-                    source = COALESCE(excluded.source, assets.source),
-                    is_favorite = excluded.is_favorite,
-                    rating = excluded.rating,
-                    latitude = excluded.latitude,
-                    longitude = excluded.longitude,
-                    altitude = excluded.altitude,
-                    orientation = excluded.orientation,
-                    duration_secs = excluded.duration_secs,
-                    timezone_offset = excluded.timezone_offset,
-                    width = excluded.width,
-                    height = excluded.height,
-                    title = excluded.title,
-                    keywords = excluded.keywords,
-                    description = excluded.description,
-                    media_subtype = excluded.media_subtype,
-                    burst_id = excluded.burst_id,
-                    is_hidden = excluded.is_hidden,
-                    is_archived = excluded.is_archived,
-                    modified_at = excluded.modified_at,
-                    is_deleted = excluded.is_deleted,
-                    deleted_at = excluded.deleted_at,
-                    provider_data = excluded.provider_data,
-                    metadata_hash = excluded.metadata_hash
-                ",
-                )
-                .map_err(|e| StateError::query("upsert_seen::prepare", e))?;
-            stmt.execute(rusqlite::params![
-                &record.id,
-                record.version_size.as_str(),
-                &record.checksum,
-                &record.filename,
-                record.created_at.timestamp(),
-                record.added_at.map(|dt| dt.timestamp()),
-                i64::try_from(record.size_bytes).unwrap_or(i64::MAX),
-                record.media_type.as_str(),
-                last_seen_at,
-                meta.source.as_deref().unwrap_or(DEFAULT_SOURCE),
-                i64::from(meta.is_favorite),
-                meta.rating.map(i64::from),
-                meta.latitude,
-                meta.longitude,
-                meta.altitude,
-                meta.orientation.map(i64::from),
-                meta.duration_secs,
-                meta.timezone_offset.map(i64::from),
-                meta.width.map(i64::from),
-                meta.height.map(i64::from),
-                meta.title.as_deref(),
-                meta.keywords.as_deref(),
-                meta.description.as_deref(),
-                meta.media_subtype.as_deref(),
-                meta.burst_id.as_deref(),
-                i64::from(meta.is_hidden),
-                i64::from(meta.is_archived),
-                meta.modified_at.map(|dt| dt.timestamp()),
-                i64::from(meta.is_deleted),
-                meta.deleted_at.map(|dt| dt.timestamp()),
-                meta.provider_data.as_deref(),
-                metadata_hash,
-            ])
-            .map_err(|e| StateError::query("upsert_seen", e))?;
-
-            Ok(())
+            upsert_asset_row(conn, &record, Utc::now().timestamp())
         })
         .await
     }
@@ -681,21 +732,15 @@ impl StateDb for SqliteStateDb {
         let download_checksum = download_checksum.map(str::to_owned);
 
         self.with_conn("mark_downloaded", move |conn| {
-            let rows = conn
-                .execute(
-                    "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
-                     local_checksum = ?3, download_checksum = ?4, last_error = NULL \
-                     WHERE id = ?5 AND version_size = ?6",
-                    rusqlite::params![
-                        downloaded_at,
-                        local_path.to_string_lossy(),
-                        &local_checksum,
-                        download_checksum.as_deref(),
-                        &id,
-                        &version_size
-                    ],
-                )
-                .map_err(|e| StateError::query("mark_downloaded", e))?;
+            let rows = update_status_to_downloaded(
+                conn,
+                &id,
+                &version_size,
+                &local_path,
+                &local_checksum,
+                download_checksum.as_deref(),
+                downloaded_at,
+            )?;
 
             if rows == 0 {
                 crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.inc();
@@ -705,6 +750,51 @@ impl StateDb for SqliteStateDb {
                 });
             }
 
+            Ok(())
+        })
+        .await
+    }
+
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+    ) -> Result<(), StateError> {
+        let record = record.clone();
+        let local_path = local_path.to_path_buf();
+        let local_checksum = local_checksum.to_owned();
+
+        self.with_conn_mut("import_adopt", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("import_adopt::begin", e))?;
+
+            let now = Utc::now().timestamp();
+            upsert_asset_row(&tx, &record, now)?;
+            let rows = update_status_to_downloaded(
+                &tx,
+                &record.id,
+                record.version_size.as_str(),
+                &local_path,
+                &local_checksum,
+                None,
+                now,
+            )?;
+            // The UPSERT in the same transaction just inserted-or-updated
+            // this row, so the UPDATE must match. Zero rows here means our
+            // own SQL is wrong, not a missed dispatch — surface the same
+            // error variant so the call site can bail loudly.
+            if rows == 0 {
+                crate::metrics::MARK_DOWNLOADED_ZERO_ROWS.inc();
+                return Err(StateError::AssetRowMissing {
+                    asset_id: record.id.to_string(),
+                    version_size: record.version_size.as_str().to_owned(),
+                });
+            }
+
+            tx.commit()
+                .map_err(|e| StateError::query("import_adopt::commit", e))?;
             Ok(())
         })
         .await
@@ -3418,6 +3508,99 @@ mod tests {
             "counter should advance by at least 1 (other parallel tests may also \
              increment); got before={before} after={after}"
         );
+    }
+
+    // ── import_adopt: atomic upsert + mark-downloaded ───────────────────
+
+    #[tokio::test]
+    async fn import_adopt_persists_downloaded_row_in_one_call() {
+        // The whole point of import_adopt: one transactional call that
+        // leaves the row fully `downloaded` with `local_path` set. No
+        // separate upsert_seen + mark_downloaded sequence at the call site.
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let record = TestAssetRecord::new("ADOPT_ONE")
+            .checksum("ck_adopt")
+            .filename("photo.jpg")
+            .size(2048)
+            .build();
+        let local_path = PathBuf::from("/tmp/photos/photo.jpg");
+
+        db.import_adopt(&record, &local_path, "local-ck-abc")
+            .await
+            .expect("import_adopt should succeed on a fresh row");
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.total_assets, 1);
+        assert_eq!(summary.downloaded, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 0);
+
+        let pages = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(pages.len(), 1);
+        let row = &pages[0];
+        assert_eq!(&*row.id, "ADOPT_ONE");
+        assert_eq!(row.status, AssetStatus::Downloaded);
+        assert_eq!(row.local_path.as_deref(), Some(local_path.as_path()));
+        assert_eq!(row.local_checksum.as_deref(), Some("local-ck-abc"));
+    }
+
+    #[tokio::test]
+    async fn import_adopt_is_idempotent_on_repeat_calls() {
+        // Re-running an import scan over the same on-disk files must not
+        // duplicate rows or drop the downloaded state — the second adopt
+        // should see the existing downloaded row and leave it healthy.
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let record = TestAssetRecord::new("ADOPT_IDEMP")
+            .checksum("ck_idemp")
+            .filename("idemp.jpg")
+            .size(1024)
+            .build();
+        let local_path = PathBuf::from("/tmp/photos/idemp.jpg");
+
+        for _ in 0..2 {
+            db.import_adopt(&record, &local_path, "local-ck-idemp")
+                .await
+                .expect("import_adopt should be idempotent");
+        }
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.total_assets, 1, "no duplicate row");
+        assert_eq!(summary.downloaded, 1);
+    }
+
+    #[tokio::test]
+    async fn import_adopt_promotes_existing_pending_row_to_downloaded() {
+        // A prior interrupted scan may have left a pending row (pre-PR-5
+        // behavior). Re-running the import must recover by upserting the
+        // metadata and flipping the row to downloaded in one transaction.
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let record = TestAssetRecord::new("ADOPT_RESUME")
+            .checksum("ck_resume")
+            .filename("resume.jpg")
+            .size(4096)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+
+        // Sanity: row is pending with no local_path.
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.downloaded, 0);
+
+        let local_path = PathBuf::from("/tmp/photos/resume.jpg");
+        db.import_adopt(&record, &local_path, "local-ck-resume")
+            .await
+            .expect("import_adopt should promote pending → downloaded");
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.downloaded, 1);
+
+        let pages = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(pages[0].local_path.as_deref(), Some(local_path.as_path()));
+        assert_eq!(pages[0].local_checksum.as_deref(), Some("local-ck-resume"));
     }
 
     // ── Gap: mark_failed increments download_attempts cumulatively ────

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,5 +13,4 @@ pub mod schema;
 pub mod types;
 
 pub use db::{SqliteStateDb, StateDb};
-pub use error::StateError;
 pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1839,6 +1839,14 @@ mod tests {
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
+            async fn import_adopt(
+                &self,
+                _: &state::types::AssetRecord,
+                _: &std::path::Path,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
             async fn mark_failed(
                 &self,
                 _: &str,
@@ -2266,6 +2274,14 @@ mod tests {
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
+            async fn import_adopt(
+                &self,
+                _: &state::types::AssetRecord,
+                _: &std::path::Path,
+                _: &str,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
             async fn mark_failed(
                 &self,
                 _: &str,
@@ -2549,6 +2565,14 @@ mod tests {
                 _: &std::path::Path,
                 _: &str,
                 _: Option<&str>,
+            ) -> Result<(), state::error::StateError> {
+                unimplemented!()
+            }
+            async fn import_adopt(
+                &self,
+                _: &state::types::AssetRecord,
+                _: &std::path::Path,
+                _: &str,
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }


### PR DESCRIPTION
## Summary

- `import-existing` previously wrote a row in two steps (`upsert_seen` then `mark_downloaded`). A crash or interrupt between the two left a `pending` row with `local_path = NULL` on disk; a subsequent sync would treat that asset as never-seen and re-download it.
- Add `StateDb::import_adopt`, which performs the same UPSERT + UPDATE inside one rusqlite transaction. Either the row commits as `downloaded` with `local_path` set, or it rolls back so the next scan re-adopts the file from scratch.
- Extract `upsert_asset_row` and `update_status_to_downloaded` helpers so `upsert_seen`, `mark_downloaded`, and `import_adopt` all run the same SQL with no risk of drift.
- Switch the import call site to `import_adopt`. The `AssetRowMissing` arm is retained as a loud-bail safety net even though the in-transaction UPSERT makes it unreachable in practice.

Closes the post-crash window described in the FOLLOWUP_PRS plan (PR-5 / robustness NB-1).

## Test plan

- [x] `cargo test --lib state::db -- --test-threads=1` (86 pass, including 3 new `import_adopt_*` cases: happy path, idempotent re-run, promoting a stale pending row to downloaded).
- [x] `cargo test --lib commands::import -- --test-threads=1` (60 pass).
- [x] `just gate` (fmt, clippy --all-targets --all-features -D warnings, full test suite, docs, audit, typos, roundtrip).