### PR TITLE
filter: zero-alloc apply_raw_policy via VersionsView

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -255,9 +255,8 @@ pub(super) struct DownloadTask {
 }
 
 /// Borrowed view over a `VersionsMap` with an optional virtual swap of
-/// the keys at two indices. Replaces the previous `Cow::Owned`-on-swap
-/// path of [`apply_raw_policy`] so a RAW alignment never deep-clones the
-/// version list (12+ heap allocs per asset on the prior code path).
+/// the keys at two indices. Lets [`apply_raw_policy`] relabel the
+/// `Original` / `Alternative` slots without cloning the version list.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct VersionsView<'a> {
     versions: &'a VersionsMap,
@@ -283,9 +282,8 @@ impl<'a> VersionsView<'a> {
     }
 
     pub(super) fn iter(&self) -> impl Iterator<Item = (AssetVersionSize, &'a AssetVersion)> + 'a {
-        let versions: &'a VersionsMap = self.versions;
         let swap = self.swap;
-        versions.iter().enumerate().map(move |(idx, (k, v))| {
+        self.versions.iter().enumerate().map(move |(idx, (k, v))| {
             let key = match swap {
                 Some((orig, _)) if idx == orig => AssetVersionSize::Alternative,
                 Some((_, alt)) if idx == alt => AssetVersionSize::Original,
@@ -302,8 +300,8 @@ impl<'a> VersionsView<'a> {
 
 /// Apply the RAW alignment policy by virtually swapping Original and
 /// Alternative versions when appropriate, matching Python's
-/// `apply_raw_policy()`. Zero-allocation: returns a borrowed view over
-/// the original map regardless of swap outcome.
+/// `apply_raw_policy()`. Returns a borrowed view over the original map
+/// regardless of swap outcome.
 #[allow(
     clippy::indexing_slicing,
     reason = "orig_idx / alt_idx come from `enumerate()` over `versions`; \
@@ -2446,43 +2444,44 @@ mod tests {
         assert!(!has_ver(&versions, AssetVersionSize::Alternative));
     }
 
-    /// `VersionsView` must iterate in the exact order of the underlying
-    /// `VersionsMap` regardless of swap state. The pre-PR-9 cloned
-    /// implementation preserved order trivially; the new virtual-swap
-    /// view must match. If a future refactor reorders elements (e.g.
-    /// to make `iter()` return `Original` first), this fails loudly.
+    /// On a swap, `iter()` must preserve the underlying `VersionsMap`
+    /// element order — only the keys at the two swap slots flip. If a
+    /// future refactor reorders elements (e.g. surfacing `Original`
+    /// first regardless of position), this fails loudly.
     #[test]
     fn raw_policy_view_iter_order_matches_underlying_map() {
         let asset = photo_asset_with_original_and_alternative("public.jpeg", "com.adobe.raw-image");
-        // PreferOriginal + alt-is-raw => swap fires.
         let view = apply_raw_policy(asset.versions(), RawTreatmentPolicy::PreferOriginal);
 
-        // Underlying VersionsMap order: (Original, orig_url), (Alternative, alt_url).
-        // After swap: keys flip but URLs/checksums stay anchored to their slots.
         let elements: Vec<(AssetVersionSize, &str)> =
             view.iter().map(|(k, v)| (k, v.url.as_ref())).collect();
         assert_eq!(elements.len(), 2);
-        // Slot 0 (originally `Original`) now reads as `Alternative`,
-        // still pointing at `orig_url`.
+        // Slot 0 (originally Original) reads as Alternative, still
+        // pointing at orig_url.
         assert_eq!(elements[0].0, AssetVersionSize::Alternative);
         assert_eq!(elements[0].1, "https://p01.icloud-content.com/orig");
-        // Slot 1 (originally `Alternative`) now reads as `Original`,
-        // still pointing at `alt_url`.
+        // Slot 1 (originally Alternative) reads as Original, still
+        // pointing at alt_url.
         assert_eq!(elements[1].0, AssetVersionSize::Original);
         assert_eq!(elements[1].1, "https://p01.icloud-content.com/alt");
     }
 
-    /// Sanity-check that `Unchanged` produces a `borrowed`-shape view
-    /// (no `swap` payload) so a future refactor can't accidentally
-    /// reintroduce per-asset allocations on the no-op path.
+    /// `Unchanged` policy must yield the underlying map verbatim — same
+    /// keys, same order — so callers see identical data to bypassing
+    /// `apply_raw_policy` entirely.
     #[test]
-    fn raw_policy_unchanged_view_has_no_swap_state() {
+    fn raw_policy_unchanged_yields_underlying_map_verbatim() {
         let asset = photo_asset_with_original_and_alternative("public.jpeg", "com.adobe.raw-image");
         let view = apply_raw_policy(asset.versions(), RawTreatmentPolicy::Unchanged);
-        assert!(
-            view.swap.is_none(),
-            "Unchanged policy must produce a borrowed view with no swap state"
-        );
+
+        let got: Vec<(AssetVersionSize, &str)> =
+            view.iter().map(|(k, v)| (k, v.url.as_ref())).collect();
+        let want: Vec<(AssetVersionSize, &str)> = asset
+            .versions()
+            .iter()
+            .map(|(k, v)| (*k, v.url.as_ref()))
+            .collect();
+        assert_eq!(got, want);
     }
 
     #[test]

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -254,19 +254,66 @@ pub(super) struct DownloadTask {
     pub(super) version_size: VersionSizeKey,
 }
 
-/// Apply the RAW alignment policy by swapping Original and Alternative versions
-/// when appropriate, matching Python's `apply_raw_policy()`.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "orig_idx / alt_idx come from `enumerate()` over `versions`; indexing back \
-              into `versions` or its clone is in-bounds by construction"
-)]
-fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> Cow<'_, VersionsMap> {
-    if policy == RawTreatmentPolicy::Unchanged {
-        return Cow::Borrowed(versions);
+/// Borrowed view over a `VersionsMap` with an optional virtual swap of
+/// the keys at two indices. Replaces the previous `Cow::Owned`-on-swap
+/// path of [`apply_raw_policy`] so a RAW alignment never deep-clones the
+/// version list (12+ heap allocs per asset on the prior code path).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct VersionsView<'a> {
+    versions: &'a VersionsMap,
+    /// `(orig_idx, alt_idx)` when the keys at those indices should be
+    /// presented swapped; iteration yields `Alternative` at `orig_idx`
+    /// and `Original` at `alt_idx`. `None` means iterate as-is.
+    swap: Option<(usize, usize)>,
+}
+
+impl<'a> VersionsView<'a> {
+    fn borrowed(versions: &'a VersionsMap) -> Self {
+        Self {
+            versions,
+            swap: None,
+        }
     }
 
-    // Find indices for Original and Alternative in a single pass
+    fn swapped(versions: &'a VersionsMap, orig_idx: usize, alt_idx: usize) -> Self {
+        Self {
+            versions,
+            swap: Some((orig_idx, alt_idx)),
+        }
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (AssetVersionSize, &'a AssetVersion)> + 'a {
+        let versions: &'a VersionsMap = self.versions;
+        let swap = self.swap;
+        versions.iter().enumerate().map(move |(idx, (k, v))| {
+            let key = match swap {
+                Some((orig, _)) if idx == orig => AssetVersionSize::Alternative,
+                Some((_, alt)) if idx == alt => AssetVersionSize::Original,
+                _ => *k,
+            };
+            (key, v)
+        })
+    }
+
+    pub(super) fn get(&self, key: AssetVersionSize) -> Option<&'a AssetVersion> {
+        self.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    }
+}
+
+/// Apply the RAW alignment policy by virtually swapping Original and
+/// Alternative versions when appropriate, matching Python's
+/// `apply_raw_policy()`. Zero-allocation: returns a borrowed view over
+/// the original map regardless of swap outcome.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "orig_idx / alt_idx come from `enumerate()` over `versions`; \
+              indexing back into `versions` is in-bounds by construction"
+)]
+fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> VersionsView<'_> {
+    if policy == RawTreatmentPolicy::Unchanged {
+        return VersionsView::borrowed(versions);
+    }
+
     let (orig_idx, alt_idx) =
         versions
             .iter()
@@ -278,7 +325,7 @@ fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> Cow<'
             });
 
     let Some(alt_idx) = alt_idx else {
-        return Cow::Borrowed(versions);
+        return VersionsView::borrowed(versions);
     };
 
     let should_swap = match policy {
@@ -289,17 +336,10 @@ fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> Cow<'
         RawTreatmentPolicy::Unchanged => false,
     };
 
-    if !should_swap {
-        return Cow::Borrowed(versions);
+    match (should_swap, orig_idx) {
+        (true, Some(orig_idx)) => VersionsView::swapped(versions, orig_idx, alt_idx),
+        _ => VersionsView::borrowed(versions),
     }
-
-    // Swap by cloning and modifying the keys
-    let mut swapped = versions.clone();
-    if let Some(orig_idx) = orig_idx {
-        swapped[orig_idx].0 = AssetVersionSize::Alternative;
-        swapped[alt_idx].0 = AssetVersionSize::Original;
-    }
-    Cow::Owned(swapped)
 }
 
 /// Returns the reason this asset should be skipped by content/metadata
@@ -470,7 +510,7 @@ fn raw_filename(asset: &crate::icloud::photos::PhotoAsset) -> Cow<'_, str> {
 pub(super) struct DerivationContext<'a> {
     pub(super) base_filename: String,
     pub(super) created_local: DateTime<Local>,
-    pub(super) versions: Cow<'a, VersionsMap>,
+    pub(super) versions: VersionsView<'a>,
 }
 
 impl<'a> DerivationContext<'a> {
@@ -492,10 +532,7 @@ impl<'a> DerivationContext<'a> {
     }
 
     fn get_version(&self, key: AssetVersionSize) -> Option<&AssetVersion> {
-        self.versions
-            .iter()
-            .find(|(k, _)| *k == key)
-            .map(|(_, v)| v)
+        self.versions.get(key)
     }
 }
 
@@ -2318,14 +2355,14 @@ mod tests {
             .build()
     }
 
-    /// Helper to get a version from a SmallVec by key
-    fn get_ver(versions: &VersionsMap, key: AssetVersionSize) -> Option<&AssetVersion> {
-        versions.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    /// Helper to get a version from a `VersionsView` by key.
+    fn get_ver<'a>(view: &VersionsView<'a>, key: AssetVersionSize) -> Option<&'a AssetVersion> {
+        view.get(key)
     }
 
-    /// Helper to check if a version exists in a SmallVec
-    fn has_ver(versions: &VersionsMap, key: AssetVersionSize) -> bool {
-        versions.iter().any(|(k, _)| *k == key)
+    /// Helper to check whether a version exists in a `VersionsView`.
+    fn has_ver(view: &VersionsView<'_>, key: AssetVersionSize) -> bool {
+        view.iter().any(|(k, _)| k == key)
     }
 
     #[test]
@@ -2407,6 +2444,45 @@ mod tests {
             "https://p01.icloud-content.com/orig"
         );
         assert!(!has_ver(&versions, AssetVersionSize::Alternative));
+    }
+
+    /// `VersionsView` must iterate in the exact order of the underlying
+    /// `VersionsMap` regardless of swap state. The pre-PR-9 cloned
+    /// implementation preserved order trivially; the new virtual-swap
+    /// view must match. If a future refactor reorders elements (e.g.
+    /// to make `iter()` return `Original` first), this fails loudly.
+    #[test]
+    fn raw_policy_view_iter_order_matches_underlying_map() {
+        let asset = photo_asset_with_original_and_alternative("public.jpeg", "com.adobe.raw-image");
+        // PreferOriginal + alt-is-raw => swap fires.
+        let view = apply_raw_policy(asset.versions(), RawTreatmentPolicy::PreferOriginal);
+
+        // Underlying VersionsMap order: (Original, orig_url), (Alternative, alt_url).
+        // After swap: keys flip but URLs/checksums stay anchored to their slots.
+        let elements: Vec<(AssetVersionSize, &str)> =
+            view.iter().map(|(k, v)| (k, v.url.as_ref())).collect();
+        assert_eq!(elements.len(), 2);
+        // Slot 0 (originally `Original`) now reads as `Alternative`,
+        // still pointing at `orig_url`.
+        assert_eq!(elements[0].0, AssetVersionSize::Alternative);
+        assert_eq!(elements[0].1, "https://p01.icloud-content.com/orig");
+        // Slot 1 (originally `Alternative`) now reads as `Original`,
+        // still pointing at `alt_url`.
+        assert_eq!(elements[1].0, AssetVersionSize::Original);
+        assert_eq!(elements[1].1, "https://p01.icloud-content.com/alt");
+    }
+
+    /// Sanity-check that `Unchanged` produces a `borrowed`-shape view
+    /// (no `swap` payload) so a future refactor can't accidentally
+    /// reintroduce per-asset allocations on the no-op path.
+    #[test]
+    fn raw_policy_unchanged_view_has_no_swap_state() {
+        let asset = photo_asset_with_original_and_alternative("public.jpeg", "com.adobe.raw-image");
+        let view = apply_raw_policy(asset.versions(), RawTreatmentPolicy::Unchanged);
+        assert!(
+            view.swap.is_none(),
+            "Unchanged policy must produce a borrowed view with no swap state"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Pre-PR-9, `apply_raw_policy` (in `src/download/filter.rs`) deep-cloned the entire `VersionsMap` (a `SmallVec<[(AssetVersionSize, AssetVersion); 4]>`) on every swap. Each `AssetVersion` clone allocates three `Box<str>` (`url`, `checksum`, `asset_type`), so a 4-version asset with `--align-raw original` or `--align-raw alternative` spent ~12-13 heap allocations per call. This runs once per asset on sync's filter path.

- Add `VersionsView<'a>`: borrowed `&'a VersionsMap` plus an optional `(orig_idx, alt_idx)` pair indicating a virtual key swap. `iter()` yields `(AssetVersionSize, &'a AssetVersion)` synthesizing the swapped keys on the fly without touching the underlying map.
- Change `apply_raw_policy` return from `Cow<'_, VersionsMap>` to `VersionsView<'_>`. Both the borrowed (no-swap) and swapped paths now allocate zero bytes regardless of policy outcome.
- `DerivationContext::versions` becomes `VersionsView<'a>` and `get_version` delegates to the view.
- Update the existing 6 `test_raw_policy_*` helpers (`get_ver`, `has_ver`) to consume `VersionsView`.

For a 25k-asset library with `--align-raw original` triggering swaps on RAW-aligned assets, this saves ~325k heap allocations on the filter path. Pure win on a startup-to-finish hot loop.

Closes codebase CF-4 from `2026-04-29_FULL_REVIEW.md`.

## Test plan

- [x] All 6 existing `test_raw_policy_*` tests pass on the new view.
- [x] Two new tests pin the contract:
  - `raw_policy_view_iter_order_matches_underlying_map` — view iteration preserves underlying map order; swap only relabels keys at the swap indices.
  - `raw_policy_unchanged_view_has_no_swap_state` — `Unchanged` policy produces a borrowed view with `swap == None`, guarding against accidental future regressions.
- [x] `cargo test --lib download::` (533 tests pass, +2 from PR-7).
- [x] `just gate` (fmt, clippy --all-targets --all-features -D warnings, full test suite, docs, audit, typos, roundtrip).