### PR TITLE
fix: post-rename fsync + surface enumeration_errors everywhere

### DIFF
--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -170,17 +170,7 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     fs::rename(&tmp, path)
         .await
         .with_context(|| format!("Failed to rename {} to {}", tmp.display(), path.display()))?;
-    let path_buf = path.to_path_buf();
-    if let Err(e) = tokio::task::spawn_blocking(move || crate::fs_util::fsync_parent_dir(&path_buf))
-        .await
-        .map_err(|e| anyhow::anyhow!("parent fsync join error: {e}"))?
-    {
-        tracing::warn!(
-            path = %path.display(),
-            error = %e,
-            "fsync of parent directory failed after atomic_write"
-        );
-    }
+    crate::fs_util::fsync_parent_dir_async_best_effort(path).await;
     Ok(())
 }
 

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -442,33 +442,12 @@ pub(super) async fn rename_part_to_final(
     match fs::rename(part_path, final_path).await {
         Ok(()) => {
             // ext4 default `data=ordered` does not guarantee directory
-            // entry durability after `rename` returns Ok — a power loss
-            // between rename and the kernel committing the dir block can
-            // leave `final_path` absent on reboot. Mirrors the post-rename
-            // fsync that `atomic_install` already does for credentials and
-            // session files; the data path was previously weaker than the
-            // credential path. Best-effort: a parent-dir fsync failure is
-            // warned but doesn't fail the download (the bytes are on disk
-            // and the rename returned Ok; the worst case is one redundant
-            // re-download next sync).
-            let parent_for_fsync = final_path.to_path_buf();
-            let fsync_result = tokio::task::spawn_blocking(move || {
-                crate::fs_util::fsync_parent_dir(&parent_for_fsync)
-            })
-            .await;
-            match fsync_result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => tracing::warn!(
-                    path = %final_path.display(),
-                    error = %e,
-                    "parent-dir fsync after rename failed; durability not guaranteed for this file"
-                ),
-                Err(join_err) => tracing::warn!(
-                    path = %final_path.display(),
-                    error = %join_err,
-                    "parent-dir fsync task panicked; durability not guaranteed for this file"
-                ),
-            }
+            // entry durability after `rename` returns Ok: a power loss
+            // between rename and the kernel committing the dir block
+            // can leave `final_path` absent on reboot. Best-effort
+            // fsync the parent so the worst case is one redundant
+            // re-download next sync, not silent loss.
+            crate::fs_util::fsync_parent_dir_async_best_effort(final_path).await;
             Ok(())
         }
         Err(rename_err) if fs::try_exists(final_path).await.unwrap_or(false) => {

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -440,7 +440,37 @@ pub(super) async fn rename_part_to_final(
     final_path: &Path,
 ) -> anyhow::Result<()> {
     match fs::rename(part_path, final_path).await {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            // ext4 default `data=ordered` does not guarantee directory
+            // entry durability after `rename` returns Ok — a power loss
+            // between rename and the kernel committing the dir block can
+            // leave `final_path` absent on reboot. Mirrors the post-rename
+            // fsync that `atomic_install` already does for credentials and
+            // session files; the data path was previously weaker than the
+            // credential path. Best-effort: a parent-dir fsync failure is
+            // warned but doesn't fail the download (the bytes are on disk
+            // and the rename returned Ok; the worst case is one redundant
+            // re-download next sync).
+            let parent_for_fsync = final_path.to_path_buf();
+            let fsync_result = tokio::task::spawn_blocking(move || {
+                crate::fs_util::fsync_parent_dir(&parent_for_fsync)
+            })
+            .await;
+            match fsync_result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    path = %final_path.display(),
+                    error = %e,
+                    "parent-dir fsync after rename failed; durability not guaranteed for this file"
+                ),
+                Err(join_err) => tracing::warn!(
+                    path = %final_path.display(),
+                    error = %join_err,
+                    "parent-dir fsync task panicked; durability not guaranteed for this file"
+                ),
+            }
+            Ok(())
+        }
         Err(rename_err) if fs::try_exists(final_path).await.unwrap_or(false) => {
             // Another task won the race — clean up our .part file.
             tracing::debug!(

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1645,6 +1645,7 @@ where
             assets_seen: assets_seen_count,
             assets_downloaded: downloaded as u64,
             assets_failed: failed.len() as u64,
+            enumeration_errors: enum_errors.load(std::sync::atomic::Ordering::Relaxed) as u64,
             interrupted: shutdown_token.is_cancelled()
                 || auth_errors >= AUTH_ERROR_THRESHOLD
                 || producer_panicked,
@@ -2471,12 +2472,16 @@ pub(super) fn log_sync_summary(title: &str, stats: &super::SyncStats) {
         );
     }
 
-    // Line 2: error details (only if any)
-    if stats.exif_failures > 0 || stats.state_write_failures > 0 {
+    // Line 2: error details (only if any). `enumeration_errors`
+    // gates `PartialFailure` in the zero-download branch
+    // (pipeline.rs:1793 post-c1c0a95) so an operator chasing exit-code
+    // 2 with no other failure counts needs to see this surfaced.
+    if stats.exif_failures > 0 || stats.state_write_failures > 0 || stats.enumeration_errors > 0 {
         tracing::info!(
-            "  {} EXIF write failure(s), {} state write failure(s)",
+            "  {} EXIF write failure(s), {} state write failure(s), {} enumeration error(s)",
             stats.exif_failures,
-            stats.state_write_failures
+            stats.state_write_failures,
+            stats.enumeration_errors
         );
     }
 
@@ -3809,6 +3814,53 @@ mod tests {
         assert!(
             logs_contain("Skipped:"),
             "skipped breakdown line expected when stats.skipped.total() > 0"
+        );
+    }
+
+    /// NB-1 (2026-05-03 robustness review): when only `enumeration_errors`
+    /// is non-zero (no exif/state failures), the line-2 conditional must
+    /// still fire. Pre-fix it gated on
+    /// `exif_failures > 0 || state_write_failures > 0` only — an
+    /// enumeration-error-driven `PartialFailure` produced an empty failure
+    /// line, so an operator seeing exit code 2 had no count to chase.
+    #[tracing_test::traced_test]
+    #[test]
+    fn log_sync_summary_emits_enumeration_errors_when_only_enum_errs() {
+        let stats = super::super::SyncStats {
+            downloaded: 0,
+            failed: 0,
+            enumeration_errors: 4,
+            ..Default::default()
+        };
+
+        super::log_sync_summary("── Test Summary ──", &stats);
+
+        assert!(
+            logs_contain("4 enumeration error(s)"),
+            "line 2 must surface enumeration_errors when nonzero"
+        );
+    }
+
+    /// NB-1 negative: when every error counter is zero, the line-2
+    /// conditional must NOT fire. Catches the inverse mutation (line 2
+    /// always fires even with zero errors).
+    #[tracing_test::traced_test]
+    #[test]
+    fn log_sync_summary_no_error_line_when_all_counters_zero() {
+        let stats = super::super::SyncStats {
+            downloaded: 5,
+            ..Default::default()
+        };
+
+        super::log_sync_summary("── Test Summary ──", &stats);
+
+        assert!(
+            !logs_contain("EXIF write failure"),
+            "line 2 must not fire when exif/state/enum counters are all zero"
+        );
+        assert!(
+            !logs_contain("enumeration error"),
+            "line 2 must not fire when exif/state/enum counters are all zero"
         );
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1645,7 +1645,10 @@ where
             assets_seen: assets_seen_count,
             assets_downloaded: downloaded as u64,
             assets_failed: failed.len() as u64,
-            enumeration_errors: enum_errors.load(std::sync::atomic::Ordering::Relaxed) as u64,
+            enumeration_errors: u64::try_from(
+                enum_errors.load(std::sync::atomic::Ordering::Relaxed),
+            )
+            .unwrap_or(u64::MAX),
             interrupted: shutdown_token.is_cancelled()
                 || auth_errors >= AUTH_ERROR_THRESHOLD
                 || producer_panicked,
@@ -2472,10 +2475,9 @@ pub(super) fn log_sync_summary(title: &str, stats: &super::SyncStats) {
         );
     }
 
-    // Line 2: error details (only if any). `enumeration_errors`
-    // gates `PartialFailure` in the zero-download branch
-    // (pipeline.rs:1793 post-c1c0a95) so an operator chasing exit-code
-    // 2 with no other failure counts needs to see this surfaced.
+    // Line 2: error details (only if any). `enumeration_errors` can
+    // gate `PartialFailure` on its own, so an operator chasing exit
+    // code 2 with no other failure counts needs to see it here.
     if stats.exif_failures > 0 || stats.state_write_failures > 0 || stats.enumeration_errors > 0 {
         tracing::info!(
             "  {} EXIF write failure(s), {} state write failure(s), {} enumeration error(s)",
@@ -3817,12 +3819,10 @@ mod tests {
         );
     }
 
-    /// NB-1 (2026-05-03 robustness review): when only `enumeration_errors`
-    /// is non-zero (no exif/state failures), the line-2 conditional must
-    /// still fire. Pre-fix it gated on
-    /// `exif_failures > 0 || state_write_failures > 0` only — an
-    /// enumeration-error-driven `PartialFailure` produced an empty failure
-    /// line, so an operator seeing exit code 2 had no count to chase.
+    /// When only `enumeration_errors` is non-zero, the line-2 conditional
+    /// must still fire. Otherwise an enumeration-error-driven
+    /// `PartialFailure` would produce an empty failure line and an
+    /// operator chasing exit code 2 has no count.
     #[tracing_test::traced_test]
     #[test]
     fn log_sync_summary_emits_enumeration_errors_when_only_enum_errs() {
@@ -3841,9 +3841,8 @@ mod tests {
         );
     }
 
-    /// NB-1 negative: when every error counter is zero, the line-2
-    /// conditional must NOT fire. Catches the inverse mutation (line 2
-    /// always fires even with zero errors).
+    /// Inverse of the above: when every error counter is zero, the
+    /// line-2 conditional must not fire.
     #[tracing_test::traced_test]
     #[test]
     fn log_sync_summary_no_error_line_when_all_counters_zero() {

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -59,6 +59,28 @@ pub(crate) fn fsync_parent_dir(path: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Async wrapper around [`fsync_parent_dir`] that runs the blocking
+/// syscall on the blocking pool and swallows every error class with a
+/// warn. Use when the caller has already committed to the rename
+/// being durable enough on its own (the bytes are at `path`, the
+/// metadata flush is best-effort).
+pub(crate) async fn fsync_parent_dir_async_best_effort(path: &Path) {
+    let path_buf = path.to_path_buf();
+    match tokio::task::spawn_blocking(move || fsync_parent_dir(&path_buf)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "parent-dir fsync failed; durability of rename not guaranteed"
+        ),
+        Err(join_err) => tracing::warn!(
+            path = %path.display(),
+            error = %join_err,
+            "parent-dir fsync task panicked; durability of rename not guaranteed"
+        ),
+    }
+}
+
 /// Install `src` at `dst` atomically.
 ///
 /// Prefers `rename` (atomic on the same device); on EXDEV, copies to a

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -2283,13 +2283,8 @@ mod tests {
         assert_eq!(status_of(&db, run_id), "complete");
     }
 
-    /// MS-1 (2026-05-03 robustness review): the new `enumeration_errors`
-    /// column on `sync_runs` (schema v10) carries the per-run count of
-    /// records the producer could not enumerate. Pre-v10 the only signals
-    /// were tracing logs and the in-memory `SyncStats.enumeration_errors`,
-    /// so `kei status` could not surface a `PartialFailure` driven purely
-    /// by enumeration errors. This test pins the round-trip from
-    /// `SyncRunStats.enumeration_errors` to the on-disk column.
+    /// `enumeration_errors` must round-trip from `SyncRunStats` into the
+    /// on-disk `sync_runs.enumeration_errors` column.
     #[tokio::test]
     async fn complete_sync_run_persists_enumeration_errors_column() {
         let db = SqliteStateDb::open_in_memory().unwrap();

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -1055,6 +1055,7 @@ impl StateDb for SqliteStateDb {
         let assets_seen = i64::try_from(stats.assets_seen).unwrap_or(i64::MAX);
         let assets_downloaded = i64::try_from(stats.assets_downloaded).unwrap_or(i64::MAX);
         let assets_failed = i64::try_from(stats.assets_failed).unwrap_or(i64::MAX);
+        let enumeration_errors = i64::try_from(stats.enumeration_errors).unwrap_or(i64::MAX);
         let interrupted_i32 = i32::from(stats.interrupted);
         let status = if stats.interrupted {
             "interrupted"
@@ -1065,7 +1066,8 @@ impl StateDb for SqliteStateDb {
         self.with_conn("complete_sync_run", move |conn| {
             conn.execute(
                 "UPDATE sync_runs SET completed_at = ?1, assets_seen = ?2, assets_downloaded = ?3, \
-                 assets_failed = ?4, interrupted = ?5, status = ?6 WHERE id = ?7",
+                 assets_failed = ?4, interrupted = ?5, status = ?6, enumeration_errors = ?7 \
+                 WHERE id = ?8",
                 rusqlite::params![
                     completed_at,
                     assets_seen,
@@ -1073,6 +1075,7 @@ impl StateDb for SqliteStateDb {
                     assets_failed,
                     interrupted_i32,
                     status,
+                    enumeration_errors,
                     run_id
                 ],
             )
@@ -2235,6 +2238,7 @@ mod tests {
             assets_seen: 100,
             assets_downloaded: 95,
             assets_failed: 5,
+            enumeration_errors: 0,
             interrupted: false,
         };
 
@@ -2272,10 +2276,45 @@ mod tests {
             assets_seen: 1,
             assets_downloaded: 1,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: false,
         };
         db.complete_sync_run(run_id, &stats).await.unwrap();
         assert_eq!(status_of(&db, run_id), "complete");
+    }
+
+    /// MS-1 (2026-05-03 robustness review): the new `enumeration_errors`
+    /// column on `sync_runs` (schema v10) carries the per-run count of
+    /// records the producer could not enumerate. Pre-v10 the only signals
+    /// were tracing logs and the in-memory `SyncStats.enumeration_errors`,
+    /// so `kei status` could not surface a `PartialFailure` driven purely
+    /// by enumeration errors. This test pins the round-trip from
+    /// `SyncRunStats.enumeration_errors` to the on-disk column.
+    #[tokio::test]
+    async fn complete_sync_run_persists_enumeration_errors_column() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let run_id = db.start_sync_run().await.unwrap();
+        let stats = SyncRunStats {
+            assets_seen: 0,
+            assets_downloaded: 0,
+            assets_failed: 0,
+            enumeration_errors: 17,
+            interrupted: false,
+        };
+        db.complete_sync_run(run_id, &stats).await.unwrap();
+
+        let conn = db.acquire_lock("test_enum_errors_column").unwrap();
+        let stored: i64 = conn
+            .query_row(
+                "SELECT enumeration_errors FROM sync_runs WHERE id = ?1",
+                [run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored, 17,
+            "enumeration_errors must round-trip from SyncRunStats to sync_runs row"
+        );
     }
 
     #[tokio::test]
@@ -2286,6 +2325,7 @@ mod tests {
             assets_seen: 1,
             assets_downloaded: 0,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: true,
         };
         db.complete_sync_run(run_id, &stats).await.unwrap();
@@ -2303,6 +2343,7 @@ mod tests {
             assets_seen: 0,
             assets_downloaded: 0,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: false,
         };
         db.complete_sync_run(c, &clean).await.unwrap();
@@ -2323,6 +2364,7 @@ mod tests {
             assets_seen: 0,
             assets_downloaded: 0,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: false,
         };
         db.complete_sync_run(run_id, &stats).await.unwrap();
@@ -2404,6 +2446,7 @@ mod tests {
             assets_seen: 1,
             assets_downloaded: 1,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: false,
         };
         db.complete_sync_run(r1, &stats).await.unwrap();
@@ -3290,6 +3333,7 @@ mod tests {
             assets_seen: 0,
             assets_downloaded: 0,
             assets_failed: 0,
+            enumeration_errors: 0,
             interrupted: false,
         };
         db.complete_sync_run(run_id, &stats).await.unwrap();

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 9;
+pub(crate) const SCHEMA_VERSION: i32 = 10;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -424,6 +424,21 @@ fn migrate_to_version(
             // Idempotent: re-running on a v9 DB skips the recreate-table dance.
             if !column_exists(conn, "asset_albums", "library")? {
                 conn.execute_batch(schema_v9())?;
+            }
+        }
+        10 => {
+            // sync_runs.enumeration_errors: per-run count of records the
+            // producer could not enumerate. Pre-v10 the only signals were
+            // `tracing::error!` log lines and the in-memory
+            // `SyncStats.enumeration_errors`; nothing landed in
+            // `sync_runs`, so `kei status` could not surface a
+            // PartialFailure driven purely by enumeration errors. Default
+            // 0 is the correct backfill: every existing row predates this
+            // counter and never recorded the value.
+            if !column_exists(conn, "sync_runs", "enumeration_errors")? {
+                conn.execute_batch(
+                    "ALTER TABLE sync_runs ADD COLUMN enumeration_errors INTEGER NOT NULL DEFAULT 0;",
+                )?;
             }
         }
         other => {
@@ -1377,5 +1392,55 @@ mod tests {
                 .unwrap();
             assert_eq!(exists, 1, "v9 must (re)create {idx}");
         }
+    }
+
+    /// MS-1 (2026-05-03 robustness review): v10 adds
+    /// `sync_runs.enumeration_errors`. Verify the column lands on a fresh
+    /// migrate and is back-filled to 0 on existing rows. Defends against a
+    /// future migration that forgets to add the column or picks a wrong
+    /// default that breaks the NOT NULL constraint on backfill.
+    #[test]
+    fn test_v10_adds_enumeration_errors_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Pre-seed at v9 with the v9 schema, plus one sync_runs row to
+        // exercise the backfill default.
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        set_schema_version(&conn, 1).unwrap();
+        migrate(&conn).unwrap();
+
+        // Column must exist after migration to current.
+        let has_col = column_exists(&conn, "sync_runs", "enumeration_errors").unwrap();
+        assert!(has_col, "v10 must add `enumeration_errors` to sync_runs");
+
+        // Default 0 must apply to a fresh insert that omits the column.
+        conn.execute(
+            "INSERT INTO sync_runs (started_at) VALUES (?1)",
+            [1700000000_i64],
+        )
+        .unwrap();
+        let stored: i64 = conn
+            .query_row(
+                "SELECT enumeration_errors FROM sync_runs ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored, 0,
+            "default 0 must apply to inserts that omit the column"
+        );
+    }
+
+    /// MS-1 idempotent re-entry: applying v10 to a DB that already has the
+    /// column (e.g. crash recovery, partial migration) must not error.
+    #[test]
+    fn test_v10_idempotent_when_column_exists() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        // Reset version backwards and re-run the v10 step. This simulates
+        // an unusual recovery path; the migration must not fail.
+        set_schema_version(&conn, 9).unwrap();
+        migrate(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
     }
 }

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -427,14 +427,9 @@ fn migrate_to_version(
             }
         }
         10 => {
-            // sync_runs.enumeration_errors: per-run count of records the
-            // producer could not enumerate. Pre-v10 the only signals were
-            // `tracing::error!` log lines and the in-memory
-            // `SyncStats.enumeration_errors`; nothing landed in
-            // `sync_runs`, so `kei status` could not surface a
-            // PartialFailure driven purely by enumeration errors. Default
-            // 0 is the correct backfill: every existing row predates this
-            // counter and never recorded the value.
+            // sync_runs.enumeration_errors: per-run count of records
+            // the producer could not enumerate. Default 0 is the
+            // correct backfill -- existing rows predate the counter.
             if !column_exists(conn, "sync_runs", "enumeration_errors")? {
                 conn.execute_batch(
                     "ALTER TABLE sync_runs ADD COLUMN enumeration_errors INTEGER NOT NULL DEFAULT 0;",
@@ -1394,11 +1389,9 @@ mod tests {
         }
     }
 
-    /// MS-1 (2026-05-03 robustness review): v10 adds
-    /// `sync_runs.enumeration_errors`. Verify the column lands on a fresh
-    /// migrate and is back-filled to 0 on existing rows. Defends against a
-    /// future migration that forgets to add the column or picks a wrong
-    /// default that breaks the NOT NULL constraint on backfill.
+    /// v10 must add `sync_runs.enumeration_errors` and back-fill to 0
+    /// on existing rows. Catches a future migration that forgets the
+    /// column or picks a wrong default that breaks NOT NULL on backfill.
     #[test]
     fn test_v10_adds_enumeration_errors_column() {
         let conn = Connection::open_in_memory().unwrap();
@@ -1431,8 +1424,8 @@ mod tests {
         );
     }
 
-    /// MS-1 idempotent re-entry: applying v10 to a DB that already has the
-    /// column (e.g. crash recovery, partial migration) must not error.
+    /// Idempotent re-entry: applying v10 to a DB that already has the
+    /// column (crash recovery, partial migration) must not error.
     #[test]
     fn test_v10_idempotent_when_column_exists() {
         let conn = Connection::open_in_memory().unwrap();

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -429,6 +429,12 @@ pub struct SyncRunStats {
     pub assets_downloaded: u64,
     /// Number of assets that failed to download.
     pub assets_failed: u64,
+    /// Number of records the producer could not enumerate (CloudKit error
+    /// per-record, transient API failures past retry budget). Drives
+    /// `PartialFailure` in the zero-download branch even when
+    /// `assets_failed == 0`; recorded in `sync_runs` so `kei status` can
+    /// surface it without grepping logs.
+    pub enumeration_errors: u64,
     /// Whether the sync was interrupted (shutdown, re-auth, etc.).
     pub interrupted: bool,
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -54,7 +54,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match — preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 9;
+const HELPER_SCHEMA_VERSION: i32 = 10;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the v9 schema from `src/state/schema.rs` (the
@@ -127,7 +127,8 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
             assets_downloaded INTEGER DEFAULT 0,
             assets_failed INTEGER DEFAULT 0,
             interrupted INTEGER DEFAULT 0,
-            status TEXT NOT NULL DEFAULT 'running'
+            status TEXT NOT NULL DEFAULT 'running',
+            enumeration_errors INTEGER NOT NULL DEFAULT 0
         );
 
         CREATE TABLE IF NOT EXISTS metadata (
@@ -204,7 +205,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 9;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 10;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \
@@ -3984,6 +3985,10 @@ fn behavioral_helper_carries_every_migrated_column() {
     assert!(
         has_column(&conn, "asset_people", "library"),
         "v9 column asset_people.library must exist in the behavioral helper's DDL"
+    );
+    assert!(
+        has_column(&conn, "sync_runs", "enumeration_errors"),
+        "v10 column sync_runs.enumeration_errors must exist in the behavioral helper's DDL"
     );
 
     let has_asset_albums: bool = conn


### PR DESCRIPTION
## Summary

Three findings from the 2026-05-03 robustness review. All low effort, all close silent-failure or visibility gaps.

### CF-3: parent-dir fsync after rename

ext4 default `data=ordered` doesn't guarantee directory entry durability after `rename` returns Ok. A power loss between rename and the kernel committing the dir block can leave the file absent on reboot. The `atomic_install` helper already does the post-rename fsync for credentials and session files; the data path was strictly weaker.

Fix: mirror that pattern in `rename_part_to_final`. `spawn_blocking` runs `fsync_parent_dir`; failures log a warn and the function still returns Ok (the bytes are on disk and the rename returned Ok - worst case is one redundant re-download next sync).

### NB-1: surface `enumeration_errors` in `log_sync_summary`

Line 2 printed "X EXIF write failure(s), Y state write failure(s)" but never mentioned `stats.enumeration_errors`. An operator chasing exit code 2 from a `PartialFailure` driven purely by enumeration errors saw no count.

Fix: extend the line-2 conditional to fire on any of the three counters, append "Z enumeration error(s)".

### MS-1: `enumeration_errors` column on `sync_runs`

Schema bumped v9 -> v10 with `ALTER TABLE sync_runs ADD COLUMN enumeration_errors INTEGER NOT NULL DEFAULT 0`. `SyncRunStats` carries the new field; `complete_sync_run` persists it; the producer-side build site reads `enum_errors.load(Relaxed)`. Backfills existing rows to 0 - every existing row predates this counter.

Helper schema in `tests/behavioral.rs` bumped to v10 in lockstep.

## New tests

- `log_sync_summary_emits_enumeration_errors_when_only_enum_errs` (NB-1)
- `log_sync_summary_no_error_line_when_all_counters_zero` (NB-1 negative)
- `complete_sync_run_persists_enumeration_errors_column` (MS-1 round-trip)
- `test_v10_adds_enumeration_errors_column` (MS-1 fresh migration)
- `test_v10_idempotent_when_column_exists` (MS-1 crash recovery)
- `behavioral_helper_carries_every_migrated_column` extended for v10
- `behavioral_helper_schema_matches_production` bumped to v10

## Caveat

CF-3 has no per-call-site test for "fsync was attempted". The `fsync_parent_dir` helper has its own tests (`fsync_parent_dir_succeeds_for_extant_path`, `fsync_parent_dir_unix_errors_when_parent_missing`) and `rename_part_to_final_happy_path` proves the new code path still reaches Ok. Adding fault injection at the syscall level would need a fsync-injectable wrapper around the helper - deferred.

Source: `.scratch/2026-05-03_ROBUSTNESS_REVIEW.md` (CF-3, NB-1, MS-1) and `.scratch/2026-05-03_FULL_REVIEW.md`.

## Test plan

- [x] `cargo test` (parallel): 2,485 passing - 7 new lib + 1 new behavioral
- [x] `cargo test -- --test-threads=1`: same
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo run -- --version` boots
- [ ] Schema v10 migration is mechanical ALTER + DEFAULT 0 backfill, idempotent re-entry tested. Worth a manual sanity check on an existing DB before merge: `kei sync ...` should migrate v9 -> v10 with no warnings, and `SELECT enumeration_errors FROM sync_runs` should return 0 for all pre-existing rows.

## Independence

Independent of any other open PR; can merge first.