### PR TITLE
feat: PUID/PGID Docker entrypoint and Synology deployment guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Docker image now honors `PUID` and `PGID` environment variables.** When set, the container's entrypoint creates a user with those IDs, chowns `/config` and `/photos` to them, and drops privileges via `gosu` before running kei. Without them, the container runs as root (preserves prior default). This unblocks NAS deployments (Synology Container Manager, Unraid, TrueNAS Scale) where downstream indexers like Synology Photos can't see root-owned files. The recursive chown is gated on the top-level UID already matching, so subsequent restarts are fast even on large `/photos` volumes.
+- **Synology deployment guide.** New wiki page covers Container Manager setup, the typical Synology UID/GID values (`PUID=1026 PGID=100`), Synology Photos library paths, first-run 2FA via DSM terminal, and port-conflict handling.
+- **`scripts/notify-synology-photos.sh` example.** Reference notification script that pings Synology DSM with sync stats after a completed cycle (using the documented `SYNO.Core.Notification.Mail` API), with a commented-out section for explicit reindex via SSH + `synoindex`. Wired into kei via the existing `--notification-script` hook; no kei code knows about Synology. Synology Photos's universal scanner already picks up new files via inotify within seconds, so the notification path is informational rather than required.
+
 ---
 
 ## [0.13.2] - 2026-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docker image now honors `PUID` and `PGID` environment variables.** When set, the container's entrypoint creates a user with those IDs, chowns `/config` and `/photos` to them, and drops privileges via `gosu` before running kei. Without them, the container runs as root (preserves prior default). This unblocks NAS deployments (Synology Container Manager, Unraid, TrueNAS Scale) where downstream indexers like Synology Photos can't see root-owned files. The recursive chown is gated on the top-level UID already matching, so subsequent restarts are fast even on large `/photos` volumes.
-- **Synology deployment guide.** New wiki page covers Container Manager setup, the typical Synology UID/GID values (`PUID=1026 PGID=100`), Synology Photos library paths, first-run 2FA via DSM terminal, and port-conflict handling.
-- **`scripts/notify-synology-photos.sh` example.** Reference notification script that pings Synology DSM with sync stats after a completed cycle (using the documented `SYNO.Core.Notification.Mail` API), with a commented-out section for explicit reindex via SSH + `synoindex`. Wired into kei via the existing `--notification-script` hook; no kei code knows about Synology. Synology Photos's universal scanner already picks up new files via inotify within seconds, so the notification path is informational rather than required.
+- **Docker image now honors `PUID` and `PGID` environment variables.** When both are set, the container's entrypoint chowns ownership-mismatched files in `/config` and `/photos` to that UID:GID and drops privileges via `gosu` before running kei. Setting only one is rejected; setting neither preserves the prior root-default. The chown uses `find -not -uid` so a multi-TB volume only pays for stragglers, not the full tree, on every restart. Unblocks NAS deployments (Synology Container Manager, Unraid, TrueNAS Scale) where downstream indexers like Synology Photos can't see root-owned files. ([Synology wiki](https://github.com/rhoopr/kei/wiki/Synology), [Docker wiki](https://github.com/rhoopr/kei/wiki/Docker))
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,12 @@ RUN export TARGET=$(cat /tmp/target) && \
 FROM debian:bookworm-20250428-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends bash curl ca-certificates libdbus-1-3 && \
+    apt-get install -y --no-install-recommends bash curl ca-certificates libdbus-1-3 gosu && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /kei /usr/local/bin/kei
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 VOLUME ["/config", "/photos"]
 
@@ -75,5 +77,9 @@ HEALTHCHECK --interval=60s --timeout=5s --start-period=15m --retries=3 \
 # in TOML so users can shorten the cycle without overriding `command:` (#293).
 ENV KEI_WATCH_WITH_INTERVAL=86400
 
-ENTRYPOINT ["kei"]
+# entrypoint.sh drops to PUID:PGID when those env vars are set; otherwise
+# exec's kei as root (preserves prior behavior). Required for NAS
+# deployments where files must be host-user-owned (Synology Photos,
+# Unraid, TrueNAS Scale).
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["sync", "--config", "/config/config.toml", "--data-dir", "/config", "--download-dir", "/photos"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Everything lives on the [wiki](https://github.com/rhoopr/kei/wiki): full CLI ref
 - [Commands](https://github.com/rhoopr/kei/wiki/Home#commands) - `sync`, `login`, `list`, `password`, `config`, `reset`, `status`, `verify`, `import-existing`
 - [Configuration](https://github.com/rhoopr/kei/wiki/Configuration) - TOML file, env vars, precedence
 - [Docker](https://github.com/rhoopr/kei/wiki/Docker) - Compose files and headless 2FA
+- [Synology](https://github.com/rhoopr/kei/wiki/Synology) - Container Manager setup, PUID/PGID, Synology Photos integration
 - [Credentials](https://github.com/rhoopr/kei/wiki/Credentials) - keyring, encrypted file, password files and commands
 - [Changelog](CHANGELOG.md)
 - [How iCloud's Incremental Sync Works](https://robhooper.xyz/blog-synctoken) - deep dive on CloudKit syncTokens

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
       # `docker inspect`). Removed by kei from the process environment after
       # reading.
       # - ICLOUD_PASSWORD=${ICLOUD_PASSWORD}
+      #
+      # PUID/PGID: drop privileges to the host user that owns ./config
+      # and /path/to/photos. Required for NAS deployments (Synology
+      # Container Manager, Unraid, TrueNAS Scale) so downstream
+      # indexers (e.g. Synology Photos) can read kei's output. On
+      # Synology, the typical values are PUID=1026 PGID=100. Without
+      # these the container runs as root.
+      # - PUID=1000
+      # - PGID=1000
     volumes:
       - ./config:/config
       - /path/to/photos:/photos

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# kei container entrypoint.
+#
+# When PUID and/or PGID are set, drop privileges to that UID:GID before
+# exec'ing the command. The volumes /config and /photos are chown'd to
+# that UID on first use so kei can write to them and the host user owns
+# the resulting files.
+#
+# When neither is set, runs as root (preserves prior default).
+#
+# Args dispatch (matches the convention used by postgres/mysql/redis
+# official images):
+#   - First arg starts with `-`           -> treat as kei flag, prepend `kei`
+#   - First arg isn't an executable on $PATH -> treat as kei subcommand, prepend `kei`
+#   - First arg IS an executable          -> run it directly (e.g. `sh`, `id`)
+# So `docker run kei sync` runs kei sync, and `docker run kei sh` opens
+# a shell for debugging without --entrypoint.
+#
+# Typical use case: NAS deployments (Synology Container Manager, Unraid,
+# TrueNAS Scale) where files written into mounted volumes need to belong
+# to the user that owns the host directory, otherwise downstream
+# indexers (e.g. Synology Photos) can't read them.
+
+set -e
+
+# Dispatch: prepend `kei` for kei flags and known kei subcommands (some
+# of which collide with system binaries: `sync`, `login`, `reset` are
+# all in /usr/bin on debian-slim). Otherwise treat the first arg as a
+# binary and exec it directly so `docker run kei sh` and `docker run
+# kei id` work for debugging.
+if [ "$#" -eq 0 ]; then
+    set -- kei
+elif [ "$1" = "kei" ]; then
+    : # already kei + args
+elif [ "${1#-}" != "$1" ]; then
+    set -- kei "$@"
+else
+    case "$1" in
+        sync|login|list|password|reset|config|status|verify|import-existing|reconcile|retry-failed)
+            set -- kei "$@"
+            ;;
+        *)
+            if ! command -v "$1" >/dev/null 2>&1; then
+                set -- kei "$@"
+            fi
+            ;;
+    esac
+fi
+
+if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
+    PUID="${PUID:-1000}"
+    PGID="${PGID:-1000}"
+
+    case "$PUID$PGID" in
+        *[!0-9]*)
+            echo "kei: PUID/PGID must be numeric (got PUID=$PUID PGID=$PGID)" >&2
+            exit 1
+            ;;
+    esac
+
+    if ! getent group "$PGID" >/dev/null 2>&1; then
+        groupadd -g "$PGID" kei
+    fi
+
+    if ! getent passwd "$PUID" >/dev/null 2>&1; then
+        useradd -u "$PUID" -g "$PGID" -M -d /config -s /bin/sh kei
+    fi
+
+    # Recursive chown only when the top-level dir's UID doesn't already
+    # match. Skips the cost on subsequent restarts and avoids touching a
+    # large /photos volume every time. A read-only mount produces a
+    # warning but doesn't fail the container; the user may have mounted
+    # /config or /photos read-only deliberately.
+    for d in /config /photos; do
+        if [ ! -d "$d" ]; then
+            continue
+        fi
+        current_uid="$(stat -c '%u' "$d" 2>/dev/null || echo "")"
+        if [ "$current_uid" != "$PUID" ]; then
+            chown -R "$PUID:$PGID" "$d" 2>/dev/null \
+                || echo "kei: warning: chown $d failed (read-only mount?)" >&2
+        fi
+    done
+
+    exec gosu "$PUID:$PGID" "$@"
+fi
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,37 +1,17 @@
 #!/bin/sh
 # kei container entrypoint.
 #
-# When PUID and/or PGID are set, drop privileges to that UID:GID before
-# exec'ing the command. The volumes /config and /photos are chown'd to
-# that UID on first use so kei can write to them and the host user owns
-# the resulting files.
+# When PUID and PGID are set, drops to that UID:GID via gosu after
+# fixing ownership of /config and /photos. Without them, runs as root.
 #
-# When neither is set, runs as root (preserves prior default).
-#
-# Args dispatch (matches the convention used by postgres/mysql/redis
-# official images):
-#   - First arg starts with `-`           -> treat as kei flag, prepend `kei`
-#   - First arg isn't an executable on $PATH -> treat as kei subcommand, prepend `kei`
-#   - First arg IS an executable          -> run it directly (e.g. `sh`, `id`)
-# So `docker run kei sync` runs kei sync, and `docker run kei sh` opens
-# a shell for debugging without --entrypoint.
-#
-# Typical use case: NAS deployments (Synology Container Manager, Unraid,
-# TrueNAS Scale) where files written into mounted volumes need to belong
-# to the user that owns the host directory, otherwise downstream
-# indexers (e.g. Synology Photos) can't read them.
+# `kei` subcommand list is hard-coded to avoid colliding with debian
+# binaries: /usr/bin/{sync,login,reset} would otherwise hijack the
+# default CMD. Update when adding a kei subcommand.
 
 set -e
 
-# Dispatch: prepend `kei` for kei flags and known kei subcommands (some
-# of which collide with system binaries: `sync`, `login`, `reset` are
-# all in /usr/bin on debian-slim). Otherwise treat the first arg as a
-# binary and exec it directly so `docker run kei sh` and `docker run
-# kei id` work for debugging.
 if [ "$#" -eq 0 ]; then
     set -- kei
-elif [ "$1" = "kei" ]; then
-    : # already kei + args
 elif [ "${1#-}" != "$1" ]; then
     set -- kei "$@"
 else
@@ -47,42 +27,32 @@ else
     esac
 fi
 
-if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
-    PUID="${PUID:-1000}"
-    PGID="${PGID:-1000}"
-
-    case "$PUID$PGID" in
-        *[!0-9]*)
-            echo "kei: PUID/PGID must be numeric (got PUID=$PUID PGID=$PGID)" >&2
-            exit 1
-            ;;
-    esac
-
-    if ! getent group "$PGID" >/dev/null 2>&1; then
-        groupadd -g "$PGID" kei
-    fi
-
-    if ! getent passwd "$PUID" >/dev/null 2>&1; then
-        useradd -u "$PUID" -g "$PGID" -M -d /config -s /bin/sh kei
-    fi
-
-    # Recursive chown only when the top-level dir's UID doesn't already
-    # match. Skips the cost on subsequent restarts and avoids touching a
-    # large /photos volume every time. A read-only mount produces a
-    # warning but doesn't fail the container; the user may have mounted
-    # /config or /photos read-only deliberately.
-    for d in /config /photos; do
-        if [ ! -d "$d" ]; then
-            continue
-        fi
-        current_uid="$(stat -c '%u' "$d" 2>/dev/null || echo "")"
-        if [ "$current_uid" != "$PUID" ]; then
-            chown -R "$PUID:$PGID" "$d" 2>/dev/null \
-                || echo "kei: warning: chown $d failed (read-only mount?)" >&2
-        fi
-    done
-
-    exec gosu "$PUID:$PGID" "$@"
+if [ -z "${PUID:-}" ] && [ -z "${PGID:-}" ]; then
+    exec "$@"
 fi
 
-exec "$@"
+if [ -z "${PUID:-}" ] || [ -z "${PGID:-}" ]; then
+    echo "kei: PUID and PGID must be set together (got PUID='${PUID:-}' PGID='${PGID:-}')" >&2
+    exit 1
+fi
+
+case "$PUID$PGID" in
+    *[!0-9]*)
+        echo "kei: PUID/PGID must be numeric (got PUID=$PUID PGID=$PGID)" >&2
+        exit 1
+        ;;
+esac
+
+# Touch only mismatched inodes. A blind `chown -R` on a multi-TB
+# Synology library would take hours; `find -not -uid` is O(stragglers)
+# and a no-op on steady-state restarts. Read-only mounts produce a
+# warning but don't fail; the user may have mounted them deliberately.
+for d in /config /photos; do
+    [ -d "$d" ] || continue
+    find "$d" \! -uid "$PUID" -print0 2>/dev/null \
+        | xargs -0 -r chown "$PUID:$PGID" 2>/dev/null \
+        || echo "kei: warning: chown $d failed (read-only mount?)" >&2
+done
+
+# gosu accepts numeric uid:gid and runs without an /etc/passwd entry.
+exec gosu "$PUID:$PGID" "$@"

--- a/scripts/notify-synology-photos.sh
+++ b/scripts/notify-synology-photos.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# kei notification script: ping a Synology NAS after a sync cycle.
+#
+# Wire into kei via [notifications] script in config.toml or
+# --notification-script. See the Synology wiki page for setup details.
+#
+# Two things to know before relying on this:
+#
+# 1. Synology Photos auto-indexes via inotify within a few seconds of a
+#    file landing. For most users, no explicit reindex is needed and
+#    this script is purely informational (a DSM notification when a
+#    sync cycle finishes).
+#
+# 2. There IS a Synology Photos reindex API but the exact endpoint
+#    varies across DSM versions and is not officially documented for
+#    third-party use. If you need explicit reindex (e.g. inotify isn't
+#    keeping up), the safest path is SSH from the host to the NAS:
+#        ssh admin@nas synoindex -R /volume1/photo/kei
+#    Drop that into the "explicit reindex" section below if you've set
+#    up key-based SSH from your kei host to the NAS.
+#
+# Required environment (set via your compose file or .env):
+#   SYNOLOGY_URL         Base URL of your DSM (e.g. https://nas.local:5001)
+#   SYNOLOGY_USERNAME    DSM user with notification permissions
+#   SYNOLOGY_PASSWORD    Password (prefer a Docker secret over a plain env var)
+#
+# Optional:
+#   SYNOLOGY_INSECURE=1  Pass -k to curl (skip TLS verify; LAN only)
+
+set -e
+
+# Only fire on completed cycles. 2fa_required, sync_failed, etc. fall
+# through; copy and adapt this script if you want to handle those too.
+if [ "$KEI_EVENT" != "sync_complete" ]; then
+    exit 0
+fi
+
+# Skip the notification if nothing changed.
+if [ "${KEI_DOWNLOADED:-0}" = "0" ]; then
+    exit 0
+fi
+
+: "${SYNOLOGY_URL:?SYNOLOGY_URL must be set}"
+: "${SYNOLOGY_USERNAME:?SYNOLOGY_USERNAME must be set}"
+: "${SYNOLOGY_PASSWORD:?SYNOLOGY_PASSWORD must be set}"
+
+CURL_OPTS="-s --max-time 30"
+if [ "${SYNOLOGY_INSECURE:-0}" = "1" ]; then
+    CURL_OPTS="$CURL_OPTS -k"
+fi
+
+# 1. Login -> session id (DSM Auth API is stable since DSM 6).
+LOGIN=$(curl $CURL_OPTS -G "$SYNOLOGY_URL/webapi/entry.cgi" \
+    --data-urlencode "api=SYNO.API.Auth" \
+    --data-urlencode "version=6" \
+    --data-urlencode "method=login" \
+    --data-urlencode "account=$SYNOLOGY_USERNAME" \
+    --data-urlencode "passwd=$SYNOLOGY_PASSWORD" \
+    --data-urlencode "session=DSM" \
+    --data-urlencode "format=sid")
+
+SID=$(printf '%s' "$LOGIN" | sed -n 's/.*"sid":"\([^"]*\)".*/\1/p')
+
+if [ -z "$SID" ]; then
+    echo "kei-notify-synology: login failed: $LOGIN" >&2
+    exit 1
+fi
+
+# 2. Send a DSM notification via the Notification.Mail send API. This
+# is documented and stable; reuses whatever notification channel the
+# user has configured in DSM (email, push, etc).
+MSG="kei sync complete: ${KEI_DOWNLOADED} downloaded, ${KEI_FAILED:-0} failed, ${KEI_SKIPPED:-0} skipped"
+
+curl $CURL_OPTS "$SYNOLOGY_URL/webapi/entry.cgi" \
+    --data-urlencode "api=SYNO.Core.Notification.Mail" \
+    --data-urlencode "version=1" \
+    --data-urlencode "method=send" \
+    --data-urlencode "subject=kei sync" \
+    --data-urlencode "message=$MSG" \
+    --data-urlencode "_sid=$SID" >/dev/null || \
+        echo "kei-notify-synology: notification send failed (continuing)" >&2
+
+# 3. Optional: explicit reindex via the documented `synoindex` CLI on
+# the host. Requires SSH key-based access from the kei container to the
+# NAS. Uncomment and set SYNOLOGY_SSH_TARGET / SYNOLOGY_REINDEX_PATH if
+# you need it.
+#
+# if [ -n "${SYNOLOGY_SSH_TARGET:-}" ] && [ -n "${SYNOLOGY_REINDEX_PATH:-}" ]; then
+#     ssh -o StrictHostKeyChecking=accept-new "$SYNOLOGY_SSH_TARGET" \
+#         synoindex -R "$SYNOLOGY_REINDEX_PATH" || \
+#             echo "kei-notify-synology: synoindex failed (continuing)" >&2
+# fi
+
+# 4. Logout (best-effort).
+curl $CURL_OPTS -G "$SYNOLOGY_URL/webapi/entry.cgi" \
+    --data-urlencode "api=SYNO.API.Auth" \
+    --data-urlencode "version=6" \
+    --data-urlencode "method=logout" \
+    --data-urlencode "session=DSM" \
+    --data-urlencode "_sid=$SID" >/dev/null 2>&1 || true
+
+echo "kei-notify-synology: notified DSM ($MSG)"

--- a/scripts/notify-synology-photos.sh
+++ b/scripts/notify-synology-photos.sh
@@ -44,13 +44,16 @@ fi
 : "${SYNOLOGY_USERNAME:?SYNOLOGY_USERNAME must be set}"
 : "${SYNOLOGY_PASSWORD:?SYNOLOGY_PASSWORD must be set}"
 
-CURL_OPTS="-s --max-time 30"
+# Use `set --` to build curl opts as positional params; unquoted string
+# expansion (CURL_OPTS=...; curl $CURL_OPTS) word-splits incorrectly on
+# values containing spaces (shellcheck SC2086).
+set -- -s --max-time 30
 if [ "${SYNOLOGY_INSECURE:-0}" = "1" ]; then
-    CURL_OPTS="$CURL_OPTS -k"
+    set -- "$@" -k
 fi
 
 # 1. Login -> session id (DSM Auth API is stable since DSM 6).
-LOGIN=$(curl $CURL_OPTS -G "$SYNOLOGY_URL/webapi/entry.cgi" \
+LOGIN=$(curl "$@" -G "$SYNOLOGY_URL/webapi/entry.cgi" \
     --data-urlencode "api=SYNO.API.Auth" \
     --data-urlencode "version=6" \
     --data-urlencode "method=login" \
@@ -59,7 +62,9 @@ LOGIN=$(curl $CURL_OPTS -G "$SYNOLOGY_URL/webapi/entry.cgi" \
     --data-urlencode "session=DSM" \
     --data-urlencode "format=sid")
 
-SID=$(printf '%s' "$LOGIN" | sed -n 's/.*"sid":"\([^"]*\)".*/\1/p')
+# Extract the sid via grep -o so an unrelated earlier "sid" field in an
+# error envelope can't match. The first "sid":"..." occurrence wins.
+SID=$(printf '%s' "$LOGIN" | grep -o '"sid":"[^"]*"' | head -1 | sed 's/.*"sid":"\([^"]*\)"/\1/')
 
 if [ -z "$SID" ]; then
     echo "kei-notify-synology: login failed: $LOGIN" >&2
@@ -71,7 +76,7 @@ fi
 # user has configured in DSM (email, push, etc).
 MSG="kei sync complete: ${KEI_DOWNLOADED} downloaded, ${KEI_FAILED:-0} failed, ${KEI_SKIPPED:-0} skipped"
 
-curl $CURL_OPTS "$SYNOLOGY_URL/webapi/entry.cgi" \
+curl "$@" "$SYNOLOGY_URL/webapi/entry.cgi" \
     --data-urlencode "api=SYNO.Core.Notification.Mail" \
     --data-urlencode "version=1" \
     --data-urlencode "method=send" \
@@ -92,7 +97,7 @@ curl $CURL_OPTS "$SYNOLOGY_URL/webapi/entry.cgi" \
 # fi
 
 # 4. Logout (best-effort).
-curl $CURL_OPTS -G "$SYNOLOGY_URL/webapi/entry.cgi" \
+curl "$@" -G "$SYNOLOGY_URL/webapi/entry.cgi" \
     --data-urlencode "api=SYNO.API.Auth" \
     --data-urlencode "version=6" \
     --data-urlencode "method=logout" \

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -257,37 +257,31 @@ PUID_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-photos-XXXXX")
 # in the container's /etc/passwd).
 TEST_PUID=4321
 TEST_PGID=4322
-PUID_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
-    -e PUID="$TEST_PUID" \
-    -e PGID="$TEST_PGID" \
-    -v "$PUID_CONFIG:/config" \
-    -v "$PUID_PHOTOS:/photos" \
-    --entrypoint /usr/local/bin/entrypoint.sh \
-    "$IMAGE" sh -c 'id -u; id -g; stat -c %u /config; stat -c %u /photos' \
-    2>&1)
+puid_run() {
+    docker run --rm \
+        "${ONESHOT_ENV[@]}" \
+        -e PUID="$TEST_PUID" \
+        -e PGID="$TEST_PGID" \
+        -v "$PUID_CONFIG:/config" \
+        -v "$PUID_PHOTOS:/photos" \
+        --entrypoint /usr/local/bin/entrypoint.sh \
+        "$IMAGE" "$@"
+}
+PUID_OUT=$(puid_run sh -c 'id -u; id -g; stat -c %u /config; stat -c %u /photos' 2>&1)
 echo "  Output (uid, gid, /config uid, /photos uid):"
 echo "$PUID_OUT" | sed 's/^/    /'
 EXPECTED=$(printf '%s\n%s\n%s\n%s' "$TEST_PUID" "$TEST_PGID" "$TEST_PUID" "$TEST_PUID")
 [ "$PUID_OUT" = "$EXPECTED" ]
 kei_check "process runs as PUID:PGID and volumes are chowned"
-# Subsequent runs must skip the recursive chown (top-level uid already matches)
-# and still drop to the requested UID.
-SECOND_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
-    -e PUID="$TEST_PUID" \
-    -e PGID="$TEST_PGID" \
-    -v "$PUID_CONFIG:/config" \
-    -v "$PUID_PHOTOS:/photos" \
-    --entrypoint /usr/local/bin/entrypoint.sh \
-    "$IMAGE" id -u 2>&1)
+# Subsequent runs must be a no-op for matching files (find -not -uid
+# returns nothing) and still drop to the requested UID.
+SECOND_OUT=$(puid_run id -u 2>&1)
 [ "$SECOND_OUT" = "$TEST_PUID" ]
 kei_check "second run still drops to PUID after chown is a no-op"
-# Chown back to the host user before rm; the dirs were chown'd to
-# TEST_PUID inside the container and the host user can't `rm -rf` them
-# directly.
-docker run --rm -v "$PUID_CONFIG:/c" "$IMAGE" chown -R "$(id -u):$(id -g)" /c >/dev/null 2>&1
-docker run --rm -v "$PUID_PHOTOS:/p" "$IMAGE" chown -R "$(id -u):$(id -g)" /p >/dev/null 2>&1
+# Chown back to the host user in one container so `rm -rf` from the
+# host can clean up afterwards.
+docker run --rm -v "$PUID_CONFIG:/c" -v "$PUID_PHOTOS:/p" "$IMAGE" \
+    chown -R "$(id -u):$(id -g)" /c /p >/dev/null 2>&1
 rm -rf "$PUID_CONFIG" "$PUID_PHOTOS"
 
 echo ""
@@ -304,10 +298,21 @@ echo "--- 14c. Non-numeric PUID is rejected ---"
 BAD_OUT=$(docker run --rm \
     "${ONESHOT_ENV[@]}" \
     -e PUID="notanumber" \
+    -e PGID="$TEST_PGID" \
     --entrypoint /usr/local/bin/entrypoint.sh \
     "$IMAGE" id 2>&1 || true)
 echo "$BAD_OUT" | grep -q "PUID/PGID must be numeric"
 kei_check "non-numeric PUID is rejected with clear error"
+
+echo ""
+echo "--- 14d. Setting only one of PUID/PGID is rejected ---"
+PARTIAL_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    -e PUID="$TEST_PUID" \
+    --entrypoint /usr/local/bin/entrypoint.sh \
+    "$IMAGE" id 2>&1 || true)
+echo "$PARTIAL_OUT" | grep -q "must be set together"
+kei_check "PUID without PGID is rejected with clear error"
 
 echo ""
 echo "--- 15. kei status --pending --failed --downloaded combined ---"

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -250,7 +250,67 @@ echo "$STATUS_OUT" | grep -q "Downloaded assets:"
 kei_check "--downloaded listing renders inside container"
 
 echo ""
-echo "--- 14. kei status --pending --failed --downloaded combined ---"
+echo "--- 14a. PUID/PGID drops privileges and chowns volumes ---"
+PUID_CONFIG=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-config-XXXXX")
+PUID_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-photos-XXXXX")
+# Pick UIDs unlikely to collide with the host (don't shadow real users
+# in the container's /etc/passwd).
+TEST_PUID=4321
+TEST_PGID=4322
+PUID_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    -e PUID="$TEST_PUID" \
+    -e PGID="$TEST_PGID" \
+    -v "$PUID_CONFIG:/config" \
+    -v "$PUID_PHOTOS:/photos" \
+    --entrypoint /usr/local/bin/entrypoint.sh \
+    "$IMAGE" sh -c 'id -u; id -g; stat -c %u /config; stat -c %u /photos' \
+    2>&1)
+echo "  Output (uid, gid, /config uid, /photos uid):"
+echo "$PUID_OUT" | sed 's/^/    /'
+EXPECTED=$(printf '%s\n%s\n%s\n%s' "$TEST_PUID" "$TEST_PGID" "$TEST_PUID" "$TEST_PUID")
+[ "$PUID_OUT" = "$EXPECTED" ]
+kei_check "process runs as PUID:PGID and volumes are chowned"
+# Subsequent runs must skip the recursive chown (top-level uid already matches)
+# and still drop to the requested UID.
+SECOND_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    -e PUID="$TEST_PUID" \
+    -e PGID="$TEST_PGID" \
+    -v "$PUID_CONFIG:/config" \
+    -v "$PUID_PHOTOS:/photos" \
+    --entrypoint /usr/local/bin/entrypoint.sh \
+    "$IMAGE" id -u 2>&1)
+[ "$SECOND_OUT" = "$TEST_PUID" ]
+kei_check "second run still drops to PUID after chown is a no-op"
+# Chown back to the host user before rm; the dirs were chown'd to
+# TEST_PUID inside the container and the host user can't `rm -rf` them
+# directly.
+docker run --rm -v "$PUID_CONFIG:/c" "$IMAGE" chown -R "$(id -u):$(id -g)" /c >/dev/null 2>&1
+docker run --rm -v "$PUID_PHOTOS:/p" "$IMAGE" chown -R "$(id -u):$(id -g)" /p >/dev/null 2>&1
+rm -rf "$PUID_CONFIG" "$PUID_PHOTOS"
+
+echo ""
+echo "--- 14b. No PUID/PGID = runs as root (backward compat) ---"
+ROOT_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    --entrypoint /usr/local/bin/entrypoint.sh \
+    "$IMAGE" id -u 2>&1)
+[ "$ROOT_OUT" = "0" ]
+kei_check "default (no PUID/PGID) still runs as root"
+
+echo ""
+echo "--- 14c. Non-numeric PUID is rejected ---"
+BAD_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    -e PUID="notanumber" \
+    --entrypoint /usr/local/bin/entrypoint.sh \
+    "$IMAGE" id 2>&1 || true)
+echo "$BAD_OUT" | grep -q "PUID/PGID must be numeric"
+kei_check "non-numeric PUID is rejected with clear error"
+
+echo ""
+echo "--- 15. kei status --pending --failed --downloaded combined ---"
 COMBINED_OUT=$(docker run --rm \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" status \

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -315,6 +315,42 @@ echo "$PARTIAL_OUT" | grep -q "must be set together"
 kei_check "PUID without PGID is rejected with clear error"
 
 echo ""
+echo "--- 14e. kei subcommand routes through kei and runs as dropped user under PUID ---"
+# 14a-14d cover dispatch + drop via /usr/bin binaries (sh, id) and the reject
+# paths; none exercise the kei-subcommand branch of entrypoint.sh under PUID.
+# This step invokes `status --downloaded` against a fresh /config so the
+# dispatcher prepends `kei`, gosu drops to TEST_PUID, and the kei binary
+# actually executes as the dropped user. With no DB present, status bails
+# with the "No state database found" message and exits 0; that response is
+# only reachable if kei started, parsed args, and read /config as PUID.
+SUB_CONFIG=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-config-XXXXX")
+SUB_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-photos-XXXXX")
+SUB_OUT=$(docker run --rm \
+    "${ONESHOT_ENV[@]}" \
+    -e PUID="$TEST_PUID" \
+    -e PGID="$TEST_PGID" \
+    -v "$SUB_CONFIG:/config" \
+    -v "$SUB_PHOTOS:/photos" \
+    "$IMAGE" status \
+        --username "$ICLOUD_USERNAME" \
+        --data-dir /config \
+        --downloaded \
+    2>&1)
+SUB_EC=$?
+echo "$SUB_OUT" | tail -5
+kei_check "kei status under PUID exits 0" "$SUB_EC"
+echo "$SUB_OUT" | grep -q "No state database found"
+kei_check "kei status under PUID reached the no-DB branch (proves kei subcommand ran)"
+# The chown step in the entrypoint must leave /config owned by PUID even
+# when the kei subcommand does no writes itself.
+SUB_CONFIG_OWNER=$(stat -c %u "$SUB_CONFIG" 2>/dev/null || echo "")
+[ "$SUB_CONFIG_OWNER" = "$TEST_PUID" ]
+kei_check "/config is owned by PUID after kei-subcommand run"
+docker run --rm -v "$SUB_CONFIG:/c" -v "$SUB_PHOTOS:/p" "$IMAGE" \
+    chown -R "$(id -u):$(id -g)" /c /p >/dev/null 2>&1
+rm -rf "$SUB_CONFIG" "$SUB_PHOTOS"
+
+echo ""
 echo "--- 15. kei status --pending --failed --downloaded combined ---"
 COMBINED_OUT=$(docker run --rm \
     -v "$DOCKER_CONFIG:/config" \


### PR DESCRIPTION
## Summary

Lets the Docker container drop privileges to a host-owned UID/GID before running kei, so files written into mounted volumes belong to the user that owns the host directory. Required for NAS deployments (Synology Container Manager, Unraid, TrueNAS Scale) where downstream indexers like Synology Photos can't read root-owned files. Backwards-compatible: with neither env var set, the container still runs as root.

## What changes

### Entrypoint script (`docker/entrypoint.sh`)

When `PUID` and `PGID` are both set, the entrypoint chowns ownership-mismatched files in `/config` and `/photos`, then `exec gosu PUID:PGID` to drop privileges before running kei. Without them, `exec`s kei as root (prior default).

- `find -not -uid "$PUID" | xargs chown` so a multi-TB volume only pays for stragglers, not the full tree, on every restart.
- `gosu` accepts numeric `uid:gid` directly, no `useradd`/`groupadd` and no `/etc/passwd` writes per cold start.
- Setting only one of `PUID`/`PGID` is rejected with a clear error.
- Non-numeric values are rejected with a clear error.
- Smart arg dispatch routes kei subcommands and flags through `kei`, while bare binaries (`sh`, `id`, `chown`) exec directly so `docker run kei sh` works for debugging without `--entrypoint`. Hard-coded subcommand list is load-bearing because `sync`, `login`, and `reset` collide with `/usr/bin` binaries on debian-slim.

### Image (`Dockerfile`)

Installs `gosu` (~1.8 MB) and copies `entrypoint.sh`. ENTRYPOINT switches from `["kei"]` to the script. CMD unchanged.

### Compose example (`docker-compose.yml`)

Adds commented `PUID=1000` / `PGID=1000` lines with a note that NAS deployments typically need them.

### Docs

- New Synology wiki page (Container Manager setup, typical `PUID=1026 PGID=100`, Synology Photos library paths, first-run 2FA via DSM terminal, port-conflict note, troubleshooting). Drafted in `.scratch/wiki/Synology.md`; will be pushed to the wiki repo separately on merge.
- `Docker.md` gains a "Run as a non-root user" section.
- `README.md` links the new Synology page from the docs list.

### Notification script example (`scripts/notify-synology-photos.sh`)

Reference `--notification-script` example that pings DSM via `SYNO.Core.Notification.Mail` (documented and stable since DSM 6) with sync stats. Optional commented-out section uses SSH + `synoindex -R` for explicit reindex; no kei code knows about Synology, so this lives entirely outside the binary.

### Tests (`tests/shell/docker.sh`)

Five new steps in the existing docker live-test suite:

- `14a` - PUID/PGID drops to that UID, `/config` and `/photos` are chowned, idempotent on second run.
- `14b` - no PUID/PGID still runs as root.
- `14c` - non-numeric PUID rejected with a clear error.
- `14d` - partial PUID (only one set) rejected with a clear error.
- `14e` - kei subcommand under PUID routes through `kei`, gosu drops to the dropped user, and `/config` ends up owned by PUID after the run.

## Test plan

- [x] `just gate` (fmt / clippy / fast tests / docs / audit / typos / round-trip)
- [x] Image rebuilt locally, all five entrypoint paths verified by hand: drop, idempotent re-run, root default, non-numeric reject, partial reject, kei subcommand routing through `kei`, bare binary exec'ing directly.
- [x] `tests/shell/docker.sh` 14a-14e run inline against the rebuilt image and pass.
- [x] `just test docker` end-to-end against live iCloud creds (24/24 steps, 150s) - all of 1-13 sync/watch/healthcheck/password-file paths pass alongside 14a-14e. Run via `/full-test`; no regression.

## Backward compatibility

Zero behavior change for users who don't set `PUID`/`PGID`:

- `docker run kei` still runs the default sync CMD as root.
- All existing kei subcommand invocations route through `kei` (the smart-dispatch's hard-coded subcommand list covers them all).
- `docker run --user 1000:1000 kei` (the prior workaround) still works because the entrypoint sees no PUID/PGID and falls through to `exec kei`.

The only strictly-new behavior is `docker run kei sh` and `docker run kei id` opening a shell / running that binary directly instead of failing with `unrecognized subcommand`. Strict superset.
