### PR TITLE
docs: cleanup historical artifacts and rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ MIT - see [LICENSE](LICENSE)
 
 ## Acknowledgments
 
-kei started as `icloudpd-rs`, a Rust rewrite of [icloud-photos-downloader](https://github.com/icloud-photos-downloader/icloud_photos_downloader). Thanks to the original maintainers for their reverse-engineering work.
+The iCloud adapter builds on years of reverse-engineering by the [icloud-photos-downloader](https://github.com/icloud-photos-downloader/icloud_photos_downloader) project (kei was originally published as `icloudpd-rs` before broadening to a multi-provider sync engine). Thanks to the original maintainers for their work, which made the iCloud side of kei possible.

--- a/src/commands/import/wiremock_tests/icloudpd_compat.rs
+++ b/src/commands/import/wiremock_tests/icloudpd_compat.rs
@@ -5,12 +5,12 @@
 //! `icloud_photos_downloader`'s own test suite), then runs kei's
 //! `import_assets` loop and asserts every file matches.
 //!
-//! Why this exists: kei's positioning is "Rust rewrite of icloudpd," so the
-//! migration story is `import-existing` against a library produced by
-//! icloudpd. These tests prove kei's path computation produces identical
-//! strings to icloudpd's at every flag profile we care about. If a test in
-//! this module fails, kei has diverged from icloudpd's layout and migrating
-//! users will see unmatched files.
+//! Why this exists: kei's iCloud adapter is the migration target for users
+//! coming from icloudpd, and `import-existing` runs against libraries that
+//! icloudpd produced. These tests prove kei's path computation produces
+//! identical strings to icloudpd's at every flag profile we care about. If
+//! a test in this module fails, kei has diverged from icloudpd's layout and
+//! migrating users will see unmatched files.
 //!
 //! Source files mirrored:
 //!   - `tests/test_download_photos.py` (default policy)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
-//! kei: photo sync engine — Rust rewrite of icloud-photos-downloader.
+//! kei: media sync engine.
 //!
-//! Downloads photos and videos from iCloud via Apple's private `CloudKit` APIs.
-//! Authentication uses SRP-6a with Apple's custom variant, followed by optional
-//! 2FA. Photos are streamed with exponential-backoff retries on transient
-//! failures.
+//! Moves photos and videos between cloud services and local storage as a
+//! transparent layer: provider-agnostic core with provider-specific adapters.
+//! iCloud is the first source: authentication uses SRP-6a with Apple's custom
+//! variant followed by optional 2FA, and assets are streamed from `CloudKit`
+//! with exponential-backoff retries on transient failures. Additional sources
+//! (Google Takeout, Immich, Nextcloud, ...) plug into the same pipeline.
 //!
 //! Lint configuration lives in `[lints.clippy]` in `Cargo.toml`.
 


### PR DESCRIPTION



## Changes

- `src/lib.rs` - crate-level doc comment leads with "media sync engine," then describes iCloud as the first adapter and names planned sources (Google Takeout, Immich, Nextcloud).
- `README.md` - Acknowledgments now credits icloudpd for the iCloud adapter's reverse-engineering  Notes the original `icloudpd-rs` name as historical context.
- `src/commands/import/wiremock_tests/icloudpd_compat.rs` - module-doc "Why this exists" block kept the migration-parity rationale but dropped the framing.

## Intentionally kept

Functional references to icloudpd that exist for code/test reasons:

- migration guide (`docs/migration-from-python.md`) and CLI flag-mapping tables
- `import-existing` baseline parity tests against icloudpd's exact fixture data
- peer-tool comparisons (e.g., ADP requirements, `--temp-suffix .part`, collision handling)
- the `icloudpd-test` test album name

`CHANGELOG.md` v0.1.0 entry was left as a frozen historical record.

## Test plan

- [x] `just gate` (fmt, clippy `-D warnings`, full test suite, doc build, audit, typos, roundtrip) - 2127 tests pass
- [x] `cargo doc --no-deps --all-features` builds with the new crate-level docstring
- [x] No functional code changed; behavior unchanged