### PR TITLE
test: close coverage gaps for HEIC XMP, credential fallback, and 421 retry guard

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -405,6 +405,34 @@ mod tests {
     }
 
     #[test]
+    fn public_api_store_retrieve_round_trips() {
+        let (_td, dir) = test_dir("pub_rt");
+        let store = CredentialStore::new("user@example.com", &dir);
+        store.store("public_api_password").unwrap();
+        let retrieved = store.retrieve().unwrap().unwrap();
+        assert_eq!(retrieved.expose_secret(), "public_api_password");
+    }
+
+    #[test]
+    fn public_api_delete_clears_credential() {
+        let (_td, dir) = test_dir("pub_delete");
+        let store = CredentialStore::new("user@example.com", &dir);
+        store.store("to_delete").unwrap();
+        assert!(store.retrieve().unwrap().is_some());
+
+        store.delete().unwrap();
+        assert!(store.retrieve().unwrap().is_none());
+    }
+
+    #[test]
+    fn public_api_retrieve_empty_returns_none() {
+        let (_td, dir) = test_dir("pub_empty");
+        let store = CredentialStore::new("user@example.com", &dir);
+        let result = store.retrieve().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn atomic_write_sync_permissions() {
         let (_td, dir) = test_dir("atomic_perms");
         let path = dir.join("test_atomic.bin");

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -407,16 +407,17 @@ mod tests {
     #[test]
     fn public_api_store_retrieve_round_trips() {
         let (_td, dir) = test_dir("pub_rt");
-        let store = CredentialStore::new("user@example.com", &dir);
+        let store = CredentialStore::new("pub-rt@kei-test.invalid", &dir);
         store.store("public_api_password").unwrap();
         let retrieved = store.retrieve().unwrap().unwrap();
         assert_eq!(retrieved.expose_secret(), "public_api_password");
+        let _ = store.delete();
     }
 
     #[test]
     fn public_api_delete_clears_credential() {
         let (_td, dir) = test_dir("pub_delete");
-        let store = CredentialStore::new("user@example.com", &dir);
+        let store = CredentialStore::new("pub-del@kei-test.invalid", &dir);
         store.store("to_delete").unwrap();
         assert!(store.retrieve().unwrap().is_some());
 
@@ -427,7 +428,7 @@ mod tests {
     #[test]
     fn public_api_retrieve_empty_returns_none() {
         let (_td, dir) = test_dir("pub_empty");
-        let store = CredentialStore::new("user@example.com", &dir);
+        let store = CredentialStore::new("pub-empty@kei-test.invalid", &dir);
         let result = store.retrieve().unwrap();
         assert!(result.is_none());
     }

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -858,6 +858,43 @@ mod tests {
     }
 
     #[test]
+    fn insert_xmp_then_extract_round_trips_payload() {
+        let heic = include_bytes!("../../tests/data/sample.heic");
+        let xmp = b"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF/></x:xmpmeta>";
+
+        let mut rewritten: Vec<u8> = Vec::new();
+        insert_xmp(heic.as_slice(), xmp.as_slice(), &mut rewritten)
+            .expect("insert_xmp must succeed on a valid HEIC");
+
+        let extracted = extract_xmp_bytes(&rewritten)
+            .expect("extract_xmp_bytes must find the XMP we just inserted");
+        assert_eq!(extracted, xmp, "round-tripped XMP must be byte-identical");
+    }
+
+    #[test]
+    fn insert_xmp_twice_retains_only_latest() {
+        let heic = include_bytes!("../../tests/data/sample.heic");
+        let first = b"<x:xmpmeta xmlns:x='adobe:ns:meta/'><first/></x:xmpmeta>";
+        let second = b"<x:xmpmeta xmlns:x='adobe:ns:meta/'><second/></x:xmpmeta>";
+
+        let mut after_first: Vec<u8> = Vec::new();
+        insert_xmp(heic.as_slice(), first.as_slice(), &mut after_first)
+            .expect("first insert must succeed");
+
+        let mut after_second: Vec<u8> = Vec::new();
+        insert_xmp(&after_first, second.as_slice(), &mut after_second)
+            .expect("second insert must succeed");
+
+        let extracted =
+            extract_xmp_bytes(&after_second).expect("extract must find XMP after double insert");
+        assert_eq!(
+            extracted,
+            second.as_slice(),
+            "only the latest XMP packet should be present"
+        );
+    }
+
+    #[test]
     fn heif_error_io_variant_carries_underlying_io_error() {
         // Sanity-check the Io variant — the writer used by insert_xmp is
         // any std::io::Write, and io::Error must convert via From.

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -60,6 +60,15 @@ fn is_session_error(err: &anyhow::Error) -> bool {
         .is_some_and(crate::icloud::error::ICloudError::is_session_error)
 }
 
+/// Whether a CloudKit init/query error should trigger an SRP re-auth retry.
+///
+/// Returns `true` only on the first session-error encounter. A second
+/// session-error bails cleanly instead of looping under Docker's restart
+/// policy.
+fn should_retry_session_init(err: &anyhow::Error, already_retried: bool) -> bool {
+    !already_retried && is_session_error(err)
+}
+
 /// Given the user's library selection, the count of iCloud shared libraries
 /// on the account, and whether the notice has already fired, return the
 /// warning message to emit, or `None` if no notice is warranted.
@@ -389,7 +398,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         let init_result = init_photos_service(this_auth, api_retry_config).await;
         let (ss, mut ps) = match init_result {
             Ok(pair) => pair,
-            Err(e) if !retried_after_session_error && is_session_error(&e) => {
+            Err(e) if should_retry_session_init(&e, retried_after_session_error) => {
                 tracing::warn!(
                     error = %e,
                     "CloudKit init failed with stale-session signature; forcing SRP re-authentication"
@@ -403,7 +412,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         };
         match resolve_libraries(&config.library, &mut ps).await {
             Ok(libs) => break (ss, ps, libs),
-            Err(e) if !retried_after_session_error && is_session_error(&e) => {
+            Err(e) if should_retry_session_init(&e, retried_after_session_error) => {
                 tracing::warn!(
                     error = %e,
                     "CloudKit returned stale-session signature; forcing SRP re-authentication"
@@ -1673,6 +1682,37 @@ mod tests {
             !is_session_error(&plain),
             "free-form anyhow::Error must not be classified as a session error"
         );
+    }
+
+    // ── should_retry_session_init ──────────────────────────────────────
+    //
+    // The init retry guard allows exactly one SRP re-auth on a session-error,
+    // then bails. This prevents infinite loops under Docker restart policies.
+
+    #[test]
+    fn should_retry_session_init_true_on_first_421() {
+        let err: anyhow::Error = crate::icloud::error::ICloudError::MisdirectedRequest.into();
+        assert!(should_retry_session_init(&err, false));
+    }
+
+    #[test]
+    fn should_retry_session_init_false_on_second_421() {
+        let err: anyhow::Error = crate::icloud::error::ICloudError::MisdirectedRequest.into();
+        assert!(!should_retry_session_init(&err, true));
+    }
+
+    #[test]
+    fn should_retry_session_init_false_for_non_session_error() {
+        let err: anyhow::Error =
+            crate::icloud::error::ICloudError::Connection("timeout".into()).into();
+        assert!(!should_retry_session_init(&err, false));
+    }
+
+    #[test]
+    fn should_retry_session_init_true_for_first_401() {
+        let err: anyhow::Error =
+            crate::icloud::error::ICloudError::SessionExpired { status: 401 }.into();
+        assert!(should_retry_session_init(&err, false));
     }
 
     // ── determine_sync_mode ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

A test audit flagged three surfaces with no coverage for their core contract. This adds 9 tests across 3 files (107 lines) and extracts one small function to make the 421 retry guard independently testable.

- **heif.rs**: Two round-trip tests for XMP insert/extract on a real HEIC fixture. One proves XMP survives a full rewrite cycle, the other proves a second insert replaces the first (no stale XMP accumulation).
- **credential.rs**: Three tests exercising the public `store()`/`retrieve()`/`delete()` API. Existing tests only hit the encrypted-file backend directly; these go through the keyring-first fallback path.
- **sync_loop.rs**: Extracted `should_retry_session_init()` from the inline `!retried_after_session_error && is_session_error(&e)` conjunction used in two match guards. Four tests cover the retry-once policy: first 421, second 421 (rejected), non-session error (rejected), first 401.

## Test plan

- [x] `cargo test --lib` - 1926 passed
- [x] `just gate` - clean (fmt, clippy, tests, docs, audit, typos)