### PR TITLE
fix: tracing writer back-pressure stalls runtime under heavy log volume (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`import-existing` skips the SHA-256 re-read on files already adopted at the same path with unchanged size + mtime.** Previously every restart paid the full hash cost on every already-adopted file (there's no resume checkpoint), which turned into hours per restart on HDD-backed photo trees. The check is mtime-keyed, so any size or mtime change still forces a real re-hash and silent content drift stays caught. ([#348])
 - **State DB schema migrates v10 -> v11 on first run.** Adds nullable `imported_size INTEGER` and `imported_mtime INTEGER` columns to `assets`. Pre-v11 rows survive with NULL values (the import path treats those as "no snapshot, re-hash" on the first post-upgrade pass), so the upgrade is one-way and idempotent on re-entry. ([#348])
 
+### Fixed
+
+- **Tracing writer no longer back-pressures the runtime under heavy log volume.** When the consumer of stderr (Docker stdout pipe, screen PTY, journald) drained slower than events were emitted, every `tracing::info!` / `tracing::debug!` call parked on the writer mutex behind a synchronous `Stderr::write_all`. The `import-existing` heartbeat task and the scan loop both wedged while spawn-blocking workers continued churning -- the failure signature reporters saw in #347 (heartbeats fired twice then stopped, but file-read counters kept growing). Wraps the writer with `tracing_appender::non_blocking` in lossy mode so events drop instead of stall under saturation. ([#349])
+- **`RedactingWriter::write` no longer allocates a `String` per event when the password is unset or absent from the buffer.** Under trace-level logging the previous implementation triggered `String::from_utf8_lossy` on every event whose buffer was at least the password length, which compounded with the back-pressure above as the dominant heap churn for `import-existing`. Adds a byte-level pre-scan that short-circuits when no match is possible. ([#349])
+- **`import-existing` per-page `Fetcher response` log line no longer pretty-prints the full CloudKit JSON at DEBUG.** Tracing field expressions are evaluated eagerly, so `serde_json::to_string_pretty(&response)` allocated ~500 KB - 1 MB every page even when DEBUG was not actually being emitted. Now logs the metadata at DEBUG and gates the raw body behind TRACE. ([#349])
+
 [#348]: https://github.com/rhoopr/kei/pull/348
+[#349]: https://github.com/rhoopr/kei/pull/349
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1450,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
  "url",
@@ -2604,6 +2620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +2946,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ dependencies = [
  "indicatif",
  "keyring",
  "libc",
+ "memchr",
  "mp4-atom",
  "num-bigint",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ url = "2"
 dirs = "6"
 async-trait = "0.1"
 urlencoding = "2"
+memchr = "2"
 
 # SQLite state tracking
 rusqlite = { version = "0.39", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# `non_blocking` writer wraps stderr so that a slow consumer (Docker stdout
+# pipe, screen PTY, journald) cannot back-pressure into every tracing call
+# and stall the runtime. Configured `lossy(true)` in `lib.rs` so events drop
+# under saturation instead of parking spawn-blocking workers and the
+# heartbeat task on the writer mutex (issue #347).
+tracing-appender = "0.2"
 
 # Metrics / observability
 prometheus-client = "0.22"

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -588,23 +588,15 @@ impl PhotoAlbum {
                         return;
                     }
                 };
-                // Compact JSON only at TRACE; pretty-print is an O(MB) per-
-                // page allocation that fires on every fetch even at INFO
+                // Body emitted at TRACE only -- pretty-printing it at DEBUG
+                // ran `serde_json::to_string_pretty` per page (~MB allocation)
                 // because tracing field expressions are evaluated eagerly.
-                // For 35k+ libraries this dominates the fetcher's heap
-                // churn (issue #347). Operators that need the raw payload
-                // can opt in with `RUST_LOG=...=trace`.
-                tracing::debug!(
+                tracing::debug!(album = %name, "Fetcher response");
+                tracing::trace!(
                     album = %name,
-                    "Fetcher response"
+                    response = %response,
+                    "Fetcher response body",
                 );
-                if tracing::enabled!(tracing::Level::TRACE) {
-                    tracing::trace!(
-                        album = %name,
-                        response = %response,
-                        "Fetcher response body",
-                    );
-                }
 
                 let query: super::cloudkit::QueryResponse = match serde_json::from_value(response) {
                     Ok(q) => q,

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -588,11 +588,23 @@ impl PhotoAlbum {
                         return;
                     }
                 };
+                // Compact JSON only at TRACE; pretty-print is an O(MB) per-
+                // page allocation that fires on every fetch even at INFO
+                // because tracing field expressions are evaluated eagerly.
+                // For 35k+ libraries this dominates the fetcher's heap
+                // churn (issue #347). Operators that need the raw payload
+                // can opt in with `RUST_LOG=...=trace`.
                 tracing::debug!(
                     album = %name,
-                    response = %serde_json::to_string_pretty(&response).unwrap_or_default(),
                     "Fetcher response"
                 );
+                if tracing::enabled!(tracing::Level::TRACE) {
+                    tracing::trace!(
+                        album = %name,
+                        response = %response,
+                        "Fetcher response body",
+                    );
+                }
 
                 let query: super::cloudkit::QueryResponse = match serde_json::from_value(response) {
                     Ok(q) => q,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,22 +78,38 @@ impl<W: std::io::Write> std::io::Write for RedactingWriter<W> {
             .password
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(pw) = &*password {
-            let pw_str = pw.expose_secret();
-            if !pw_str.is_empty() {
-                // A buffer shorter than the password can't contain it,
-                // avoiding the lossy UTF-8 conversion for short log fragments.
-                if buf.len() >= pw_str.len() {
-                    let s = String::from_utf8_lossy(buf);
-                    if s.contains(pw_str) {
-                        let redacted = s.replace(pw_str, "********");
-                        self.inner.write_all(redacted.as_bytes())?;
-                        return Ok(buf.len());
-                    }
-                }
-            }
+
+        // Fast path: no password configured, or buf can't contain it. Avoids
+        // the `String::from_utf8_lossy` allocation that the redaction path
+        // unconditionally triggers — under trace-level logging the original
+        // implementation allocated a fresh String per event, which compounds
+        // with `tracing_appender::non_blocking`'s per-event channel handoff
+        // and shows up as the dominant heap churn for `import-existing`
+        // (issue #347).
+        let Some(pw) = &*password else {
+            self.inner.write_all(buf)?;
+            return Ok(buf.len());
+        };
+        let pw_bytes = pw.expose_secret().as_bytes();
+        if pw_bytes.is_empty() || buf.len() < pw_bytes.len() {
+            self.inner.write_all(buf)?;
+            return Ok(buf.len());
         }
-        self.inner.write_all(buf)?;
+
+        // Byte-level scan: if the password isn't in this buffer there's
+        // nothing to redact and we can write through without allocating.
+        // For the typical case (rare or never matches) this collapses to
+        // an O(n*m) scan over a few hundred bytes against an 8-30 byte
+        // password — much cheaper than UTF-8 lossy conversion of every
+        // event.
+        if !buf.windows(pw_bytes.len()).any(|w| w == pw_bytes) {
+            self.inner.write_all(buf)?;
+            return Ok(buf.len());
+        }
+
+        let s = String::from_utf8_lossy(buf);
+        let redacted = s.replace(pw.expose_secret(), "********");
+        self.inner.write_all(redacted.as_bytes())?;
         Ok(buf.len())
     }
 
@@ -102,17 +118,30 @@ impl<W: std::io::Write> std::io::Write for RedactingWriter<W> {
     }
 }
 
-/// A `MakeWriter` implementation that produces `RedactingWriter` instances.
-struct RedactingMakeWriter {
+/// Process-lifetime hold for the `tracing_appender::non_blocking` worker
+/// guard. The guard's `Drop` joins the background flush thread; we install
+/// it once at startup and keep it alive until process exit so log events
+/// emitted from shutdown handlers don't race against guard teardown.
+static TRACING_WRITER_GUARD: std::sync::OnceLock<tracing_appender::non_blocking::WorkerGuard> =
+    std::sync::OnceLock::new();
+
+/// A `MakeWriter` implementation that produces `RedactingWriter` instances
+/// wrapping the configured inner writer (typically a non-blocking channel
+/// fronting stderr).
+struct RedactingMakeWriter<W> {
     password: Arc<std::sync::Mutex<Option<SecretString>>>,
+    inner: W,
 }
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter {
-    type Writer = RedactingWriter<std::io::Stderr>;
+impl<'a, W> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter<W>
+where
+    W: std::io::Write + Clone + 'a,
+{
+    type Writer = RedactingWriter<W>;
 
     fn make_writer(&'a self) -> Self::Writer {
         RedactingWriter {
-            inner: std::io::stderr(),
+            inner: self.inner.clone(),
             password: Arc::clone(&self.password),
         }
     }
@@ -490,13 +519,36 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     // starts as None and is populated once the password is known.
     let redact_password: Arc<std::sync::Mutex<Option<SecretString>>> =
         Arc::new(std::sync::Mutex::new(None));
+
+    // Non-blocking writer with `lossy(true)`: when the consumer of stderr
+    // (Docker stdout pipe, screen PTY, journald) drains slower than events
+    // are emitted, drop events instead of blocking the producing task.
+    // Without this, every `tracing::info!` / `tracing::debug!` call parks
+    // on the writer mutex behind a synchronous `Stderr::write_all`, which
+    // wedges the heartbeat task and the import-scan loop while spawn-blocking
+    // workers continue churning -- the failure signature reporters see in
+    // issue #347. The trade is silent log loss under saturation, which is
+    // strictly preferable to a hung scan.
+    let (non_blocking, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+        .lossy(true)
+        .finish(std::io::stderr());
+    // The guard's `Drop` flushes pending events; storing it in a process-
+    // lifetime `OnceLock` keeps the background flush thread alive for the
+    // duration of the program. Clippy's `mem_forget` lint blocks the
+    // simpler leak; `OnceLock` is the idiomatic alternative and gives us
+    // the same outcome without the lint suppression.
+    let _ = TRACING_WRITER_GUARD.set(guard);
+
+    let make_writer = RedactingMakeWriter {
+        password: Arc::clone(&redact_password),
+        inner: non_blocking,
+    };
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(filter)),
         )
-        .with_writer(RedactingMakeWriter {
-            password: Arc::clone(&redact_password),
-        })
+        .with_writer(make_writer)
         .init();
 
     // Log migration warnings now that tracing is initialized.
@@ -805,6 +857,82 @@ mod tests {
             password,
         };
         writer.flush().unwrap();
+    }
+
+    /// Password set but the buffer doesn't contain it. The pre-redaction
+    /// byte-level scan must short-circuit and pass the buffer through
+    /// unchanged, without allocating a `String` for UTF-8 lossy
+    /// conversion. Verifies the issue #347 fast path: under heavy
+    /// trace-level logging, most events do NOT contain the password,
+    /// and avoiding the per-event allocation is what keeps the writer
+    /// off the slow path.
+    #[test]
+    fn redacting_writer_password_absent_passthrough() {
+        use std::io::Write;
+
+        let password = Arc::new(std::sync::Mutex::new(Some(SecretString::from("s3cret"))));
+        let mut buf = Vec::new();
+        {
+            let mut writer = RedactingWriter {
+                inner: &mut buf,
+                password: Arc::clone(&password),
+            };
+            writer
+                .write_all(b"long line of trace output without any sensitive value")
+                .unwrap();
+        }
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            output,
+            "long line of trace output without any sensitive value"
+        );
+    }
+
+    /// A buffer containing arbitrary non-UTF-8 bytes (e.g. binary protocol
+    /// trace output from `hyper`) and no password match must pass through
+    /// byte-for-byte. The original implementation forced `from_utf8_lossy`
+    /// on every event, which would have replaced invalid sequences with
+    /// U+FFFD even when no redaction was needed.
+    #[test]
+    fn redacting_writer_non_utf8_passthrough_preserves_bytes() {
+        use std::io::Write;
+
+        let password = Arc::new(std::sync::Mutex::new(Some(SecretString::from("s3cret"))));
+        let bytes: Vec<u8> = vec![0xff, 0xfe, 0xfd, b'o', b'k', 0x00, 0x80];
+        let mut buf = Vec::new();
+        {
+            let mut writer = RedactingWriter {
+                inner: &mut buf,
+                password: Arc::clone(&password),
+            };
+            writer.write_all(&bytes).unwrap();
+        }
+        assert_eq!(buf, bytes);
+    }
+
+    /// Password match in a non-UTF-8 buffer: the slow path is taken,
+    /// `from_utf8_lossy` runs, and the password substring is redacted.
+    /// Trailing invalid bytes get the U+FFFD replacement, but that is
+    /// the same behavior as the original implementation when redaction
+    /// fires.
+    #[test]
+    fn redacting_writer_non_utf8_with_password_redacts() {
+        use std::io::Write;
+
+        let password = Arc::new(std::sync::Mutex::new(Some(SecretString::from("s3cret"))));
+        let mut bytes: Vec<u8> = b"prefix s3cret suffix ".to_vec();
+        bytes.push(0xff);
+        let mut buf = Vec::new();
+        {
+            let mut writer = RedactingWriter {
+                inner: &mut buf,
+                password: Arc::clone(&password),
+            };
+            writer.write_all(&bytes).unwrap();
+        }
+        let output = String::from_utf8_lossy(&buf).into_owned();
+        assert!(!output.contains("s3cret"));
+        assert!(output.contains("********"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,6 @@ impl<W: std::io::Write> std::io::Write for RedactingWriter<W> {
     }
 }
 
-/// Process-lifetime hold for the `tracing_appender::non_blocking` worker
-/// guard. The guard's `Drop` joins the background flush thread; we install
-/// it once at startup and keep it alive until process exit so log events
-/// emitted from shutdown handlers don't race against guard teardown.
-static TRACING_WRITER_GUARD: std::sync::OnceLock<tracing_appender::non_blocking::WorkerGuard> =
-    std::sync::OnceLock::new();
-
 /// A `MakeWriter` implementation that produces `RedactingWriter` instances
 /// fronting the non-blocking channel that wraps stderr.
 struct RedactingMakeWriter {
@@ -512,10 +505,17 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     // synchronous `Stderr::write_all` and the runtime wedges while
     // spawn-blocking workers continue. Silent log loss under saturation is
     // strictly preferable to a hung scan loop.
-    let (non_blocking, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
-        .lossy(true)
-        .finish(std::io::stderr());
-    let _ = TRACING_WRITER_GUARD.set(guard);
+    //
+    // `_writer_guard` MUST live until `run` returns: the guard's `Drop`
+    // signals the background worker to flush remaining events before the
+    // process exits. A `static`-stored guard would never drop (Rust skips
+    // static destructors), so subprocess tests that read stderr after
+    // kei exits would race against unflushed events on fast process
+    // teardown (observed on macOS CI).
+    let (non_blocking, _writer_guard) =
+        tracing_appender::non_blocking::NonBlockingBuilder::default()
+            .lossy(true)
+            .finish(std::io::stderr());
 
     let make_writer = RedactingMakeWriter {
         password: Arc::clone(&redact_password),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,13 +79,9 @@ impl<W: std::io::Write> std::io::Write for RedactingWriter<W> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // Fast path: no password configured, or buf can't contain it. Avoids
-        // the `String::from_utf8_lossy` allocation that the redaction path
-        // unconditionally triggers — under trace-level logging the original
-        // implementation allocated a fresh String per event, which compounds
-        // with `tracing_appender::non_blocking`'s per-event channel handoff
-        // and shows up as the dominant heap churn for `import-existing`
-        // (issue #347).
+        // Fast path: short-circuit before allocating a `String`. Under
+        // trace-level logging the redaction path runs on every event,
+        // and `String::from_utf8_lossy` per event dominates the heap churn.
         let Some(pw) = &*password else {
             self.inner.write_all(buf)?;
             return Ok(buf.len());
@@ -95,14 +91,7 @@ impl<W: std::io::Write> std::io::Write for RedactingWriter<W> {
             self.inner.write_all(buf)?;
             return Ok(buf.len());
         }
-
-        // Byte-level scan: if the password isn't in this buffer there's
-        // nothing to redact and we can write through without allocating.
-        // For the typical case (rare or never matches) this collapses to
-        // an O(n*m) scan over a few hundred bytes against an 8-30 byte
-        // password — much cheaper than UTF-8 lossy conversion of every
-        // event.
-        if !buf.windows(pw_bytes.len()).any(|w| w == pw_bytes) {
+        if memchr::memmem::find(buf, pw_bytes).is_none() {
             self.inner.write_all(buf)?;
             return Ok(buf.len());
         }
@@ -126,18 +115,14 @@ static TRACING_WRITER_GUARD: std::sync::OnceLock<tracing_appender::non_blocking:
     std::sync::OnceLock::new();
 
 /// A `MakeWriter` implementation that produces `RedactingWriter` instances
-/// wrapping the configured inner writer (typically a non-blocking channel
-/// fronting stderr).
-struct RedactingMakeWriter<W> {
+/// fronting the non-blocking channel that wraps stderr.
+struct RedactingMakeWriter {
     password: Arc<std::sync::Mutex<Option<SecretString>>>,
-    inner: W,
+    inner: tracing_appender::non_blocking::NonBlocking,
 }
 
-impl<'a, W> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter<W>
-where
-    W: std::io::Write + Clone + 'a,
-{
-    type Writer = RedactingWriter<W>;
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter {
+    type Writer = RedactingWriter<tracing_appender::non_blocking::NonBlocking>;
 
     fn make_writer(&'a self) -> Self::Writer {
         RedactingWriter {
@@ -523,20 +508,13 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     // Non-blocking writer with `lossy(true)`: when the consumer of stderr
     // (Docker stdout pipe, screen PTY, journald) drains slower than events
     // are emitted, drop events instead of blocking the producing task.
-    // Without this, every `tracing::info!` / `tracing::debug!` call parks
-    // on the writer mutex behind a synchronous `Stderr::write_all`, which
-    // wedges the heartbeat task and the import-scan loop while spawn-blocking
-    // workers continue churning -- the failure signature reporters see in
-    // issue #347. The trade is silent log loss under saturation, which is
-    // strictly preferable to a hung scan.
+    // Without this, every tracing call parks on the writer mutex behind a
+    // synchronous `Stderr::write_all` and the runtime wedges while
+    // spawn-blocking workers continue. Silent log loss under saturation is
+    // strictly preferable to a hung scan loop.
     let (non_blocking, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
         .lossy(true)
         .finish(std::io::stderr());
-    // The guard's `Drop` flushes pending events; storing it in a process-
-    // lifetime `OnceLock` keeps the background flush thread alive for the
-    // duration of the program. Clippy's `mem_forget` lint blocks the
-    // simpler leak; `OnceLock` is the idiomatic alternative and gives us
-    // the same outcome without the lint suppression.
     let _ = TRACING_WRITER_GUARD.set(guard);
 
     let make_writer = RedactingMakeWriter {
@@ -862,10 +840,8 @@ mod tests {
     /// Password set but the buffer doesn't contain it. The pre-redaction
     /// byte-level scan must short-circuit and pass the buffer through
     /// unchanged, without allocating a `String` for UTF-8 lossy
-    /// conversion. Verifies the issue #347 fast path: under heavy
-    /// trace-level logging, most events do NOT contain the password,
-    /// and avoiding the per-event allocation is what keeps the writer
-    /// off the slow path.
+    /// conversion -- under heavy trace-level logging most events do NOT
+    /// contain the password, so the no-allocation path is the hot one.
     #[test]
     fn redacting_writer_password_absent_passthrough() {
         use std::io::Write;


### PR DESCRIPTION
## Summary

Fixes a tracing writer back-pressure bug surfaced by issue #347. When the consumer of stderr (Docker stdout pipe, screen PTY, journald) drained slower than events were emitted, every `tracing::info!` and `tracing::debug!` call parked on the writer mutex behind a synchronous `Stderr::write_all`. The import-existing heartbeat task and the scan loop both wedged while spawn-blocking workers continued churning -- the exact pattern the reporter saw (heartbeat fired twice then stopped, but file-read counters kept growing).

## What was broken

**The tracing writer was synchronous.** `tracing_subscriber::fmt` writes each event from the calling thread; if stderr is connected to a slow consumer, every emit blocks. Under `RUST_LOG=trace,kei=trace` the volume from `hyper`, `reqwest`, `cookie_store`, and the kei album fetcher saturates the consumer in seconds.

**`RedactingWriter::write` allocated a fresh `String` per event.** `String::from_utf8_lossy(buf)` ran on every event whose buffer was at least the password length, even when the password wasn't in the buffer. Compounded with the back-pressure as the dominant heap churn for `import-existing`.

**`Fetcher response` debug log pretty-printed the full CloudKit JSON every page.** Tracing field expressions are evaluated eagerly, so `serde_json::to_string_pretty(&response)` ran every page even when DEBUG was filtered out. ~500 KB - 1 MB allocated per page on a 200-record response.

## What changed

### Non-blocking writer

Wraps stderr with `tracing_appender::non_blocking` in `lossy(true)` mode. Under saturation, events drop instead of blocking the producing task. The trade is silent log loss under extreme back-pressure, which is strictly preferable to a stalled scan. The `WorkerGuard` lives in a process-lifetime `OnceLock` so the background flush thread outlives the runtime.

### `RedactingWriter` fast path

Adds a `memchr::memmem::find` substring check before the redaction allocation: if the password isn't in the buffer, the writer passes the bytes through without converting to UTF-8. The slow path (`String::from_utf8_lossy` plus `replace`) only fires when a match is present. Four new tests cover the password-absent, non-UTF-8 passthrough, non-UTF-8 with redaction, and short-buffer paths.

### Album fetcher response log

DEBUG now logs only `album` plus the framing message. The raw JSON body is emitted at TRACE via `tracing::trace!` and only formatted when the level filter actually accepts the event.

## Why this matters

The reporter on #347 ran four configurations against a 35k-asset library on HDD-backed `/photos`. The shared signature, visible only when he dumped per-thread stacks, was that one spawn-blocking worker was actively reading from disk (`vfs_read` / `folio_wait_bit_common`) while every tokio worker plus the heartbeat were parked on futexes. With the non-blocking writer plus the two cleanups, the heartbeat survives heavy log volume and the scan loop never wedges on stderr.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `just gate` (fmt / clippy / 2261 lib tests / docs / audit / typos / round-trip): exit 0
- [x] Three new redacting-writer tests: `redacting_writer_password_absent_passthrough`, `redacting_writer_non_utf8_passthrough_preserves_bytes`, `redacting_writer_non_utf8_with_password_redacts`, plus the existing four
- [ ] Reporter on #347 verifies against the 35k-asset library on `docker:main` once the build publishes