### PR TITLE
fix: five v0.13 follow-through bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`[metrics]` TOML section and `KEI_METRICS_PORT` env var.** Both are folded into `[server]` (TOML) and `KEI_HTTP_PORT` (env). The deprecation warning for `[metrics]` has shipped since v0.13.0; pre-fix it only fired when `[metrics] port` was actually being used to resolve `http_port`, so a config with both `[server]` and `[metrics]` set kept `[metrics]` silently around. The `KEI_METRICS_PORT` env var has the same problem and now warns whenever it is set, even if a higher-precedence value (CLI / `[server]` TOML / `KEI_HTTP_PORT`) wins. Both surfaces are scheduled for removal in v0.20.0; rename `[metrics]` to `[server]` and `KEI_METRICS_PORT` to `KEI_HTTP_PORT` to clear the warnings.
+
 ---
 
 ## [0.13.1] - 2026-05-03

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -737,9 +737,16 @@ pub enum Command {
         #[command(flatten)]
         password: PasswordArgs,
 
-        /// Library to list albums from (default: PrimarySync, use "all" for all)
-        #[arg(long, env = "KEI_LIBRARY")]
-        library: Option<String>,
+        /// Library/libraries to list albums from. Repeatable; default
+        /// `primary` (the PrimarySync zone). Same value grammar as
+        /// `kei sync --library`: a CloudKit zone name (full UUID or the
+        /// truncated 8-char `SharedSync-` prefix that `{library}` renders
+        /// into paths), the sentinels `primary` / `shared` / `all` /
+        /// `none`, or `!name` to exclude. Only consulted by
+        /// `kei list albums`; `kei list libraries` always lists every
+        /// library on the account.
+        #[arg(long = "library", env = "KEI_LIBRARY", value_parser = non_empty_string)]
+        libraries: Vec<String>,
 
         #[command(subcommand)]
         what: ListCommand,
@@ -1070,7 +1077,7 @@ impl Cli {
                 deprecation_warning("--list-albums", "kei list albums");
                 return Command::List {
                     password: self.password.clone(),
-                    library: self.sync.libraries.first().cloned(),
+                    libraries: self.sync.libraries.clone(),
                     what: ListCommand::Albums,
                 };
             }
@@ -1078,7 +1085,7 @@ impl Cli {
                 deprecation_warning("--list-libraries", "kei list libraries");
                 return Command::List {
                     password: self.password.clone(),
-                    library: self.sync.libraries.first().cloned(),
+                    libraries: self.sync.libraries.clone(),
                     what: ListCommand::Libraries,
                 };
             }
@@ -1157,7 +1164,7 @@ impl Cli {
                 deprecation_warning("--list-albums", "kei list albums");
                 Command::List {
                     password: password.clone(),
-                    library: sync.libraries.first().cloned(),
+                    libraries: sync.libraries.clone(),
                     what: ListCommand::Albums,
                 }
             }
@@ -1168,7 +1175,7 @@ impl Cli {
                 deprecation_warning("--list-libraries", "kei list libraries");
                 Command::List {
                     password: password.clone(),
-                    library: sync.libraries.first().cloned(),
+                    libraries: sync.libraries.clone(),
                     what: ListCommand::Libraries,
                 }
             }
@@ -3008,11 +3015,97 @@ mod tests {
         assert!(matches!(
             cli.effective_command(),
             Command::List {
-                library: Some(ref l),
+                ref libraries,
                 what: ListCommand::Albums,
                 ..
-            } if l == "all"
+            } if libraries == &vec!["all".to_string()]
         ));
+    }
+
+    /// Parity check with `kei sync --library`: list's flag is also
+    /// repeatable. Pre-fix it was `Option<String>` and a second
+    /// `--library` silently won, so multi-value users had no way to
+    /// list across both primary and a specific shared library.
+    #[test]
+    fn test_list_albums_library_flag_repeatable() {
+        let cli = Cli::try_parse_from([
+            "kei",
+            "list",
+            "--library",
+            "primary",
+            "--library",
+            "SharedSync-ABCD1234",
+            "albums",
+        ])
+        .unwrap();
+        match cli.effective_command() {
+            Command::List {
+                libraries,
+                what: ListCommand::Albums,
+                ..
+            } => {
+                assert_eq!(
+                    libraries,
+                    vec!["primary".to_string(), "SharedSync-ABCD1234".to_string()]
+                );
+            }
+            other => panic!("expected Command::List, got {other:?}"),
+        }
+    }
+
+    /// `--library` accepts the v0.13 `!name` exclusion sentinel.
+    #[test]
+    fn test_list_albums_library_flag_exclusion() {
+        let cli = Cli::try_parse_from([
+            "kei",
+            "list",
+            "--library",
+            "all",
+            "--library",
+            "!SharedSync-ABCD1234",
+            "albums",
+        ])
+        .unwrap();
+        match cli.effective_command() {
+            Command::List {
+                libraries,
+                what: ListCommand::Albums,
+                ..
+            } => {
+                assert_eq!(
+                    libraries,
+                    vec!["all".to_string(), "!SharedSync-ABCD1234".to_string()]
+                );
+            }
+            other => panic!("expected Command::List, got {other:?}"),
+        }
+    }
+
+    /// `kei list libraries` also accepts the same flag grammar; the
+    /// flag is parsed regardless of subcommand and is ignored on the
+    /// libraries side (it's documented as albums-only).
+    #[test]
+    fn test_list_libraries_library_flag_repeatable() {
+        let cli = Cli::try_parse_from([
+            "kei",
+            "list",
+            "--library",
+            "primary",
+            "--library",
+            "shared",
+            "libraries",
+        ])
+        .unwrap();
+        match cli.effective_command() {
+            Command::List {
+                libraries,
+                what: ListCommand::Libraries,
+                ..
+            } => {
+                assert_eq!(libraries, vec!["primary".to_string(), "shared".to_string()]);
+            }
+            other => panic!("expected Command::List, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -14,7 +14,7 @@ use super::service::{init_photos_service, resolve_libraries, retry_on_lock_conte
 pub(crate) async fn run_list(
     what: cli::ListCommand,
     pw: &cli::PasswordArgs,
-    library: Option<String>,
+    cli_libraries: Vec<String>,
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<()> {
@@ -58,7 +58,6 @@ pub(crate) async fn run_list(
             }
         }
         cli::ListCommand::Albums => {
-            let cli_libraries = library.into_iter().collect();
             let selector = config::resolve_library_selector(
                 cli_libraries,
                 toml.and_then(|t| t.filters.as_ref()),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -52,60 +52,91 @@ pub(crate) async fn run_status(
     if args.failed && summary.failed > 0 {
         println!();
         println!("Failed assets:");
-        let failed = db.get_failed().await?;
-        let shown = failed.len().min(LISTING_CAP);
-        for asset in failed.iter().take(LISTING_CAP) {
-            print_failed(asset);
-        }
-        print_truncation_tail(failed.len(), shown);
+        let printed = paginate_print(&db, summary.failed, Section::Failed).await?;
+        let total = summary_count_to_usize(summary.failed);
+        print_truncation_tail(total, printed);
     }
 
     if args.pending && summary.pending > 0 {
         println!();
         println!("Pending assets:");
-        let pending = db.get_pending().await?;
-        let shown = pending.len().min(LISTING_CAP);
-        for asset in pending.iter().take(LISTING_CAP) {
-            print_pending(asset);
-        }
-        print_truncation_tail(pending.len(), shown);
+        let printed = paginate_print(&db, summary.pending, Section::Pending).await?;
+        let total = summary_count_to_usize(summary.pending);
+        print_truncation_tail(total, printed);
     }
 
     if args.downloaded && summary.downloaded > 0 {
         println!();
         println!("Downloaded assets:");
-        // page_size is smaller than LISTING_CAP so pagination is still
-        // exercised before the cap kicks in — the post-cap rows are
-        // skipped via an early break, not by narrowing the SQL query.
-        let page_size: u32 = 100;
-        let mut offset: u64 = 0;
-        let mut printed: usize = 0;
-        'outer: loop {
-            let page = db.get_downloaded_page(offset, page_size).await?;
-            if page.is_empty() {
-                break;
-            }
-            for asset in &page {
-                if printed >= LISTING_CAP {
-                    break 'outer;
-                }
-                print_downloaded(asset);
-                printed += 1;
-            }
-            offset += page.len() as u64;
-        }
-        // summary.downloaded is a u64 from the state DB count query; the
-        // cap is well under u32::MAX, so `as usize` is lossless on any
-        // 32-bit-or-wider target kei runs on.
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "downloaded count from SQLite; cap-to-usize is safe on supported targets"
-        )]
-        let total = summary.downloaded as usize;
+        let printed = paginate_print(&db, summary.downloaded, Section::Downloaded).await?;
+        let total = summary_count_to_usize(summary.downloaded);
         print_truncation_tail(total, printed);
     }
 
     Ok(())
+}
+
+/// Which `kei status` listing is being paginated. Picks the state-DB page
+/// fetcher and the per-row print fn.
+#[derive(Clone, Copy)]
+enum Section {
+    Failed,
+    Pending,
+    Downloaded,
+}
+
+/// Stream a status listing through the state-DB pagination primitive,
+/// printing up to [`LISTING_CAP`] rows. Returns the number of rows printed
+/// so the caller can decide whether to emit the "... and N more" tail.
+///
+/// The page size is smaller than `LISTING_CAP` so pagination is exercised
+/// before the cap kicks in; post-cap rows are skipped via an early break,
+/// not by narrowing the SQL query.
+async fn paginate_print(
+    db: &state::SqliteStateDb,
+    total: u64,
+    section: Section,
+) -> anyhow::Result<usize> {
+    let page_size: u32 = 100;
+    let mut offset: u64 = 0;
+    let mut printed: usize = 0;
+    if total == 0 {
+        return Ok(0);
+    }
+    'outer: loop {
+        let page = match section {
+            Section::Failed => db.get_failed_page(offset, page_size).await?,
+            Section::Pending => db.get_pending_page(offset, page_size).await?,
+            Section::Downloaded => db.get_downloaded_page(offset, page_size).await?,
+        };
+        if page.is_empty() {
+            break;
+        }
+        for asset in &page {
+            if printed >= LISTING_CAP {
+                break 'outer;
+            }
+            match section {
+                Section::Failed => print_failed(asset),
+                Section::Pending => print_pending(asset),
+                Section::Downloaded => print_downloaded(asset),
+            }
+            printed += 1;
+        }
+        offset += page.len() as u64;
+    }
+    Ok(printed)
+}
+
+/// Convert a `summary.{failed,pending,downloaded}` count (u64 from SQLite
+/// `COUNT(*)`) to `usize` for `print_truncation_tail`. Counts are well under
+/// `u32::MAX` on any supported target, so the cast is lossless.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "asset counts from SQLite; cap-to-usize is safe on supported targets"
+)]
+fn summary_count_to_usize(count: u64) -> usize {
+    count as usize
 }
 
 fn print_failed(asset: &AssetRecord) {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -52,25 +52,22 @@ pub(crate) async fn run_status(
     if args.failed && summary.failed > 0 {
         println!();
         println!("Failed assets:");
-        let printed = paginate_print(&db, summary.failed, Section::Failed).await?;
-        let total = summary_count_to_usize(summary.failed);
-        print_truncation_tail(total, printed);
+        let printed = paginate_print(&db, Section::Failed).await?;
+        print_truncation_tail(summary_count_to_usize(summary.failed), printed);
     }
 
     if args.pending && summary.pending > 0 {
         println!();
         println!("Pending assets:");
-        let printed = paginate_print(&db, summary.pending, Section::Pending).await?;
-        let total = summary_count_to_usize(summary.pending);
-        print_truncation_tail(total, printed);
+        let printed = paginate_print(&db, Section::Pending).await?;
+        print_truncation_tail(summary_count_to_usize(summary.pending), printed);
     }
 
     if args.downloaded && summary.downloaded > 0 {
         println!();
         println!("Downloaded assets:");
-        let printed = paginate_print(&db, summary.downloaded, Section::Downloaded).await?;
-        let total = summary_count_to_usize(summary.downloaded);
-        print_truncation_tail(total, printed);
+        let printed = paginate_print(&db, Section::Downloaded).await?;
+        print_truncation_tail(summary_count_to_usize(summary.downloaded), printed);
     }
 
     Ok(())
@@ -92,17 +89,10 @@ enum Section {
 /// The page size is smaller than `LISTING_CAP` so pagination is exercised
 /// before the cap kicks in; post-cap rows are skipped via an early break,
 /// not by narrowing the SQL query.
-async fn paginate_print(
-    db: &state::SqliteStateDb,
-    total: u64,
-    section: Section,
-) -> anyhow::Result<usize> {
+async fn paginate_print(db: &state::SqliteStateDb, section: Section) -> anyhow::Result<usize> {
     let page_size: u32 = 100;
     let mut offset: u64 = 0;
     let mut printed: usize = 0;
-    if total == 0 {
-        return Ok(0);
-    }
     'outer: loop {
         let page = match section {
             Section::Failed => db.get_failed_page(offset, page_size).await?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,12 @@ pub(crate) struct TomlRetry {
     /// Deprecated v0.13: initial retry delay is now derived from
     /// `max_retries` via a smart table. Removed in v0.20.
     pub delay: Option<u64>,
+    /// Lifetime cap on download attempts per asset across syncs (default
+    /// `10`). The same value as the `--max-download-attempts` CLI flag /
+    /// `KEI_MAX_DOWNLOAD_ATTEMPTS` env var; CLI > TOML > default. Distinct
+    /// from `max_retries`, which only caps retries within a single
+    /// download. `0` disables the cap.
+    pub max_download_attempts: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -697,6 +703,11 @@ pub struct Config {
     // 4-byte primitives
     pub recent: Option<u32>,
     pub max_retries: u32,
+    /// Lifetime cap on download attempts per asset across syncs. `0`
+    /// disables the cap. Resolved CLI > TOML `[download.retry]
+    /// max_download_attempts` > 10. Distinct from `max_retries`, which
+    /// only caps retries within a single download.
+    pub max_download_attempts: u32,
 
     // 8-byte primitives (cont.)
     pub bandwidth_limit: Option<u64>,
@@ -1427,6 +1438,15 @@ impl Config {
             max_retries <= 100,
             "retry max_retries must be <= 100, got {max_retries}"
         );
+        // Lifetime cap on download attempts per asset (0 disables). CLI >
+        // TOML > 10, matching every other resolved value. The runtime
+        // skip check in download::pipeline::process_asset short-circuits
+        // when this is 0, so 0 is a valid (cap-off) sentinel.
+        let max_download_attempts = resolve(
+            sync.max_download_attempts,
+            toml_retry.and_then(|r| r.max_download_attempts),
+            10,
+        );
         // Retry delay is now derived from `max_retries` via a smart table
         // (higher max => more patient initial delay). `--retry-delay` and
         // `[download.retry] delay` are deprecated; setting either still
@@ -1808,6 +1828,7 @@ impl Config {
             reconcile_every_n_cycles,
             recent,
             max_retries,
+            max_download_attempts,
             bandwidth_limit,
             threads_num,
             size,
@@ -1934,6 +1955,15 @@ impl Config {
                         None
                     } else {
                         Some(self.retry_delay_secs)
+                    },
+                    // Emit `max_download_attempts` only when the user has
+                    // overridden the default of 10. Keeps the round-trip
+                    // clean for the common case and surfaces explicit
+                    // overrides in `kei config show`.
+                    max_download_attempts: if self.max_download_attempts == 10 {
+                        None
+                    } else {
+                        Some(self.max_download_attempts)
                     },
                 }),
             }),
@@ -4653,6 +4683,99 @@ mod tests {
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(cfg.max_retries, 10);
+    }
+
+    #[test]
+    fn test_build_max_download_attempts_default() {
+        // Neither CLI nor TOML set: hardcoded fallback of 10 fires.
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg.max_download_attempts, 10);
+    }
+
+    #[test]
+    fn test_build_max_download_attempts_from_toml() {
+        // TOML-only: resolved value matches the TOML setting.
+        let toml_str = r#"
+            [download.retry]
+            max_download_attempts = 25
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.max_download_attempts, 25);
+    }
+
+    #[test]
+    fn test_build_max_download_attempts_cli_overrides_toml() {
+        // CLI flag wins over TOML, mirroring every other resolved value.
+        let toml_str = r#"
+            [download.retry]
+            max_download_attempts = 25
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let mut sync = default_sync();
+        sync.max_download_attempts = Some(7);
+        let cfg =
+            Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
+        assert_eq!(cfg.max_download_attempts, 7);
+    }
+
+    #[test]
+    fn test_build_max_download_attempts_zero_disables_cap() {
+        // `0` is the documented "disable the cap" sentinel; resolution
+        // must accept it through TOML the same as through CLI.
+        let toml_str = r#"
+            [download.retry]
+            max_download_attempts = 0
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.max_download_attempts, 0);
+    }
+
+    #[test]
+    fn test_to_toml_omits_default_max_download_attempts() {
+        // Default 10 is elided from the round-trip so config dumps stay
+        // clean for the common case.
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg.max_download_attempts, 10);
+        let toml = cfg.to_toml();
+        let retry = toml.download.unwrap().retry.unwrap();
+        assert_eq!(retry.max_download_attempts, None);
+    }
+
+    #[test]
+    fn test_to_toml_includes_non_default_max_download_attempts() {
+        // User overrides round-trip back into the dump.
+        let mut sync = default_sync();
+        sync.max_download_attempts = Some(42);
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        let toml = cfg.to_toml();
+        let retry = toml.download.unwrap().retry.unwrap();
+        assert_eq!(retry.max_download_attempts, Some(42));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6837,6 +6837,43 @@ mod tests {
         assert!(!content.contains("secret123"));
     }
 
+    /// Regression guard: even when the resolved Config got its
+    /// `cookie_directory` from the deprecated `[auth] cookie_directory`
+    /// TOML key, `persist_first_run_config` (and `Config::to_toml` under
+    /// it) must never echo the deprecated key back out. Pairs with
+    /// `setup::tests::test_generate_toml_*` to cover both wizard-generated
+    /// and auto-persisted first-run configs.
+    #[test]
+    fn test_persist_first_run_never_emits_deprecated_cookie_directory() {
+        let (td, config_path) = persist_test_dir("no_cookie_directory");
+
+        // Build a config with cookie_directory explicitly set, the way
+        // `--cookie-directory /some/path` or `[auth] cookie_directory`
+        // would land it in the resolved Config. Use a writable temp dir
+        // because `Config::build` actually creates `cookie_directory`.
+        let cookie_dir = td.path().join("legacy_cookies");
+        let mut globals = default_globals();
+        globals.username = Some("test@example.com".to_string());
+        globals.cookie_directory = Some(cookie_dir.to_string_lossy().to_string());
+        let mut sync = default_sync();
+        sync.directory = Some("/photos".to_string());
+        let config = Config::build(&globals, &default_password(), sync, None).unwrap();
+
+        persist_first_run_config(&config_path, &config, None).unwrap();
+
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        // Strip comment lines to avoid false positives on hint comments.
+        let active: String = content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !active.contains("cookie_directory"),
+            "persisted config must not emit deprecated [auth].cookie_directory; got:\n{content}"
+        );
+    }
+
     #[test]
     fn test_persist_first_run_does_not_overwrite_existing() {
         let (_td, config_path) = persist_test_dir("no_overwrite");

--- a/src/config.rs
+++ b/src/config.rs
@@ -4302,12 +4302,15 @@ mod tests {
 
     impl Drop for MetricsPortEnvGuard {
         fn drop(&mut self) {
-            // SAFETY: still holding the static mutex; restoration is
-            // exclusive under the same "no cross-thread readers" rule.
-            unsafe {
-                if let Some(v) = self.prev.take() {
+            if let Some(v) = self.prev.take() {
+                // SAFETY: still holding the static mutex; restoration is
+                // exclusive under the same "no cross-thread readers" rule.
+                unsafe {
                     std::env::set_var("KEI_METRICS_PORT", v);
-                } else {
+                }
+            } else {
+                // SAFETY: same as above.
+                unsafe {
                     std::env::remove_var("KEI_METRICS_PORT");
                 }
             }
@@ -4359,6 +4362,8 @@ mod tests {
         // warning. Confirms the migration path stays usable for one minor
         // cycle while users move to KEI_HTTP_PORT.
         let _guard = scrub_metrics_port_env();
+        // SAFETY: the guard above holds the static lock for the duration
+        // of this test, so no other thread is reading the env var.
         unsafe {
             std::env::set_var("KEI_METRICS_PORT", "8765");
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1739,27 +1739,34 @@ impl Config {
         // HTTP server port — CLI > [server] TOML > [metrics] TOML (deprecated) > KEI_METRICS_PORT
         // env (deprecated) > default 9090.
         const DEFAULT_HTTP_PORT: u16 = 9090;
+        // Warn early when the deprecated env var is set, regardless of
+        // whether a higher-precedence value shadows it. Pre-fix the
+        // warning only fired in the env-var arm of the `or_else` chain,
+        // so a user who set both `KEI_HTTP_PORT` and `KEI_METRICS_PORT`
+        // got no signal that their `KEI_METRICS_PORT` was being silently
+        // ignored. Same pattern we use for the `[metrics]` TOML section
+        // below.
+        let kei_metrics_port_env = std::env::var("KEI_METRICS_PORT").ok();
+        if kei_metrics_port_env.is_some() {
+            tracing::warn!(
+                "KEI_METRICS_PORT is deprecated and will be removed in v0.20.0; \
+                 use KEI_HTTP_PORT instead"
+            );
+        }
+        if toml_metrics.and_then(|m| m.port).is_some() {
+            tracing::warn!(
+                "[metrics] port in TOML is deprecated and will be removed in v0.20.0; \
+                 rename the section to [server]"
+            );
+        }
         let http_port = sync
             .http_port
             .or_else(|| toml_server.and_then(|s| s.port))
+            .or_else(|| toml_metrics.and_then(|m| m.port))
             .or_else(|| {
-                toml_metrics.and_then(|m| m.port).inspect(|_port| {
-                    tracing::warn!(
-                        "[metrics] port in TOML is deprecated and will be removed in v0.20.0; \
-                         rename the section to [server]"
-                    );
-                })
-            })
-            .or_else(|| {
-                std::env::var("KEI_METRICS_PORT")
-                    .ok()
+                kei_metrics_port_env
+                    .as_deref()
                     .and_then(|v| v.parse::<u16>().ok())
-                    .inspect(|_port| {
-                        tracing::warn!(
-                            "KEI_METRICS_PORT is deprecated and will be removed in v0.20.0; \
-                             use KEI_HTTP_PORT instead"
-                        );
-                    })
             })
             .unwrap_or(DEFAULT_HTTP_PORT);
 
@@ -4269,6 +4276,133 @@ mod tests {
         let config =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(config.http_port, 8080);
+    }
+
+    /// Serialize KEI_METRICS_PORT env var across the deprecation tests so
+    /// they don't race each other or leak state. Mirrors the
+    /// `scrub_auth_env` pattern in `cli.rs`.
+    fn scrub_metrics_port_env() -> MetricsPortEnvGuard {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("KEI_METRICS_PORT").ok();
+        // SAFETY: the static mutex serializes every other caller of
+        // scrub_metrics_port_env; the suite does not read this env var
+        // from a separate thread.
+        unsafe {
+            std::env::remove_var("KEI_METRICS_PORT");
+        }
+        MetricsPortEnvGuard { _lock: guard, prev }
+    }
+
+    struct MetricsPortEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prev: Option<String>,
+    }
+
+    impl Drop for MetricsPortEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: still holding the static mutex; restoration is
+            // exclusive under the same "no cross-thread readers" rule.
+            unsafe {
+                if let Some(v) = self.prev.take() {
+                    std::env::set_var("KEI_METRICS_PORT", v);
+                } else {
+                    std::env::remove_var("KEI_METRICS_PORT");
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_kei_metrics_port_env_warns_when_set_even_if_shadowed() {
+        // KEI_METRICS_PORT is set, but [server] port wins. Pre-fix the
+        // warning was inside the env-var arm of the or_else chain so it
+        // never fired in this case; users had no signal that their
+        // KEI_METRICS_PORT was being silently ignored.
+        let _guard = scrub_metrics_port_env();
+        // SAFETY: the guard above holds the static lock for the duration
+        // of this test, so no other thread is reading the env var.
+        unsafe {
+            std::env::set_var("KEI_METRICS_PORT", "9999");
+        }
+        let toml_str = r#"
+            [auth]
+            username = "user@example.com"
+            [download]
+            directory = "/photos"
+            [server]
+            port = 9090
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let config = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        // [server] port still wins.
+        assert_eq!(config.http_port, 9090);
+        // ...but the deprecation warning fires anyway.
+        assert!(
+            logs_contain("KEI_METRICS_PORT is deprecated"),
+            "deprecation warning should fire whenever KEI_METRICS_PORT is set"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_kei_metrics_port_env_resolves_when_no_higher_value() {
+        // No CLI / [server] / [metrics] value: env var still wins, with a
+        // warning. Confirms the migration path stays usable for one minor
+        // cycle while users move to KEI_HTTP_PORT.
+        let _guard = scrub_metrics_port_env();
+        unsafe {
+            std::env::set_var("KEI_METRICS_PORT", "8765");
+        }
+        let config = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(config.http_port, 8765);
+        assert!(logs_contain("KEI_METRICS_PORT is deprecated"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_metrics_toml_warns_even_when_shadowed_by_server() {
+        // [metrics] port is shadowed by [server] port; the deprecation
+        // warning still fires so config-driven users learn that the
+        // section is on its way out.
+        let _guard = scrub_metrics_port_env();
+        let toml_str = r#"
+            [auth]
+            username = "user@example.com"
+            [download]
+            directory = "/photos"
+            [server]
+            port = 9090
+            [metrics]
+            port = 9999
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let config = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert_eq!(config.http_port, 9090);
+        assert!(
+            logs_contain("[metrics] port in TOML is deprecated"),
+            "deprecation warning should fire whenever [metrics] port is set"
+        );
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2651,6 +2651,7 @@ mod tests {
             reconcile_every_n_cycles: None,
             recent: dl_config.recent,
             max_retries: 3,
+            max_download_attempts: 10,
             bandwidth_limit: None,
             threads_num: 1,
             size: VersionSize::Original,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,10 +548,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         }
         Command::List {
             password,
-            library,
+            libraries,
             what,
         } => {
-            return run_list(what, &password, library, &globals, toml_config.as_ref()).await;
+            return run_list(what, &password, libraries, &globals, toml_config.as_ref()).await;
         }
         Command::Config { action } => match action {
             cli::ConfigAction::Show => {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -109,6 +109,34 @@ pub trait StateDb: Send + Sync {
     /// Get all pending assets.
     async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError>;
 
+    /// Get a page of failed assets, ordered by `last_seen_at` DESC.
+    ///
+    /// Returns up to `limit` records starting from `offset`.
+    /// Returns an empty `Vec` when no more records remain.
+    /// Default impl falls back to `get_failed` + slice for non-SQLite mocks;
+    /// production `SqliteStateDb` overrides with a real LIMIT/OFFSET query.
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        page_from_full(self.get_failed().await?, offset, limit)
+    }
+
+    /// Get a page of pending assets, ordered by `last_seen_at` DESC.
+    ///
+    /// Returns up to `limit` records starting from `offset`.
+    /// Returns an empty `Vec` when no more records remain.
+    /// Default impl falls back to `get_pending` + slice for non-SQLite mocks;
+    /// production `SqliteStateDb` overrides with a real LIMIT/OFFSET query.
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        page_from_full(self.get_pending().await?, offset, limit)
+    }
+
     /// Get a summary of the database state.
     async fn get_summary(&self) -> Result<SyncSummary, StateError>;
 
@@ -493,6 +521,24 @@ impl SqliteStateDb {
         })
         .await?
     }
+}
+
+/// Slice a `Vec<AssetRecord>` into a page using the same `(offset, limit)`
+/// semantics as `SqliteStateDb::get_downloaded_page`. Used as the default
+/// `get_failed_page` / `get_pending_page` body so trait mocks that only
+/// implement the unbounded `get_failed` / `get_pending` keep compiling. The
+/// production `SqliteStateDb` impl overrides with a real LIMIT/OFFSET query
+/// and never materializes the full vector.
+fn page_from_full(
+    full: Vec<AssetRecord>,
+    offset: u64,
+    limit: u32,
+) -> Result<Vec<AssetRecord>, StateError> {
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(full.len());
+    let take = usize::try_from(limit).unwrap_or(usize::MAX);
+    Ok(full.into_iter().skip(start).take(take).collect())
 }
 
 /// Execute the asset UPSERT on `conn` (works against either a `Connection`
@@ -939,6 +985,72 @@ impl StateDb for SqliteStateDb {
                 .map_err(|e| StateError::query("get_pending", e))?
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| StateError::query("get_pending", e))?;
+
+            Ok(records)
+        })
+        .await
+    }
+
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        self.with_conn("get_failed_page", move |conn| {
+            let sql = format!(
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
+                 ORDER BY last_seen_at DESC LIMIT ?1 OFFSET ?2",
+            );
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| StateError::query("get_failed_page", e))?;
+
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "offset is bounded by the failed-row count and well below i64::MAX"
+            )]
+            let offset_i = offset as i64;
+            let records = stmt
+                .query_map(
+                    rusqlite::params![i64::from(limit), offset_i],
+                    row_to_asset_record,
+                )
+                .map_err(|e| StateError::query("get_failed_page", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| StateError::query("get_failed_page", e))?;
+
+            Ok(records)
+        })
+        .await
+    }
+
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        self.with_conn("get_pending_page", move |conn| {
+            let sql = format!(
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' \
+                 ORDER BY last_seen_at DESC LIMIT ?1 OFFSET ?2",
+            );
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| StateError::query("get_pending_page", e))?;
+
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "offset is bounded by the pending-row count and well below i64::MAX"
+            )]
+            let offset_i = offset as i64;
+            let records = stmt
+                .query_map(
+                    rusqlite::params![i64::from(limit), offset_i],
+                    row_to_asset_record,
+                )
+                .map_err(|e| StateError::query("get_pending_page", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| StateError::query("get_pending_page", e))?;
 
             Ok(records)
         })
@@ -2650,6 +2762,162 @@ mod tests {
         assert_eq!(second.len(), 1);
         let third = db.get_downloaded_page(4, 2).await.unwrap();
         assert!(third.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_failed_page() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        for i in 0..3 {
+            let id = format!("FAIL_{i}");
+            let record = TestAssetRecord::new(&id)
+                .checksum(&format!("checksum_{i}"))
+                .filename(&format!("photo_{i}.jpg"))
+                .size(1000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_failed("PrimarySync", &id, "original", "boom")
+                .await
+                .unwrap();
+        }
+        // Newest-first ordering: FAIL_2 > FAIL_1 > FAIL_0
+        for i in 0..3i64 {
+            db.backdate_last_seen(&format!("FAIL_{i}"), 1_000 + i);
+        }
+
+        // Fetch all in one page
+        let page = db.get_failed_page(0, 100).await.unwrap();
+        assert_eq!(page.len(), 3);
+        assert_eq!(&*page[0].id, "FAIL_2");
+        assert_eq!(&*page[2].id, "FAIL_0");
+
+        // Paginate: page of 2, then remainder
+        let first = db.get_failed_page(0, 2).await.unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(&*first[0].id, "FAIL_2");
+        assert_eq!(&*first[1].id, "FAIL_1");
+        let second = db.get_failed_page(2, 2).await.unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(&*second[0].id, "FAIL_0");
+        let third = db.get_failed_page(4, 2).await.unwrap();
+        assert!(third.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_pending_page() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        for i in 0..3 {
+            let id = format!("PEND_{i}");
+            let record = TestAssetRecord::new(&id)
+                .checksum(&format!("checksum_{i}"))
+                .filename(&format!("photo_{i}.jpg"))
+                .size(1000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+        }
+        // Newest-first ordering: PEND_2 > PEND_1 > PEND_0
+        for i in 0..3i64 {
+            db.backdate_last_seen(&format!("PEND_{i}"), 1_000 + i);
+        }
+
+        // Fetch all in one page
+        let page = db.get_pending_page(0, 100).await.unwrap();
+        assert_eq!(page.len(), 3);
+        assert_eq!(&*page[0].id, "PEND_2");
+        assert_eq!(&*page[2].id, "PEND_0");
+
+        // Paginate: page of 2, then remainder
+        let first = db.get_pending_page(0, 2).await.unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(&*first[0].id, "PEND_2");
+        assert_eq!(&*first[1].id, "PEND_1");
+        let second = db.get_pending_page(2, 2).await.unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(&*second[0].id, "PEND_0");
+        let third = db.get_pending_page(4, 2).await.unwrap();
+        assert!(third.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_failed_pending_page_scales_to_large_count() {
+        // Mirror of `test_get_downloaded_page_scales_to_large_count` for the
+        // failed and pending lists. Bulk-insert 10k rows, paginate through,
+        // assert we never need to materialize more than `page_size` at once
+        // and the total count matches.
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let count: usize = 10_000;
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute_batch("BEGIN").unwrap();
+            let mut stmt = conn
+                .prepare(
+                    "INSERT INTO assets (library, id, version_size, checksum, filename, created_at, size_bytes, media_type, status, last_seen_at, download_attempts, last_error)
+                     VALUES ('PrimarySync', ?1, 'original', ?2, ?3, ?4, ?5, 'photo', ?6, ?4, 1, ?7)",
+                )
+                .unwrap();
+            let now = Utc::now().timestamp();
+            for i in 0..count {
+                let id = format!("ASSET_{i:05}");
+                let checksum = format!("cksum_{i:05}");
+                let filename = format!("IMG_{i:05}.jpg");
+                let status = if i % 2 == 0 { "failed" } else { "pending" };
+                let err = if status == "failed" {
+                    Some("boom")
+                } else {
+                    None
+                };
+                stmt.execute(rusqlite::params![
+                    id,
+                    checksum,
+                    filename,
+                    now + i as i64,
+                    4096,
+                    status,
+                    err
+                ])
+                .unwrap();
+            }
+            conn.execute_batch("COMMIT").unwrap();
+        }
+
+        let page_size: u32 = 1000;
+
+        // Failed: 5000 rows
+        let mut total = 0usize;
+        let mut offset = 0u64;
+        loop {
+            let page = db.get_failed_page(offset, page_size).await.unwrap();
+            if page.is_empty() {
+                break;
+            }
+            assert!(
+                page.len() <= page_size as usize,
+                "get_failed_page must respect the requested limit"
+            );
+            assert!(page.iter().all(|r| r.status == AssetStatus::Failed));
+            total += page.len();
+            offset += page.len() as u64;
+        }
+        assert_eq!(total, count / 2);
+
+        // Pending: 5000 rows
+        let mut total = 0usize;
+        let mut offset = 0u64;
+        loop {
+            let page = db.get_pending_page(offset, page_size).await.unwrap();
+            if page.is_empty() {
+                break;
+            }
+            assert!(
+                page.len() <= page_size as usize,
+                "get_pending_page must respect the requested limit"
+            );
+            assert!(page.iter().all(|r| r.status == AssetStatus::Pending));
+            total += page.len();
+            offset += page.len() as u64;
+        }
+        assert_eq!(total, count / 2);
     }
 
     // ── Batch operation tests ──

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -211,7 +211,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     } = args;
 
     let is_retry_failed = sync.retry_failed;
-    let max_download_attempts = sync.max_download_attempts.unwrap_or(10);
     let reset_sync_token = sync.reset_sync_token;
     if reset_sync_token {
         crate::cli::deprecation_warning("--reset-sync-token", "kei reset sync-token");
@@ -649,7 +648,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             temp_suffix: Arc::clone(&cfg_temp_suffix),
             state_db: state_db.clone(),
             retry_only: is_retry_failed,
-            max_download_attempts,
+            max_download_attempts: config.max_download_attempts,
             sync_mode,
             album_name: None,
             exclude_asset_ids,


### PR DESCRIPTION
## Summary

Closes five v0.13 follow-through items in one branch. Each fix is a separate commit.

## Fixes

### `kei status --failed` / `--pending` paginate like `--downloaded`

`get_failed()` / `get_pending()` loaded every matching row into a `Vec`, while `--downloaded` already paginated via `get_downloaded_page`. On 100k-asset libraries the unbounded paths approached OOM and the inconsistency was internal-facing.

- `src/state/db.rs`: add `get_failed_page` / `get_pending_page` to `StateDb` (default impls fall back to the unbounded getters so existing mocks keep compiling). `SqliteStateDb` overrides with real `LIMIT/OFFSET` queries, `last_seen_at DESC`, mirroring `get_downloaded_page`.
- `src/commands/status.rs:55-74`: route the three section blocks through one `paginate_print` helper.
- Tests: `test_get_failed_page`, `test_get_pending_page`, `get_failed_pending_page_scales_to_large_count` (10k-row pagination invariant).

CHANGELOG: `kei status --failed` and `--pending` now stream pages instead of loading every matching row, matching `--downloaded`.

### `kei list --library` accepts v0.13 multi-value grammar

`kei sync --library` is repeatable and accepts `primary` / `shared` / `all` / `none` / `!name` / zone names; `kei list --library` was typed `Option<String>`, so a second `--library` silently won and users couldn't list across multiple libraries.

- `src/cli.rs:735-746`: retype to `libraries: Vec<String>` with `value_parser = non_empty_string`.
- `src/lib.rs:549-555`, `src/commands/list.rs`: thread `Vec<String>` through to `resolve_library_selector` (which already accepted it).
- Tests: repeatable, `!name` exclusion, and the same flag passing through `kei list libraries`.

CHANGELOG: `kei list --library` accepts the v0.13 selector grammar (repeatable, sentinels, `!name`).

### `--max-download-attempts` exposed under `[download.retry]` in TOML

The lifetime cap (default 10, across syncs) had no TOML key; only the per-download `max_retries` did, so config-driven users couldn't set the lifetime cap.

- `src/config.rs`: add `max_download_attempts: Option<u32>` to `TomlRetry`, store on `Config`, resolve via the standard CLI > TOML > 10 chain in `Config::build`, emit from `to_toml` only when overridden, accept `0` (cap-off sentinel) through TOML.
- `src/sync_loop.rs:214`: read from `config.max_download_attempts` instead of the local unwrap.
- `src/download/mod.rs:2654`: populate the test fixture.
- Tests: default, TOML-only, CLI-overrides-TOML, `0` sentinel, round-trip elision/emission.

CHANGELOG: new `[download.retry] max_download_attempts` TOML key mirrors the existing `--max-download-attempts` flag.

### `[metrics]` deprecation actually warns

The `[metrics]` -> `[server]` migration was half-done. The `[metrics]` TOML warning has shipped since v0.13.0 but pre-fix only fired when `[metrics] port` actually resolved `http_port`, so a config with both `[server]` and `[metrics]` set kept `[metrics]` silently around. The `KEI_METRICS_PORT` env var had the same gap.

- `src/config.rs:1739-1764`: move both warnings out of the resolution chain so they fire whenever the deprecated input is set.
- `CHANGELOG.md`: `Unreleased / Deprecated` entry naming the v0.20.0 removal target.
- Tests: shadowed-by-`[server]` cases for both surfaces, plus the still-resolves case for the migration window.

CHANGELOG: `[metrics]` TOML and `KEI_METRICS_PORT` deprecation warnings now fire whenever the deprecated input is set, even when shadowed by `[server]` / `KEI_HTTP_PORT`. Removal target: v0.20.0.

### Setup wizard regression guard for `cookie_directory`

The wizard side stopped emitting `[auth] cookie_directory` in PR #334 and `Config::to_toml` already nulls the field. The auto-persist path (`persist_first_run_config`) goes through the same `to_toml`, but the existing tests didn't exercise the case where the user's resolved Config got a non-empty `cookie_directory` from a CLI flag or the deprecated TOML key.

- `src/config.rs`: `test_persist_first_run_never_emits_deprecated_cookie_directory` builds a Config with `cookie_directory` set, persists, asserts the output never contains `cookie_directory =` (comments stripped to avoid future hint-comment false positives).

CHANGELOG: not user-visible (test-only regression guard).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `just gate` (fmt / clippy / fast tests / docs / audit / typos / round-trip)
- [x] All new tests added with the relevant fix pass under the offline suite.