### PR TITLE
ci(docker): trigger on tag push, not release-published event

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
   push:
     branches: [main]
     paths:
@@ -10,6 +8,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - Dockerfile
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       ref:
@@ -54,7 +53,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=main,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

Restores semver-tagged docker images on release. Closes #325.

## Why

PR #324 changed `release.yml` from `on: release: types: [created]` to `on: push: tags: ['v*']`. Under the new flow, `release.yml` creates the GitHub release itself via `softprops/action-gh-release` using the default `GITHUB_TOKEN`. GitHub does not fire downstream workflow events for actions taken by `GITHUB_TOKEN` ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)), so `docker.yml`'s `release: published` trigger never fired for v0.12.2.

The only `docker.yml` run for v0.12.2 was the push-to-main trigger from the version-bump merge. Under the policy from 5ee525b that path stamps `:main` and the commit sha, never `:0.12.2`, `:0.12`, or `:latest`. The v0.12.0 / v0.12.1 releases worked because the user manually created those releases via PAT before the workflow ran (release authors are `rhoopr`, not `github-actions[bot]`).

## What changes

- `docker.yml`: drop the `release: types: [published]` trigger, add `push: tags: ['v*']`. Mirrors `release.yml` and is independent of who creates the release.
- `:latest` gate switches from `github.event_name == 'release'` to `startsWith(github.ref, 'refs/tags/v')`. Same intent under the new trigger.
- `:main` and the per-commit `:sha` tags are unchanged on push to main.

## Test plan

- [ ] Cut a patch release after merge and confirm `:0.12.3`, `:0.12`, `:latest`, and `:<sha>` all land in ghcr.
- [ ] `:main` still tracks main HEAD on a non-tag push.

## Out of scope (separate issue)

The `workflow_dispatch` hotfix path (`gh workflow run docker.yml -f ref=vX.Y.Z`) is broken for tag-content republish: `metadata-action`'s `type=semver` and `type=sha` read from `github.ref` / `github.sha` which are `main` on dispatch, so the build content from the input ref ends up tagged `:main` and `:<main-sha>`. Not regressed by this PR; predates it. Worth a follow-up that passes `value=${{ inputs.ref || github.ref_name }}` to the semver patterns and reroutes `:main` to skip dispatch.