### PR TITLE
import: empty-library guard with --force-empty override

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -539,11 +539,13 @@ pub struct ImportArgs {
     pub no_progress_bar: bool,
 
     /// Override the empty-library safety guard. Without this flag,
-    /// `import-existing` aborts when a library returns zero assets while
-    /// the state DB has prior asset rows -- the library is almost
-    /// certainly mid-glitch (transient permissions / stale auth) and
-    /// scanning would produce a misleading `matched: 0` report. Set
-    /// this only if you have genuinely emptied the library.
+    /// `import-existing` aborts when a selected library returns zero
+    /// assets while the state DB has prior asset rows -- often a
+    /// transient iCloud permissions glitch or stale auth, where
+    /// scanning would silently produce a misleading `matched: 0`
+    /// report. Set this if you genuinely emptied the library, or if
+    /// you're attaching a new sub-library to an account that already
+    /// has data (the prior-row check is global, not per-zone).
     #[arg(long, env = "KEI_FORCE_EMPTY")]
     pub force_empty: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -537,6 +537,15 @@ pub struct ImportArgs {
     /// Disable progress bar
     #[arg(long)]
     pub no_progress_bar: bool,
+
+    /// Override the empty-library safety guard. Without this flag,
+    /// `import-existing` aborts when a library returns zero assets while
+    /// the state DB has prior asset rows -- the library is almost
+    /// certainly mid-glitch (transient permissions / stale auth) and
+    /// scanning would produce a misleading `matched: 0` report. Set
+    /// this only if you have genuinely emptied the library.
+    #[arg(long, env = "KEI_FORCE_EMPTY")]
+    pub force_empty: bool,
 }
 
 /// Arguments for the verify command.
@@ -2696,6 +2705,50 @@ mod tests {
     fn import_existing_force_size_flag_parses_to_true() {
         let args = parse_import(&["--force-size"]);
         assert_eq!(args.force_size, Some(true));
+    }
+
+    #[test]
+    fn import_existing_force_empty_flag_parses_to_true() {
+        let _guard = scrub_auth_env();
+        // SAFETY: scrub_auth_env serializes against the env_var test that
+        // also mutates KEI_FORCE_EMPTY. Clearing here protects against a
+        // developer shell that has KEI_FORCE_EMPTY=true exported.
+        unsafe {
+            std::env::remove_var("KEI_FORCE_EMPTY");
+        }
+        let args = parse_import(&["--force-empty"]);
+        assert!(args.force_empty);
+    }
+
+    #[test]
+    fn import_existing_force_empty_default_is_false() {
+        let _guard = scrub_auth_env();
+        // SAFETY: same rationale as the flag test above.
+        unsafe {
+            std::env::remove_var("KEI_FORCE_EMPTY");
+        }
+        let args = parse_import(&[]);
+        assert!(!args.force_empty);
+    }
+
+    #[test]
+    fn import_existing_force_empty_env_var_parses_to_true() {
+        let _guard = scrub_auth_env();
+        // SAFETY: scrub_auth_env serializes against any other test that
+        // mutates these env vars; KEI_FORCE_EMPTY is read synchronously by
+        // clap during parse below.
+        unsafe {
+            std::env::set_var("KEI_FORCE_EMPTY", "true");
+        }
+        let cli =
+            Cli::try_parse_from(["kei", "import-existing", "--download-dir", "/tmp"]).unwrap();
+        unsafe {
+            std::env::remove_var("KEI_FORCE_EMPTY");
+        }
+        match cli.command {
+            Some(Command::ImportExisting(args)) => assert!(args.force_empty),
+            _ => panic!("Expected ImportExisting command"),
+        }
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -6,6 +6,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use anyhow::Context;
+
 use crate::auth;
 use crate::cli;
 use crate::config;
@@ -364,6 +366,21 @@ pub(crate) async fn run_import_existing(
     let selection = config::resolve_library_selection(args.library.clone(), toml_filters);
     let libraries = resolve_libraries(&selection, &mut photos_service).await?;
 
+    let prior_db_total = db.get_summary().await?.total_assets;
+    if prior_db_total > 0 && !args.force_empty {
+        let mut empty_zones: Vec<String> = Vec::new();
+        for library in &libraries {
+            let count =
+                library.all().len().await.with_context(|| {
+                    format!("counting assets in library {}", library.zone_name())
+                })?;
+            if count == 0 {
+                empty_zones.push(library.zone_name().to_string());
+            }
+        }
+        check_empty_library_guard(&empty_zones, prior_db_total)?;
+    }
+
     if !args.no_progress_bar {
         println!("Scanning iCloud assets and matching with local files...");
     }
@@ -402,6 +419,25 @@ pub(crate) async fn run_import_existing(
     println!("  Hash errors:          {}", totals.hash_errors);
 
     Ok(())
+}
+
+/// Refuse to scan when one or more selected libraries returned zero assets
+/// while the state DB has prior asset rows -- the library is almost certainly
+/// mid-glitch (transient permissions / stale auth) and a `matched: 0` report
+/// would be misleading. Caller short-circuits when `prior_db_total == 0` or
+/// `--force-empty` is set, so this function only runs when a guard is wanted.
+fn check_empty_library_guard(empty_zones: &[String], prior_db_total: u64) -> anyhow::Result<()> {
+    if empty_zones.is_empty() {
+        return Ok(());
+    }
+    let zones = empty_zones.join(", ");
+    anyhow::bail!(
+        "library {zones} returned 0 assets but the state DB has {prior_db_total} prior \
+         asset rows -- aborting to avoid a misleading `matched: 0` report. This is most \
+         often a transient iCloud permissions glitch or stale auth; re-run after \
+         confirming via `kei list libraries` or the iCloud web UI. Pass --force-empty \
+         (or set KEI_FORCE_EMPTY=true) only if you genuinely emptied the library."
+    );
 }
 
 /// Resolve a [`download::DownloadConfig`] from import-existing CLI args + TOML.
@@ -2519,6 +2555,42 @@ mod build_config_tests {
                 "{label} must name the rejection and the path; got: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn empty_library_guard_passes_with_no_empty_zones() {
+        super::check_empty_library_guard(&[], 1234)
+            .expect("no empty zones must not bail regardless of prior count");
+    }
+
+    #[test]
+    fn empty_library_guard_bails_naming_zone_and_count() {
+        let zones = vec!["PrimarySync".to_string()];
+        let err = super::check_empty_library_guard(&zones, 4321)
+            .expect_err("empty zone with prior assets must bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("PrimarySync"),
+            "must name the zone, got: {msg}"
+        );
+        assert!(
+            msg.contains("4321"),
+            "must name the prior count, got: {msg}"
+        );
+        assert!(
+            msg.contains("--force-empty"),
+            "must mention the override flag, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_library_guard_lists_all_empty_zones() {
+        let zones = vec!["PrimarySync".to_string(), "SharedSync-abc".to_string()];
+        let err = super::check_empty_library_guard(&zones, 99)
+            .expect_err("multiple empty zones must bail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("PrimarySync"), "missing PrimarySync: {msg}");
+        assert!(msg.contains("SharedSync-abc"), "missing SharedSync: {msg}");
     }
 
     /// CG-10: setting both `--directory` (deprecated) and `--download-dir`

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -368,17 +368,24 @@ pub(crate) async fn run_import_existing(
 
     let prior_db_total = db.get_summary().await?.total_assets;
     if prior_db_total > 0 && !args.force_empty {
-        let mut empty_zones: Vec<String> = Vec::new();
-        for library in &libraries {
-            let count =
-                library.all().len().await.with_context(|| {
-                    format!("counting assets in library {}", library.zone_name())
-                })?;
-            if count == 0 {
-                empty_zones.push(library.zone_name().to_string());
-            }
-        }
-        check_empty_library_guard(&empty_zones, prior_db_total)?;
+        use futures_util::{StreamExt, TryStreamExt};
+        let counts: Vec<u64> =
+            futures_util::stream::iter(libraries.iter())
+                .map(|library| async move {
+                    library.all().len().await.with_context(|| {
+                        format!("counting assets in library {}", library.zone_name())
+                    })
+                })
+                .buffered(libraries.len().max(1))
+                .try_collect()
+                .await?;
+        let empty_zones: Vec<&str> = libraries
+            .iter()
+            .zip(&counts)
+            .filter(|(_, &count)| count == 0)
+            .map(|(library, _)| library.zone_name())
+            .collect();
+        validate_non_empty_libraries(&empty_zones, prior_db_total)?;
     }
 
     if !args.no_progress_bar {
@@ -422,21 +429,28 @@ pub(crate) async fn run_import_existing(
 }
 
 /// Refuse to scan when one or more selected libraries returned zero assets
-/// while the state DB has prior asset rows -- the library is almost certainly
-/// mid-glitch (transient permissions / stale auth) and a `matched: 0` report
-/// would be misleading. Caller short-circuits when `prior_db_total == 0` or
-/// `--force-empty` is set, so this function only runs when a guard is wanted.
-fn check_empty_library_guard(empty_zones: &[String], prior_db_total: u64) -> anyhow::Result<()> {
-    if empty_zones.is_empty() {
+/// while the state DB has prior asset rows. `prior_db_total` is global, not
+/// per-zone (the assets table has no zone column), so a brand-new SharedSync
+/// joining an account with a populated PrimarySync also trips this guard --
+/// `--force-empty` is the documented escape hatch for that case. Caller
+/// short-circuits when `prior_db_total == 0` or `--force-empty` is set, so
+/// this function only runs when a guard is wanted.
+fn validate_non_empty_libraries(empty_zones: &[&str], prior_db_total: u64) -> anyhow::Result<()> {
+    let [head, tail @ ..] = empty_zones else {
         return Ok(());
-    }
-    let zones = empty_zones.join(", ");
+    };
+    let zones = if tail.is_empty() {
+        format!("library {head}")
+    } else {
+        format!("libraries {}", empty_zones.join(", "))
+    };
     anyhow::bail!(
-        "library {zones} returned 0 assets but the state DB has {prior_db_total} prior \
-         asset rows -- aborting to avoid a misleading `matched: 0` report. This is most \
-         often a transient iCloud permissions glitch or stale auth; re-run after \
+        "{zones} returned 0 assets but the state DB has {prior_db_total} prior asset \
+         rows -- aborting to avoid a misleading `matched: 0` report. Most often this \
+         is a transient iCloud permissions glitch or stale auth; re-run after \
          confirming via `kei list libraries` or the iCloud web UI. Pass --force-empty \
-         (or set KEI_FORCE_EMPTY=true) only if you genuinely emptied the library."
+         (or set KEI_FORCE_EMPTY=true) if you genuinely emptied the library or are \
+         attaching a new sub-library to an account that already has data."
     );
 }
 
@@ -2558,20 +2572,19 @@ mod build_config_tests {
     }
 
     #[test]
-    fn empty_library_guard_passes_with_no_empty_zones() {
-        super::check_empty_library_guard(&[], 1234)
+    fn validate_non_empty_libraries_passes_with_no_empty_zones() {
+        super::validate_non_empty_libraries(&[], 1234)
             .expect("no empty zones must not bail regardless of prior count");
     }
 
     #[test]
-    fn empty_library_guard_bails_naming_zone_and_count() {
-        let zones = vec!["PrimarySync".to_string()];
-        let err = super::check_empty_library_guard(&zones, 4321)
+    fn validate_non_empty_libraries_bails_naming_zone_and_count() {
+        let err = super::validate_non_empty_libraries(&["PrimarySync"], 4321)
             .expect_err("empty zone with prior assets must bail");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("PrimarySync"),
-            "must name the zone, got: {msg}"
+            msg.contains("library PrimarySync"),
+            "must use singular `library` and name the zone, got: {msg}"
         );
         assert!(
             msg.contains("4321"),
@@ -2584,13 +2597,14 @@ mod build_config_tests {
     }
 
     #[test]
-    fn empty_library_guard_lists_all_empty_zones() {
-        let zones = vec!["PrimarySync".to_string(), "SharedSync-abc".to_string()];
-        let err = super::check_empty_library_guard(&zones, 99)
+    fn validate_non_empty_libraries_pluralizes_for_multiple_zones() {
+        let err = super::validate_non_empty_libraries(&["PrimarySync", "SharedSync-abc"], 99)
             .expect_err("multiple empty zones must bail");
         let msg = format!("{err:#}");
-        assert!(msg.contains("PrimarySync"), "missing PrimarySync: {msg}");
-        assert!(msg.contains("SharedSync-abc"), "missing SharedSync: {msg}");
+        assert!(
+            msg.contains("libraries PrimarySync, SharedSync-abc"),
+            "must use plural `libraries` and list both, got: {msg}"
+        );
     }
 
     /// CG-10: setting both `--directory` (deprecated) and `--download-dir`


### PR DESCRIPTION
## Summary

When a selected iCloud library returns zero assets but the state DB already holds prior rows, the most likely cause is a transient permissions glitch or stale auth, not that the user emptied the library. Today `import-existing` scans, prints `matched: 0`, and exits 0; the operator gets no signal that anything went wrong.

This PR adds a pre-scan guard that queries the per-library `HyperionIndexCountLookup` count and bails with a message naming each empty zone, the prior DB total, and how to override.

The guard is gated by `prior_db_total > 0 && !args.force_empty`, so first-run users (fresh DB) skip the network round-trip entirely.

Closes the robustness MS-2 finding (PR-11 in `.scratch/2026-04-29_FOLLOWUP_PRS.md`).

## Behavior

| state DB | library size | `--force-empty` | result |
|----------|--------------|-----------------|--------|
| empty (fresh run) | any | any | scan as before, no extra API call |
| populated | non-empty | n/a | scan as before, one extra API call |
| populated | **empty** | not set | **bail** naming the zone + count |
| populated | empty | set | scan, print `matched: 0` |

## New flag

`--force-empty` / `KEI_FORCE_EMPTY` — override the guard for users who genuinely emptied the library.

## Test plan

- [x] `just gate` clean.
- [x] Three pure-helper unit tests for `check_empty_library_guard`: no-op when empty input, bails naming zone + count, lists multiple zones.
- [x] Three CLI unit tests for `--force-empty`: long flag parses, env var parses, default is false.
- [x] Verified `--force-empty` appears in `kei import-existing --help`.