### PR TITLE
deps: bump mp4-atom past upstream HDR colr fix and paste removal

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,13 +6,6 @@
 
 [advisories]
 ignore = [
-    # `paste 1.0.15` unmaintained. Reaches kei only transitively via
-    # `mp4-atom 0.10.1` (the HEIC atom editor used by the EXIF writer).
-    # Not a vulnerability; no actionable fix on our side until upstream
-    # mp4-atom ships a paste-free release. Tracked: kei issue #310.
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
-    "RUSTSEC-2024-0436",
-
     # `rand 0.9.2` unsound with a custom logger. kei's direct
     # rand=0.10.1 is unaffected; the 0.9.2 copy reaches us only
     # transitively via reqwest -> quinn -> quinn-proto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **HDR / wide-gamut HEICs now embed XMP metadata correctly.** iOS HDR captures (iPhone 12 Pro and newer in HDR mode) carry an ICC profile in the HEIC `colr` atom under `colour_type = "prof"` (Display P3 / Display P3 Linear); a smaller share use `rICC`. The pinned mp4-atom rev decoded the profile bytes via `Buf::slice` without advancing the cursor, so the parent atom's strict end-check rejected every such file with `under decode: colr` and `--embed-xmp` / `--set-exif-rating` / `--set-exif-datetime` left the image without metadata. The kei-side retry marker would then loop forever. Fixed by bumping the mp4-atom pin past the upstream cursor-advance fix. Image bytes (`mdat`) were never affected. Closes #276; addresses #269.
+
+### Security
+
+- **`paste 1.0.15` (RUSTSEC-2024-0436, unmaintained) is no longer in the dependency graph.** Reached kei transitively through mp4-atom; the new pin uses upstream's `pastey` replacement. The `cargo audit` ignore for the advisory was removed from `.cargo/audit.toml`. Closes #310.
+
 ### Added
 
 - **Fuzz harnesses for 10 parser entry points.** New `fuzz/` directory with cargo-fuzz targets covering CloudKit JSON deserializers, auth responses (SRP init, account login, 2FA challenge), TOML config, the `*Enc` field decoders, path sanitization, HEIF atom walking, the HEIF XMP probe pipeline, Adobe XMP Toolkit (run via FFI so ASan can see C++ memory bugs), `PhotoAsset::from_records`, and the state enum `from_str` parsers. Checked-in seeds under `fuzz/seeds/` include two OOM regression repros for an upstream `mp4-atom` bug that kei calls synchronously during the EXIF probe. `just fuzz run TARGET` replays them on every invocation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,11 +1585,11 @@ dependencies = [
 [[package]]
 name = "mp4-atom"
 version = "0.10.1"
-source = "git+https://github.com/kixelated/mp4-atom?rev=d1e9e923571cbbb42c049aec7f53cd70c6f3d8ff#d1e9e923571cbbb42c049aec7f53cd70c6f3d8ff"
+source = "git+https://github.com/kixelated/mp4-atom?rev=3366b08671a6d6d7292532b922d1973f6718d5a1#3366b08671a6d6d7292532b922d1973f6718d5a1"
 dependencies = [
  "derive_more",
  "num",
- "paste",
+ "pastey",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -1774,10 +1774,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,12 +86,17 @@ xmp_toolkit = { version = "1", optional = true }
 # lives in a `mime`-type item inside the `meta` box; mp4-atom gives us the
 # box primitives to surgically insert it without decoding image data.
 #
-# Pinned to a git rev past PR #123 (which adds `uri ` infe-item support
-# needed for iOS 17+ HEICs that embed `tag:apple.com,2023:photos/<id>`
-# references — see kei #274). The fix is on `main` but unreleased; v0.11.0
-# is gated behind kixelated/mp4-atom#130. Switch back to a crates.io
-# version when 0.11.0 ships.
-mp4-atom = { git = "https://github.com/kixelated/mp4-atom", rev = "d1e9e923571cbbb42c049aec7f53cd70c6f3d8ff" }
+# Rev-tracking upstream main because several fixes we depend on are merged
+# but not yet in a crates.io release (0.11.0 is unreleased):
+#   - #123  `uri ` infe-item support for iOS 17+ HEICs (kei #274)
+#   - #153  colr cursor advance for `prof` / `rICC` ICC profiles, fixing
+#           metadata embed on HDR HEICs (kei #269, #276)
+#   - #157  bound `Vec::with_capacity` in `parse_vorbis_comment` / `Avcc`,
+#           fixes the fuzz-found OOM (upstream #154)
+#   - #161  drops the unmaintained `paste` dep in favor of `pastey`,
+#           clearing RUSTSEC-2024-0436 (kei #310)
+# Switch back to a crates.io version once a release containing these ships.
+mp4-atom = { git = "https://github.com/kixelated/mp4-atom", rev = "3366b08671a6d6d7292532b922d1973f6718d5a1" }
 
 # Error handling
 anyhow = "1"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -64,23 +64,26 @@ are gitignored.
 
 ## Findings
 
-`heif_atoms` and `heif_xmp_probe` both find an unbounded allocation in
-`mp4-atom` within seconds: a 110-byte malformed input drives a
-~21 GiB `malloc` and trips libfuzzer's OOM guard. Two distinct repros
-per target are checked in at `fuzz/seeds/heif_atoms/regression-iloc-oom*`
-and `fuzz/seeds/heif_xmp_probe/regression-iloc-oom*`. Run them through
-the harness to reproduce:
+`heif_atoms` and `heif_xmp_probe` originally found an unbounded allocation
+in `mp4-atom`: a 110-byte malformed input drove a ~21 GiB `malloc` and
+tripped libfuzzer's OOM guard. Two distinct repros per target are checked
+in at `fuzz/seeds/heif_atoms/regression-iloc-oom*` and
+`fuzz/seeds/heif_xmp_probe/regression-iloc-oom*` for posterity:
 
 ```sh
 cargo +nightly fuzz run heif_atoms fuzz/seeds/heif_atoms/regression-iloc-oom
 ```
 
-The bug is upstream in `mp4-atom`'s `parse_vorbis_comment`, not in
-kei's code. Filed as kixelated/mp4-atom#154. kei's defense-in-depth is
-PR #286, which walks top-level boxes by header and only invokes the
-iinf / iloc decoders. With #286 merged, neither harness reproduces the
-seeds anymore; without it, `just fuzz run heif_atoms` trips the seed on
-its first iteration.
+Two independent fixes ship the regression:
+
+- Upstream: kixelated/mp4-atom#157 caps `parse_vorbis_comment` and `Avcc`
+  at a 4 KiB upfront reservation (closes mp4-atom #154). kei's pinned
+  rev includes it.
+- kei: PR #286 walks top-level boxes by header and only invokes the
+  iinf / iloc decoders, skipping `dfLa` / `Avcc` entirely. Defense-in-depth
+  against any sibling decoder regressing in the same shape.
+
+Either fix on its own makes the seeds non-reproducing; both ship together.
 
 To fuzz past the OOM (so libfuzzer can find *other* bugs in the same
 target before #286 lands) raise the limit:

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -114,11 +114,12 @@ pub(crate) fn is_heif_content(bytes: &[u8]) -> bool {
 /// rather than using `Any::decode_maybe` which dispatches into mp4-atom's
 /// full type table on every box kind. That dispatch is unsafe for
 /// kei: parsers like `Dfla::decode_body` (`flac.rs::parse_vorbis_comment`)
-/// and `Avcc::decode_body` allocate from attacker-controlled length fields
-/// without a `min(..)` cap, so a malformed sub-100-byte HEIC turns into a
-/// 20+ GiB allocation. Filed upstream as kixelated/mp4-atom#154; this
-/// function avoids the problem regardless of when that lands by only
-/// invoking the iinf / iloc decoders we actually need.
+/// and `Avcc::decode_body` allocated from attacker-controlled length fields
+/// without a `min(..)` cap, so a malformed sub-100-byte HEIC turned into a
+/// 20+ GiB allocation. Fixed upstream in kixelated/mp4-atom#157 (the rev
+/// pinned in Cargo.toml includes it); this header-walk is retained as
+/// defense-in-depth against the same class of bug surfacing in a sibling
+/// decoder we don't actually need.
 pub(crate) fn extract_xmp_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
     let mut cursor: &[u8] = bytes;
     while cursor.has_remaining() {
@@ -173,12 +174,12 @@ fn extract_xmp_from_meta(file_bytes: &[u8], meta_body: &[u8]) -> Option<Vec<u8>>
         }
         let body = cursor.get(..sz)?;
         // Defense-in-depth cap on the bytes handed to the typed decoders:
-        // HEIC iinf/iloc are KB-scale in real-world files. If a future
-        // mp4-atom audit turns up the same `Vec::with_capacity(<attacker
-        // count>)` pattern in `ItemInfoEntry::decode_body` or
-        // `ItemLocation::decode_body` that bit `parse_vorbis_comment`
-        // (kixelated/mp4-atom#154), this guard shorts the OOM before the
-        // decoder ever sees the body.
+        // HEIC iinf/iloc are KB-scale in real-world files. The original
+        // `Vec::with_capacity(<attacker count>)` shape that bit
+        // `parse_vorbis_comment` is fixed upstream (kixelated/mp4-atom#157,
+        // closing #154); this guard remains so the same pattern surfacing
+        // later in `ItemInfoEntry::decode_body` or `ItemLocation::decode_body`
+        // shorts the OOM before the decoder ever sees the body.
         const MAX_META_SUBBOX_BYTES: usize = 8 * 1024 * 1024;
         if body.len() <= MAX_META_SUBBOX_BYTES {
             if h.kind == FourCC::new(b"iinf") {
@@ -732,9 +733,10 @@ mod tests {
         // Pre-fix, `Any::decode_maybe` saw a top-level `dfLa` FourCC,
         // dispatched to `Dfla::decode_body` -> `parse_vorbis_comment`, and
         // tried to `Vec::with_capacity(~876_000_000)` for a `Vec<String>`
-        // (~21 GiB) - upstream kixelated/mp4-atom#154. The kei-side fix is
-        // to walk top-level boxes by header and only descend into `meta`,
-        // so this input must return None promptly without allocating.
+        // (~21 GiB) - upstream kixelated/mp4-atom#154, fixed in #157. The
+        // kei-side fix is independent: walk top-level boxes by header and
+        // only descend into `meta`, so a hostile `dfLa` here is skipped
+        // even if a future regression reintroduces the upstream bug.
         const REPRO: &[u8] = &[
             0x00, 0x00, 0x00, 0x08, 0x00, 0x1d, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00, 0x64, 0x66,
             0x4c, 0x61, 0x00, 0x00, 0x00, 0xf6, 0x6a, 0x00, 0x00, 0x10, 0x0d, 0xaa, 0x6b, 0x9d,
@@ -751,11 +753,13 @@ mod tests {
 
     #[test]
     fn extract_xmp_bytes_meta_with_nested_dfla_is_safe() {
-        // The same upstream OOM is reachable from a `meta` box that contains
+        // The same upstream OOM was reachable from a `meta` box containing
         // a nested `dfLa` sub-atom, because mp4_atom::Meta::decode_body uses
-        // `Any::decode_maybe` internally on every item. The kei-side fix
-        // also walks meta sub-boxes by header so only `iinf`/`iloc` decoders
-        // run; an attacker-supplied `dfLa` inside `meta` is skipped.
+        // `Any::decode_maybe` internally on every item. Upstream #157 caps
+        // the `parse_vorbis_comment` allocation at the root, but the kei
+        // header-walk also descends into meta with only `iinf`/`iloc`
+        // decoders, so an attacker-supplied `dfLa` inside `meta` is skipped
+        // regardless of upstream regressions.
         //
         // Layout: <meta box header> <version+flags> <hdlr box> <dfLa box>.
         // The dfLa body declares 0xFFFF_FFFF Vorbis comment fields; pre-fix

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1040,7 +1040,9 @@ pub mod __fuzz {
     }
 
     /// Walk an HEIC byte buffer for the embedded XMP packet. Defense-in-depth
-    /// against the upstream mp4-atom OOM (kixelated/mp4-atom#154).
+    /// against the upstream mp4-atom OOM class that hit `parse_vorbis_comment`
+    /// (kixelated/mp4-atom#154, fixed upstream in #157) and any sibling
+    /// decoders that might regress in the same shape.
     pub fn heif_extract_xmp(bytes: &[u8]) -> Option<Vec<u8>> {
         crate::download::heif::extract_xmp_bytes(bytes)
     }


### PR DESCRIPTION
## Summary

Bumps the `mp4-atom` rev pin from `d1e9e923` to `3366b086` (six commits ahead) to pick up three upstream fixes that resolve open kei issues:

- **kixelated/mp4-atom#153** - `colr` cursor advance for `prof` / `rICC` ICC profiles. Fixes metadata-embed failure on HDR / wide-gamut HEICs (Display P3, Display P3 Linear). **Closes #276**; addresses #269.
- **kixelated/mp4-atom#157** - bound `Vec::with_capacity` in `parse_vorbis_comment` / `Avcc`. Caps the OOM that the heif fuzz harness found (upstream #154). kei's by-header walk in `extract_xmp_bytes` stays as defense-in-depth for any sibling decoder that might regress in the same shape.
- **kixelated/mp4-atom#161** - replace unmaintained `paste` with `pastey`. Drops `RUSTSEC-2024-0436` from the dependency graph. **Closes #310**.

The non-mine commits in the range (#149 colr non-exhaustive, #155 colr test cleanup, **#145 unsized reads/writes refactor**) are picked up too. `#145` was the only API-shape risk; `cargo check --all-targets --all-features` is clean against the new pin.

`0.11.0` release PR upstream is still open, so the pin stays on a git rev. The `Cargo.toml` comment now enumerates which fixes the rev brings in.

## Side cleanups

- `.cargo/audit.toml` drops the `RUSTSEC-2024-0436` ignore (paste is gone from the lockfile).
- `src/download/heif.rs`, `src/lib.rs`, `fuzz/README.md` reword `#154` comments from "filed upstream" to "fixed upstream in #157; defense-in-depth retained".
- `CHANGELOG` Unreleased gets a `Fixed` (HDR HEIC embed) and a `Security` (paste) entry.

## Test plan

- [x] `cargo check --all-targets --all-features` against the new pin
- [x] `cargo audit --deny warnings` (exit 0 with the ignore removed)
- [x] `just gate` (fmt + clippy + lib/cli/behavioral tests, 1894 + 131 + 102 passing)
- [x] **Live HDR HEIC repro on the maintainer's account.** `--recent 30 --skip-videos --embed-xmp --set-exif-datetime --set-exif-rating` against the test account: 28 downloaded, 16 HEICs, 0 metadata-write failures. Spot-checked `IMG_0179.HEIC` - file has `colr prof` (the #276 affected shape) plus an embedded `<x:xmpmeta>` packet, which is exactly the case that pre-fix produced `under decode: colr`.

## Issue cleanup after merge

- `#310` and `#276` auto-close via the `Closes` keywords above.
- `#269` stays open until the reporter retests; the symptom shape ("Opening ... for XMP update") is xmp_toolkit's wrapper, so there's residual uncertainty even though the live repro looks promising.