### PR TITLE
ci: one-shot workflow to republish v0.12.2 docker tags (#325)

### DIFF
--- a/.github/workflows/retag-v0.12.2.yml
+++ b/.github/workflows/retag-v0.12.2.yml
@@ -1,0 +1,56 @@
+name: Retag v0.12.2 on ghcr (one-shot)
+
+# One-shot remediation for issue #325. The v0.12.2 docker.yml run produced only
+# :main and the per-commit :6a37560 tag (the underlying release: published trigger
+# never fired -- see PR #327 for the permanent fix). This workflow republishes the
+# already-built :6a37560 manifest under the missing :0.12.2 / :0.12 / :latest tags.
+#
+# Runs entirely registry-side via docker buildx imagetools create; no rebuild,
+# no pull/push of layers, multi-arch manifest preserved.
+#
+# DELETE THIS FILE after a successful run -- it is intentionally workflow_dispatch
+# only and has no other purpose.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show source manifest (:6a37560 = v0.12.2 commit)
+        run: docker buildx imagetools inspect ghcr.io/rhoopr/kei:6a37560
+
+      - name: Retag :6a37560 as :0.12.2 / :0.12 / :latest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/rhoopr/kei:0.12.2 \
+            --tag ghcr.io/rhoopr/kei:0.12 \
+            --tag ghcr.io/rhoopr/kei:latest \
+            ghcr.io/rhoopr/kei:6a37560
+
+      - name: Verify all four tags resolve to the same multi-arch manifest
+        run: |
+          for tag in 0.12.2 0.12 latest 6a37560; do
+            echo "::group::ghcr.io/rhoopr/kei:$tag"
+            docker buildx imagetools inspect "ghcr.io/rhoopr/kei:$tag"
+            echo "::endgroup::"
+          done
+
+      - name: Smoke test :0.12.2 prints kei 0.12.2
+        run: |
+          OUT=$(docker run --rm ghcr.io/rhoopr/kei:0.12.2 --version)
+          echo "$OUT"
+          echo "$OUT" | grep -q "0.12.2" || { echo "::error::version smoke test failed: $OUT"; exit 1; }


### PR DESCRIPTION
## Summary

One-shot remediation for #325. Adds `.github/workflows/retag-v0.12.2.yml` (workflow_dispatch only) that republishes the existing `:6a37560` multi-arch image under the missing `:0.12.2`, `:0.12`, and `:latest` tags.

## Why this works

`:6a37560` was built and pushed by `docker.yml`'s push-to-main run when the v0.12.2 version-bump merged (`6a37560` is the v0.12.2 tag commit). It is the correct binary, multi-arch (linux/amd64 + linux/arm64), just under the wrong tag name. `docker buildx imagetools create` rewrites the registry-side manifest list without rebuilding or re-pushing layers, so we avoid both a fresh build and the `workflow_dispatch` semver-tag gap mentioned as out-of-scope on PR #327.

## Plan after merge

1. `gh workflow run retag-v0.12.2.yml --repo rhoopr/kei`
2. Confirm the workflow's smoke test step passes (`docker run --rm ghcr.io/rhoopr/kei:0.12.2 --version` prints `kei 0.12.2`).
3. Confirm via `gh api /users/rhoopr/packages/container/kei/versions` that `0.12.2`, `0.12`, `latest`, `6a37560` all share one manifest digest.
4. Open a tiny follow-up PR deleting `retag-v0.12.2.yml`.
5. Close #325 with a note pointing at PR #327 for the permanent fix.

## Independent of PR #327

Can merge in either order. PR #327 fixes future releases; this PR fixes the v0.12.2 hole that already shipped.