### PR TITLE
fix: paginate fetch_folders, reject shared-only --smart-folder

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,8 +17,9 @@ pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
 pub(crate) use reset::{run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
-    attempt_reauth, init_photos_service, resolve_libraries, resolve_passes, wait_and_retry_2fa,
-    AlbumPass, AlbumPlan, PassKind, MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, init_photos_service, resolve_libraries, resolve_passes,
+    validate_smart_folder_fulfillability, wait_and_retry_2fa, AlbumPass, AlbumPlan, PassKind,
+    MAX_REAUTH_ATTEMPTS,
 };
 pub(crate) use status::run_status;
 pub(crate) use verify::run_verify;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -480,6 +480,45 @@ fn library_entry_matches_zone(entry: &str, zone: &str, truncated: &str) -> bool 
     entry.eq_ignore_ascii_case(zone) || entry.eq_ignore_ascii_case(truncated)
 }
 
+/// Pre-flight: bail when the resolved library set cannot fulfill the
+/// requested smart-folder selection. Apple's CloudKit shared zones don't
+/// expose smart folders (`library.albums()` skips smart-folder injection
+/// for `SharedSync-*` zones), so a `--library shared --smart-folder X`
+/// configuration produces zero smart-folder passes and exit 0 — silent
+/// failure. Detect that at startup, before per-library `resolve_passes`
+/// runs, so the user gets an actionable message instead of a
+/// successful-looking sync that quietly skipped what they asked for.
+///
+/// Mixed library sets (primary + shared) pass: smart folders apply to the
+/// primary library, and the shared zones' lack of smart-folder passes is
+/// expected behavior.
+pub(crate) fn validate_smart_folder_fulfillability(
+    libraries: &[icloud::photos::PhotoLibrary],
+    selection: &crate::selection::Selection,
+) -> anyhow::Result<()> {
+    use crate::selection::SmartFolderSelector;
+    if matches!(selection.smart_folders, SmartFolderSelector::None) {
+        return Ok(());
+    }
+    let any_supports = libraries
+        .iter()
+        .any(|l| !icloud::photos::is_shared_zone(l.zone_name()));
+    if any_supports {
+        return Ok(());
+    }
+    let zones: Vec<&str> = libraries
+        .iter()
+        .map(icloud::photos::PhotoLibrary::zone_name)
+        .collect();
+    anyhow::bail!(
+        "--smart-folder requires a library that supports smart folders, but \
+         --library resolved to only shared zones: {zones:?}. Apple does not \
+         expose smart folders on shared libraries. Either include the primary \
+         library (e.g. `--library all` or `--library primary`) or drop \
+         `--smart-folder` (`--smart-folder none`)."
+    )
+}
+
 /// Category of a download pass: a named user album, an Apple-defined smart
 /// folder, or the library-wide unfiled pseudo-pass. Drives template/token
 /// selection in the path renderer.
@@ -1188,6 +1227,95 @@ mod tests {
             err.to_string().contains("not an Apple smart folder"),
             "msg: {err}"
         );
+    }
+
+    // ── validate_smart_folder_fulfillability (CF-2, 2026-05-03) ─────────
+    //
+    // Apple's CloudKit shared zones don't have smart folders. Before the
+    // fix, `--library shared --smart-folder Favorites` (or any shared-only
+    // library set with a smart-folder selection) silently warn-and-skipped
+    // every smart-folder pass and exited 0. The user looked at their
+    // primary-library Favorites and assumed shared-Favorites came along.
+    //
+    // The fix is a pre-flight check that bails at startup when the
+    // selected library set cannot fulfill the smart-folder selection.
+
+    fn shared_lib_stub(zone: &str) -> PhotoLibrary {
+        PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), zone)
+    }
+
+    #[test]
+    fn validate_smart_folder_named_against_shared_only_libraries_bails() {
+        let libs = vec![shared_lib_stub("SharedSync-AAAA1111")];
+        let sel = Selection {
+            albums: AlbumSelector::None,
+            smart_folders: SmartFolderSelector::Named {
+                included: names(&["Favorites"]),
+                excluded: BTreeSet::new(),
+            },
+            libraries: crate::selection::LibrarySelector::default(),
+            unfiled: false,
+        };
+        let err = validate_smart_folder_fulfillability(&libs, &sel).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--smart-folder"),
+            "error must name the offending flag, got: {msg}"
+        );
+        assert!(
+            msg.contains("primary"),
+            "error must guide the user toward the primary library, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_smart_folder_all_against_shared_only_libraries_bails() {
+        let libs = vec![shared_lib_stub("SharedSync-BBBB2222")];
+        let sel = Selection {
+            albums: AlbumSelector::None,
+            smart_folders: SmartFolderSelector::All {
+                include_sensitive: false,
+                excluded: BTreeSet::new(),
+            },
+            libraries: crate::selection::LibrarySelector::default(),
+            unfiled: false,
+        };
+        let err = validate_smart_folder_fulfillability(&libs, &sel).unwrap_err();
+        assert!(err.to_string().contains("--smart-folder"));
+    }
+
+    #[test]
+    fn validate_smart_folder_named_against_mixed_libraries_passes() {
+        // Primary in the set fulfills smart folders; shared zones simply
+        // get no smart-folder passes (expected and documented).
+        let primary =
+            PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), "PrimarySync");
+        let shared = shared_lib_stub("SharedSync-CCCC3333");
+        let sel = Selection {
+            albums: AlbumSelector::None,
+            smart_folders: SmartFolderSelector::Named {
+                included: names(&["Favorites"]),
+                excluded: BTreeSet::new(),
+            },
+            libraries: crate::selection::LibrarySelector::default(),
+            unfiled: false,
+        };
+        validate_smart_folder_fulfillability(&[primary, shared], &sel)
+            .expect("primary in mix fulfills smart folders");
+    }
+
+    #[test]
+    fn validate_smart_folder_none_passes_even_on_shared_only() {
+        // No smart-folder pass requested -> nothing to validate.
+        let libs = vec![shared_lib_stub("SharedSync-DDDD4444")];
+        let sel = Selection {
+            albums: AlbumSelector::None,
+            smart_folders: SmartFolderSelector::None,
+            libraries: crate::selection::LibrarySelector::default(),
+            unfiled: false,
+        };
+        validate_smart_folder_fulfillability(&libs, &sel)
+            .expect("smart-folder None imposes no constraint on the library set");
     }
 
     #[tokio::test]

--- a/src/icloud/photos/cloudkit.rs
+++ b/src/icloud/photos/cloudkit.rs
@@ -40,6 +40,13 @@ pub(crate) struct QueryResponse {
     pub records: Vec<Record>,
     #[serde(default, rename = "syncToken")]
     pub sync_token: Option<String>,
+    /// CloudKit pagination cursor. Present iff there are more records;
+    /// callers must echo it in the next request body to fetch the next
+    /// page. Apple's `records/query` defaults to `resultsLimit=200`, so
+    /// a caller that ignores this field silently truncates any query
+    /// whose result set exceeds 200 rows.
+    #[serde(default, rename = "continuationMarker")]
+    pub continuation_marker: Option<String>,
 }
 
 /// Response from `/internal/records/query/batch`.
@@ -209,6 +216,11 @@ mod tests {
         let resp: QueryResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.records.len(), 1);
         assert_eq!(resp.sync_token.as_deref(), Some("st-abc-123"));
+        assert_eq!(
+            resp.continuation_marker.as_deref(),
+            Some("cm-xyz-456"),
+            "continuationMarker must surface so paginated record queries can loop"
+        );
     }
 
     #[test]
@@ -216,6 +228,10 @@ mod tests {
         let json = r#"{"records": []}"#;
         let resp: QueryResponse = serde_json::from_str(json).unwrap();
         assert!(resp.sync_token.is_none());
+        assert!(
+            resp.continuation_marker.is_none(),
+            "missing continuationMarker means single-page response — must be None"
+        );
     }
 
     #[test]

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -302,22 +302,73 @@ impl PhotoLibrary {
             self.service_endpoint,
             encode_params(&self.params)
         );
-        let body = json!({
-            "query": {"recordType": "CPLAlbumByPositionLive"},
-            "zoneID": &*self.zone_id,
-        });
-        let response = super::session::retry_post(
-            self.session.as_ref(),
-            &url,
-            &body.to_string(),
-            &[("Content-type", "text/plain")],
-            &self.retry_config,
-        )
-        .await?;
 
-        let query: super::cloudkit::QueryResponse =
-            serde_json::from_value(response).context("failed to parse library query response")?;
-        Ok(query.records)
+        // Apple's `records/query` defaults to resultsLimit=200 and returns
+        // a `continuationMarker` when more records are available. Loop
+        // until the marker is absent. Cap defensively at FOLDER_PAGE_CAP
+        // pages so a server bug or pathological account can't spin
+        // forever — at 200 records/page the cap is well past any
+        // plausible real iCloud library.
+        const FOLDER_PAGE_CAP: usize = 64;
+        let mut all_records = Vec::new();
+        let mut continuation: Option<String> = None;
+
+        for page in 0..FOLDER_PAGE_CAP {
+            let body = match &continuation {
+                Some(marker) => json!({
+                    "query": {"recordType": "CPLAlbumByPositionLive"},
+                    "zoneID": &*self.zone_id,
+                    "continuationMarker": marker,
+                }),
+                None => json!({
+                    "query": {"recordType": "CPLAlbumByPositionLive"},
+                    "zoneID": &*self.zone_id,
+                }),
+            };
+
+            let response = super::session::retry_post(
+                self.session.as_ref(),
+                &url,
+                &body.to_string(),
+                &[("Content-type", "text/plain")],
+                &self.retry_config,
+            )
+            .await?;
+
+            let query: super::cloudkit::QueryResponse = serde_json::from_value(response)
+                .context("failed to parse library query response")?;
+
+            let page_size = query.records.len();
+            all_records.extend(query.records);
+
+            match query.continuation_marker {
+                Some(marker) if !marker.is_empty() => {
+                    tracing::debug!(
+                        page = page,
+                        page_size,
+                        running_total = all_records.len(),
+                        "fetch_folders: continuationMarker present, fetching next page"
+                    );
+                    continuation = Some(marker);
+                }
+                _ => return Ok(all_records),
+            }
+        }
+
+        // Fell through the cap with the marker still set. Surface loudly
+        // so a regression that loosens the cap or a server pathology is
+        // visible in routine logs. Return what we have rather than an
+        // Err — partial results are more useful than a hard failure on
+        // the album-discovery path, and downstream consumers
+        // (`pick_album_names`) already bail loudly on missing names.
+        tracing::warn!(
+            cap = FOLDER_PAGE_CAP,
+            running_total = all_records.len(),
+            "fetch_folders: hit pagination cap with more pages still indicated; \
+             returning truncated album list. If you genuinely have >12,000 albums \
+             please file an issue."
+        );
+        Ok(all_records)
     }
 
     /// Returns the zone name (e.g., "`PrimarySync`", "SharedSync-{UUID}").
@@ -779,6 +830,189 @@ mod tests {
             matches!(err, ICloudError::MisdirectedRequest),
             "expected MisdirectedRequest so sync_loop can invalidate cache and \
              force SRP re-auth, got: {err:?}"
+        );
+    }
+
+    // ── fetch_folders pagination (CF-1, 2026-05-03 robustness review) ────
+    //
+    // Apple's CloudKit `records/query` endpoint defaults to
+    // resultsLimit=200 and returns a `continuationMarker` when more
+    // records exist. Before the fix, `fetch_folders` issued a single
+    // POST and trusted the response was complete — users with >200 user
+    // albums silently lost the tail. Tail-album members would route
+    // into the unfiled pass instead of `{album}` paths, and
+    // `--album all !TailAlbum` would bail "Excluded album not found"
+    // even though the album exists in iCloud.
+
+    /// Mock session that returns a queue of canned responses on
+    /// successive POSTs and records every body it received. Used to
+    /// exercise the pagination loop in `fetch_folders` without a real
+    /// HTTP server.
+    struct PaginatingFolderSession {
+        responses: std::sync::Mutex<Vec<Value>>,
+        received_bodies: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl PaginatingFolderSession {
+        fn new(responses: Vec<Value>) -> Self {
+            Self {
+                responses: std::sync::Mutex::new(responses),
+                received_bodies: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn body_log(&self) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
+            std::sync::Arc::clone(&self.received_bodies)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for PaginatingFolderSession {
+        async fn post(
+            &self,
+            _url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            self.received_bodies.lock().unwrap().push(body);
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                anyhow::bail!("PaginatingFolderSession: out of canned responses");
+            }
+            Ok(responses.remove(0))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            unimplemented!(
+                "PaginatingFolderSession::clone_box is not exercised by \
+                 fetch_folders; if a future test needs it, share Arcs over \
+                 the response queue and body log"
+            )
+        }
+    }
+
+    fn make_folder_records(count: usize, prefix: &str) -> Vec<Value> {
+        use base64::engine::general_purpose::STANDARD;
+        (0..count)
+            .map(|i| {
+                let name = format!("Album-{prefix}-{i}");
+                let enc = STANDARD.encode(name.as_bytes());
+                json!({
+                    "recordName": format!("{prefix}-{i}"),
+                    "recordType": "CPLAlbum",
+                    "fields": {
+                        "albumNameEnc": {"value": enc},
+                    },
+                })
+            })
+            .collect()
+    }
+
+    fn make_library_with_session(session: Box<dyn PhotosSession>) -> PhotoLibrary {
+        PhotoLibrary {
+            service_endpoint: Arc::from("https://example.com"),
+            params: Arc::new(HashMap::new()),
+            session,
+            zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+            library_type: Arc::from("private"),
+            retry_config: RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        }
+    }
+
+    /// CF-1: with >200 albums, the second page must be fetched and
+    /// merged. Pre-fix, fetch_folders returned only the first page.
+    #[tokio::test]
+    async fn fetch_folders_follows_continuation_marker_until_exhausted() {
+        let page1 = make_folder_records(200, "p1");
+        let page2 = make_folder_records(100, "p2");
+        let session = PaginatingFolderSession::new(vec![
+            json!({"records": page1, "continuationMarker": "ck-p1"}),
+            json!({"records": page2}),
+        ]);
+        let body_log = session.body_log();
+        let lib = make_library_with_session(Box::new(session));
+
+        let folders = lib.fetch_folders().await.unwrap();
+        assert_eq!(
+            folders.len(),
+            300,
+            "fetch_folders must follow continuationMarker until the \
+             response omits it; got {} records, expected 300",
+            folders.len()
+        );
+
+        let bodies = body_log.lock().unwrap();
+        assert_eq!(
+            bodies.len(),
+            2,
+            "expected exactly two POSTs (one per page), got {}",
+            bodies.len()
+        );
+        assert!(
+            !bodies[0].contains("continuationMarker"),
+            "first POST must not include a continuationMarker"
+        );
+        assert!(
+            bodies[1].contains("ck-p1"),
+            "second POST must echo the prior page's continuationMarker; \
+             body was: {}",
+            bodies[1]
+        );
+    }
+
+    /// CF-1 negative: a single-page response (no marker) must short-circuit
+    /// after one POST. Catches a regression that always sends a second
+    /// request.
+    #[tokio::test]
+    async fn fetch_folders_single_page_response_does_not_paginate() {
+        let page1 = make_folder_records(50, "only");
+        let session = PaginatingFolderSession::new(vec![json!({"records": page1})]);
+        let body_log = session.body_log();
+        let lib = make_library_with_session(Box::new(session));
+
+        let folders = lib.fetch_folders().await.unwrap();
+        assert_eq!(folders.len(), 50);
+        assert_eq!(
+            body_log.lock().unwrap().len(),
+            1,
+            "no continuationMarker means no second POST"
+        );
+    }
+
+    /// CF-1 defensive cap: if the server keeps returning a marker forever
+    /// (server bug or pathological account), fetch_folders must bail
+    /// rather than loop unbounded. The cap and warn message are part of
+    /// the contract — a future refactor that drops them would silently
+    /// allow infinite loops.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn fetch_folders_caps_iteration_when_continuation_never_clears() {
+        // Far more responses than the cap; every one carries a marker.
+        let mut responses = Vec::new();
+        for i in 0..200 {
+            responses.push(json!({
+                "records": make_folder_records(1, &format!("page-{i}")),
+                "continuationMarker": format!("marker-{i}"),
+            }));
+        }
+        let session = PaginatingFolderSession::new(responses);
+        let body_log = session.body_log();
+        let lib = make_library_with_session(Box::new(session));
+
+        let _ = lib.fetch_folders().await;
+
+        let post_count = body_log.lock().unwrap().len();
+        assert!(
+            post_count <= 64,
+            "fetch_folders must stop within the documented cap; made {post_count} POSTs"
+        );
+        assert!(
+            logs_contain("fetch_folders") && logs_contain("cap"),
+            "the cap-fired event must surface in logs so a future regression \
+             that silently loosens the cap is loud"
         );
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -12,8 +12,8 @@ use tokio_util::sync::CancellationToken;
 use crate::auth;
 use crate::cli;
 use crate::commands::{
-    attempt_reauth, init_photos_service, resolve_libraries, resolve_passes, wait_and_retry_2fa,
-    MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, init_photos_service, resolve_libraries, resolve_passes,
+    validate_smart_folder_fulfillability, wait_and_retry_2fa, MAX_REAUTH_ATTEMPTS,
 };
 use crate::config;
 use crate::credential;
@@ -444,6 +444,12 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         zones = %libraries.iter().map(|l| l.zone_name().to_string()).collect::<Vec<_>>().join(", "),
         "Resolved libraries"
     );
+
+    // CloudKit shared zones don't expose smart folders. Catch the
+    // impossible-config case (e.g. `--library shared --smart-folder X`)
+    // here, before any per-library work, so the user gets a clear error
+    // instead of a silent zero-pass run with exit code 0.
+    validate_smart_folder_fulfillability(&libraries, &config.selection)?;
 
     // Initialize state database.
     // Skip for --dry-run so a preview doesn't create the DB or poison


### PR DESCRIPTION
## Summary

Two High-severity findings from the 2026-05-03 robustness review. Both are surface area introduced by v0.13. Both are silent failures - no error, no exit-code change, the user only finds out by inspection.

### CF-1: `fetch_folders` pagination

CloudKit `records/query` defaults to `resultsLimit=200` and returns a `continuationMarker` when more records exist. `fetch_folders` was issuing a single POST and trusting the response was complete. Accounts with >200 user albums silently lost the tail:

- Tail-album members routed into the unfiled pass instead of `{album}` paths.
- `--album all !TailAlbum` exclusions bailed "Excluded album not found" - looked like a typo to the user, but the album existed in iCloud.
- The truncation replayed every cycle, since album discovery is independent of per-zone sync tokens.

Fix: added `continuation_marker: Option<String>` to `QueryResponse` so the cursor surfaces. Loop in `fetch_folders` echoes the prior page's marker until the server omits it. Capped at 64 pages (~12,800 albums) with a warn on cap-fire so a server pathology or future regression that loosens the cap is loud.

### CF-2: `--smart-folder` against shared-only library set

CloudKit shared zones don't expose smart folders - `library.albums()` skips smart-folder injection for `SharedSync-*` zones. A `--library shared --smart-folder Favorites` configuration warn-and-skipped every smart-folder pass and exited 0. The summary line, exit code, and `enumeration_errors` all stayed clean. Users looked at primary-library Favorites and assumed shared-Favorites came along.

Fix: added `validate_smart_folder_fulfillability` as a pre-flight in `sync_loop`, called once after `resolve_libraries`. Bails when the resolved library set has zero zones that support smart folders AND `selection.smart_folders != None`. Mixed sets (primary + shared) pass through: primary handles smart folders, the shared zones' lack of smart-folder passes is documented and expected.

### New tests

CF-1:
- `fetch_folders_follows_continuation_marker_until_exhausted`
- `fetch_folders_single_page_response_does_not_paginate`
- `fetch_folders_caps_iteration_when_continuation_never_clears`

CF-2:
- `validate_smart_folder_named_against_shared_only_libraries_bails`
- `validate_smart_folder_all_against_shared_only_libraries_bails`
- `validate_smart_folder_named_against_mixed_libraries_passes`
- `validate_smart_folder_none_passes_even_on_shared_only`

Plus a strengthened cloudkit field test asserting the marker round-trips into `QueryResponse.continuation_marker`.

Source: `.scratch/2026-05-03_ROBUSTNESS_REVIEW.md` (CF-1 + CF-2) and `.scratch/2026-05-03_FULL_REVIEW.md`.

## Test plan

- [x] `cargo test` (parallel): 2,474 passing - 7 new lib tests
- [x] `cargo test -- --test-threads=1`: 2,474 passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo run -- --version` boots
- [ ] CF-2 path needs live Apple auth to exercise end-to-end; the unit tests cover the validation logic, but a binary-level confirmation against a real account is best done before merge. Sample command: `cargo run -- sync --library shared --smart-folder Favorites ...` - should bail with the new error message instead of running silently.

## Dependencies

Independent of #335 (Phase 2 test additions). Either can merge first.