### PR TITLE
fix: skip-rehash + heartbeat for import-existing (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`import-existing` 30-second heartbeat log line.** The existing `Matched N files so far...` progress only ticked every 100 *matches*, so a long ExcludedAlbum or filtered run left INFO-level output silent for many minutes and users (#347) read silence as a hang. The heartbeat prints total scanned, matched, skipped-re-hash, filtered, unmatched, hash errors, and the last-seen asset id. ([#347])
+
+### Changed
+
+- **`import-existing` skips the SHA-256 re-read on files already adopted at the same path with unchanged size + mtime.** Previously every restart paid the full hash cost on every already-adopted file (there's no resume checkpoint), which turned into hours per restart on HDD-backed photo trees. The check is mtime-keyed, so any size or mtime change still forces a real re-hash and silent content drift stays caught. ([#347])
+- **State DB schema migrates v10 -> v11 on first run.** Adds nullable `imported_size INTEGER` and `imported_mtime INTEGER` columns to `assets`. Pre-v11 rows survive with NULL values (the import path treats those as "no snapshot, re-hash" on the first post-upgrade pass), so the upgrade is one-way and idempotent on re-entry. ([#347])
+
+[#347]: https://github.com/rhoopr/kei/pull/347
+
 ---
 
 ## [0.13.2] - 2026-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`import-existing` 30-second heartbeat log line.** The existing `Matched N files so far...` progress only ticked every 100 *matches*, so a long ExcludedAlbum or filtered run left INFO-level output silent for many minutes and users (#347) read silence as a hang. The heartbeat prints total scanned, matched, skipped-re-hash, filtered, unmatched, hash errors, and the last-seen asset id. ([#347])
+- **`import-existing` 30-second heartbeat log line.** The existing `Matched N files so far...` progress only ticked every 100 *matches*, so a long ExcludedAlbum or filtered run left INFO-level output silent for many minutes and users (#347) read silence as a hang. The heartbeat prints total scanned, matched, skipped-re-hash, filtered, unmatched, hash errors, and the last-seen asset id. ([#348])
 
 ### Changed
 
-- **`import-existing` skips the SHA-256 re-read on files already adopted at the same path with unchanged size + mtime.** Previously every restart paid the full hash cost on every already-adopted file (there's no resume checkpoint), which turned into hours per restart on HDD-backed photo trees. The check is mtime-keyed, so any size or mtime change still forces a real re-hash and silent content drift stays caught. ([#347])
-- **State DB schema migrates v10 -> v11 on first run.** Adds nullable `imported_size INTEGER` and `imported_mtime INTEGER` columns to `assets`. Pre-v11 rows survive with NULL values (the import path treats those as "no snapshot, re-hash" on the first post-upgrade pass), so the upgrade is one-way and idempotent on re-entry. ([#347])
+- **`import-existing` skips the SHA-256 re-read on files already adopted at the same path with unchanged size + mtime.** Previously every restart paid the full hash cost on every already-adopted file (there's no resume checkpoint), which turned into hours per restart on HDD-backed photo trees. The check is mtime-keyed, so any size or mtime change still forces a real re-hash and silent content drift stays caught. ([#348])
+- **State DB schema migrates v10 -> v11 on first run.** Adds nullable `imported_size INTEGER` and `imported_mtime INTEGER` columns to `assets`. Pre-v11 rows survive with NULL values (the import path treats those as "no snapshot, re-hash" on the first post-upgrade pass), so the upgrade is one-way and idempotent on re-entry. ([#348])
 
-[#347]: https://github.com/rhoopr/kei/pull/347
+[#348]: https://github.com/rhoopr/kei/pull/348
 
 ---
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -28,13 +28,22 @@ use super::service::{init_photos_service, resolve_libraries, resolve_passes};
 /// work has started, distinct from process-spawn or auth completion.
 pub(crate) const SCAN_STARTED_STAGE: &str = "scan_started";
 
+/// Value of the `stage` field on the periodic heartbeat tracing event
+/// emitted by the import scan task. Operators tailing logs use this to
+/// distinguish heartbeat lines (running counters, last-seen asset id)
+/// from per-asset debug/warn lines.
+const HEARTBEAT_STAGE: &str = "heartbeat";
+
 /// Per-library counters returned by [`import_assets`].
 ///
 /// Counters span asset- and expected-path levels so that divergent
 /// totals in the summary surface silently dropped work instead of
 /// masquerading as a clean run. `total` and `filtered` tick per asset;
-/// `matched`, `unmatched`, and `hash_errors` tick per expected path
-/// (one asset can yield multiple paths, e.g. live photos).
+/// `matched`, `unmatched`, `hash_errors`, and `skipped_already_imported`
+/// tick per expected path (one asset can yield multiple paths, e.g.
+/// live photos). `skipped_already_imported` is a subset of `matched`:
+/// the file matched, but the DB had a prior adopt with the same size +
+/// mtime so the SHA-256 re-read was skipped.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ImportStats {
     pub total: u64,
@@ -42,6 +51,7 @@ pub(crate) struct ImportStats {
     pub unmatched: u64,
     pub filtered: u64,
     pub hash_errors: u64,
+    pub skipped_already_imported: u64,
 }
 
 impl std::ops::AddAssign for ImportStats {
@@ -51,6 +61,132 @@ impl std::ops::AddAssign for ImportStats {
         self.unmatched += rhs.unmatched;
         self.filtered += rhs.filtered;
         self.hash_errors += rhs.hash_errors;
+        self.skipped_already_imported += rhs.skipped_already_imported;
+    }
+}
+
+/// Default cadence for the `import-existing` heartbeat log line.
+const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Live counters shared between the scan loop and the heartbeat task.
+///
+/// Atomics are cheaper than wrapping `ImportStats` in a lock because the
+/// scan loop bumps these on every asset; the heartbeat task only ever
+/// reads them. `last_seen_id` is kept under a `std::sync::Mutex` -- it's
+/// touched once per asset and read every 30s, so contention is irrelevant
+/// and a `Mutex<Option<String>>` avoids the ABA dance an atomic pointer
+/// would require.
+#[derive(Debug, Default)]
+struct HeartbeatState {
+    total: std::sync::atomic::AtomicU64,
+    matched: std::sync::atomic::AtomicU64,
+    unmatched: std::sync::atomic::AtomicU64,
+    filtered: std::sync::atomic::AtomicU64,
+    hash_errors: std::sync::atomic::AtomicU64,
+    skipped_already_imported: std::sync::atomic::AtomicU64,
+    last_seen_id: std::sync::Mutex<Option<String>>,
+}
+
+impl HeartbeatState {
+    fn snapshot(&self) -> HeartbeatSnapshot {
+        use std::sync::atomic::Ordering;
+        HeartbeatSnapshot {
+            total: self.total.load(Ordering::Relaxed),
+            matched: self.matched.load(Ordering::Relaxed),
+            unmatched: self.unmatched.load(Ordering::Relaxed),
+            filtered: self.filtered.load(Ordering::Relaxed),
+            hash_errors: self.hash_errors.load(Ordering::Relaxed),
+            skipped_already_imported: self.skipped_already_imported.load(Ordering::Relaxed),
+            last_seen_id: self.last_seen_id.lock().ok().and_then(|g| g.clone()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HeartbeatSnapshot {
+    total: u64,
+    matched: u64,
+    unmatched: u64,
+    filtered: u64,
+    hash_errors: u64,
+    skipped_already_imported: u64,
+    last_seen_id: Option<String>,
+}
+
+/// RAII handle for the heartbeat task spawned by [`import_assets`].
+///
+/// On drop, cancels the cancellation token so the task exits even if the
+/// scan loop bails early. The task itself is fire-and-forget; we don't
+/// `await` its `JoinHandle` in Drop because Drop is sync and the task
+/// will race-to-exit promptly once the token flips.
+struct HeartbeatGuard {
+    token: tokio_util::sync::CancellationToken,
+}
+
+impl HeartbeatGuard {
+    fn spawn(
+        state: Arc<HeartbeatState>,
+        library_label: String,
+        interval: std::time::Duration,
+    ) -> Self {
+        let token = tokio_util::sync::CancellationToken::new();
+        let task_token = token.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Skip the immediate-fire so the first heartbeat lands ~interval
+            // after spawn rather than at t=0 (avoids a noisy log line before
+            // any work has happened).
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    () = task_token.cancelled() => break,
+                    _ = ticker.tick() => {
+                        let snap = state.snapshot();
+                        tracing::info!(
+                            library = %library_label,
+                            stage = HEARTBEAT_STAGE,
+                            total = snap.total,
+                            matched = snap.matched,
+                            unmatched = snap.unmatched,
+                            filtered = snap.filtered,
+                            hash_errors = snap.hash_errors,
+                            skipped_already_imported = snap.skipped_already_imported,
+                            last_seen_id = snap.last_seen_id.as_deref().unwrap_or("(none)"),
+                            "import scan heartbeat",
+                        );
+                    }
+                }
+            }
+        });
+        Self { token }
+    }
+}
+
+impl Drop for HeartbeatGuard {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
+}
+
+/// Convert a [`std::fs::Metadata`] modified time into an epoch-second `i64`.
+///
+/// Returns `None` when the host filesystem doesn't expose a usable mtime
+/// or when the value falls outside `i64` range; callers treat `None` as
+/// "no mtime, can't trust skip-rehash" rather than as an error.
+fn file_mtime_epoch(metadata: &std::fs::Metadata) -> Option<i64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|st| st.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+}
+
+/// Print the every-100-matches progress milestone if `show_progress` is set.
+/// Hoisted out of the scan loop so the skip-rehash arm and the hash-and-adopt
+/// arm can't drift in their formatting or cadence.
+fn log_progress_milestone(library_label: &str, matched: u64, show_progress: bool) {
+    if show_progress && matched.is_multiple_of(100) {
+        println!("  [{library_label}] Matched {matched} files so far...");
     }
 }
 
@@ -139,10 +275,36 @@ where
     S: futures_util::Stream<Item = anyhow::Result<PhotoAsset>>,
 {
     use futures_util::StreamExt;
+    use std::sync::atomic::Ordering;
 
     tokio::pin!(stream);
     let mut stats = ImportStats::default();
     let mut scan_started_emitted = false;
+
+    let heartbeat_state = Arc::new(HeartbeatState::default());
+    let _heartbeat = HeartbeatGuard::spawn(
+        Arc::clone(&heartbeat_state),
+        library_label.to_owned(),
+        HEARTBEAT_INTERVAL,
+    );
+
+    // Bulk-load every prior import-time snapshot for this library once so
+    // the per-asset path is an O(1) HashMap probe instead of a DB round-trip
+    // per match candidate. On a fresh DB the map is empty and the lookup
+    // path falls straight through to the real hash, so this costs one
+    // single-row no-op query for first-time imports and saves N queries
+    // (and N SHA-256 reads) on every subsequent pass.
+    let imported_index = match db.get_all_imported_records(library_label).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!(
+                library = %library_label,
+                error = %e,
+                "get_all_imported_records failed; skip-rehash optimization disabled this pass",
+            );
+            std::collections::HashMap::new()
+        }
+    };
 
     while let Some(result) = stream.next().await {
         // Emit a one-shot marker as soon as the first asset is dequeued so
@@ -170,10 +332,15 @@ where
         };
 
         stats.total += 1;
+        heartbeat_state.total.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut last) = heartbeat_state.last_seen_id.lock() {
+            *last = Some(asset.id().to_string());
+        }
 
         if asset.versions().is_empty() {
             tracing::debug!(id = %asset.id(), "Skipping asset with no versions");
             stats.filtered += 1;
+            heartbeat_state.filtered.fetch_add(1, Ordering::Relaxed);
             continue;
         }
 
@@ -186,6 +353,7 @@ where
         if let Some(reason) = is_asset_filtered(&asset, download_config) {
             tracing::debug!(id = %asset.id(), ?reason, "Skipping (is_asset_filtered)");
             stats.filtered += 1;
+            heartbeat_state.filtered.fetch_add(1, Ordering::Relaxed);
             continue;
         }
 
@@ -200,6 +368,7 @@ where
                 "Skipping asset with no expected paths from path-derivation",
             );
             stats.filtered += 1;
+            heartbeat_state.filtered.fetch_add(1, Ordering::Relaxed);
             continue;
         }
 
@@ -219,7 +388,7 @@ where
             // unmatched on import even though it's what kei would also
             // have written under the same collision. Try the suffix
             // shape as a fallback.
-            let (expected_path, _metadata) = match resolve_match_path(
+            let (expected_path, metadata) = match resolve_match_path(
                 &primary_path,
                 expected_size,
                 download_config.file_match_policy,
@@ -230,11 +399,46 @@ where
                 Some(found) => found,
                 None => {
                     stats.unmatched += 1;
+                    heartbeat_state.unmatched.fetch_add(1, Ordering::Relaxed);
                     continue;
                 }
             };
 
             if !dry_run {
+                // Skip-rehash short-circuit: if a prior adopt left a row
+                // for this (library, id, version_size) at the same path
+                // with the same on-disk size + mtime, the file hasn't
+                // changed and re-hashing buys nothing. Skipping is what
+                // makes restart-after-interrupt tolerable on slow storage
+                // (e.g. /photos on HDD).
+                let mtime_epoch = file_mtime_epoch(&metadata);
+                let already_imported = imported_index
+                    .get(&(asset.id().to_string(), version_size.as_str().to_string()))
+                    .filter(|rec| {
+                        rec.local_path == expected_path
+                            && rec.imported_size == Some(metadata.len())
+                            && rec.imported_mtime.is_some()
+                            && rec.imported_mtime == mtime_epoch
+                    });
+
+                if let Some(rec) = already_imported {
+                    tracing::debug!(
+                        asset_id = %asset.id(),
+                        version = ?version_size,
+                        path = %expected_path.display(),
+                        prior_checksum = %rec.local_checksum,
+                        "Skipping re-hash: file unchanged since last import",
+                    );
+                    stats.matched += 1;
+                    stats.skipped_already_imported += 1;
+                    heartbeat_state.matched.fetch_add(1, Ordering::Relaxed);
+                    heartbeat_state
+                        .skipped_already_imported
+                        .fetch_add(1, Ordering::Relaxed);
+                    log_progress_milestone(library_label, stats.matched, show_progress);
+                    continue;
+                }
+
                 // Hash the file BEFORE creating the pending row. If the read
                 // fails (permissions, vanished file, I/O error), bailing
                 // here leaves no orphan `pending` row that a future sync
@@ -244,6 +448,7 @@ where
                     Err(e) => {
                         tracing::warn!(path = %expected_path.display(), error = %e, "Failed to hash file");
                         stats.hash_errors += 1;
+                        heartbeat_state.hash_errors.fetch_add(1, Ordering::Relaxed);
                         continue;
                     }
                 };
@@ -274,7 +479,13 @@ where
                     media_type,
                 );
                 if let Err(e) = db
-                    .import_adopt(&record, &expected_path, &local_checksum)
+                    .import_adopt(
+                        &record,
+                        &expected_path,
+                        &local_checksum,
+                        metadata.len(),
+                        mtime_epoch,
+                    )
                     .await
                 {
                     tracing::warn!(asset_id = %asset.id(), version = ?version_size, error = %e, "Failed to adopt asset");
@@ -283,13 +494,8 @@ where
             }
 
             stats.matched += 1;
-            if show_progress && stats.matched.is_multiple_of(100) {
-                println!(
-                    "  [{label}] Matched {matched} files so far...",
-                    label = library_label,
-                    matched = stats.matched,
-                );
-            }
+            heartbeat_state.matched.fetch_add(1, Ordering::Relaxed);
+            log_progress_milestone(library_label, stats.matched, show_progress);
         }
     }
 
@@ -466,6 +672,10 @@ pub(crate) async fn run_import_existing(
     }
     println!("  Total assets scanned: {}", totals.total);
     println!("  Files matched:        {}", totals.matched);
+    println!(
+        "  ... skipped re-hash:  {}",
+        totals.skipped_already_imported
+    );
     println!("  Unmatched versions:   {}", totals.unmatched);
     println!("  Filtered (no path):   {}", totals.filtered);
     println!("  Hash errors:          {}", totals.hash_errors);
@@ -2567,6 +2777,107 @@ mod wiremock_tests {
         );
     }
 
+    // ── Skip-rehash optimization (issue #347) ─────────────────────────
+
+    /// Skip-rehash optimization: a second `import_assets` pass over the
+    /// same on-disk tree must increment `skipped_already_imported` for
+    /// every match. The counter sits in the same arm of the loop where
+    /// the SHA-256 read and `import_adopt` call are skipped, so a tick
+    /// proves the optimization engaged. Without this, every restart
+    /// re-pays the SHA-256 cost on every already-imported file (#347).
+    #[tokio::test]
+    async fn second_pass_skips_rehash_on_unchanged_files() {
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("REHASH1", "IMG_REH1.JPG", "public.jpeg").orig(
+            2048,
+            "ck_reh1",
+            "public.jpeg",
+        );
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        stage_expected(&asset.to_photo_asset(), &config);
+
+        let db = open_db(&tmp).await;
+
+        let stats1 = run_import(
+            &server,
+            std::slice::from_ref(&asset),
+            db.as_ref(),
+            &config,
+            false,
+        )
+        .await;
+        assert_eq!(stats1.matched, 1);
+        assert_eq!(
+            stats1.skipped_already_imported, 0,
+            "fresh DB has nothing to skip",
+        );
+
+        // wiremock keeps every mount; the first pass's stub has served its
+        // single page and would now return empty if we just re-mounted on
+        // top. Reset clears the server so the new stub serves fresh.
+        server.reset().await;
+        let stats2 = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+        assert_eq!(stats2.matched, 1, "match still tallies on skip path");
+        assert_eq!(
+            stats2.skipped_already_imported, 1,
+            "skip-rehash counter must tick on the second pass",
+        );
+    }
+
+    /// If the on-disk file's mtime jumps between passes, the skip path
+    /// must NOT engage — we re-hash and re-adopt. Otherwise a silent
+    /// content change goes undetected forever once the row is adopted.
+    #[tokio::test]
+    async fn second_pass_rehashes_when_file_mtime_changes() {
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("REHASH2", "IMG_REH2.JPG", "public.jpeg").orig(
+            2048,
+            "ck_reh2",
+            "public.jpeg",
+        );
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        let staged = stage_expected(&asset.to_photo_asset(), &config);
+
+        let db = open_db(&tmp).await;
+
+        let _ = run_import(
+            &server,
+            std::slice::from_ref(&asset),
+            db.as_ref(),
+            &config,
+            false,
+        )
+        .await;
+
+        // Bump mtime on every staged file. Keep size identical (to stay
+        // matched) and touch the file to force a fresh mtime. The 1.1s
+        // sleep covers filesystems with second-granularity mtime.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        for path in &staged {
+            let f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(path)
+                .expect("open for mtime bump");
+            f.set_len(2048).expect("set_len same size");
+            drop(f);
+        }
+
+        // See sibling test for why reset() is necessary between passes.
+        server.reset().await;
+        let stats2 = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+        assert_eq!(stats2.matched, 1);
+        assert_eq!(
+            stats2.skipped_already_imported, 0,
+            "mtime change must invalidate the skip path",
+        );
+    }
+
     // ── icloudpd compat baseline ──────────────────────────────────────
     //
     // Scenario-driven tests that stage on-disk layouts using icloudpd's
@@ -2999,6 +3310,59 @@ mod build_config_tests {
         assert!(
             msg.contains("--directory") && (msg.contains("deprecated") || msg.contains("pick one")),
             "error must name the deprecation conflict, got: {msg}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod heartbeat_tests {
+    //! Heartbeat-task unit tests. The skip-rehash + heartbeat-firing
+    //! end-to-end tests live in `wiremock_tests` because they need the
+    //! full wiremock + on-disk staging setup; this module covers the
+    //! snapshot + guard behaviour in isolation.
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    /// `HeartbeatState::snapshot` must mirror the live atomics so the
+    /// emitted log line reflects whatever the scan loop has counted up
+    /// to that instant.
+    #[tokio::test]
+    async fn heartbeat_state_snapshot_reflects_loop_progress() {
+        let state = Arc::new(super::HeartbeatState::default());
+        state.total.fetch_add(7, Ordering::Relaxed);
+        state.matched.fetch_add(3, Ordering::Relaxed);
+        state.filtered.fetch_add(2, Ordering::Relaxed);
+        state
+            .skipped_already_imported
+            .fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut last) = state.last_seen_id.lock() {
+            *last = Some("ASSET-XYZ".to_string());
+        }
+
+        let snap = state.snapshot();
+        assert_eq!(snap.total, 7);
+        assert_eq!(snap.matched, 3);
+        assert_eq!(snap.filtered, 2);
+        assert_eq!(snap.skipped_already_imported, 1);
+        assert_eq!(snap.last_seen_id.as_deref(), Some("ASSET-XYZ"));
+    }
+
+    /// `HeartbeatGuard::drop` must cancel the spawned task so a bailing
+    /// scan loop doesn't leak a periodic logger.
+    #[tokio::test]
+    async fn heartbeat_guard_cancels_task_on_drop() {
+        let state = Arc::new(super::HeartbeatState::default());
+        let guard = super::HeartbeatGuard::spawn(
+            Arc::clone(&state),
+            "test-lib".to_string(),
+            std::time::Duration::from_millis(50),
+        );
+        let token = guard.token.clone();
+        assert!(!token.is_cancelled(), "fresh guard is not cancelled");
+        drop(guard);
+        assert!(
+            token.is_cancelled(),
+            "Drop must flip the cancellation token",
         );
     }
 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -2795,7 +2795,14 @@ mod tests {
         ) -> Result<(), StateError> {
             unimplemented!()
         }
-        async fn import_adopt(&self, _: &AssetRecord, _: &Path, _: &str) -> Result<(), StateError> {
+        async fn import_adopt(
+            &self,
+            _: &AssetRecord,
+            _: &Path,
+            _: &str,
+            _: u64,
+            _: Option<i64>,
+        ) -> Result<(), StateError> {
             unimplemented!()
         }
         async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {
@@ -3581,7 +3588,14 @@ mod tests {
                 Ok(())
             }
         }
-        async fn import_adopt(&self, _: &AssetRecord, _: &Path, _: &str) -> Result<(), StateError> {
+        async fn import_adopt(
+            &self,
+            _: &AssetRecord,
+            _: &Path,
+            _: &str,
+            _: u64,
+            _: Option<i64>,
+        ) -> Result<(), StateError> {
             unimplemented!()
         }
         async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -23,6 +23,23 @@ use super::types::{
 /// this fallback is a safety net, not the intended write path.
 const DEFAULT_SOURCE: &str = "icloud";
 
+/// Snapshot of an already-imported asset, returned by
+/// [`StateDb::get_imported_record`].
+///
+/// `import-existing` consults this on every match candidate to decide whether
+/// the on-disk file can be trusted as unchanged since the last adopt. If
+/// `local_path`, `imported_size`, and `imported_mtime` all match what the
+/// filesystem reports right now, the SHA-256 re-read is skipped. Pre-v11
+/// rows have `imported_size`/`imported_mtime` of `None`, which forces a real
+/// hash on the first post-upgrade pass.
+#[derive(Debug, Clone)]
+pub struct ImportedRecord {
+    pub local_path: PathBuf,
+    pub local_checksum: String,
+    pub imported_size: Option<u64>,
+    pub imported_mtime: Option<i64>,
+}
+
 /// Trait for state database operations.
 ///
 /// This trait is object-safe and can be used with `Arc<dyn StateDb>` for
@@ -82,12 +99,37 @@ pub trait StateDb: Send + Sync {
     ///
     /// Used by `import-existing` so an interrupted scan never leaves a
     /// `pending` row with `local_path = NULL` for the next sync to redownload.
+    ///
+    /// `imported_size` and `imported_mtime` snapshot the on-disk file's size
+    /// (bytes) and modification time (epoch seconds) at adopt time. Subsequent
+    /// `import-existing` runs read these via `get_imported_record` and skip
+    /// the SHA-256 re-read when the file is unchanged. `imported_mtime` is
+    /// `None` only when the host filesystem doesn't expose a usable mtime.
     async fn import_adopt(
         &self,
         record: &AssetRecord,
         local_path: &Path,
         local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
     ) -> Result<(), StateError>;
+
+    /// Bulk-load every import-time snapshot for `library`, keyed by
+    /// `(asset_id, version_size)`.
+    ///
+    /// Used by `import-existing` to short-circuit the SHA-256 re-read on
+    /// subsequent runs when the on-disk file is unchanged. Bulk-loaded once
+    /// at scan start (mirroring `get_downloaded_ids` /
+    /// `get_downloaded_checksums`) so the scan loop's per-asset path is an
+    /// O(1) HashMap probe rather than a DB round-trip per file. The default
+    /// impl returns an empty map so test stubs that don't exercise the
+    /// optimization don't have to reimplement it.
+    async fn get_all_imported_records(
+        &self,
+        _library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
+        Ok(HashMap::new())
+    }
 
     /// Mark an asset as failed with an error message.
     async fn mark_failed(
@@ -838,6 +880,8 @@ impl StateDb for SqliteStateDb {
         record: &AssetRecord,
         local_path: &Path,
         local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
     ) -> Result<(), StateError> {
         let record = record.clone();
         let local_path = local_path.to_path_buf();
@@ -865,9 +909,72 @@ impl StateDb for SqliteStateDb {
                 "import_adopt UPDATE missed the row inserted by UPSERT in the same tx — SQL bug"
             );
 
+            // Snapshot on-disk size + mtime so the next import-existing run
+            // can short-circuit the SHA-256 re-read when the file is
+            // unchanged. Done as a separate UPDATE (rather than rolled into
+            // `update_status_to_downloaded`) because the production download
+            // path doesn't have these values and shouldn't carry them.
+            tx.execute(
+                "UPDATE assets SET imported_size = ?1, imported_mtime = ?2 \
+                 WHERE library = ?3 AND id = ?4 AND version_size = ?5",
+                rusqlite::params![
+                    i64::try_from(imported_size).unwrap_or(i64::MAX),
+                    imported_mtime,
+                    &record.library,
+                    &record.id,
+                    record.version_size.as_str(),
+                ],
+            )
+            .map_err(|e| StateError::query("import_adopt::imported_meta", e))?;
+
             tx.commit()
                 .map_err(|e| StateError::query("import_adopt::commit", e))?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn get_all_imported_records(
+        &self,
+        library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
+        let library = library.to_owned();
+
+        self.with_conn("get_all_imported_records", move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, version_size, local_path, local_checksum, \
+                            imported_size, imported_mtime \
+                     FROM assets \
+                     WHERE library = ?1 AND status = 'downloaded'",
+                )
+                .map_err(|e| StateError::query("get_all_imported_records::prepare", e))?;
+            let rows = stmt
+                .query_map([&library], |row| {
+                    let id: String = row.get(0)?;
+                    let version_size: String = row.get(1)?;
+                    let local_path: String = row.get(2)?;
+                    let local_checksum: String = row.get(3)?;
+                    let imported_size: Option<i64> = row.get(4)?;
+                    let imported_mtime: Option<i64> = row.get(5)?;
+                    Ok((
+                        (id, version_size),
+                        ImportedRecord {
+                            local_path: PathBuf::from(local_path),
+                            local_checksum,
+                            imported_size: imported_size.and_then(|v| u64::try_from(v).ok()),
+                            imported_mtime,
+                        },
+                    ))
+                })
+                .map_err(|e| StateError::query("get_all_imported_records::query", e))?;
+            let mut out = HashMap::new();
+            for r in rows {
+                let (k, v) =
+                    r.map_err(|e| StateError::query("get_all_imported_records::row", e))?;
+                out.insert(k, v);
+            }
+            Ok(out)
         })
         .await
     }
@@ -4185,9 +4292,15 @@ mod tests {
             .build();
         let local_path = PathBuf::from("/tmp/photos/photo.jpg");
 
-        db.import_adopt(&record, &local_path, "local-ck-abc")
-            .await
-            .expect("import_adopt should succeed on a fresh row");
+        db.import_adopt(
+            &record,
+            &local_path,
+            "local-ck-abc",
+            2048,
+            Some(1_700_000_000),
+        )
+        .await
+        .expect("import_adopt should succeed on a fresh row");
 
         let summary = db.get_summary().await.unwrap();
         assert_eq!(summary.total_assets, 1);
@@ -4219,9 +4332,15 @@ mod tests {
         let local_path = PathBuf::from("/tmp/photos/idemp.jpg");
 
         for _ in 0..2 {
-            db.import_adopt(&record, &local_path, "local-ck-idemp")
-                .await
-                .expect("import_adopt should be idempotent");
+            db.import_adopt(
+                &record,
+                &local_path,
+                "local-ck-idemp",
+                1024,
+                Some(1_700_000_001),
+            )
+            .await
+            .expect("import_adopt should be idempotent");
         }
 
         let summary = db.get_summary().await.unwrap();
@@ -4249,9 +4368,15 @@ mod tests {
         assert_eq!(summary.downloaded, 0);
 
         let local_path = PathBuf::from("/tmp/photos/resume.jpg");
-        db.import_adopt(&record, &local_path, "local-ck-resume")
-            .await
-            .expect("import_adopt should promote pending → downloaded");
+        db.import_adopt(
+            &record,
+            &local_path,
+            "local-ck-resume",
+            4096,
+            Some(1_700_000_002),
+        )
+        .await
+        .expect("import_adopt should promote pending → downloaded");
 
         let summary = db.get_summary().await.unwrap();
         assert_eq!(summary.pending, 0);

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 10;
+pub(crate) const SCHEMA_VERSION: i32 = 11;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -434,6 +434,19 @@ fn migrate_to_version(
                 conn.execute_batch(
                     "ALTER TABLE sync_runs ADD COLUMN enumeration_errors INTEGER NOT NULL DEFAULT 0;",
                 )?;
+            }
+        }
+        11 => {
+            // imported_size / imported_mtime: snapshot of the on-disk file
+            // metadata at adopt time. import-existing reads these on
+            // subsequent runs to skip the SHA-256 re-read when size + mtime
+            // are unchanged (fresh DBs and rows imported pre-v11 leave
+            // these NULL, which forces a real hash).
+            if !column_exists(conn, "assets", "imported_size")? {
+                conn.execute_batch("ALTER TABLE assets ADD COLUMN imported_size INTEGER;")?;
+            }
+            if !column_exists(conn, "assets", "imported_mtime")? {
+                conn.execute_batch("ALTER TABLE assets ADD COLUMN imported_mtime INTEGER;")?;
             }
         }
         other => {
@@ -1433,6 +1446,38 @@ mod tests {
         // Reset version backwards and re-run the v10 step. This simulates
         // an unusual recovery path; the migration must not fail.
         set_schema_version(&conn, 9).unwrap();
+        migrate(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
+
+    /// v11 introduces `imported_size` and `imported_mtime` on `assets`.
+    /// Both are nullable so pre-v11 rows survive the upgrade with NULL,
+    /// which the import-existing skip-rehash path treats as "no snapshot,
+    /// re-hash" rather than as an error.
+    #[test]
+    fn test_v11_adds_imported_size_and_mtime_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        set_schema_version(&conn, 1).unwrap();
+        migrate(&conn).unwrap();
+
+        assert!(
+            column_exists(&conn, "assets", "imported_size").unwrap(),
+            "v11 must add `imported_size` to assets",
+        );
+        assert!(
+            column_exists(&conn, "assets", "imported_mtime").unwrap(),
+            "v11 must add `imported_mtime` to assets",
+        );
+    }
+
+    /// v11 must be re-runnable on a DB that already has both columns
+    /// (crash mid-migration, replay through migrate()).
+    #[test]
+    fn test_v11_idempotent_when_columns_exist() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        set_schema_version(&conn, 10).unwrap();
         migrate(&conn).unwrap();
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
     }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2526,6 +2526,8 @@ mod tests {
                 _: &state::types::AssetRecord,
                 _: &std::path::Path,
                 _: &str,
+                _: u64,
+                _: Option<i64>,
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
@@ -2973,6 +2975,8 @@ mod tests {
                 _: &state::types::AssetRecord,
                 _: &std::path::Path,
                 _: &str,
+                _: u64,
+                _: Option<i64>,
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
@@ -3280,6 +3284,8 @@ mod tests {
                 _: &state::types::AssetRecord,
                 _: &std::path::Path,
                 _: &str,
+                _: u64,
+                _: Option<i64>,
             ) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }


### PR DESCRIPTION
## Summary

Two import-existing fixes for issue #347. User reported the command "hanging" on Unraid with `/photos` on HDD; investigation surfaced two distinct problems behind the symptom.

## What was broken

**The `Matched N files so far...` progress line only ticked every 100 *matches*.** A long ExcludedAlbum-skip run (e.g. `unfiled = true` with `libraries = ["all"]`, where the unfiled pass deliberately drops every album member) leaves INFO output silent for many minutes while the loop is alive at DEBUG. Users read silence as a hang.

**Every restart of `import-existing` paid the full SHA-256 cost on every already-adopted file.** There's no resume checkpoint. On HDD-backed photo trees with multi-MB videos this is hours per restart, and a Ctrl-C halfway through forces a full re-pay on the next run.

## What changed

### Skip-rehash on unchanged files

Schema v11 adds nullable `imported_size INTEGER` and `imported_mtime INTEGER` to `assets`. `import_adopt` now snapshots both at adopt time. On subsequent runs, the scan loop short-circuits the SHA-256 read and the `import_adopt` write when `local_path`, `imported_size`, and `imported_mtime` all match what's on disk. Any size or mtime change still forces a real re-hash, so silent content drift stays caught.

Records are bulk-loaded once per pass via a new `StateDb::get_all_imported_records(library)` method (mirrors the existing `get_downloaded_ids` / `get_downloaded_checksums` pattern). Per-asset path is an O(1) HashMap probe; first pass costs one DB query returning empty.

Pre-v11 rows have NULL for the new fields and fall through to a real hash on the first post-upgrade pass, so the upgrade is one-way and idempotent on re-entry.

### 30-second heartbeat log

A tokio task spawned alongside the scan emits one INFO line every 30s with the running counters (total / matched / skipped-re-hash / filtered / unmatched / hash_errors) plus the last-seen asset id. Closes the visibility gap during long ExcludedAlbum runs without spamming logs on small libraries.

Lifetime is RAII via `HeartbeatGuard`: a `tokio_util::sync::CancellationToken` cancels on drop, so a bailing scan never leaks the periodic logger. Counter sharing uses `Arc<AtomicU64>` for the integer fields and `Arc<Mutex<Option<String>>>` for the last-seen id (sync mutex held briefly per asset, no cross-await holds).

### Stats + tests

New `skipped_already_imported` counter on `ImportStats`, surfaced in the import summary print and the heartbeat snapshot. Wiremock tests cover both the second-pass idempotent-skip path and the mtime-changed re-hash path. Schema v11 has fresh-DB and idempotent-replay tests mirroring the existing per-version pattern.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `just gate` (fmt / clippy / fast tests / docs / audit / typos / round-trip)
- [x] New tests: `second_pass_skips_rehash_on_unchanged_files`, `second_pass_rehashes_when_file_mtime_changes`, `heartbeat_state_snapshot_reflects_loop_progress`, `heartbeat_guard_cancels_task_on_drop`, `test_v11_adds_imported_size_and_mtime_columns`, `test_v11_idempotent_when_columns_exist`
- [x] \`cargo run -- import-existing --help\` boots