### PR TITLE
docs: truth-up migration guides against shipped v0.13.0

### DIFF
--- a/docs/migration-from-python.md
+++ b/docs/migration-from-python.md
@@ -12,7 +12,16 @@ kei import-existing --username you@example.com --download-dir ~/Photos/iCloud
 
 This scans your local files and builds a SQLite state database so kei knows what's already been downloaded. The next `sync` run will only fetch what's new or previously failed.
 
-The import matches files by computing the expected path for each iCloud asset (using `--folder-structure` and `--download-dir`) and checking if a file exists at that path with a matching size. **If your folder structure or directory doesn't match what Python used, the import will silently count those files as unmatched** - it won't error out or download duplicates. The unmatched count is printed at the end. If most files show as unmatched, double-check that your `--folder-structure` matches your existing layout.
+The import matches files by computing the expected path for each iCloud asset (using your folder-structure flags and `--download-dir`) and checking if a file exists at that path with a matching size. **If your folder structure or directory doesn't match what Python used, the import will silently count those files as unmatched** - it won't error out or download duplicates. The unmatched count is printed at the end. If most files show as unmatched, double-check that your folder-structure flags match your existing layout.
+
+If your existing tree was produced with `icloudpd --folder-structure '{album}/%Y/%m/%d'`, point `--folder-structure-albums` at the same template:
+
+```sh
+kei import-existing --username you@example.com --download-dir ~/Photos/iCloud \
+  --folder-structure-albums '{album}/%Y/%m/%d'
+```
+
+`--folder-structure` (without the `-albums` suffix) only covers the unfiled-pass tree in v0.13. Putting `{album}` there still works but auto-migrates with a deprecation warning.
 
 The import is idempotent - running it multiple times is safe. It uses `upsert` operations, so re-importing the same files just updates the existing database entries.
 
@@ -34,10 +43,10 @@ Most flags are the same or very close. Here's the full mapping:
 |------|-------|
 | `-u, --username` | |
 | `-p, --password` | |
-| `-d, --download-dir` | Renamed from Python's `-d, --directory`. The old flag still parses (hidden, with a deprecation warning) — drop it on your next run. |
-| `-a, --album` | Multiple `--album` flags supported, same as Python |
+| `-d, --download-dir` | Renamed from Python's `-d, --directory`. The old flag still parses (hidden, with a deprecation warning); drop it on your next run. |
+| `-a, --album` | Repeatable, like Python. v0.13 adds sentinels (`all` / `none`) and `!name` to exclude. Default is `all` (every user album), so `kei sync` with no `-a` syncs everything; pass `--album '!Drafts'` to omit one album from `all`. |
 | `-l, --list-albums` | Deprecated; use `kei list albums` |
-| `--library` | Default library when none is specified: `PrimarySync`. Use `all` to sync every library at once. |
+| `--library` | Repeatable in v0.13. Sentinels: `primary` (default), `shared`, `all`, `none`. Accepts named zones (`PrimarySync`, full `SharedSync-...` UUID, or the truncated 8-char prefix kei renders into paths) and `!name` to exclude. |
 | `--list-libraries` | Deprecated; use `kei list libraries` |
 | `--recent` | |
 | `--skip-videos` | |
@@ -64,7 +73,7 @@ Most flags are the same or very close. Here's the full mapping:
 
 | Python | Rust | What changed |
 |--------|------|-------------|
-| `--folder-structure "{:%Y/%m/%d}"` | `--folder-structure "%Y/%m/%d"` | Both Python `{:%Y}` and plain `%Y` strftime syntax accepted. You can keep using the Python format. |
+| `--folder-structure "{:%Y/%m/%d}"` | `--folder-structure "%Y/%m/%d"` | Both Python `{:%Y}` and plain `%Y` strftime accepted. v0.13 splits the template into three flags by pass type: `--folder-structure` is the unfiled-pass template (default `%Y/%m/%d`), `--folder-structure-albums` is the album-pass template (default `{album}` flat), `--folder-structure-smart-folders` is the smart-folder-pass template (default `{smart-folder}` flat). `{album}` still works in `--folder-structure` but auto-migrates to `--folder-structure-albums` with a deprecation warning; that compat path is removed in v0.20. See [v0.13 migration guide](v0.13-migration.md) for details. |
 | `--size original` | `--size original` | Same values, but Python allows multiple `--size` flags (not yet supported in Rust - [#14](https://github.com/rhoopr/kei/issues/14)) |
 | `--cookie-directory ~/.pyicloud` | `--data-dir ~/.config/kei/` | New flag name and default path. `--cookie-directory` is still accepted (hidden from `--help`) but deprecated and will be removed in v0.20.0. |
 | `--threads-num` (deprecated, always 1) | `--threads 10` | Actually works in Rust. Default: 10 parallel downloads. kei's `--threads-num` is also deprecated (still parses, hidden, removal in v0.20.0); prefer `--threads`. |
@@ -110,10 +119,23 @@ Most flags are the same or very close. Here's the full mapping:
 | `config show` | Dump resolved config as TOML |
 | `config setup` | Interactive config wizard (was top-level `setup`) |
 | `--live-photo-mode` | Control live photo handling: `both`, `image-only`, `video-only`, `skip`. Replaces `--skip-live-photos`. |
-| `--exclude-album` | Exclude specific albums from sync. Multi-value. |
+| `--smart-folder` | Sync Apple smart folders (Favorites, Hidden, Screenshots, ...). Repeatable. Sentinels `all` (excludes Hidden + Recently Deleted) / `all-with-sensitive` / `none` (default). New in v0.13. |
+| `--unfiled` | Toggle the library-wide unfiled pass for photos not in any user album. Defaults to `true`. New in v0.13. |
+| `--folder-structure-albums` | Per-pass template for album folders. Default `{album}` (flat). New in v0.13. |
+| `--folder-structure-smart-folders` | Per-pass template for smart-folder folders. Default `{smart-folder}` (flat). New in v0.13. |
 | `--filename-exclude` | Exclude files by glob pattern (e.g., `*.AAE`, `Screenshot*`). Case-insensitive, multi-value. |
-| `{album}` in `--folder-structure` | Organize by album name: `--folder-structure "{album}/%Y/%m"`. |
+| `{library}` in any folder-structure template | Renders as `PrimarySync` or a truncated 8-char `SharedSync-A1B2C3D4` zone name. Useful with `--library all` to keep multi-library trees separate. |
 | `KEI_*` env vars | Every CLI flag has an env var (`KEI_DOWNLOAD_DIR`, `KEI_DATA_DIR`, `KEI_SIZE`, etc.). Useful for Docker. |
+
+### Deprecated, scheduled for removal
+
+| Flag / pattern | Replacement | Removal |
+|---|---|---|
+| `--exclude-album NAME` (and `KEI_EXCLUDE_ALBUM`) | `--album '!NAME'`. The comma-separated env form (`KEI_EXCLUDE_ALBUM=A,B`) doesn't carry over - use one `--album '!A' --album '!B'` per name, or set `[filters].albums = ["!A", "!B"]` in TOML. | v0.20 |
+| `{album}` in `--folder-structure` | Move to `--folder-structure-albums`. Auto-migrates with a startup warning. | v0.20 |
+| `[filters].album` (TOML, single string) | `[filters].albums` (array) | v0.20 |
+| `[filters].exclude_albums` (TOML) | `[filters].albums` with `!name` entries | v0.20 |
+| `[filters].library` (TOML, single string) | `[filters].libraries` (array) | v0.20 |
 
 ## Docker migration
 

--- a/docs/v0.13-migration.md
+++ b/docs/v0.13-migration.md
@@ -4,24 +4,36 @@ v0.13 reshapes how you tell kei *what* to download and *where* to put it. Existi
 
 ## What you actually need to do
 
-- If you use `--exclude-album`, switch to `--album '!NAME'`. If you used the comma-separated form (`--exclude-album A,B`), expand to one flag per name (`--album '!A' --album '!B'`); the new `--album` flag does not split on commas.
-- If you have `{album}` in `--folder-structure`, kei auto-migrates it to `--folder-structure-albums` and prints a warning. Optional: update your CLI/TOML to silence the warning.
-- If your v0.12 setup ran `kei sync` with no `-a` flag and no `{album}` in your `--folder-structure`, kei was making one library-wide enumeration per sync; v0.13 makes one enumeration per album plus one for unfiled. Output paths are unchanged when `--folder-structure` stays at the default `%Y/%m/%d`. v0.12 setups that already used `-a all` (or `{album}` in the template, which auto-promoted to `-a all`) see no change in API surface. The startup log line `Sync plan for library` reports the concrete pass count per library.
+- If you use `--exclude-album`, switch to `--album '!NAME'`. The old flag still works through v0.20 with a deprecation warning. The comma-separated form (`--exclude-album A,B` or `KEI_EXCLUDE_ALBUM=A,B`) does not carry over: `--album` does not split on commas, so use one flag per name (`--album '!A' --album '!B'`) or the TOML array form (`[filters].albums = ["!A", "!B"]`).
+- If you have `{album}` in `--folder-structure`, kei auto-migrates it to `--folder-structure-albums` and prints a one-line warning naming the equivalent flag. Update your CLI/TOML to silence the warning; the auto-migration goes away in v0.20.
+- If you ran `kei sync` with no `-a` flag and no `{album}` in your `--folder-structure`, v0.12 ran a single library-wide enumeration. v0.13 runs one enumeration per album plus one unfiled pass. With the default `--folder-structure %Y/%m/%d` (no `{album}`), on-disk paths stay identical to v0.12. The startup log line `Sync plan for library` reports the concrete pass count.
+- v0.12 configs that already used `-a all` (or had `{album}` in the template, which auto-promoted to `-a all`) see no change in API surface; the new no-flag default matches what they were already running.
 
 Everything else is additive: new flags exist, old flags keep working until v0.20.
 
 ## Quick before/after
 
 ```sh
-# Before (v0.12)
+# Before (v0.12) - two named album passes, exclusion, album-prefixed dates
 kei sync -a Vacation -a Family --exclude-album Drafts --folder-structure '{album}/%Y/%m/%d'
 
-# After (v0.13, equivalent)
-kei sync --album Vacation --album Family --album '!Drafts' --folder-structure-albums '{album}/%Y/%m/%d'
+# After (v0.13) - same on-disk layout, plus an unfiled pass alongside
+kei sync --album Vacation --album Family --album '!Drafts' \
+         --folder-structure-albums '{album}/%Y/%m/%d'
 ```
 
+The v0.13 form runs an additional unfiled pass by default (every photo not in any user album, written to `--folder-structure`'s default `%Y/%m/%d`). To match v0.12 exactly - just the named passes, nothing else - add `--unfiled false`:
+
 ```sh
-# New: separate template for unfiled photos (closes #215)
+kei sync --album Vacation --album Family --album '!Drafts' \
+         --folder-structure-albums '{album}/%Y/%m/%d' \
+         --unfiled false
+```
+
+kei warns once on startup whenever `--unfiled` is implicit and the album selector isn't `none`, pointing at this exact toggle.
+
+```sh
+# Separate template for unfiled photos (closes #215)
 kei sync --folder-structure-albums '{album}' --folder-structure '%Y/%m'
 # Albumed photos -> Vacation/IMG.JPG
 # Unfiled photos -> 2024/06/IMG.JPG
@@ -111,11 +123,11 @@ Old keys keep working through v0.19 with a warning, removed in v0.20:
 
 ## Behavior changes worth knowing
 
-- **`kei sync` with no flags** now enumerates each user album and runs an unfiled pass instead of one library-wide stream. v0.12 setups that already used `-a all` (or `{album}` in the template, which auto-promoted to `-a all`) see no change in API surface; the new no-flag default matches what they were already running. v0.12 no-flag setups go from 1 enumeration to N+1 (one per album, plus unfiled). On-disk paths stay identical to v0.12 only when your `--folder-structure` has no `{album}` token. With the default template (`%Y/%m/%d`), output is unchanged. The startup log line `Sync plan for library` reports the concrete pass count per library.
-- **`--unfiled` defaults to `true` regardless of `--album`.** `kei sync --album Vacation` runs the Vacation pass *and* the unfiled pass. To restrict to just Vacation, add `--unfiled false`.
+- **`kei sync` with no flags** runs N+1 enumerations (one per album, one unfiled) instead of v0.12's single library-wide pass. With the default `--folder-structure %Y/%m/%d` (no `{album}`), on-disk paths are unchanged. See "What you actually need to do" above for the full breakdown.
+- **`--unfiled` defaults to `true` regardless of `--album`.** `kei sync --album Vacation` runs the Vacation pass *and* the unfiled pass. To restrict to just Vacation, add `--unfiled false`. kei prints a one-line warning at startup whenever `--unfiled` is implicit and the album selector isn't `none`, pointing at the toggle.
 - **`--smart-folder all` skips Hidden + Recently Deleted** (mirroring iOS Photos). Use `--smart-folder all-with-sensitive` for literal everything.
-- **Album in multiple folders gets one copy per album folder** (unchanged from v0.12). Photos in any album are excluded from the unfiled pass.
-- **An album literally named `all`, `none`, or starting with `!`** is unaddressable. Documented limitation; corner case.
+- **A photo in N albums writes N on-disk copies** (unchanged from v0.12) when the active `--folder-structure-albums` template renders distinct paths per `{album}`. Photos in any album are excluded from the unfiled pass.
+- **An album literally named `all`, `none`, or starting with `!`** is unaddressable: those values parse as sentinels or exclusions. Corner case; rename the album in iCloud if it bites you.
 
 ## State DB schema v9
 
@@ -125,9 +137,10 @@ The `assets`, `asset_albums`, and `asset_people` tables all gain a `library` col
 
 | You did this | kei does this |
 |---|---|
-| `--album Vacatiom` (typo, no such album) | Bails at startup with "Album 'Vacatiom' not found. Available albums: [...]". |
-| `--album '!Vacatiom'` (typo in exclusion) | Bails at startup with the available album list, same as a typo'd inclusion. |
+| `--album Vacatiom` (typo, no such album) | Bails at startup: `Album 'Vacatiom' not found. Available albums: [...]`. |
+| `--album '!Vacatiom'` (typo in exclusion) | Bails at startup: `Excluded album 'Vacatiom' not found. Available albums: [...]`. Stops a typo from silently matching nothing. |
+| `--album Favorites` (passing a smart folder to `--album`) | Bails: `'Favorites' is a smart folder; pass --smart-folder Favorites instead of --album`. |
 | `--album Foo --album '!Foo'` | Bails at parse time. |
-| `--library none` (no source selected) | Bails. |
-| `--album none --smart-folder none --unfiled false` (everything turned off, valid library) | Runs as no-op, exits 0. |
-| `{album}` in `--folder-structure-smart-folders` | Bails at startup. |
+| `--library none` | Bails: `'--library none' is not allowed: kei needs at least one source library to sync`. |
+| `--album none --smart-folder none --unfiled false` (everything turned off, valid library) | Config builds; the sync exits without doing any download work. |
+| `{album}` in `--folder-structure-smart-folders` (or `{smart-folder}` in `--folder-structure-albums`) | Bails at startup. |


### PR DESCRIPTION
## Summary

- `docs/migration-from-python.md`: move `--exclude-album` and `{album}` in `--folder-structure` out of "New in kei" and into a new "Deprecated, scheduled for removal" table; add `--smart-folder`, `--unfiled`, `--folder-structure-albums`, `--folder-structure-smart-folders`, and `{library}`; expand `-a, --album` and `--library` notes for v0.13 sentinels + repeatability; steer importers at `--folder-structure-albums` for icloudpd-shaped trees; drop a stray em-dash.
- `docs/v0.13-migration.md`: cut the duplicated already-`-a all` paragraph, name the implicit-unfiled warning, fix the "Quick before/after" so the v0.13 form's extra unfiled pass is called out instead of silently changing the meaning, and replace the validation-table error strings with the actual messages emitted by `src/commands/service.rs` and `src/selection.rs`. Add the smart-folder-passed-to-album diagnostic, since the binary surfaces a hint pointing at `--smart-folder`.

Both files were authored before v0.13 shipped and described intended behavior; these edits reconcile them with what the v0.13.0 binary actually does.

## Test plan

- [x] `just gate` (fmt + clippy + lib/cli/behavioral tests + doc + audit + typos + roundtrip-gate) green
- [x] Cross-checked validation error strings against `src/commands/service.rs:670-728` and `src/selection.rs:340-378`
- [x] Cross-checked the implicit-unfiled warning text against `src/config.rs:444-461`
- [x] No production code touched; this is a docs-only PR