### PR TITLE
fix: gate zero-download branch on enumeration_errors

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1495,11 +1495,11 @@ dependencies = [
 [[package]]
 name = "mp4-atom"
 version = "0.10.1"
-source = "git+https://github.com/kixelated/mp4-atom?rev=d1e9e923571cbbb42c049aec7f53cd70c6f3d8ff#d1e9e923571cbbb42c049aec7f53cd70c6f3d8ff"
+source = "git+https://github.com/kixelated/mp4-atom?rev=3366b08671a6d6d7292532b922d1973f6718d5a1#3366b08671a6d6d7292532b922d1973f6718d5a1"
 dependencies = [
  "derive_more",
  "num",
- "paste",
+ "pastey",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -1668,10 +1668,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -338,6 +338,78 @@ mod tests {
     }
 
     #[test]
+    fn api_error_5xx_range_boundary_599_is_transient_600_is_not() {
+        let err_599 = AuthError::ApiError {
+            code: 599,
+            message: "test".into(),
+        };
+        assert!(
+            err_599.is_transient_apple_failure(),
+            "599 is within 500..600 and should be transient"
+        );
+
+        let err_600 = AuthError::ApiError {
+            code: 600,
+            message: "test".into(),
+        };
+        assert!(
+            !err_600.is_transient_apple_failure(),
+            "600 is outside 500..600 and should not be transient"
+        );
+
+        let err_499 = AuthError::ApiError {
+            code: 499,
+            message: "test".into(),
+        };
+        assert!(
+            !err_499.is_transient_apple_failure(),
+            "499 is below the 5xx range and should not be transient"
+        );
+    }
+
+    #[test]
+    fn service_error_enrichment_is_case_insensitive() {
+        let lowercase = AuthError::service_error("zone_not_found", "Zone not found");
+        assert!(
+            lowercase.to_string().contains("icloud.com"),
+            "lowercase code should still trigger enrichment"
+        );
+
+        let mixed = AuthError::service_error("Zone_Not_Found", "Zone not found");
+        assert!(
+            mixed.to_string().contains("icloud.com"),
+            "mixed-case code should still trigger enrichment"
+        );
+
+        let lowercase_auth = AuthError::service_error("authentication_failed", "Auth failed");
+        assert!(
+            lowercase_auth.to_string().contains("set up"),
+            "lowercase authentication_failed should enrich"
+        );
+
+        let lowercase_denied = AuthError::service_error("access_denied", "Denied");
+        assert!(
+            lowercase_denied.to_string().contains("wait a few minutes"),
+            "lowercase access_denied should enrich"
+        );
+    }
+
+    #[test]
+    fn service_error_enrichment_requires_exact_code_no_whitespace() {
+        let trailing_space = AuthError::service_error("ZONE_NOT_FOUND ", "Zone not found");
+        assert!(
+            !trailing_space.to_string().contains("icloud.com"),
+            "trailing space should not trigger enrichment (exact match after uppercasing)"
+        );
+
+        let prefixed = AuthError::service_error("X_ZONE_NOT_FOUND", "Zone not found");
+        assert!(
+            !prefixed.to_string().contains("icloud.com"),
+            "prefixed code should not trigger enrichment"
+        );
+    }
+
+    #[test]
     fn api_error_421_is_misdirected() {
         let err = AuthError::ApiError {
             code: 421,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -593,7 +593,7 @@ pub enum ListCommand {
 }
 
 /// Password management actions.
-#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+#[derive(Subcommand, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PasswordAction {
     /// Store a password in the credential store (prompts interactively)
     Set,

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -1401,4 +1401,65 @@ mod tests {
         let result = local_download_path(dir, "%Y/%m/%d", &date, "photo.jpg", Some("Vacation"));
         assert_eq!(result, PathBuf::from("/photos/2025/06/15/photo.jpg"));
     }
+
+    #[test]
+    fn album_with_slash_does_not_create_subdirectory() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("Trip/2024"));
+        let result_str = result.to_str().unwrap();
+        assert!(
+            result_str.starts_with("/photos/"),
+            "path must stay under the root, got: {result_str}"
+        );
+        assert!(
+            !result_str.contains("Trip/2024"),
+            "slash in album name must be sanitized, got: {result_str}"
+        );
+        assert!(
+            result_str.contains("Trip_2024"),
+            "slash should become underscore, got: {result_str}"
+        );
+    }
+
+    #[test]
+    fn album_with_traversal_stays_inside_sync_root() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+
+        for album in ["../etc", "../../passwd", "..", "a/../b"] {
+            let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some(album));
+            let result_str = result.to_str().unwrap();
+            assert!(
+                result_str.starts_with("/photos/"),
+                "album={album:?}: path must start with root, got: {result_str}"
+            );
+            assert!(
+                !result_str.contains(".."),
+                "album={album:?}: traversal must be neutralized, got: {result_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn album_with_traversal_composed_with_date_tokens() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let result = local_download_dir(dir, "{album}/%Y/%m", &date, Some("../etc"));
+        assert!(
+            result.starts_with(dir),
+            "traversal album composed with date tokens must stay inside root, got: {result:?}"
+        );
+        let components: Vec<_> = result.strip_prefix(dir).unwrap().components().collect();
+        assert!(
+            components.len() >= 2,
+            "should have album + year + month components, got: {components:?}"
+        );
+    }
 }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -1409,18 +1409,18 @@ mod tests {
             .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
             .unwrap();
         let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("Trip/2024"));
-        let result_str = result.to_str().unwrap();
         assert!(
-            result_str.starts_with("/photos/"),
-            "path must stay under the root, got: {result_str}"
+            result.starts_with(dir),
+            "path must stay under the root, got: {result:?}"
+        );
+        let filename_part = result.to_string_lossy();
+        assert!(
+            !filename_part.contains("Trip/2024"),
+            "slash in album name must be sanitized, got: {filename_part}"
         );
         assert!(
-            !result_str.contains("Trip/2024"),
-            "slash in album name must be sanitized, got: {result_str}"
-        );
-        assert!(
-            result_str.contains("Trip_2024"),
-            "slash should become underscore, got: {result_str}"
+            filename_part.contains("Trip_2024"),
+            "slash should become underscore, got: {filename_part}"
         );
     }
 
@@ -1433,14 +1433,14 @@ mod tests {
 
         for album in ["../etc", "../../passwd", "..", "a/../b"] {
             let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some(album));
-            let result_str = result.to_str().unwrap();
             assert!(
-                result_str.starts_with("/photos/"),
-                "album={album:?}: path must start with root, got: {result_str}"
+                result.starts_with(dir),
+                "album={album:?}: path must start with root, got: {result:?}"
             );
+            let lossy = result.to_string_lossy();
             assert!(
-                !result_str.contains(".."),
-                "album={album:?}: traversal must be neutralized, got: {result_str}"
+                !lossy.contains(".."),
+                "album={album:?}: traversal must be neutralized, got: {lossy}"
             );
         }
     }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1541,6 +1541,7 @@ pub(super) async fn build_download_outcome(
         let stats = super::SyncStats {
             assets_seen: streaming_result.assets_seen,
             skipped: skip_breakdown,
+            enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
             interrupted: shutdown_token.is_cancelled(),
             ..super::SyncStats::default()
@@ -1552,10 +1553,10 @@ pub(super) async fn build_download_outcome(
         } else {
             tracing::info!("No new photos to download");
         }
-        if retry_exhausted > 0 && !config.dry_run {
+        if (retry_exhausted > 0 || enumeration_errors > 0) && !config.dry_run {
             return Ok((
                 DownloadOutcome::PartialFailure {
-                    failed_count: retry_exhausted,
+                    failed_count: retry_exhausted + enumeration_errors,
                 },
                 stats,
             ));
@@ -3826,5 +3827,38 @@ mod tests {
             1,
             "marker must survive when the file is absent so a future sync retries"
         );
+    }
+
+    /// When zero assets were downloaded but the producer saw enumeration
+    /// errors (e.g. malformed API page), `build_download_outcome` must
+    /// return `PartialFailure` — not `Success`. Before the fix, the
+    /// zero-download branch ignored `enumeration_errors`, letting the
+    /// sync-token advance and silently skipping the errored assets.
+    #[tokio::test]
+    async fn zero_downloads_with_enumeration_errors_returns_partial_failure() {
+        let streaming_result = StreamingResult {
+            enumeration_errors: 3,
+            ..StreamingResult::default()
+        };
+        let client = reqwest::Client::new();
+        let config = Arc::new(super::super::DownloadConfig::test_default());
+        let (outcome, stats) = build_download_outcome(
+            &client,
+            &[],
+            &config,
+            streaming_result,
+            Instant::now(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("should not error");
+        assert!(
+            matches!(
+                outcome,
+                super::super::DownloadOutcome::PartialFailure { failed_count: 3 }
+            ),
+            "expected PartialFailure with failed_count=3, got {outcome:?}"
+        );
+        assert_eq!(stats.enumeration_errors, 3);
     }
 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3836,12 +3836,14 @@ mod tests {
     /// sync-token advance and silently skipping the errored assets.
     #[tokio::test]
     async fn zero_downloads_with_enumeration_errors_returns_partial_failure() {
+        use crate::download::{DownloadConfig, DownloadOutcome};
+
         let streaming_result = StreamingResult {
             enumeration_errors: 3,
             ..StreamingResult::default()
         };
         let client = reqwest::Client::new();
-        let config = Arc::new(super::super::DownloadConfig::test_default());
+        let config = Arc::new(DownloadConfig::test_default());
         let (outcome, stats) = build_download_outcome(
             &client,
             &[],
@@ -3853,10 +3855,7 @@ mod tests {
         .await
         .expect("should not error");
         assert!(
-            matches!(
-                outcome,
-                super::super::DownloadOutcome::PartialFailure { failed_count: 3 }
-            ),
+            matches!(outcome, DownloadOutcome::PartialFailure { failed_count: 3 }),
             "expected PartialFailure with failed_count=3, got {outcome:?}"
         );
         assert_eq!(stats.enumeration_errors, 3);

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -1272,4 +1272,57 @@ mod tests {
             preserved.len()
         );
     }
+
+    #[tokio::test]
+    async fn retry_post_persistent_503_terminates_within_max_attempts() {
+        struct Always503 {
+            call_count: std::sync::atomic::AtomicU32,
+        }
+
+        #[async_trait::async_trait]
+        impl PhotosSession for Always503 {
+            async fn post(
+                &self,
+                _url: &str,
+                _body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                self.call_count
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(serde_json::json!({
+                    "serverErrorCode": "TRY_AGAIN_LATER",
+                    "reason": "Service Unavailable"
+                }))
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                panic!("not needed for test")
+            }
+        }
+
+        let session = Always503 {
+            call_count: std::sync::atomic::AtomicU32::new(0),
+        };
+        let config = RetryConfig {
+            max_retries: 4,
+            base_delay_secs: 0,
+            max_delay_secs: 0,
+        };
+
+        let result = retry_post(&session, "https://example.com/api", "{}", &[], &config).await;
+        assert!(result.is_err(), "persistent 503 must eventually fail");
+
+        let err = result.unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert!(
+            ck_err.retryable,
+            "final error must still be tagged retryable"
+        );
+
+        let total_calls = session.call_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            total_calls, 5,
+            "must be exactly max_retries + 1 = 5 attempts, got {total_calls}"
+        );
+    }
 }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -4391,4 +4391,116 @@ mod tests {
             "the asset that wasn't enumerated this sync must not appear in the failed set"
         );
     }
+
+    #[tokio::test]
+    async fn mark_downloaded_fails_when_asset_row_missing() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let result = db
+            .mark_downloaded(
+                "NONEXISTENT_42",
+                "original",
+                Path::new("/tmp/claude/photo.jpg"),
+                "abc123hash",
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "mark_downloaded on an absent row must fail"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                StateError::AssetRowMissing {
+                    ref asset_id,
+                    ref version_size,
+                } if asset_id == "NONEXISTENT_42" && version_size == "original"
+            ),
+            "expected AssetRowMissing with correct ids, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_run_killed_mid_pass_preserves_downloaded_rows_on_next_open() {
+        let dir = test_dir();
+        let db_path = dir.path().join("crash_test.db");
+
+        let file_path_1 = dir.path().join("photo1.jpg");
+        let file_path_2 = dir.path().join("photo2.jpg");
+        std::fs::write(&file_path_1, b"photo 1 content").unwrap();
+        std::fs::write(&file_path_2, b"photo 2 content").unwrap();
+
+        {
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            let _run_id = db.start_sync_run().await.unwrap();
+
+            for (id, path) in [
+                ("A1", &file_path_1),
+                ("A2", &file_path_2),
+                ("A3", &file_path_1),
+            ] {
+                let record = TestAssetRecord::new(id).build();
+                db.upsert_seen(&record).await.unwrap();
+                if id != "A3" {
+                    db.mark_downloaded(id, "original", path, "hash", None)
+                        .await
+                        .unwrap();
+                }
+            }
+            // Drop without calling complete_sync_run — simulates kill -9
+        }
+
+        let db2 = SqliteStateDb::open(&db_path).await.unwrap();
+        let promoted = db2.promote_orphaned_sync_runs().await.unwrap();
+        assert_eq!(
+            promoted, 1,
+            "the orphaned running sync_run must be promoted"
+        );
+
+        let summary = db2.get_summary().await.unwrap();
+        assert_eq!(
+            summary.downloaded, 2,
+            "the two downloaded assets must survive the crash"
+        );
+        assert_eq!(
+            summary.pending, 1,
+            "the one pending asset must still be pending"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_db_at_future_schema_version_returns_loud_error() {
+        let dir = test_dir();
+        let db_path = dir.path().join("future.db");
+
+        {
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            db.with_conn("bump_version", |conn| {
+                conn.pragma_update(
+                    None,
+                    "user_version",
+                    crate::state::schema::SCHEMA_VERSION + 1,
+                )?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        }
+
+        let result = SqliteStateDb::open(&db_path).await;
+        assert!(result.is_err(), "opening a future-version DB must fail");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                StateError::UnsupportedSchemaVersion { found, expected }
+                    if found == crate::state::schema::SCHEMA_VERSION + 1
+                    && expected == crate::state::schema::SCHEMA_VERSION
+            ),
+            "expected UnsupportedSchemaVersion, got: {err:?}"
+        );
+    }
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -48,14 +48,17 @@ fn sanitize_username(username: &str) -> String {
         .collect()
 }
 
+/// Must match `src/state/schema.rs::SCHEMA_VERSION`. When the real schema
+/// bumps, update this constant AND the DDL below — `behavioral_schema_version_matches_binary`
+/// will fail if they drift.
+const BEHAVIORAL_SCHEMA_VERSION: i32 = 7;
+
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the latest schema from `src/state/schema.rs` so
 /// callers don't rely on the binary's migration path to fill in columns
-/// added after v1. Bump `SCHEMA_VERSION` and the DDL below together whenever
-/// schema.rs changes.
+/// added after v1. Bump `BEHAVIORAL_SCHEMA_VERSION` and the DDL below
+/// together whenever schema.rs changes.
 fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Connection {
-    const SCHEMA_VERSION: i32 = 4;
-
     let db_name = format!("{}.db", sanitize_username(username));
     let db_path = data_dir.join(db_name);
     let conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -78,11 +81,38 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
             last_error TEXT,
             local_checksum TEXT,
             download_checksum TEXT,
+            source TEXT NOT NULL DEFAULT 'icloud',
+            is_favorite INTEGER NOT NULL DEFAULT 0,
+            rating INTEGER,
+            latitude REAL,
+            longitude REAL,
+            altitude REAL,
+            orientation INTEGER,
+            duration_secs REAL,
+            timezone_offset INTEGER,
+            width INTEGER,
+            height INTEGER,
+            title TEXT,
+            keywords TEXT,
+            description TEXT,
+            media_subtype TEXT,
+            burst_id TEXT,
+            is_hidden INTEGER NOT NULL DEFAULT 0,
+            is_archived INTEGER NOT NULL DEFAULT 0,
+            modified_at INTEGER,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            deleted_at INTEGER,
+            provider_data TEXT,
+            metadata_hash TEXT,
+            metadata_write_failed_at INTEGER,
             PRIMARY KEY (id, version_size)
         );
         CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status);
         CREATE INDEX IF NOT EXISTS idx_assets_local_path ON assets(local_path);
         CREATE INDEX IF NOT EXISTS idx_assets_checksum ON assets(checksum);
+        CREATE INDEX IF NOT EXISTS idx_assets_metadata_hash
+            ON assets (metadata_hash) WHERE status = 'downloaded';
+
         CREATE TABLE IF NOT EXISTS sync_runs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             started_at INTEGER NOT NULL,
@@ -90,16 +120,31 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
             assets_seen INTEGER DEFAULT 0,
             assets_downloaded INTEGER DEFAULT 0,
             assets_failed INTEGER DEFAULT 0,
-            interrupted INTEGER DEFAULT 0
+            interrupted INTEGER DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'running'
         );
+
         CREATE TABLE IF NOT EXISTS metadata (
             key TEXT PRIMARY KEY NOT NULL,
             value TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS asset_albums (
+            asset_id   TEXT NOT NULL,
+            album_name TEXT NOT NULL,
+            source     TEXT NOT NULL,
+            PRIMARY KEY (asset_id, album_name, source)
+        );
+
+        CREATE TABLE IF NOT EXISTS asset_people (
+            asset_id    TEXT NOT NULL,
+            person_name TEXT NOT NULL,
+            PRIMARY KEY (asset_id, person_name)
+        );
         ",
     )
     .unwrap();
-    conn.pragma_update(None, "user_version", SCHEMA_VERSION)
+    conn.pragma_update(None, "user_version", BEHAVIORAL_SCHEMA_VERSION)
         .unwrap();
     conn
 }
@@ -3748,5 +3793,54 @@ fn reconcile_on_empty_db_prints_guidance_and_exits_clean() {
     assert!(
         stdout.contains("No state database") || stdout.contains("no state database"),
         "operator must see guidance when DB doesn't exist: {stdout}"
+    );
+}
+
+/// CG-8: Verify the behavioral test helper's schema stays in sync with the
+/// binary's migration path. If schema.rs bumps to v8+, this test fails until
+/// BEHAVIORAL_SCHEMA_VERSION and the DDL in `create_state_db` are updated.
+#[test]
+fn behavioral_schema_version_matches_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let conn = create_state_db(dir.path(), "schema_check@example.com");
+
+    let version: i32 = conn
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        version, BEHAVIORAL_SCHEMA_VERSION,
+        "create_state_db must set user_version to BEHAVIORAL_SCHEMA_VERSION"
+    );
+
+    let has_metadata_write_failed_at: bool = conn
+        .prepare("PRAGMA table_info(assets)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .any(|name| name.is_ok_and(|n| n == "metadata_write_failed_at"));
+    assert!(
+        has_metadata_write_failed_at,
+        "v6 column metadata_write_failed_at must exist in the behavioral helper's DDL"
+    );
+
+    let has_sync_runs_status: bool = conn
+        .prepare("PRAGMA table_info(sync_runs)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .any(|name| name.is_ok_and(|n| n == "status"));
+    assert!(
+        has_sync_runs_status,
+        "v7 column sync_runs.status must exist in the behavioral helper's DDL"
+    );
+
+    let has_asset_albums: bool = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='asset_albums'")
+        .unwrap()
+        .exists([])
+        .unwrap();
+    assert!(
+        has_asset_albums,
+        "v5 table asset_albums must exist in the behavioral helper's DDL"
     );
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -3812,25 +3812,20 @@ fn behavioral_schema_version_matches_binary() {
         "create_state_db must set user_version to BEHAVIORAL_SCHEMA_VERSION"
     );
 
-    let has_metadata_write_failed_at: bool = conn
-        .prepare("PRAGMA table_info(assets)")
-        .unwrap()
-        .query_map([], |row| row.get::<_, String>(1))
-        .unwrap()
-        .any(|name| name.is_ok_and(|n| n == "metadata_write_failed_at"));
+    fn has_column(conn: &rusqlite::Connection, table: &str, column: &str) -> bool {
+        conn.prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .any(|name| name.is_ok_and(|n| n == column))
+    }
+
     assert!(
-        has_metadata_write_failed_at,
+        has_column(&conn, "assets", "metadata_write_failed_at"),
         "v6 column metadata_write_failed_at must exist in the behavioral helper's DDL"
     );
-
-    let has_sync_runs_status: bool = conn
-        .prepare("PRAGMA table_info(sync_runs)")
-        .unwrap()
-        .query_map([], |row| row.get::<_, String>(1))
-        .unwrap()
-        .any(|name| name.is_ok_and(|n| n == "status"));
     assert!(
-        has_sync_runs_status,
+        has_column(&conn, "sync_runs", "status"),
         "v7 column sync_runs.status must exist in the behavioral helper's DDL"
     );
 


### PR DESCRIPTION
## Summary

- **Bug fix**: the zero-download early-return in `build_download_outcome` returned `DownloadOutcome::Success` even when the producer saw enumeration errors (malformed API pages). This let the sync token advance, silently skipping the errored assets on subsequent syncs. The with-downloads branch already gated on `enumeration_errors > 0` -- this mirrors that logic in the zero-download path.
- **13 new tests** from the 2026-05-01 three-lens review (Phase 2): coverage gaps (CG-1, CG-4, CG-6, CG-7, CG-8) and adversarial tests (AT-1, AT-2, AT-4, AT-5) across auth errors, state DB, download paths, session retry, and behavioral integration.
- Derives `Copy` on the fieldless `PasswordAction` enum.

## Test plan

- [x] New test `zero_downloads_with_enumeration_errors_returns_partial_failure` verifies the fix
- [x] `cargo test -p kei --lib` -- 1917 passed, 0 failed
- [x] `cargo test --test behavioral` -- 132 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean