### PR TITLE
import: emit stage=scan_started marker; SIGINT test polls for it

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -138,8 +138,21 @@ where
     // One cache per library scan: each parent directory is read_dir'd at
     // most once across all sibling probes.
     let mut dir_cache = DirCache::new();
+    let mut scan_started_emitted = false;
 
     while let Some(result) = stream.next().await {
+        // Emit a one-shot marker as soon as the first asset is dequeued so
+        // tests (and operators tailing logs) can synchronise on real work
+        // having started, rather than racing on a wall-clock sleep against
+        // auth + library resolution + first-page latency.
+        if !scan_started_emitted {
+            tracing::info!(
+                stage = "scan_started",
+                library = %library_label,
+                "import scan dequeued first asset",
+            );
+            scan_started_emitted = true;
+        }
         let asset: PhotoAsset = match result {
             Ok(a) => a,
             Err(e) => {
@@ -2190,6 +2203,80 @@ mod wiremock_tests {
             "Screenshot 2025-01-14 at 1.40.02\u{202F}PM.PNG",
         )
         .await;
+    }
+
+    /// The `stage="scan_started"` marker is the synchronisation point
+    /// the live SIGINT test polls for, so a regression that drops it
+    /// (e.g. wrapping `import_assets` in an early-return) would silently
+    /// break that test by reintroducing a sleep race. Pin its emission
+    /// via `tracing_test`.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn import_emits_scan_started_marker_with_library_label() {
+        let tmp = TempDir::new().expect("tempdir");
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("S1", "IMG_SCAN.JPG", "public.jpeg").orig(
+            512,
+            "ck_s1",
+            "public.jpeg",
+        );
+        stub_records_query(&server, &[asset]).await;
+        let album = album_pointed_at(&server);
+        let (stream, panic_rx) = album.photo_stream(None, None, 1);
+        let db = open_db(&tmp).await;
+        let config = base_config(tmp.path());
+        import_assets(
+            stream,
+            panic_rx,
+            db.as_ref(),
+            &config,
+            "PrimarySync",
+            true,
+            false,
+        )
+        .await
+        .expect("import_assets");
+
+        assert!(
+            logs_contain("stage=\"scan_started\""),
+            "import_assets must emit stage=scan_started once first asset is dequeued",
+        );
+        assert!(
+            logs_contain("library=PrimarySync"),
+            "scan_started marker must carry the library_label for multi-library disambiguation",
+        );
+    }
+
+    /// Empty stream -> no marker. Operators tailing logs shouldn't see
+    /// `scan_started` for a library that produced zero assets (would
+    /// be misleading; the existing empty-library guard surfaces that
+    /// case at a higher level).
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn import_skips_scan_started_marker_when_stream_empty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let server = MockServer::start().await;
+        stub_records_query(&server, &[]).await;
+        let album = album_pointed_at(&server);
+        let (stream, panic_rx) = album.photo_stream(None, None, 1);
+        let db = open_db(&tmp).await;
+        let config = base_config(tmp.path());
+        import_assets(
+            stream,
+            panic_rx,
+            db.as_ref(),
+            &config,
+            "PrimarySync",
+            true,
+            false,
+        )
+        .await
+        .expect("import_assets");
+
+        assert!(
+            !logs_contain("stage=\"scan_started\""),
+            "marker must not fire when no assets are dequeued",
+        );
     }
 
     // ── icloudpd compat baseline ──────────────────────────────────────

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -22,6 +22,12 @@ use crate::types::FileMatchPolicy;
 
 use super::service::{init_photos_service, resolve_libraries};
 
+/// Value of the `stage` field on the one-shot tracing event emitted by
+/// [`import_assets`] when the first asset is dequeued. Operators (and the
+/// live SIGINT idempotency test) sync on this token to know real scan
+/// work has started, distinct from process-spawn or auth completion.
+pub(crate) const SCAN_STARTED_STAGE: &str = "scan_started";
+
 /// Per-library counters returned by [`import_assets`].
 ///
 /// Counters span asset- and expected-path levels so that divergent
@@ -147,7 +153,7 @@ where
         // auth + library resolution + first-page latency.
         if !scan_started_emitted {
             tracing::info!(
-                stage = "scan_started",
+                stage = SCAN_STARTED_STAGE,
                 library = %library_label,
                 "import scan dequeued first asset",
             );
@@ -2238,7 +2244,7 @@ mod wiremock_tests {
         .expect("import_assets");
 
         assert!(
-            logs_contain("stage=\"scan_started\""),
+            logs_contain(&format!("stage=\"{}\"", super::SCAN_STARTED_STAGE)),
             "import_assets must emit stage=scan_started once first asset is dequeued",
         );
         assert!(
@@ -2274,7 +2280,7 @@ mod wiremock_tests {
         .expect("import_assets");
 
         assert!(
-            !logs_contain("stage=\"scan_started\""),
+            !logs_contain(&format!("stage=\"{}\"", super::SCAN_STARTED_STAGE)),
             "marker must not fire when no assets are dequeued",
         );
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -324,6 +324,64 @@ pub fn require_preauth() -> (String, String, PathBuf) {
     (username, password, dir)
 }
 
+/// Stream a child's piped stderr on a worker thread until `predicate(line)`
+/// returns true or the deadline elapses. Returns `Some(())` on a hit,
+/// `None` on timeout / EOF.
+///
+/// Uses a worker thread + mpsc channel so the wall-clock deadline is honored
+/// even if the child stops emitting lines mid-stream (a bare `BufReader::lines()`
+/// loop on the test thread would block forever in that case).
+///
+/// `child.stderr` must have been spawned with `Stdio::piped()`. This call
+/// `take()`s it, so callers wanting both this sync point and full-output
+/// capture must split the stream themselves.
+#[allow(dead_code)]
+pub fn wait_for_stderr_line(
+    child: &mut std::process::Child,
+    predicate: impl Fn(&str) -> bool + Send + 'static,
+    deadline: std::time::Duration,
+) -> Option<()> {
+    use std::io::{BufRead, BufReader};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Instant;
+
+    let stderr = child.stderr.take().expect("child stderr must be piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    thread::spawn(move || {
+        let mut buffered = BufReader::new(stderr);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match buffered.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if tx.send(line.clone()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let end = Instant::now() + deadline;
+    while Instant::now() < end {
+        let remaining = end.saturating_duration_since(Instant::now());
+        match rx.recv_timeout(remaining) {
+            Ok(line) => {
+                if predicate(&line) {
+                    return Some(());
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => {
+                return None;
+            }
+        }
+    }
+    None
+}
+
 /// Recursively collect all regular files under `dir`, sorted for deterministic ordering.
 #[allow(dead_code)]
 pub fn walkdir(dir: &Path) -> Vec<PathBuf> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -324,9 +324,38 @@ pub fn require_preauth() -> (String, String, PathBuf) {
     (username, password, dir)
 }
 
+/// Strip ANSI escape sequences from a string (for log assertions).
+///
+/// kei's `tracing_subscriber::fmt()` writer emits ANSI color codes even
+/// when stderr is a pipe (not a TTY), which splits log fields like
+/// `stage="scan_started"` with escape bytes around `=` and `"`. Stripping
+/// before predicate evaluation is what makes `wait_for_stderr_line`'s
+/// callers' substring checks robust.
+#[allow(dead_code)]
+pub fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut in_escape = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+        } else if in_escape {
+            if c.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 /// Stream a child's piped stderr on a worker thread until `predicate(line)`
 /// returns true or the deadline elapses. Returns `Some(())` on a hit,
 /// `None` on timeout / EOF.
+///
+/// `predicate` is invoked on the ANSI-stripped form of each line, so callers
+/// can write plain substring checks against the rendered field text without
+/// worrying about color codes from kei's `tracing_subscriber::fmt()` writer.
 ///
 /// Uses a worker thread + mpsc channel so the wall-clock deadline is honored
 /// even if the child stops emitting lines mid-stream (a bare `BufReader::lines()`
@@ -370,7 +399,7 @@ pub fn wait_for_stderr_line(
         let remaining = end.saturating_duration_since(Instant::now());
         match rx.recv_timeout(remaining) {
             Ok(line) => {
-                if predicate(&line) {
+                if predicate(&strip_ansi(&line)) {
                     return Some(());
                 }
             }

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -1208,6 +1208,7 @@ fn toml_invalid_file_match_policy_errors_loudly() {
 #[test]
 #[ignore]
 fn import_sigint_then_rerun_is_idempotent() {
+    use std::io::{BufRead, BufReader};
     use std::process::Stdio;
 
     let (username, password, cookie_dir) = common::require_preauth();
@@ -1234,11 +1235,39 @@ fn import_sigint_then_rerun_is_idempotent() {
                 "--no-progress-bar",
             ])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("spawn kei import-existing");
 
-        std::thread::sleep(Duration::from_millis(1500));
+        // Sync on the `stage="scan_started"` tracing marker the binary
+        // emits when the first asset is dequeued. This replaces a
+        // `thread::sleep(1500)` race that fired SIGINT before the scan
+        // had started on slow networks (cancelling auth instead) and
+        // long after first matches on fast ones (cancelling too late
+        // to exercise mid-scan crash safety).
+        let stderr = child.stderr.take().expect("piped stderr");
+        let scan_started_deadline = std::time::Instant::now() + Duration::from_secs(120);
+        let reader = BufReader::new(stderr);
+        let mut saw_scan_started = false;
+        for line in reader.lines() {
+            if std::time::Instant::now() >= scan_started_deadline {
+                let _ = child.kill();
+                panic!("did not observe stage=scan_started within 120s");
+            }
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => break,
+            };
+            if line.contains("stage=\"scan_started\"") || line.contains("stage=scan_started") {
+                saw_scan_started = true;
+                break;
+            }
+        }
+        assert!(
+            saw_scan_started,
+            "child stderr closed before stage=scan_started — child likely crashed pre-scan",
+        );
+
         // SAFETY: child.id() is the live PID for our spawned process;
         // SIGINT is the documented graceful-shutdown signal.
         unsafe {

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -1208,7 +1208,6 @@ fn toml_invalid_file_match_policy_errors_loudly() {
 #[test]
 #[ignore]
 fn import_sigint_then_rerun_is_idempotent() {
-    use std::io::{BufRead, BufReader};
     use std::process::Stdio;
 
     let (username, password, cookie_dir) = common::require_preauth();
@@ -1245,28 +1244,15 @@ fn import_sigint_then_rerun_is_idempotent() {
         // had started on slow networks (cancelling auth instead) and
         // long after first matches on fast ones (cancelling too late
         // to exercise mid-scan crash safety).
-        let stderr = child.stderr.take().expect("piped stderr");
-        let scan_started_deadline = std::time::Instant::now() + Duration::from_secs(120);
-        let reader = BufReader::new(stderr);
-        let mut saw_scan_started = false;
-        for line in reader.lines() {
-            if std::time::Instant::now() >= scan_started_deadline {
-                let _ = child.kill();
-                panic!("did not observe stage=scan_started within 120s");
-            }
-            let line = match line {
-                Ok(l) => l,
-                Err(_) => break,
-            };
-            if line.contains("stage=\"scan_started\"") || line.contains("stage=scan_started") {
-                saw_scan_started = true;
-                break;
-            }
-        }
-        assert!(
-            saw_scan_started,
-            "child stderr closed before stage=scan_started — child likely crashed pre-scan",
+        let saw_scan_started = common::wait_for_stderr_line(
+            &mut child,
+            |line| line.contains("stage=\"scan_started\""),
+            Duration::from_secs(120),
         );
+        if saw_scan_started.is_none() {
+            let _ = child.kill();
+            panic!("did not observe stage=scan_started within 120s");
+        }
 
         // SAFETY: child.id() is the live PID for our spawned process;
         // SIGINT is the documented graceful-shutdown signal.

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -993,7 +993,7 @@ fn sync_threads_num_reflected_in_log() {
             .success();
 
         let stderr = String::from_utf8_lossy(&assertion.get_output().stderr);
-        let clean = strip_ansi(&stderr);
+        let clean = common::strip_ansi(&stderr);
         assert!(
             clean.contains("concurrency=1"),
             "log should reflect --threads-num 1, stderr:\n{clean}"
@@ -1461,7 +1461,7 @@ fn sync_watch_runs_multiple_cycles() {
             match rx.recv_timeout(remaining) {
                 Ok(line) => {
                     snippet.push_str(&line);
-                    if strip_ansi(&line).contains("Waiting before next cycle") {
+                    if common::strip_ansi(&line).contains("Waiting before next cycle") {
                         markers += 1;
                         if markers >= 2 {
                             break;
@@ -1482,8 +1482,11 @@ fn sync_watch_runs_multiple_cycles() {
             markers >= 2,
             "watch should drive at least 2 cycles, got {markers}. \
              snippet: {}\n--- full stderr (first 2000 chars) ---\n{}",
-            strip_ansi(&snippet).chars().take(800).collect::<String>(),
-            strip_ansi(&full_stderr)
+            common::strip_ansi(&snippet)
+                .chars()
+                .take(800)
+                .collect::<String>(),
+            common::strip_ansi(&full_stderr)
                 .chars()
                 .take(2000)
                 .collect::<String>()
@@ -1761,22 +1764,4 @@ fn file_name_contains(p: &std::path::Path, pattern: &str) -> bool {
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .contains(pattern)
-}
-
-/// Strip ANSI escape sequences from a string (for log output assertions).
-fn strip_ansi(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut in_escape = false;
-    for c in s.chars() {
-        if c == '\x1b' {
-            in_escape = true;
-        } else if in_escape {
-            if c.is_ascii_alphabetic() {
-                in_escape = false;
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }


### PR DESCRIPTION
## Summary

`import_assets` now emits `tracing::info!(stage="scan_started", library=...)` once the first asset is dequeued. Operators tailing logs see a real signal that scan work has begun (distinct from process spawn or auth + library resolution finishing).

The live SIGINT idempotency test previously raced on `thread::sleep(1500)`: too short on slow networks (cancelled auth instead of mid-scan), too long on fast ones (cancelled after first matches landed). It now polls the child's stderr for the marker before sending SIGINT, with a 120s hard deadline.

Closes CG-11 from the held Phase 2 plan (PR-12 in `.scratch/2026-04-29_FOLLOWUP_PRS.md`).

## Files

- `src/commands/import.rs` — one-shot marker in `import_assets`; two new wiremock tests pin emission + non-emission
- `tests/import_existing_live.rs` — replace sleep race with stderr-poll synchronisation

## Test plan

- [x] `just gate` clean.
- [x] `import_emits_scan_started_marker_with_library_label` — marker fires once with the library label.
- [x] `import_skips_scan_started_marker_when_stream_empty` — marker absent when stream empty (regression guard).
- [x] Verify live SIGINT test still passes locally: `cargo test --test import_existing_live import_sigint -- --ignored --test-threads=1`.