### PR TITLE
test: close 4 framework gaps surfaced by 2026-05-03 review

### DIFF
--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3763,6 +3763,55 @@ mod tests {
         );
     }
 
+    /// CG-2 (broadened from adversarial pass, 2026-05-03): `log_sync_summary`
+    /// had no test coverage at all. The mutation experiment showed that
+    /// dropping every `tracing::info!()` from the body would land green —
+    /// silently disabling sync-completion reporting in production logs.
+    /// This test is a baseline contract: at least one info event must fire
+    /// per call, the structured `title` field must be captured, and the
+    /// `downloaded` / `failed` counts must reach the captured output.
+    #[tracing_test::traced_test]
+    #[test]
+    fn log_sync_summary_emits_sync_counts_via_tracing() {
+        let stats = super::super::SyncStats {
+            downloaded: 3,
+            failed: 1,
+            skipped: super::super::SkipBreakdown {
+                by_state: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        super::log_sync_summary("── Test Summary ──", &stats);
+
+        // Title-line: structured `title` field must be present.
+        // Note: tracing renders `title = %title` (Display) unquoted.
+        assert!(
+            logs_contain("title=── Test Summary ──"),
+            "structured title field expected on first event"
+        );
+        // Title-line: message text must be present.
+        assert!(
+            logs_contain("Sync summary"),
+            "title-line event message expected"
+        );
+        // Count line: every count must reach the captured stream.
+        assert!(
+            logs_contain("3 downloaded"),
+            "downloaded count missing from summary line"
+        );
+        assert!(
+            logs_contain("1 failed"),
+            "failed count missing from summary line"
+        );
+        // Skipped breakdown line: when skipped > 0, a Skipped: line fires.
+        assert!(
+            logs_contain("Skipped:"),
+            "skipped breakdown line expected when stats.skipped.total() > 0"
+        );
+    }
+
     #[tokio::test]
     async fn flush_pending_state_writes_succeeds_on_first_try() {
         let db = FailingStateDb::new(0);

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -652,6 +652,63 @@ mod tests {
         assert!(err.to_string().contains("'!all'"));
     }
 
+    /// CG-8 (2026-05-03 test review): cross-category sentinel collision.
+    /// `primary` and `shared` are sentinels in `--library`, not `--album`.
+    /// A user with an iCloud album literally named `Primary` (or `primary`,
+    /// or `shared`) must have it parsed as a literal album, not silently
+    /// hijacked into a library sentinel. Similarly, `all-with-sensitive`
+    /// is a smart-folder sentinel and must round-trip as a literal album
+    /// name when supplied to `parse_album_selector`.
+    ///
+    /// The mutation this catches: a future "smart" refactor that consults
+    /// a single shared sentinel-word list across selectors would silently
+    /// match `primary` (and friends) and drop the user's real album.
+    #[test]
+    fn parse_album_selector_treats_other_categories_sentinels_as_literal_names() {
+        for word in [
+            "Primary",
+            "primary",
+            "Shared",
+            "shared",
+            "all-with-sensitive",
+        ] {
+            let r = parse_album_selector(&s(&[word]), false).unwrap();
+            assert_eq!(
+                r,
+                AlbumSelector::Named {
+                    included: set(&[word]),
+                    excluded: BTreeSet::new(),
+                },
+                "album value `{word}` must round-trip as a literal album name, \
+                 not as a cross-category sentinel"
+            );
+        }
+    }
+
+    /// CG-8 sibling: pin the documented case-insensitivity boundary —
+    /// only `all` and `none` are case-insensitive sentinels for albums.
+    /// Lowercase `primary` / `shared` are NOT album sentinels.
+    #[test]
+    fn parse_album_selector_only_all_and_none_are_album_sentinels() {
+        // `all` family -> AlbumSelector::All
+        for word in ["all", "All", "ALL"] {
+            let r = parse_album_selector(&s(&[word]), false).unwrap();
+            assert!(
+                matches!(r, AlbumSelector::All { .. }),
+                "album `{word}` must resolve to AlbumSelector::All"
+            );
+        }
+        // `none` family -> AlbumSelector::None
+        for word in ["none", "None", "NONE"] {
+            let r = parse_album_selector(&s(&[word]), false).unwrap();
+            assert_eq!(
+                r,
+                AlbumSelector::None,
+                "album `{word}` must resolve to AlbumSelector::None"
+            );
+        }
+    }
+
     // ── SmartFolderSelector ────────────────────────────────────────────
 
     #[test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2179,6 +2179,64 @@ mod tests {
         );
     }
 
+    /// CG-6 (2026-05-03 test review): the existing suite asserts the
+    /// *return value* of `find_multi_library_commingle_flags`, but
+    /// nothing pins the contract that `warn_if_multi_library_paths_commingle`
+    /// emits the `library_count` and `missing` lists as structured tracing
+    /// fields. A future refactor that drops the named args (or replaces
+    /// them with a positional message) would silently lose operator
+    /// visibility into commingle scenarios. Pin the field shape so the
+    /// regression is loud.
+    #[tracing_test::traced_test]
+    #[test]
+    fn warn_if_multi_library_paths_commingle_emits_structured_fields() {
+        let sel = selection_all_passes_active();
+        warn_if_multi_library_paths_commingle(3, "%Y/%m/%d", "{album}", "{smart-folder}", &sel);
+        assert!(
+            logs_contain("library_count=3"),
+            "structured library_count field expected on warn line"
+        );
+        // `missing = ?missing` debug-formats the Vec; the rendered output
+        // contains the bare flag names. Pin at least the unfiled-related
+        // root flag and the album-template flag.
+        assert!(
+            logs_contain("missing="),
+            "structured `missing` field expected on warn line"
+        );
+        assert!(
+            logs_contain("--folder-structure"),
+            "missing list should include the root --folder-structure flag"
+        );
+        assert!(
+            logs_contain("--folder-structure-albums"),
+            "missing list should include the album-template flag"
+        );
+        assert!(
+            logs_contain("--folder-structure-smart-folders"),
+            "missing list should include the smart-folder-template flag"
+        );
+    }
+
+    /// CG-6 negative: when `{library}` is present in every active
+    /// template, the warn must NOT fire. Catches the inverse mutation
+    /// (warn fires unconditionally).
+    #[tracing_test::traced_test]
+    #[test]
+    fn warn_if_multi_library_paths_commingle_silent_when_no_commingle() {
+        let sel = selection_all_passes_active();
+        warn_if_multi_library_paths_commingle(
+            3,
+            "{library}/%Y/%m/%d",
+            "{library}/{album}",
+            "{library}/{smart-folder}",
+            &sel,
+        );
+        assert!(
+            !logs_contain("library_count="),
+            "warn must not fire when every active template carries `{{library}}`"
+        );
+    }
+
     // ── count_passes ────────────────────────────────────────────────────
     //
     // Pass tally feeds the per-library `Sync plan for library` info line.

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2190,6 +2190,64 @@ fn verify_checksums_mismatch() {
     assert!(stdout.contains("CORRUPTED"), "stdout: {stdout}");
 }
 
+/// CG-1 (2026-05-03 test review): if a future refactor of the
+/// `CORRUPTED:` line in `run_verify` drops the asset id from the
+/// printed output, operators can see "1 corrupted" without any way
+/// to find which asset. This test pins the contract that the asset
+/// id reaches stdout for every corrupted entry. Sibling to
+/// `verify_checksums_mismatch` so the existing test stays focused
+/// on exit-code + summary text and this one stays focused on the
+/// per-asset trace.
+#[test]
+fn verify_checksums_mismatch_emits_asset_id_in_output() {
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    let file_path = dir.path().join("bad.jpg");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        f.write_all(b"actual content").unwrap();
+    }
+
+    let asset_id = "ASSET_FOR_CG1_VERIFY";
+    insert_asset(
+        &conn,
+        asset_id,
+        "downloaded",
+        "bad.jpg",
+        Some(file_path.to_str().unwrap()),
+        None,
+        Some("0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "verify",
+            "--checksums",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("CORRUPTED"),
+        "expected CORRUPTED line, stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(asset_id),
+        "expected asset id {asset_id} in CORRUPTED line, stdout: {stdout}"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // State DB pre-seeded tests: reset
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

6 tests added across 4 files. Production code is untouched. Closes 4 of 8 framework gaps from `.scratch/2026-05-03_TEST_REVIEW_PLAN.md`. CG-3 and CG-5 turned out to be already covered (the plan was stale on those). CG-4 and CG-7 stay open as separate follow-ups because each needs a small production refactor before it's testable.

### What landed

CG-1 - `verify --checksums` already prints the asset id alongside `CORRUPTED:`, but no test asserted on it. A future refactor that drops the id would land green. New sibling test in `tests/behavioral.rs` pins the contract.

CG-2 - `log_sync_summary` had zero coverage. The mutation experiment showed that deleting every `tracing::info!` from the body would land green. New test pins the title-line message, the structured `title` field, and the count-line emissions.

CG-6 - The multi-library commingle warning's structured fields (`library_count`, `missing`) had no tests. A future refactor that drops the named args would silently lose operator visibility into commingle scenarios. Two new tests pin the field shape, positive and negative.

CG-8 - The v0.13 selection redesign introduced cross-category sentinels. An album literally named `Primary`, `Shared`, or `all-with-sensitive` must round-trip as a literal album, not collapse into a library or smart-folder sentinel. Two new tests pin the boundary.

### Skipped or deferred

CG-3 (599/600 boundary) - already covered by `api_error_5xx_range_boundary_599_is_transient_600_is_not` at `src/auth/error.rs:341-368`.

CG-5 (invalid base64) - already covered by `test_temp_download_path_invalid_base64` at `src/download/file.rs:760-765`.

CG-4 (graceful-shutdown timeout) - the timeout branch calls `std::process::exit(130)` directly and the timeout duration is a compile-time constant. Closing the gap needs an injectable duration plus an exit callback. Stays open as a follow-up.

CG-7 (`enum_config_hash` drift) - the hash-compare logic is inline in `run_cycle` (private, heavy fixture types). Closing the gap needs a `pub(crate)` extraction. Stays open as a follow-up.

Source: `.scratch/2026-05-03_TEST_REVIEW_PLAN.md` and `.scratch/2026-05-03_TEST_REVIEW.md`.

## Test plan

- [x] `cargo test` (parallel): 2,473 passing
- [x] `cargo test -- --test-threads=1`: 2,473 passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] No production code changed - no binary smoke needed