### PR TITLE
config: extract resolve_path_derivation_fields shared by sync + import

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -2378,12 +2378,12 @@ mod build_config_tests {
         );
     }
 
-    /// PR-6: Sync's `Config::build` and import's
-    /// `build_import_download_config` share `resolve_path_derivation_fields`.
-    /// For the same CLI/TOML inputs the path-derivation knobs they emit
-    /// must agree byte-for-byte. If a future change layers extra logic
-    /// into either path without going through the shared resolver, this
-    /// test catches the drift.
+    /// Sync's `Config::build` and import's `build_import_download_config`
+    /// share `resolve_path_derivation_fields`. For the same CLI/TOML
+    /// inputs the path-derivation knobs they emit must agree
+    /// byte-for-byte. If a future change layers extra logic into either
+    /// path without going through the shared resolver, this test catches
+    /// the drift.
     #[test]
     fn sync_and_import_agree_on_path_derivation_fields() {
         use crate::cli::SyncArgs;

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -16,10 +16,7 @@ use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
 use crate::state::StateDb;
-use crate::types::{
-    AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize,
-    RawTreatmentPolicy, VersionSize,
-};
+use crate::types::FileMatchPolicy;
 
 use super::service::{init_photos_service, resolve_libraries};
 
@@ -402,10 +399,7 @@ fn build_import_download_config(
     args: &cli::ImportArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<download::DownloadConfig> {
-    use rustc_hash::FxHashSet;
-
     let toml_dl = toml.and_then(|t| t.download.as_ref());
-    let toml_photos = toml.and_then(|t| t.photos.as_ref());
 
     anyhow::ensure!(
         !(args.download_dir.is_some() && args.directory.is_some()),
@@ -431,98 +425,27 @@ fn build_import_download_config(
     }
     let directory: Arc<Path> = Arc::from(config::expand_tilde(&directory_str).as_path());
 
-    let folder_structure = args
-        .folder_structure
-        .clone()
-        .or_else(|| toml_dl.and_then(|d| d.folder_structure.clone()))
-        .unwrap_or_else(|| "%Y/%m/%d".to_string());
+    let path_fields = config::resolve_path_derivation_fields(
+        config::PathDerivationCliArgs {
+            folder_structure: args.folder_structure.clone(),
+            size: args.size,
+            live_photo_mode: args.live_photo_mode,
+            live_photo_size: args.live_photo_size,
+            live_photo_mov_filename_policy: args.live_photo_mov_filename_policy,
+            align_raw: args.align_raw,
+            file_match_policy: args.file_match_policy,
+            force_size: args.force_size,
+            keep_unicode_in_filenames: args.keep_unicode_in_filenames,
+        },
+        toml,
+    );
 
-    let keep_unicode_in_filenames = args
-        .keep_unicode_in_filenames
-        .or_else(|| toml_photos.and_then(|p| p.keep_unicode_in_filenames))
-        .unwrap_or(false);
-
-    let file_match_policy = args
-        .file_match_policy
-        .or_else(|| toml_photos.and_then(|p| p.file_match_policy))
-        .unwrap_or(FileMatchPolicy::NameSizeDedupWithSuffix);
-
-    let size: AssetVersionSize = args
-        .size
-        .or_else(|| toml_photos.and_then(|p| p.size))
-        .unwrap_or(VersionSize::Original)
-        .into();
-
-    let live_photo_mode = args
-        .live_photo_mode
-        .or_else(|| toml_photos.and_then(|p| p.live_photo_mode))
-        .unwrap_or(LivePhotoMode::Both);
-
-    let live_photo_size: AssetVersionSize = args
-        .live_photo_size
-        .or_else(|| toml_photos.and_then(|p| p.live_photo_size))
-        .unwrap_or(LivePhotoSize::Original)
-        .to_asset_version_size();
-
-    let live_photo_mov_filename_policy = args
-        .live_photo_mov_filename_policy
-        .or_else(|| toml_photos.and_then(|p| p.live_photo_mov_filename_policy))
-        .unwrap_or(LivePhotoMovFilenamePolicy::Suffix);
-
-    let align_raw = args
-        .align_raw
-        .or_else(|| toml_photos.and_then(|p| p.align_raw))
-        .unwrap_or(RawTreatmentPolicy::Unchanged);
-
-    let force_size = args
-        .force_size
-        .or_else(|| toml_photos.and_then(|p| p.force_size))
-        .unwrap_or(false);
-
-    Ok(download::DownloadConfig {
+    Ok(download::DownloadConfig::for_path_derivation_only(
         directory,
-        folder_structure,
-        size,
-        skip_videos: false,
-        skip_photos: false,
-        skip_created_before: None,
-        skip_created_after: None,
-        #[cfg(feature = "xmp")]
-        set_exif_datetime: false,
-        #[cfg(feature = "xmp")]
-        set_exif_rating: false,
-        #[cfg(feature = "xmp")]
-        set_exif_gps: false,
-        #[cfg(feature = "xmp")]
-        set_exif_description: false,
-        #[cfg(feature = "xmp")]
-        embed_xmp: false,
-        #[cfg(feature = "xmp")]
-        xmp_sidecar: false,
-        dry_run: args.dry_run,
-        concurrent_downloads: 1,
-        recent: None,
-        retry: retry::RetryConfig::default(),
-        live_photo_mode,
-        live_photo_size,
-        live_photo_mov_filename_policy,
-        align_raw,
-        no_progress_bar: args.no_progress_bar,
-        only_print_filenames: false,
-        file_match_policy,
-        force_size,
-        keep_unicode_in_filenames,
-        filename_exclude: Arc::from(Vec::<glob::Pattern>::new()),
-        temp_suffix: Arc::from(".kei-tmp"),
-        state_db: None,
-        retry_only: false,
-        max_download_attempts: 0,
-        sync_mode: download::SyncMode::Full,
-        album_name: None,
-        exclude_asset_ids: Arc::new(FxHashSet::default()),
-        asset_groupings: Arc::new(download::AssetGroupings::default()),
-        bandwidth_limiter: None,
-    })
+        path_fields,
+        args.dry_run,
+        args.no_progress_bar,
+    ))
 }
 
 #[cfg(test)]
@@ -2223,7 +2146,7 @@ mod build_config_tests {
     //! parse path that production uses.
     use super::build_import_download_config;
     use crate::cli::{Cli, Command};
-    use crate::config::{TomlConfig, TomlPhotos};
+    use crate::config::{Config, GlobalArgs, TomlConfig, TomlPhotos};
     use crate::types::{
         AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
         LivePhotoSize, RawTreatmentPolicy, VersionSize,
@@ -2452,6 +2375,91 @@ mod build_config_tests {
         assert!(
             msg.contains("--download-dir is required"),
             "error must name the missing flag, got: {msg}"
+        );
+    }
+
+    /// PR-6: Sync's `Config::build` and import's
+    /// `build_import_download_config` share `resolve_path_derivation_fields`.
+    /// For the same CLI/TOML inputs the path-derivation knobs they emit
+    /// must agree byte-for-byte. If a future change layers extra logic
+    /// into either path without going through the shared resolver, this
+    /// test catches the drift.
+    #[test]
+    fn sync_and_import_agree_on_path_derivation_fields() {
+        use crate::cli::SyncArgs;
+
+        let toml_str = r#"
+            [download]
+            folder_structure = "%Y/%m"
+
+            [photos]
+            size = "adjusted"
+            file_match_policy = "name-id7"
+            live_photo_mov_filename_policy = "original"
+            align_raw = "original"
+            force_size = true
+            keep_unicode_in_filenames = true
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+
+        let import_args = parse_import_args(&[
+            "--folder-structure",
+            "%Y/%m",
+            "--size",
+            "adjusted",
+            "--file-match-policy",
+            "name-id7",
+            "--live-photo-mov-filename-policy",
+            "original",
+            "--align-raw",
+            "original",
+            "--force-size",
+            "--keep-unicode-in-filenames",
+        ]);
+        let import_cfg = build_import_download_config(&import_args, Some(&toml)).unwrap();
+
+        let sync = SyncArgs {
+            folder_structure: Some("%Y/%m".to_string()),
+            size: Some(VersionSize::Adjusted),
+            file_match_policy: Some(FileMatchPolicy::NameId7),
+            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
+            align_raw: Some(RawTreatmentPolicy::PreferOriginal),
+            force_size: Some(true),
+            keep_unicode_in_filenames: Some(true),
+            directory: Some("/photos".to_string()),
+            ..Default::default()
+        };
+        let globals = GlobalArgs {
+            username: Some("u@example.com".to_string()),
+            domain: None,
+            data_dir: None,
+            cookie_directory: None,
+        };
+        let sync_cfg = Config::build(
+            &globals,
+            crate::cli::PasswordArgs::default(),
+            sync,
+            Some(toml.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(import_cfg.folder_structure, sync_cfg.folder_structure);
+        assert_eq!(import_cfg.size, sync_cfg.size.into());
+        assert_eq!(import_cfg.live_photo_mode, sync_cfg.live_photo_mode);
+        assert_eq!(
+            import_cfg.live_photo_size,
+            sync_cfg.live_photo_size.to_asset_version_size()
+        );
+        assert_eq!(
+            import_cfg.live_photo_mov_filename_policy,
+            sync_cfg.live_photo_mov_filename_policy
+        );
+        assert_eq!(import_cfg.align_raw, sync_cfg.align_raw);
+        assert_eq!(import_cfg.file_match_policy, sync_cfg.file_match_policy);
+        assert_eq!(import_cfg.force_size, sync_cfg.force_size);
+        assert_eq!(
+            import_cfg.keep_unicode_in_filenames,
+            sync_cfg.keep_unicode_in_filenames
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -458,7 +458,7 @@ pub(crate) struct PathDerivationCliArgs {
 /// Resolved path-derivation fields used by both `Config::build` (sync) and
 /// `build_import_download_config` (import-existing) so the two code paths
 /// derive identical expected file paths for the same inputs.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct PathDerivationFields {
     pub folder_structure: String,
     pub size: VersionSize,
@@ -482,11 +482,10 @@ pub(crate) fn resolve_path_derivation_fields(
     let toml_dl = toml.and_then(|t| t.download.as_ref());
     let toml_photos = toml.and_then(|t| t.photos.as_ref());
 
-    let folder_structure = resolve(
-        cli.folder_structure,
-        toml_dl.and_then(|d| d.folder_structure.clone()),
-        "%Y/%m/%d".to_string(),
-    );
+    let folder_structure = cli
+        .folder_structure
+        .or_else(|| toml_dl.and_then(|d| d.folder_structure.clone()))
+        .unwrap_or_else(|| "%Y/%m/%d".to_string());
     let size = resolve(
         cli.size,
         toml_photos.and_then(|p| p.size),
@@ -1128,10 +1127,9 @@ impl Config {
             }
         }
 
-        // Photos / path-derivation: shared resolver (CLI > TOML > default
-        // chain identical to import-existing). `folder_structure` is
-        // already resolved above; pass it through as `Some(...)` so the
-        // resolver short-circuits.
+        // Path-derivation knobs (CLI > TOML > default). `folder_structure`
+        // was already resolved above for `resolve_album_selection`; pass
+        // it through so the resolver short-circuits.
         let PathDerivationFields {
             folder_structure: _,
             size,

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,6 +436,111 @@ fn resolve_flag(cli_flag: Option<bool>, toml_val: Option<bool>) -> bool {
     cli_flag.or(toml_val).unwrap_or(false)
 }
 
+/// CLI inputs for [`resolve_path_derivation_fields`].
+///
+/// Each field is `Option<T>`; `Some` means the CLI (or env var) supplied
+/// the value, `None` means fall through to TOML and then to the default.
+/// Sync's `--skip-live-photos` deprecation is folded into `live_photo_mode`
+/// by the caller before calling the resolver.
+#[derive(Debug, Default)]
+pub(crate) struct PathDerivationCliArgs {
+    pub folder_structure: Option<String>,
+    pub size: Option<VersionSize>,
+    pub live_photo_mode: Option<LivePhotoMode>,
+    pub live_photo_size: Option<LivePhotoSize>,
+    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
+    pub align_raw: Option<RawTreatmentPolicy>,
+    pub file_match_policy: Option<FileMatchPolicy>,
+    pub force_size: Option<bool>,
+    pub keep_unicode_in_filenames: Option<bool>,
+}
+
+/// Resolved path-derivation fields used by both `Config::build` (sync) and
+/// `build_import_download_config` (import-existing) so the two code paths
+/// derive identical expected file paths for the same inputs.
+#[derive(Debug, Clone)]
+pub(crate) struct PathDerivationFields {
+    pub folder_structure: String,
+    pub size: VersionSize,
+    pub live_photo_mode: LivePhotoMode,
+    pub live_photo_size: LivePhotoSize,
+    pub live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
+    pub align_raw: RawTreatmentPolicy,
+    pub file_match_policy: FileMatchPolicy,
+    pub force_size: bool,
+    pub keep_unicode_in_filenames: bool,
+}
+
+/// Resolve the CLI > TOML > default chain for every field that affects
+/// path derivation, shared by sync and import. The smart default for
+/// `live_photo_size` (track `--size adjusted` when the user didn't
+/// override it) lives here so import-existing matches sync.
+pub(crate) fn resolve_path_derivation_fields(
+    cli: PathDerivationCliArgs,
+    toml: Option<&TomlConfig>,
+) -> PathDerivationFields {
+    let toml_dl = toml.and_then(|t| t.download.as_ref());
+    let toml_photos = toml.and_then(|t| t.photos.as_ref());
+
+    let folder_structure = resolve(
+        cli.folder_structure,
+        toml_dl.and_then(|d| d.folder_structure.clone()),
+        "%Y/%m/%d".to_string(),
+    );
+    let size = resolve(
+        cli.size,
+        toml_photos.and_then(|p| p.size),
+        VersionSize::Original,
+    );
+    let default_live_photo_size = if size == VersionSize::Adjusted {
+        LivePhotoSize::Adjusted
+    } else {
+        LivePhotoSize::Original
+    };
+    let live_photo_size = resolve(
+        cli.live_photo_size,
+        toml_photos.and_then(|p| p.live_photo_size),
+        default_live_photo_size,
+    );
+    let live_photo_mode = resolve(
+        cli.live_photo_mode,
+        toml_photos.and_then(|p| p.live_photo_mode),
+        LivePhotoMode::Both,
+    );
+    let live_photo_mov_filename_policy = resolve(
+        cli.live_photo_mov_filename_policy,
+        toml_photos.and_then(|p| p.live_photo_mov_filename_policy),
+        LivePhotoMovFilenamePolicy::Suffix,
+    );
+    let align_raw = resolve(
+        cli.align_raw,
+        toml_photos.and_then(|p| p.align_raw),
+        RawTreatmentPolicy::Unchanged,
+    );
+    let file_match_policy = resolve(
+        cli.file_match_policy,
+        toml_photos.and_then(|p| p.file_match_policy),
+        FileMatchPolicy::NameSizeDedupWithSuffix,
+    );
+    let force_size = resolve_flag(cli.force_size, toml_photos.and_then(|p| p.force_size));
+    let keep_unicode_in_filenames = resolve_flag(
+        cli.keep_unicode_in_filenames,
+        toml_photos.and_then(|p| p.keep_unicode_in_filenames),
+    );
+
+    PathDerivationFields {
+        folder_structure,
+        size,
+        live_photo_mode,
+        live_photo_size,
+        live_photo_mov_filename_policy,
+        align_raw,
+        file_match_policy,
+        force_size,
+        keep_unicode_in_filenames,
+    }
+}
+
 /// Global CLI args needed by `resolve_auth` and `Config::build`.
 ///
 /// Bundles the fields that moved from per-command `AuthArgs` to
@@ -917,9 +1022,14 @@ impl Config {
         let albums = resolve_album_selection(raw_albums, &folder_structure)?;
         let skip_videos = resolve_flag(sync.skip_videos, toml_filters.and_then(|f| f.skip_videos));
         let skip_photos = resolve_flag(sync.skip_photos, toml_filters.and_then(|f| f.skip_photos));
-        // Resolve live photo mode: --live-photo-mode > --skip-live-photos > TOML photos > TOML filters compat
-        let live_photo_mode = if let Some(mode) = sync.live_photo_mode {
-            mode
+        // Fold sync's deprecated `--skip-live-photos` / `[filters]
+        // skip_live_photos` paths into a single `Option<LivePhotoMode>` so
+        // the shared resolver still sees the chosen value and emits the
+        // deprecation warnings before falling through to defaults.
+        let live_photo_mode_pre_resolved: Option<LivePhotoMode> = if let Some(mode) =
+            sync.live_photo_mode
+        {
+            Some(mode)
         } else if sync.skip_live_photos == Some(true) {
             #[allow(
                 clippy::print_stderr,
@@ -930,9 +1040,9 @@ impl Config {
                     "warning: `--skip-live-photos` / `KEI_SKIP_LIVE_PHOTOS` is deprecated and will be removed in v0.20.0, use `--live-photo-mode skip` instead"
                 );
             }
-            LivePhotoMode::Skip
+            Some(LivePhotoMode::Skip)
         } else if let Some(mode) = toml_photos.and_then(|p| p.live_photo_mode) {
-            mode
+            Some(mode)
         } else if toml_filters.and_then(|f| f.skip_live_photos) == Some(true) {
             #[allow(
                 clippy::print_stderr,
@@ -943,9 +1053,9 @@ impl Config {
                     "warning: `[filters] skip_live_photos` is deprecated and will be removed in v0.20.0, use `[photos] live_photo_mode = \"skip\"` instead"
                 );
             }
-            LivePhotoMode::Skip
+            Some(LivePhotoMode::Skip)
         } else {
-            LivePhotoMode::Both
+            None
         };
         let exclude_albums = if sync.exclude_albums.is_empty() {
             toml_filters
@@ -1018,43 +1128,33 @@ impl Config {
             }
         }
 
-        // Photos
-        let size = resolve(
-            sync.size,
-            toml_photos.and_then(|p| p.size),
-            VersionSize::Original,
-        );
-        // When --size adjusted and live-photo-size is not explicitly set,
-        // default to adjusted live photo companions too.
-        let default_live_photo_size = if size == VersionSize::Adjusted {
-            LivePhotoSize::Adjusted
-        } else {
-            LivePhotoSize::Original
-        };
-        let live_photo_size = resolve(
-            sync.live_photo_size,
-            toml_photos.and_then(|p| p.live_photo_size),
-            default_live_photo_size,
-        );
-        let live_photo_mov_filename_policy = resolve(
-            sync.live_photo_mov_filename_policy,
-            toml_photos.and_then(|p| p.live_photo_mov_filename_policy),
-            LivePhotoMovFilenamePolicy::Suffix,
-        );
-        let align_raw = resolve(
-            sync.align_raw,
-            toml_photos.and_then(|p| p.align_raw),
-            RawTreatmentPolicy::Unchanged,
-        );
-        let file_match_policy = resolve(
-            sync.file_match_policy,
-            toml_photos.and_then(|p| p.file_match_policy),
-            FileMatchPolicy::NameSizeDedupWithSuffix,
-        );
-        let force_size = resolve_flag(sync.force_size, toml_photos.and_then(|p| p.force_size));
-        let keep_unicode_in_filenames = resolve_flag(
-            sync.keep_unicode_in_filenames,
-            toml_photos.and_then(|p| p.keep_unicode_in_filenames),
+        // Photos / path-derivation: shared resolver (CLI > TOML > default
+        // chain identical to import-existing). `folder_structure` is
+        // already resolved above; pass it through as `Some(...)` so the
+        // resolver short-circuits.
+        let PathDerivationFields {
+            folder_structure: _,
+            size,
+            live_photo_mode,
+            live_photo_size,
+            live_photo_mov_filename_policy,
+            align_raw,
+            file_match_policy,
+            force_size,
+            keep_unicode_in_filenames,
+        } = resolve_path_derivation_fields(
+            PathDerivationCliArgs {
+                folder_structure: Some(folder_structure.clone()),
+                size: sync.size,
+                live_photo_mode: live_photo_mode_pre_resolved,
+                live_photo_size: sync.live_photo_size,
+                live_photo_mov_filename_policy: sync.live_photo_mov_filename_policy,
+                align_raw: sync.align_raw,
+                file_match_policy: sync.file_match_policy,
+                force_size: sync.force_size,
+                keep_unicode_in_filenames: sync.keep_unicode_in_filenames,
+            },
+            toml.as_ref(),
         );
 
         // Watch
@@ -3572,6 +3672,124 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(cfg.file_match_policy, FileMatchPolicy::NameId7));
+    }
+
+    // ── resolve_path_derivation_fields: shared by sync + import ─────
+
+    /// Defaults are wired so a caller passing all-`None` CLI args and no
+    /// TOML lands on the documented defaults — this is the no-flags path
+    /// both `sync` and `import-existing` follow when invoked bare.
+    #[test]
+    fn resolve_path_derivation_all_defaults() {
+        let pd = resolve_path_derivation_fields(PathDerivationCliArgs::default(), None);
+        assert_eq!(pd.folder_structure, "%Y/%m/%d");
+        assert_eq!(pd.size, VersionSize::Original);
+        assert_eq!(pd.live_photo_mode, LivePhotoMode::Both);
+        assert_eq!(pd.live_photo_size, LivePhotoSize::Original);
+        assert_eq!(
+            pd.live_photo_mov_filename_policy,
+            LivePhotoMovFilenamePolicy::Suffix
+        );
+        assert_eq!(pd.align_raw, RawTreatmentPolicy::Unchanged);
+        assert_eq!(
+            pd.file_match_policy,
+            FileMatchPolicy::NameSizeDedupWithSuffix
+        );
+        assert!(!pd.force_size);
+        assert!(!pd.keep_unicode_in_filenames);
+    }
+
+    /// `--size adjusted` without explicit `--live-photo-size` must drag
+    /// the live-photo companion size to `adjusted` too. Both sync and
+    /// import inherit this from the shared resolver — pinning here
+    /// catches anyone "simplifying" the smart default away.
+    #[test]
+    fn resolve_path_derivation_size_adjusted_drags_live_photo_size() {
+        let cli = PathDerivationCliArgs {
+            size: Some(VersionSize::Adjusted),
+            ..Default::default()
+        };
+        let pd = resolve_path_derivation_fields(cli, None);
+        assert_eq!(pd.size, VersionSize::Adjusted);
+        assert_eq!(
+            pd.live_photo_size,
+            LivePhotoSize::Adjusted,
+            "smart default: --size adjusted should drag live_photo_size"
+        );
+    }
+
+    /// CLI explicit `--live-photo-size original` must beat the smart
+    /// default so a user can opt out of the size-adjusted drag.
+    #[test]
+    fn resolve_path_derivation_explicit_live_photo_size_beats_smart_default() {
+        let cli = PathDerivationCliArgs {
+            size: Some(VersionSize::Adjusted),
+            live_photo_size: Some(LivePhotoSize::Original),
+            ..Default::default()
+        };
+        let pd = resolve_path_derivation_fields(cli, None);
+        assert_eq!(pd.live_photo_size, LivePhotoSize::Original);
+    }
+
+    /// CLI > TOML > default. The resolver short-circuits on the first
+    /// `Some`; this confirms we don't double-resolve and accidentally
+    /// fall through to the TOML value when the CLI already chose.
+    #[test]
+    fn resolve_path_derivation_cli_beats_toml() {
+        let toml: TomlConfig = toml::from_str(
+            r#"
+            [photos]
+            size = "adjusted"
+            file_match_policy = "name-id7"
+            force_size = true
+            keep_unicode_in_filenames = true
+            align_raw = "original"
+            "#,
+        )
+        .unwrap();
+        let cli = PathDerivationCliArgs {
+            size: Some(VersionSize::Original),
+            file_match_policy: Some(FileMatchPolicy::NameSizeDedupWithSuffix),
+            force_size: Some(false),
+            keep_unicode_in_filenames: Some(false),
+            align_raw: Some(RawTreatmentPolicy::Unchanged),
+            ..Default::default()
+        };
+        let pd = resolve_path_derivation_fields(cli, Some(&toml));
+        assert_eq!(pd.size, VersionSize::Original);
+        assert_eq!(
+            pd.file_match_policy,
+            FileMatchPolicy::NameSizeDedupWithSuffix
+        );
+        assert!(!pd.force_size);
+        assert!(!pd.keep_unicode_in_filenames);
+        assert_eq!(pd.align_raw, RawTreatmentPolicy::Unchanged);
+    }
+
+    /// TOML wins when the CLI is silent. Pin this so anyone refactoring
+    /// the resolver doesn't accidentally swallow TOML defaults.
+    #[test]
+    fn resolve_path_derivation_toml_when_cli_absent() {
+        let toml: TomlConfig = toml::from_str(
+            r#"
+            [download]
+            folder_structure = "%Y/%m"
+
+            [photos]
+            size = "adjusted"
+            live_photo_mode = "skip"
+            file_match_policy = "name-id7"
+            "#,
+        )
+        .unwrap();
+        let pd = resolve_path_derivation_fields(PathDerivationCliArgs::default(), Some(&toml));
+        assert_eq!(pd.folder_structure, "%Y/%m");
+        assert_eq!(pd.size, VersionSize::Adjusted);
+        assert_eq!(pd.live_photo_mode, LivePhotoMode::Skip);
+        assert_eq!(pd.file_match_policy, FileMatchPolicy::NameId7);
+        // Smart default should still drag here because `--live-photo-size`
+        // wasn't set in either CLI or TOML.
+        assert_eq!(pd.live_photo_size, LivePhotoSize::Adjusted);
     }
 
     // ── Config::build: boolean flag merge exhaustive ───────────────

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -503,6 +503,70 @@ impl DownloadConfig {
         self.folder_structure.contains("{album}")
     }
 
+    /// Construct a `DownloadConfig` populated only with the fields that
+    /// affect path derivation, leaving every download-pipeline field at an
+    /// inert default. Used by `import-existing`, which never instantiates a
+    /// pipeline; it only calls `expected_paths_for` to figure out where a
+    /// file *would* live on disk and matches that against existing files.
+    ///
+    /// The inert fields (state_db, retry, concurrent_downloads, bandwidth
+    /// limiter, sync_mode, album_name, etc.) are unread by the path
+    /// derivation layer; introducing real values here would silently
+    /// misroute import-existing if those fields ever start to influence
+    /// path computation. The asserting tests in `commands::import` cover
+    /// the expected-path matrix for the live values.
+    pub(crate) fn for_path_derivation_only(
+        directory: Arc<Path>,
+        fields: crate::config::PathDerivationFields,
+        dry_run: bool,
+        no_progress_bar: bool,
+    ) -> Self {
+        Self {
+            directory,
+            folder_structure: fields.folder_structure,
+            size: fields.size.into(),
+            skip_videos: false,
+            skip_photos: false,
+            skip_created_before: None,
+            skip_created_after: None,
+            #[cfg(feature = "xmp")]
+            set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
+            set_exif_rating: false,
+            #[cfg(feature = "xmp")]
+            set_exif_gps: false,
+            #[cfg(feature = "xmp")]
+            set_exif_description: false,
+            #[cfg(feature = "xmp")]
+            embed_xmp: false,
+            #[cfg(feature = "xmp")]
+            xmp_sidecar: false,
+            dry_run,
+            concurrent_downloads: 1,
+            recent: None,
+            retry: RetryConfig::default(),
+            live_photo_mode: fields.live_photo_mode,
+            live_photo_size: fields.live_photo_size.to_asset_version_size(),
+            live_photo_mov_filename_policy: fields.live_photo_mov_filename_policy,
+            align_raw: fields.align_raw,
+            no_progress_bar,
+            only_print_filenames: false,
+            file_match_policy: fields.file_match_policy,
+            force_size: fields.force_size,
+            keep_unicode_in_filenames: fields.keep_unicode_in_filenames,
+            filename_exclude: Arc::from(Vec::<glob::Pattern>::new()),
+            temp_suffix: Arc::from(".kei-tmp"),
+            state_db: None,
+            retry_only: false,
+            max_download_attempts: 0,
+            sync_mode: SyncMode::Full,
+            album_name: None,
+            exclude_asset_ids: Arc::new(FxHashSet::default()),
+            asset_groupings: Arc::new(AssetGroupings::default()),
+            bandwidth_limiter: None,
+        }
+    }
+
     /// Clone this config with a different `album_name`, for per-album processing
     /// when `{album}` is in `folder_structure`. Pre-expands the `{album}` token
     /// in `folder_structure` so `local_download_dir` avoids per-asset

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -503,18 +503,11 @@ impl DownloadConfig {
         self.folder_structure.contains("{album}")
     }
 
-    /// Construct a `DownloadConfig` populated only with the fields that
-    /// affect path derivation, leaving every download-pipeline field at an
-    /// inert default. Used by `import-existing`, which never instantiates a
-    /// pipeline; it only calls `expected_paths_for` to figure out where a
-    /// file *would* live on disk and matches that against existing files.
-    ///
-    /// The inert fields (state_db, retry, concurrent_downloads, bandwidth
-    /// limiter, sync_mode, album_name, etc.) are unread by the path
-    /// derivation layer; introducing real values here would silently
-    /// misroute import-existing if those fields ever start to influence
-    /// path computation. The asserting tests in `commands::import` cover
-    /// the expected-path matrix for the live values.
+    /// Construct a `DownloadConfig` with only the path-derivation fields
+    /// populated. Used by `import-existing`, which calls
+    /// `expected_paths_for` against existing files but never runs the
+    /// download pipeline; the pipeline-only fields (state_db, retry,
+    /// concurrent_downloads, etc.) stay at inert defaults.
     pub(crate) fn for_path_derivation_only(
         directory: Arc<Path>,
         fields: crate::config::PathDerivationFields,


### PR DESCRIPTION
## Summary

- `Config::build` (sync) and `build_import_download_config` (import-existing) both walked the same CLI > TOML > default chain for `folder_structure`, `size`, `live_photo_*`, `align_raw`, `file_match_policy`, `force_size`, and `keep_unicode_in_filenames` - two near-identical implementations that could drift and silently misroute import-existing.
- Extract one `resolve_path_derivation_fields(cli, toml) -> PathDerivationFields` helper in `src/config.rs`. Smart defaults like \"`--size adjusted` drags `--live-photo-size` to `Adjusted`\" live in the resolver so both code paths inherit them.
- Sync's `--skip-live-photos` / `[filters] skip_live_photos` deprecation handling pre-resolves into a single `Option<LivePhotoMode>` that flows through the shared resolver, preserving the deprecation warnings.
- Replace the 40-field `DownloadConfig { ... }` literal in import with a new `DownloadConfig::for_path_derivation_only(directory, fields, dry_run, no_progress_bar)` constructor that documents which fields are inert and asserts they remain so over time.

Closes codebase CF-2 from `2026-04-29_FULL_REVIEW.md`.

## Test plan

- [x] 5 new resolver unit tests in `src/config.rs`: defaults, size→live_photo_size smart default + opt-out, CLI > TOML, TOML when CLI absent.
- [x] 1 new cross-check in `src/commands/import.rs::sync_and_import_agree_on_path_derivation_fields` that drives `Config::build` and `build_import_download_config` with the same CLI/TOML and asserts every shared field agrees.
- [x] `cargo test --lib config::` (243 pass, +5).
- [x] `cargo test --lib commands::import` (61 pass, +1).
- [x] `just gate` (fmt, clippy --all-targets --all-features -D warnings, full test suite, docs, audit, typos, roundtrip).