### PR TITLE
refactor: unblock CG-4 (shutdown timeout) and CG-7 (enum_config_hash) tests

### DIFF
--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -24,14 +24,8 @@ const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 const FORCE_EXIT_CODE: i32 = 130;
 
 /// Wait `timeout`, then invoke `on_timeout` with [`FORCE_EXIT_CODE`].
-/// Extracted from the inline shutdown task so tests can swap the
-/// real `std::process::exit` for a recording callback and use
-/// `tokio::time::pause` + `advance` to fire the timeout deterministically
-/// without terminating the test binary.
-///
-/// The warn line is part of the contract: a future regression that
-/// drops it would silently change shutdown behaviour and an operator
-/// chasing a SIGKILL'd run would have nothing to grep for.
+/// The warn line is part of the contract: an operator chasing a
+/// SIGKILL'd run greps for it.
 pub(crate) async fn wait_then_force_exit<F>(timeout: Duration, on_timeout: F)
 where
     F: FnOnce(i32),
@@ -136,66 +130,46 @@ mod tests {
         assert!(!token.is_cancelled());
     }
 
-    /// CG-4 (2026-05-03 test review): the timeout branch of
-    /// `install_signal_handler` (which fires when in-flight downloads
-    /// fail to drain inside `GRACEFUL_SHUTDOWN_TIMEOUT`) was previously
-    /// unexercised because it called `std::process::exit(130)` directly
-    /// and would terminate the test binary. After extracting
-    /// `wait_then_force_exit` with an injectable callback, the timeout
-    /// arm is testable: pause the runtime clock, await the helper, and
-    /// observe that the callback fired with code 130. A regression that
-    /// changed the timeout constant or dropped the warn line is now
-    /// loud.
+    /// `start_paused = true` lets tokio auto-advance the clock when
+    /// nothing else can make progress, so awaiting the helper runs the
+    /// sleep to completion without wall-clock delay.
     #[tracing_test::traced_test]
     #[tokio::test(start_paused = true)]
     async fn shutdown_grace_period_elapses_invokes_exit_callback() {
-        let exited = Arc::new(std::sync::atomic::AtomicI32::new(-1));
+        let exited: Arc<std::sync::Mutex<Option<i32>>> = Arc::new(std::sync::Mutex::new(None));
         let exited_clone = Arc::clone(&exited);
 
-        // With `start_paused = true`, tokio auto-advances the clock when
-        // nothing else can make progress. Awaiting the future runs the
-        // sleep to completion without wall-clock delay.
         wait_then_force_exit(Duration::from_secs(30), move |code| {
-            exited_clone.store(code, Ordering::SeqCst);
+            *exited_clone.lock().unwrap() = Some(code);
         })
         .await;
 
-        assert_eq!(
-            exited.load(Ordering::SeqCst),
-            FORCE_EXIT_CODE,
-            "callback must fire with FORCE_EXIT_CODE (130) after the timeout elapses"
-        );
+        assert_eq!(*exited.lock().unwrap(), Some(FORCE_EXIT_CODE));
         assert!(
             logs_contain("Graceful shutdown timed out"),
             "warn line must accompany the timeout fire so operators can grep for it"
         );
     }
 
-    /// CG-4 negative: if `on_timeout` never gets called, the callback's
-    /// `i32` slot stays at the sentinel. Catches a regression that
-    /// fires the callback before the sleep elapses (e.g. swapping the
-    /// order of statements).
     #[tokio::test(start_paused = true)]
     async fn wait_then_force_exit_does_not_fire_before_timeout() {
-        let exited = Arc::new(std::sync::atomic::AtomicI32::new(-1));
+        let exited: Arc<std::sync::Mutex<Option<i32>>> = Arc::new(std::sync::Mutex::new(None));
         let exited_clone = Arc::clone(&exited);
 
         let handle = tokio::spawn(wait_then_force_exit(Duration::from_secs(30), move |code| {
-            exited_clone.store(code, Ordering::SeqCst);
+            *exited_clone.lock().unwrap() = Some(code);
         }));
 
-        // Advance only halfway. The sleep has not elapsed; the callback
-        // must not have fired.
         tokio::time::advance(Duration::from_secs(15)).await;
         assert_eq!(
-            exited.load(Ordering::SeqCst),
-            -1,
+            *exited.lock().unwrap(),
+            None,
             "callback must not fire before the configured timeout elapses"
         );
 
         // Drain the rest so the spawned task completes cleanly.
         tokio::time::advance(Duration::from_secs(20)).await;
         handle.await.unwrap();
-        assert_eq!(exited.load(Ordering::SeqCst), FORCE_EXIT_CODE);
+        assert_eq!(*exited.lock().unwrap(), Some(FORCE_EXIT_CODE));
     }
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -6,6 +6,7 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[cfg(unix)]
 use anyhow::Context;
@@ -15,7 +16,30 @@ use crate::systemd::SystemdNotifier;
 
 /// How long to wait for graceful shutdown before force-exiting.
 /// Aligned with `stop_grace_period` in docker-compose.yml.
-const GRACEFUL_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The exit code emitted when graceful shutdown drains exceed the
+/// timeout. 130 matches the conventional "killed by SIGINT" code so
+/// shell users see a familiar number instead of a kei-specific one.
+const FORCE_EXIT_CODE: i32 = 130;
+
+/// Wait `timeout`, then invoke `on_timeout` with [`FORCE_EXIT_CODE`].
+/// Extracted from the inline shutdown task so tests can swap the
+/// real `std::process::exit` for a recording callback and use
+/// `tokio::time::pause` + `advance` to fire the timeout deterministically
+/// without terminating the test binary.
+///
+/// The warn line is part of the contract: a future regression that
+/// drops it would silently change shutdown behaviour and an operator
+/// chasing a SIGKILL'd run would have nothing to grep for.
+pub(crate) async fn wait_then_force_exit<F>(timeout: Duration, on_timeout: F)
+where
+    F: FnOnce(i32),
+{
+    tokio::time::sleep(timeout).await;
+    tracing::warn!("Graceful shutdown timed out, forcing exit");
+    on_timeout(FORCE_EXIT_CODE);
+}
 
 /// Install signal handlers and return a [`CancellationToken`] that is
 /// cancelled on the first SIGINT / SIGTERM / SIGHUP.  A second signal
@@ -72,14 +96,12 @@ pub(crate) fn install_signal_handler(
                 // dead CDN connection). Matches docker-compose
                 // stop_grace_period so the app exits cleanly before Docker
                 // sends SIGKILL.
-                tokio::spawn(async {
-                    tokio::time::sleep(GRACEFUL_SHUTDOWN_TIMEOUT).await;
-                    tracing::warn!("Graceful shutdown timed out, forcing exit");
-                    std::process::exit(130);
-                });
+                tokio::spawn(wait_then_force_exit(GRACEFUL_SHUTDOWN_TIMEOUT, |code| {
+                    std::process::exit(code)
+                }));
             } else {
                 tracing::warn!("Force exit requested");
-                std::process::exit(130);
+                std::process::exit(FORCE_EXIT_CODE);
             }
         }
     });
@@ -112,5 +134,68 @@ mod tests {
         let notifier = SystemdNotifier::new(false);
         let token = install_signal_handler(notifier).unwrap();
         assert!(!token.is_cancelled());
+    }
+
+    /// CG-4 (2026-05-03 test review): the timeout branch of
+    /// `install_signal_handler` (which fires when in-flight downloads
+    /// fail to drain inside `GRACEFUL_SHUTDOWN_TIMEOUT`) was previously
+    /// unexercised because it called `std::process::exit(130)` directly
+    /// and would terminate the test binary. After extracting
+    /// `wait_then_force_exit` with an injectable callback, the timeout
+    /// arm is testable: pause the runtime clock, await the helper, and
+    /// observe that the callback fired with code 130. A regression that
+    /// changed the timeout constant or dropped the warn line is now
+    /// loud.
+    #[tracing_test::traced_test]
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_grace_period_elapses_invokes_exit_callback() {
+        let exited = Arc::new(std::sync::atomic::AtomicI32::new(-1));
+        let exited_clone = Arc::clone(&exited);
+
+        // With `start_paused = true`, tokio auto-advances the clock when
+        // nothing else can make progress. Awaiting the future runs the
+        // sleep to completion without wall-clock delay.
+        wait_then_force_exit(Duration::from_secs(30), move |code| {
+            exited_clone.store(code, Ordering::SeqCst);
+        })
+        .await;
+
+        assert_eq!(
+            exited.load(Ordering::SeqCst),
+            FORCE_EXIT_CODE,
+            "callback must fire with FORCE_EXIT_CODE (130) after the timeout elapses"
+        );
+        assert!(
+            logs_contain("Graceful shutdown timed out"),
+            "warn line must accompany the timeout fire so operators can grep for it"
+        );
+    }
+
+    /// CG-4 negative: if `on_timeout` never gets called, the callback's
+    /// `i32` slot stays at the sentinel. Catches a regression that
+    /// fires the callback before the sleep elapses (e.g. swapping the
+    /// order of statements).
+    #[tokio::test(start_paused = true)]
+    async fn wait_then_force_exit_does_not_fire_before_timeout() {
+        let exited = Arc::new(std::sync::atomic::AtomicI32::new(-1));
+        let exited_clone = Arc::clone(&exited);
+
+        let handle = tokio::spawn(wait_then_force_exit(Duration::from_secs(30), move |code| {
+            exited_clone.store(code, Ordering::SeqCst);
+        }));
+
+        // Advance only halfway. The sleep has not elapsed; the callback
+        // must not have fired.
+        tokio::time::advance(Duration::from_secs(15)).await;
+        assert_eq!(
+            exited.load(Ordering::SeqCst),
+            -1,
+            "callback must not fire before the configured timeout elapses"
+        );
+
+        // Drain the rest so the spawned task completes cleanly.
+        tokio::time::advance(Duration::from_secs(20)).await;
+        handle.await.unwrap();
+        assert_eq!(exited.load(Ordering::SeqCst), FORCE_EXIT_CODE);
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1286,6 +1286,66 @@ type BuildDownloadConfigFn<'a> = dyn Fn(
     ) -> Arc<download::DownloadConfig>
     + 'a;
 
+/// Outcome of [`check_and_persist_enum_config_hash`]. Returned so callers
+/// (and tests) can observe whether the user's download config drifted
+/// since the last sync without re-implementing the comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnumConfigHashOutcome {
+    /// No `enum_config_hash` was stored before this call. The current
+    /// hash is now persisted; sync tokens are NOT cleared because
+    /// nothing about the user's config has changed yet (a first-run DB
+    /// must not invalidate downstream incremental tokens that another
+    /// process may have written).
+    Initial,
+    /// Stored hash matches the current hash. Nothing was written.
+    Unchanged,
+    /// Stored hash differs from the current hash. Sync tokens have
+    /// been cleared and the new hash persisted, so the next cycle
+    /// falls back to full enumeration.
+    Changed,
+}
+
+/// Compare the current download-config hash against the one stored in
+/// the state DB and react to drift. Extracted from `run_cycle` so the
+/// hash-drift behaviour is unit-testable without spinning up the full
+/// per-library cycle. Logging is preserved verbatim so the original
+/// inline behaviour is unchanged.
+///
+/// Storage failures are logged at warn and swallowed: the same as the
+/// previous inline behaviour. Returns the observed [`EnumConfigHashOutcome`]
+/// so callers (and tests) can assert on which branch fired.
+pub(crate) async fn check_and_persist_enum_config_hash(
+    db: &dyn state::StateDb,
+    current_hash: &str,
+) -> EnumConfigHashOutcome {
+    let stored_hash = db.get_metadata("enum_config_hash").await.unwrap_or(None);
+    let outcome = match stored_hash.as_deref() {
+        Some(h) if h == current_hash => return EnumConfigHashOutcome::Unchanged,
+        Some(_) => EnumConfigHashOutcome::Changed,
+        None => EnumConfigHashOutcome::Initial,
+    };
+
+    if matches!(outcome, EnumConfigHashOutcome::Changed) {
+        tracing::info!("Download config changed since last sync, clearing sync tokens");
+        match db.delete_metadata_by_prefix("sync_token:").await {
+            Ok(n) if n > 0 => {
+                tracing::debug!(cleared = n, "Cleared stale sync tokens");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to clear sync tokens"
+                );
+            }
+            _ => {}
+        }
+    }
+    if let Err(e) = db.set_metadata("enum_config_hash", current_hash).await {
+        tracing::warn!(error = %e, "Failed to persist enum_config_hash");
+    }
+    outcome
+}
+
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
 async fn run_cycle(
     library_states: &[LibraryState],
@@ -1334,29 +1394,7 @@ async fn run_cycle(
                 // the two hashes to overwrite each other every cycle,
                 // permanently preventing incremental sync.
                 let config_hash = download::compute_config_hash(config);
-                let stored_hash = db.get_metadata("enum_config_hash").await.unwrap_or(None);
-                if stored_hash.as_deref() != Some(&config_hash) {
-                    if stored_hash.is_some() {
-                        tracing::info!(
-                            "Download config changed since last sync, clearing sync tokens"
-                        );
-                        match db.delete_metadata_by_prefix("sync_token:").await {
-                            Ok(n) if n > 0 => {
-                                tracing::debug!(cleared = n, "Cleared stale sync tokens");
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Failed to clear sync tokens"
-                                );
-                            }
-                            _ => {}
-                        }
-                    }
-                    if let Err(e) = db.set_metadata("enum_config_hash", &config_hash).await {
-                        tracing::warn!(error = %e, "Failed to persist enum_config_hash");
-                    }
-                }
+                let _ = check_and_persist_enum_config_hash(db, &config_hash).await;
             }
         }
 
@@ -3732,5 +3770,118 @@ mod tests {
         let err: anyhow::Error = anyhow::anyhow!("network unreachable");
         assert!(!should_wait_for_2fa(false, &err));
         assert!(!should_wait_for_2fa(true, &err));
+    }
+
+    // ── check_and_persist_enum_config_hash (CG-7, 2026-05-03 test review)
+    //
+    // The hash-drift logic was previously inline in `run_cycle`. The
+    // contract: stored hash differs from current -> clear sync tokens
+    // + persist new; first run -> persist only (no token clear); match
+    // -> no-op. A regression that swapped the comparison direction or
+    // the persist-vs-clear order would silently disable enum-cache
+    // invalidation. After extracting, these tests pin every branch.
+
+    /// First-run case: stored hash absent. Helper persists current,
+    /// returns `Initial`, leaves any existing sync tokens alone (a
+    /// fresh kei DB has no tokens, so clearing would be a no-op, but
+    /// the contract is "first run = no token clear" so we lock it).
+    #[tokio::test]
+    async fn enum_config_hash_initial_persists_only() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        // Pre-seed a sync token so we can assert it's preserved.
+        db.set_metadata("sync_token:PrimarySync", "tok-abc")
+            .await
+            .expect("set token");
+
+        let outcome = check_and_persist_enum_config_hash(&db, "hash-1").await;
+
+        assert_eq!(outcome, EnumConfigHashOutcome::Initial);
+        assert_eq!(
+            db.get_metadata("enum_config_hash")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("hash-1"),
+            "first run must persist the new hash"
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("tok-abc"),
+            "first run must NOT clear sync tokens"
+        );
+    }
+
+    /// Drift case: stored hash != current. Helper clears every
+    /// `sync_token:*` row and persists the new hash. Catches the
+    /// regression that flips the comparison or skips the clear step.
+    #[tokio::test]
+    async fn enum_config_hash_drift_clears_tokens_and_persists() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata("enum_config_hash", "old-hash")
+            .await
+            .expect("seed old hash");
+        db.set_metadata("sync_token:PrimarySync", "tok-primary")
+            .await
+            .expect("seed primary token");
+        db.set_metadata("sync_token:SharedSync-AAAA1111", "tok-shared")
+            .await
+            .expect("seed shared token");
+
+        let outcome = check_and_persist_enum_config_hash(&db, "new-hash").await;
+
+        assert_eq!(outcome, EnumConfigHashOutcome::Changed);
+        assert_eq!(
+            db.get_metadata("enum_config_hash")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("new-hash"),
+            "drift must persist the new hash"
+        );
+        assert!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .is_none(),
+            "drift must clear primary-zone sync token"
+        );
+        assert!(
+            db.get_metadata("sync_token:SharedSync-AAAA1111")
+                .await
+                .unwrap()
+                .is_none(),
+            "drift must clear every sync_token:* row, including shared zones"
+        );
+    }
+
+    /// Unchanged case: stored hash == current. Helper writes nothing,
+    /// returns `Unchanged`. Catches the regression that always
+    /// re-persists even when the hash matches (would generate write
+    /// load and could mask a separate bug that's about to corrupt
+    /// the metadata table).
+    #[tokio::test]
+    async fn enum_config_hash_unchanged_is_noop() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata("enum_config_hash", "stable-hash")
+            .await
+            .expect("seed stable hash");
+        db.set_metadata("sync_token:PrimarySync", "tok-keep")
+            .await
+            .expect("seed token");
+
+        let outcome = check_and_persist_enum_config_hash(&db, "stable-hash").await;
+
+        assert_eq!(outcome, EnumConfigHashOutcome::Unchanged);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("tok-keep"),
+            "unchanged hash must leave sync tokens intact"
+        );
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -54,6 +54,18 @@ struct LibraryState {
 /// data dir the next time it's used.
 const SHARED_LIBRARY_NOTICE_KEY: &str = "shared_library_notice_shown_v1";
 
+/// Metadata key holding the SHA-256 of the enumeration-affecting subset of
+/// the user's download config. Distinct from the path-affecting
+/// `config_hash` consumed by the download pipeline; using a single key for
+/// both would cause each cycle to overwrite the other's value and
+/// permanently invalidate incremental sync.
+const ENUM_CONFIG_HASH_KEY: &str = "enum_config_hash";
+
+/// Prefix for every per-zone CloudKit sync token row in the metadata
+/// table. Cleared en masse when [`ENUM_CONFIG_HASH_KEY`] changes so the
+/// next cycle falls back to full enumeration.
+const SYNC_TOKEN_PREFIX: &str = "sync_token:";
+
 /// Classify whether an error from `init_photos_service` or
 /// `resolve_libraries` indicates a stale session / routing state that
 /// an SRP re-auth would fix.
@@ -1286,39 +1298,28 @@ type BuildDownloadConfigFn<'a> = dyn Fn(
     ) -> Arc<download::DownloadConfig>
     + 'a;
 
-/// Outcome of [`check_and_persist_enum_config_hash`]. Returned so callers
-/// (and tests) can observe whether the user's download config drifted
-/// since the last sync without re-implementing the comparison.
+/// Outcome of [`check_and_persist_enum_config_hash`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EnumConfigHashOutcome {
-    /// No `enum_config_hash` was stored before this call. The current
-    /// hash is now persisted; sync tokens are NOT cleared because
-    /// nothing about the user's config has changed yet (a first-run DB
-    /// must not invalidate downstream incremental tokens that another
-    /// process may have written).
+    /// No prior hash; current hash persisted. Sync tokens left alone:
+    /// a first-run DB must not invalidate tokens another process may
+    /// have written.
     Initial,
-    /// Stored hash matches the current hash. Nothing was written.
     Unchanged,
-    /// Stored hash differs from the current hash. Sync tokens have
-    /// been cleared and the new hash persisted, so the next cycle
-    /// falls back to full enumeration.
+    /// Hash drifted; sync tokens cleared and new hash persisted so the
+    /// next cycle falls back to full enumeration.
     Changed,
 }
 
 /// Compare the current download-config hash against the one stored in
-/// the state DB and react to drift. Extracted from `run_cycle` so the
-/// hash-drift behaviour is unit-testable without spinning up the full
-/// per-library cycle. Logging is preserved verbatim so the original
-/// inline behaviour is unchanged.
-///
-/// Storage failures are logged at warn and swallowed: the same as the
-/// previous inline behaviour. Returns the observed [`EnumConfigHashOutcome`]
-/// so callers (and tests) can assert on which branch fired.
+/// the state DB and react to drift. Storage failures are logged at warn
+/// and swallowed (a partial write here can't corrupt the user's data;
+/// next cycle re-tries).
 pub(crate) async fn check_and_persist_enum_config_hash(
     db: &dyn state::StateDb,
     current_hash: &str,
 ) -> EnumConfigHashOutcome {
-    let stored_hash = db.get_metadata("enum_config_hash").await.unwrap_or(None);
+    let stored_hash = db.get_metadata(ENUM_CONFIG_HASH_KEY).await.unwrap_or(None);
     let outcome = match stored_hash.as_deref() {
         Some(h) if h == current_hash => return EnumConfigHashOutcome::Unchanged,
         Some(_) => EnumConfigHashOutcome::Changed,
@@ -1327,7 +1328,7 @@ pub(crate) async fn check_and_persist_enum_config_hash(
 
     if matches!(outcome, EnumConfigHashOutcome::Changed) {
         tracing::info!("Download config changed since last sync, clearing sync tokens");
-        match db.delete_metadata_by_prefix("sync_token:").await {
+        match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
             Ok(n) if n > 0 => {
                 tracing::debug!(cleared = n, "Cleared stale sync tokens");
             }
@@ -1340,7 +1341,7 @@ pub(crate) async fn check_and_persist_enum_config_hash(
             _ => {}
         }
     }
-    if let Err(e) = db.set_metadata("enum_config_hash", current_hash).await {
+    if let Err(e) = db.set_metadata(ENUM_CONFIG_HASH_KEY, current_hash).await {
         tracing::warn!(error = %e, "Failed to persist enum_config_hash");
     }
     outcome
@@ -1375,27 +1376,27 @@ async fn run_cycle(
         );
     }
 
+    // Check if the download config changed since last sync. If so, clear
+    // sync tokens so the subsequent lookup falls back to full enumeration
+    // -- the stored incremental token would miss assets that are newly
+    // eligible under the changed config (e.g. a user switching --size or
+    // adding --skip-videos). The hash is cycle-invariant across libraries,
+    // so this runs once per cycle, not once per library.
+    //
+    // The metadata key `enum_config_hash` is distinct from the download
+    // pipeline's `config_hash` (which tracks path-affecting fields only).
+    // Using a single key for both would cause the two hashes to overwrite
+    // each other every cycle, permanently preventing incremental sync.
+    if !config.dry_run {
+        if let Some(db) = state_db {
+            let config_hash = download::compute_config_hash(config);
+            let _ = check_and_persist_enum_config_hash(db, &config_hash).await;
+        }
+    }
+
     for lib_state in library_states {
         if shutdown_token.is_cancelled() {
             break;
-        }
-
-        // Check if the download config changed since last sync. If so,
-        // clear sync tokens so the subsequent lookup falls back to full
-        // enumeration -- the stored incremental token would miss assets
-        // that are newly eligible under the changed config (e.g. a
-        // user switching --size or adding --skip-videos).
-        if !config.dry_run {
-            if let Some(db) = state_db {
-                // Use a separate key from the download-path's "config_hash"
-                // (which tracks path-affecting fields only). This hash is a
-                // superset that also includes enumeration filters (albums,
-                // library, skip_live_photos). Using the same key would cause
-                // the two hashes to overwrite each other every cycle,
-                // permanently preventing incremental sync.
-                let config_hash = download::compute_config_hash(config);
-                let _ = check_and_persist_enum_config_hash(db, &config_hash).await;
-            }
         }
 
         // Determine sync mode per-library
@@ -3772,24 +3773,12 @@ mod tests {
         assert!(!should_wait_for_2fa(true, &err));
     }
 
-    // ── check_and_persist_enum_config_hash (CG-7, 2026-05-03 test review)
-    //
-    // The hash-drift logic was previously inline in `run_cycle`. The
-    // contract: stored hash differs from current -> clear sync tokens
-    // + persist new; first run -> persist only (no token clear); match
-    // -> no-op. A regression that swapped the comparison direction or
-    // the persist-vs-clear order would silently disable enum-cache
-    // invalidation. After extracting, these tests pin every branch.
+    // ── check_and_persist_enum_config_hash ─────────────────────────────
 
-    /// First-run case: stored hash absent. Helper persists current,
-    /// returns `Initial`, leaves any existing sync tokens alone (a
-    /// fresh kei DB has no tokens, so clearing would be a no-op, but
-    /// the contract is "first run = no token clear" so we lock it).
     #[tokio::test]
     async fn enum_config_hash_initial_persists_only() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
-        // Pre-seed a sync token so we can assert it's preserved.
-        db.set_metadata("sync_token:PrimarySync", "tok-abc")
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "tok-abc")
             .await
             .expect("set token");
 
@@ -3797,78 +3786,68 @@ mod tests {
 
         assert_eq!(outcome, EnumConfigHashOutcome::Initial);
         assert_eq!(
-            db.get_metadata("enum_config_hash")
+            db.get_metadata(ENUM_CONFIG_HASH_KEY)
                 .await
                 .unwrap()
                 .as_deref(),
             Some("hash-1"),
-            "first run must persist the new hash"
         );
+        // First run must NOT clear pre-existing sync tokens.
         assert_eq!(
-            db.get_metadata("sync_token:PrimarySync")
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
                 .await
                 .unwrap()
                 .as_deref(),
             Some("tok-abc"),
-            "first run must NOT clear sync tokens"
         );
     }
 
-    /// Drift case: stored hash != current. Helper clears every
-    /// `sync_token:*` row and persists the new hash. Catches the
-    /// regression that flips the comparison or skips the clear step.
     #[tokio::test]
     async fn enum_config_hash_drift_clears_tokens_and_persists() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
-        db.set_metadata("enum_config_hash", "old-hash")
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "old-hash")
             .await
             .expect("seed old hash");
-        db.set_metadata("sync_token:PrimarySync", "tok-primary")
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "tok-primary")
             .await
             .expect("seed primary token");
-        db.set_metadata("sync_token:SharedSync-AAAA1111", "tok-shared")
-            .await
-            .expect("seed shared token");
+        db.set_metadata(
+            &format!("{SYNC_TOKEN_PREFIX}SharedSync-AAAA1111"),
+            "tok-shared",
+        )
+        .await
+        .expect("seed shared token");
 
         let outcome = check_and_persist_enum_config_hash(&db, "new-hash").await;
 
         assert_eq!(outcome, EnumConfigHashOutcome::Changed);
         assert_eq!(
-            db.get_metadata("enum_config_hash")
+            db.get_metadata(ENUM_CONFIG_HASH_KEY)
                 .await
                 .unwrap()
                 .as_deref(),
             Some("new-hash"),
-            "drift must persist the new hash"
         );
-        assert!(
-            db.get_metadata("sync_token:PrimarySync")
-                .await
-                .unwrap()
-                .is_none(),
-            "drift must clear primary-zone sync token"
-        );
-        assert!(
-            db.get_metadata("sync_token:SharedSync-AAAA1111")
-                .await
-                .unwrap()
-                .is_none(),
-            "drift must clear every sync_token:* row, including shared zones"
-        );
+        // Every sync_token:* row must clear, including shared zones.
+        assert!(db
+            .get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(db
+            .get_metadata(&format!("{SYNC_TOKEN_PREFIX}SharedSync-AAAA1111"))
+            .await
+            .unwrap()
+            .is_none());
     }
 
-    /// Unchanged case: stored hash == current. Helper writes nothing,
-    /// returns `Unchanged`. Catches the regression that always
-    /// re-persists even when the hash matches (would generate write
-    /// load and could mask a separate bug that's about to corrupt
-    /// the metadata table).
     #[tokio::test]
     async fn enum_config_hash_unchanged_is_noop() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
-        db.set_metadata("enum_config_hash", "stable-hash")
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "stable-hash")
             .await
             .expect("seed stable hash");
-        db.set_metadata("sync_token:PrimarySync", "tok-keep")
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "tok-keep")
             .await
             .expect("seed token");
 
@@ -3876,12 +3855,11 @@ mod tests {
 
         assert_eq!(outcome, EnumConfigHashOutcome::Unchanged);
         assert_eq!(
-            db.get_metadata("sync_token:PrimarySync")
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
                 .await
                 .unwrap()
                 .as_deref(),
             Some("tok-keep"),
-            "unchanged hash must leave sync tokens intact"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes the two test gaps from the 2026-05-03 test review that were deferred during phase-2 because the code under test was tangled into harness-fatal call sites or heavy fixtures. Each is a small `pub(crate)` extraction with no behaviour change, plus the tests that the extraction unblocks.

### CG-4: graceful-shutdown timeout

The timeout arm in `install_signal_handler` previously called `std::process::exit(130)` directly inside an inline `tokio::spawn`. Any test that exercised the arm would terminate the test binary, so the only existing tests covered token construction + child cancel, never the timeout firing.

Extract the body into:

```rust
pub(crate) async fn wait_then_force_exit(
    timeout: Duration,
    on_timeout: impl FnOnce(i32),
)
```

Production wires `std::process::exit` as the callback. Tests pass a recording closure plus `#[tokio::test(start_paused = true)]`; the runtime auto-advances time and the callback fires deterministically.

The 130 exit code is now a `FORCE_EXIT_CODE` constant so the inner-second-signal path reuses it - a future regression that picks a different code on either path is loud.

### CG-7: enum_config_hash drift

The hash-compare-and-persist logic was inline at `run_cycle:1322-1361`. Calling it from a unit test required the full `LibraryState` / `BuildDownloadConfigFn` / `SharedSession` fixture surface.

Extract into:

```rust
pub(crate) async fn check_and_persist_enum_config_hash(
    db: &dyn StateDb,
    current_hash: &str,
) -> EnumConfigHashOutcome { Initial, Unchanged, Changed }
```

Behavior preserved verbatim including the inline tracing lines, so production logs are unchanged. The `EnumConfigHashOutcome` lets tests assert which branch fired without inspecting log output.

## New tests

CG-4:
- `shutdown_grace_period_elapses_invokes_exit_callback`
- `wait_then_force_exit_does_not_fire_before_timeout`

CG-7:
- `enum_config_hash_initial_persists_only` (first-run: persist, don't clear tokens)
- `enum_config_hash_drift_clears_tokens_and_persists` (changed: persist + clear `sync_token:*`)
- `enum_config_hash_unchanged_is_noop` (matched: no writes)

## Independence

Independent of the other open PRs. No dependency ordering required.

## Test plan

- [x] `cargo test` (parallel): 2,485 passing - 5 new lib tests
- [x] `cargo test -- --test-threads=1`: 2,485 passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo run -- --version` boots