### PR TITLE
download: share validate_download_dir between sync and import; warn on empty filename

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -238,9 +238,7 @@ where
                             asset_id = %asset.id(),
                             version = ?version_size,
                             path = %expected_path.display(),
-                            "Recording empty filename: expected path has no UTF-8 \
-                             file_name component (non-UTF8 segment, trailing slash, \
-                             or path ends in `..`)"
+                            "Recording empty filename: expected path has no UTF-8 file_name component"
                         );
                         ""
                     })
@@ -323,10 +321,8 @@ pub(crate) async fn run_import_existing(
         }
     };
 
-    // Import only reads, so a missing directory means there's nothing to
-    // scan — bail clearly. `dir_cache::read_dir_entries` swallows read
-    // errors and returns an empty map, which would otherwise surface as
-    // a silent "0 files matched" report.
+    // Bail clearly on missing/non-dir; `dir_cache::read_dir_entries`
+    // swallows read errors and would otherwise report "0 files matched".
     match tokio::fs::metadata(&directory).await {
         Ok(m) if m.is_dir() => {}
         Ok(_) => anyhow::bail!("Not a directory: {}", directory.display()),
@@ -2485,27 +2481,11 @@ mod build_config_tests {
         );
     }
 
-    /// HF-4 / CF-5: import's `build_import_download_config` rejects the
-    /// same system directories sync's `Config::build` does, with the same
-    /// error shape. Closes the asymmetry where `import-existing
-    /// --download-dir /etc` would proceed past config build.
-    #[test]
-    fn build_import_download_config_rejects_system_directory() {
-        let args = parse_import_args(&[]);
-        // Override the parse default of /photos with /etc.
-        let mut args = args;
-        args.download_dir = Some("/etc".to_string());
-        let err = build_import_download_config(&args, None)
-            .expect_err("system directory must be rejected");
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("Refusing to use system directory") && msg.contains("/etc"),
-            "error must name the rejection and the path, got: {msg}"
-        );
-    }
-
-    /// Cross-check that the helper produces the same rejection shape for
-    /// both call sites, so refactoring one path can't drift the other.
+    /// Sync's `Config::build` and import's `build_import_download_config`
+    /// share the same `validate_download_dir` system-directory deny list,
+    /// so a path like `/etc` must be rejected by both with the same error
+    /// shape. If a future refactor bypasses the helper from one path,
+    /// this test catches the drift.
     #[test]
     fn sync_and_import_reject_system_directory_with_same_message() {
         use crate::cli::SyncArgs;
@@ -2533,12 +2513,12 @@ mod build_config_tests {
 
         let import_msg = format!("{import_err:#}");
         let sync_msg = format!("{sync_err:#}");
-        assert!(
-            import_msg.contains("Refusing to use system directory")
-                && sync_msg.contains("Refusing to use system directory"),
-            "both must surface the shared rejection message; \
-             import: {import_msg}, sync: {sync_msg}"
-        );
+        for (label, msg) in [("import", &import_msg), ("sync", &sync_msg)] {
+            assert!(
+                msg.contains("Refusing to use system directory") && msg.contains("/etc"),
+                "{label} must name the rejection and the path; got: {msg}"
+            );
+        }
     }
 
     /// CG-10: setting both `--directory` (deprecated) and `--download-dir`

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -230,15 +230,26 @@ where
                 };
 
                 let media_type = download::determine_media_type(version_size, &asset);
+                let filename = expected_path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            asset_id = %asset.id(),
+                            version = ?version_size,
+                            path = %expected_path.display(),
+                            "Recording empty filename: expected path has no UTF-8 \
+                             file_name component (non-UTF8 segment, trailing slash, \
+                             or path ends in `..`)"
+                        );
+                        ""
+                    })
+                    .to_string();
                 let record = state::AssetRecord::new_pending(
                     asset.id().to_string(),
                     version_size,
                     checksum.to_string(),
-                    expected_path
-                        .file_name()
-                        .and_then(|f| f.to_str())
-                        .unwrap_or("")
-                        .to_string(),
+                    filename,
                     asset.created(),
                     Some(asset.added_date()),
                     expected_size,
@@ -312,8 +323,17 @@ pub(crate) async fn run_import_existing(
         }
     };
 
-    if !directory.exists() {
-        anyhow::bail!("Directory does not exist: {}", directory.display());
+    // Import only reads, so a missing directory means there's nothing to
+    // scan — bail clearly. `dir_cache::read_dir_entries` swallows read
+    // errors and returns an empty map, which would otherwise surface as
+    // a silent "0 files matched" report.
+    match tokio::fs::metadata(&directory).await {
+        Ok(m) if m.is_dir() => {}
+        Ok(_) => anyhow::bail!("Not a directory: {}", directory.display()),
+        Err(e) => anyhow::bail!(
+            "Cannot read download directory {}: {e}",
+            directory.display()
+        ),
     }
 
     let db = Arc::new(state::SqliteStateDb::open(&db_path).await?);
@@ -423,7 +443,9 @@ fn build_import_download_config(
     if directory_str.is_empty() {
         anyhow::bail!("--download-dir is required for import-existing");
     }
-    let directory: Arc<Path> = Arc::from(config::expand_tilde(&directory_str).as_path());
+    let directory_path = config::expand_tilde(&directory_str);
+    config::validate_download_dir(&directory_path)?;
+    let directory: Arc<Path> = Arc::from(directory_path.as_path());
 
     let path_fields = config::resolve_path_derivation_fields(
         config::PathDerivationCliArgs {
@@ -2460,6 +2482,62 @@ mod build_config_tests {
         assert_eq!(
             import_cfg.keep_unicode_in_filenames,
             sync_cfg.keep_unicode_in_filenames
+        );
+    }
+
+    /// HF-4 / CF-5: import's `build_import_download_config` rejects the
+    /// same system directories sync's `Config::build` does, with the same
+    /// error shape. Closes the asymmetry where `import-existing
+    /// --download-dir /etc` would proceed past config build.
+    #[test]
+    fn build_import_download_config_rejects_system_directory() {
+        let args = parse_import_args(&[]);
+        // Override the parse default of /photos with /etc.
+        let mut args = args;
+        args.download_dir = Some("/etc".to_string());
+        let err = build_import_download_config(&args, None)
+            .expect_err("system directory must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Refusing to use system directory") && msg.contains("/etc"),
+            "error must name the rejection and the path, got: {msg}"
+        );
+    }
+
+    /// Cross-check that the helper produces the same rejection shape for
+    /// both call sites, so refactoring one path can't drift the other.
+    #[test]
+    fn sync_and_import_reject_system_directory_with_same_message() {
+        use crate::cli::SyncArgs;
+
+        let import_args = {
+            let mut a = parse_import_args(&[]);
+            a.download_dir = Some("/etc".to_string());
+            a
+        };
+        let import_err = build_import_download_config(&import_args, None)
+            .expect_err("import: system dir must reject");
+
+        let sync = SyncArgs {
+            directory: Some("/etc".to_string()),
+            ..Default::default()
+        };
+        let globals = GlobalArgs {
+            username: Some("u@example.com".to_string()),
+            domain: None,
+            data_dir: None,
+            cookie_directory: None,
+        };
+        let sync_err = Config::build(&globals, crate::cli::PasswordArgs::default(), sync, None)
+            .expect_err("sync: system dir must reject");
+
+        let import_msg = format!("{import_err:#}");
+        let sync_msg = format!("{sync_err:#}");
+        assert!(
+            import_msg.contains("Refusing to use system directory")
+                && sync_msg.contains("Refusing to use system directory"),
+            "both must surface the shared rejection message; \
+             import: {import_msg}, sync: {sync_msg}"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -398,8 +398,11 @@ pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-/// Reject system directories that should never be used as a download target.
-fn validate_directory(path: &Path) -> anyhow::Result<()> {
+/// Reject system directories that should never be used as a download
+/// target. Shared by sync (`Config::build`) and import-existing
+/// (`build_import_download_config`) so both refuse the same set with the
+/// same error message.
+pub(crate) fn validate_download_dir(path: &Path) -> anyhow::Result<()> {
     const DENIED: &[&str] = &[
         "/bin", "/sbin", "/usr", "/etc", "/dev", "/proc", "/sys", "/boot", "/lib", "/lib64",
         "/var", "/root",
@@ -863,7 +866,7 @@ impl Config {
             .map(|d| expand_tilde(&d))
             .unwrap_or_default();
         if !directory.as_os_str().is_empty() {
-            validate_directory(&directory)?;
+            validate_download_dir(&directory)?;
         }
         let folder_structure = resolve(
             sync.folder_structure,
@@ -5121,30 +5124,30 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_directory_rejects_root() {
-        assert!(validate_directory(Path::new("/")).is_err());
+    fn test_validate_download_dir_rejects_root() {
+        assert!(validate_download_dir(Path::new("/")).is_err());
     }
 
     #[test]
-    fn test_validate_directory_rejects_system_paths() {
+    fn test_validate_download_dir_rejects_system_paths() {
         for path in ["/usr", "/etc", "/boot", "/sys", "/proc", "/dev", "/var"] {
             assert!(
-                validate_directory(Path::new(path)).is_err(),
+                validate_download_dir(Path::new(path)).is_err(),
                 "should reject {path}"
             );
         }
     }
 
     #[test]
-    fn test_validate_directory_rejects_trailing_slash() {
-        assert!(validate_directory(Path::new("/etc/")).is_err());
+    fn test_validate_download_dir_rejects_trailing_slash() {
+        assert!(validate_download_dir(Path::new("/etc/")).is_err());
     }
 
     #[test]
-    fn test_validate_directory_accepts_normal_paths() {
-        assert!(validate_directory(Path::new("/home/user/photos")).is_ok());
-        assert!(validate_directory(Path::new("/mnt/photos")).is_ok());
-        assert!(validate_directory(Path::new("/data/sync")).is_ok());
+    fn test_validate_download_dir_accepts_normal_paths() {
+        assert!(validate_download_dir(Path::new("/home/user/photos")).is_ok());
+        assert!(validate_download_dir(Path::new("/mnt/photos")).is_ok());
+        assert!(validate_download_dir(Path::new("/data/sync")).is_ok());
     }
 
     // ── resolve_library_selection ──────────────────────────────────

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -786,7 +786,9 @@ fn import_existing_rejects_nonexistent_directory() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Directory does not exist"));
+        .stderr(predicate::str::contains(
+            "Cannot read download directory /does/not/exist/anywhere",
+        ));
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Three closely related cleanups from `2026-04-29_FOLLOWUP_PRS.md` (codebase CF-5, adversarial HF-3 + HF-4):

- **Share `validate_download_dir`.** Renamed from `validate_directory`, made `pub(crate)`, and called from import's `build_import_download_config`. Sync's `Config::build` already rejected the system-directory deny list (`/bin`, `/etc`, `/usr`, ...); now import does too with the same error. Closes the asymmetry where `kei import-existing --download-dir /etc` would proceed past config build.
- **Replace import's `directory.exists()` TOCTOU.** The boolean precondition is replaced with a `tokio::fs::metadata` call that acts on its own result. `dir_cache::read_dir_entries` swallows read errors and returns an empty map, so a missing directory had been surfacing as a silent \"0 files matched\"; the new check bails clearly with `Cannot read download directory <path>: <io error>` or `Not a directory`.
- **Warn on empty-filename fallback.** `expected_path.file_name().and_then(|f| f.to_str())` can return None for non-UTF8 segments, trailing slashes, or paths ending in `..`; the resulting empty filename in the `assets` table is acceptable as a fallback (no crash) but no longer total silence.

## Test plan

- [x] 3 renamed `validate_download_dir_*` tests in `src/config.rs` (243 config tests pass).
- [x] 2 new tests in `commands::import::wiremock_tests`: `build_import_download_config_rejects_system_directory` and `sync_and_import_reject_system_directory_with_same_message` (63 import tests, +2 from PR-7).
- [x] Updated `behavioral::import_existing_rejects_nonexistent_directory` to match the new error string.
- [x] `just gate` (fmt, clippy --all-targets --all-features -D warnings, full test suite, docs, audit, typos, roundtrip).