### PR TITLE
test: cover #347 regression class + pin main_inner exit-code dispatch

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3365,4 +3365,99 @@ mod heartbeat_tests {
             "Drop must flip the cancellation token",
         );
     }
+
+    /// The watchdog and the data plane must not share a chokepoint.
+    /// Issue #347's #348 heartbeat parked on the same `Stderr::write_all`
+    /// mutex as the scan loop, so a slow stderr consumer wedged both at
+    /// once and the heartbeat couldn't disambiguate "stuck" from "alive
+    /// but slow". The fix in #349 routed both through
+    /// `tracing_appender::non_blocking` in lossy mode so producers don't
+    /// park on the writer mutex.
+    ///
+    /// This test holds the writer behind a 5 ms-per-write sink (a
+    /// realistic stderr-pipe latency, not pathological saturation —
+    /// pathological loads exhaust the lossy buffer before the worker can
+    /// drain on shutdown, which conflates the bug under test with
+    /// shutdown drop). A fake scan loop emits at 200 events/s and the
+    /// heartbeat task ticks every 50 ms. With the non-blocking pipeline,
+    /// both make forward progress and the heartbeat events land in the
+    /// captured sink. A regression that re-introduces a synchronous
+    /// `Stderr::write_all` mutex on the data path would serialize emits:
+    /// the scan task's stream alone exceeds the sink's drain rate, so
+    /// the heartbeat task would park behind it and produce 0 emits in
+    /// the captured output.
+    #[tokio::test]
+    async fn heartbeat_fires_under_writer_load() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct PipeSink {
+            buf: Arc<std::sync::Mutex<Vec<u8>>>,
+            delay: std::time::Duration,
+        }
+        impl Write for PipeSink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                std::thread::sleep(self.delay);
+                self.buf
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = PipeSink {
+            buf: Arc::clone(&buf),
+            delay: std::time::Duration::from_millis(5),
+        };
+        let (make_writer, writer_guard, _pw) = crate::build_redacting_writer(sink);
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("info"))
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+        let _dispatch_guard = tracing::subscriber::set_default(subscriber);
+
+        let state = Arc::new(super::HeartbeatState::default());
+        let hb = super::HeartbeatGuard::spawn(
+            Arc::clone(&state),
+            "test-lib".to_string(),
+            std::time::Duration::from_millis(50),
+        );
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_c = Arc::clone(&stop);
+        let scan = tokio::spawn(async move {
+            while !stop_c.load(Ordering::Relaxed) {
+                tracing::info!(target: "kei::scan_test", "scan loop fake event");
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        });
+
+        // 300 ms covers ~5 heartbeat intervals (the first tick is skipped,
+        // so emits land at t≈50, 100, 150, 200, 250 ms).
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        stop.store(true, Ordering::Relaxed);
+        scan.await.unwrap();
+
+        drop(hb);
+        drop(_dispatch_guard);
+        drop(writer_guard);
+
+        let captured = buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let captured_str = String::from_utf8_lossy(&captured);
+        let heartbeat_count = captured_str.matches("import scan heartbeat").count();
+        assert!(
+            heartbeat_count >= 2,
+            "heartbeat fired {heartbeat_count} times in 300 ms under concurrent \
+             scan-loop traffic (expected >= 2); the watchdog is sharing the data \
+             plane's chokepoint or otherwise stalled. Captured: {captured_str}",
+        );
+    }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3366,26 +3366,10 @@ mod heartbeat_tests {
         );
     }
 
-    /// The watchdog and the data plane must not share a chokepoint.
-    /// Issue #347's #348 heartbeat parked on the same `Stderr::write_all`
-    /// mutex as the scan loop, so a slow stderr consumer wedged both at
-    /// once and the heartbeat couldn't disambiguate "stuck" from "alive
-    /// but slow". The fix in #349 routed both through
-    /// `tracing_appender::non_blocking` in lossy mode so producers don't
-    /// park on the writer mutex.
-    ///
-    /// This test holds the writer behind a 5 ms-per-write sink (a
-    /// realistic stderr-pipe latency, not pathological saturation —
-    /// pathological loads exhaust the lossy buffer before the worker can
-    /// drain on shutdown, which conflates the bug under test with
-    /// shutdown drop). A fake scan loop emits at 200 events/s and the
-    /// heartbeat task ticks every 50 ms. With the non-blocking pipeline,
-    /// both make forward progress and the heartbeat events land in the
-    /// captured sink. A regression that re-introduces a synchronous
-    /// `Stderr::write_all` mutex on the data path would serialize emits:
-    /// the scan task's stream alone exceeds the sink's drain rate, so
-    /// the heartbeat task would park behind it and produce 0 emits in
-    /// the captured output.
+    /// 5 ms-per-write sink is realistic stderr-pipe latency, not
+    /// pathological saturation: pathological loads exhaust the lossy
+    /// buffer before the worker drains on shutdown, conflating the bug
+    /// under test with teardown timing.
     #[tokio::test]
     async fn heartbeat_fires_under_writer_load() {
         use std::io::Write;
@@ -3438,8 +3422,10 @@ mod heartbeat_tests {
             }
         });
 
-        // 300 ms covers ~5 heartbeat intervals (the first tick is skipped,
-        // so emits land at t≈50, 100, 150, 200, 250 ms).
+        // 300 ms covers 5 heartbeat intervals (first tick skipped; emits
+        // land at t≈50, 100, 150, 200, 250 ms). Asserting >= 3 still
+        // survives one missed tick from CI jitter without giving a real
+        // chokepoint regression a way through.
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         stop.store(true, Ordering::Relaxed);
         scan.await.unwrap();
@@ -3454,9 +3440,9 @@ mod heartbeat_tests {
         let captured_str = String::from_utf8_lossy(&captured);
         let heartbeat_count = captured_str.matches("import scan heartbeat").count();
         assert!(
-            heartbeat_count >= 2,
+            heartbeat_count >= 3,
             "heartbeat fired {heartbeat_count} times in 300 ms under concurrent \
-             scan-loop traffic (expected >= 2); the watchdog is sharing the data \
+             scan-loop traffic (expected >= 3); the watchdog is sharing the data \
              plane's chokepoint or otherwise stalled. Captured: {captured_str}",
         );
     }

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -63,6 +63,22 @@ fn determine_fetcher_count(total_items: u64, page_size: usize, concurrency: usiz
     pages_as_usize.min(concurrency).max(1)
 }
 
+/// Log a per-page Fetcher response. The metadata is at DEBUG; the raw
+/// body is gated behind TRACE because pretty-printing it at DEBUG ran a
+/// `to_string_pretty(&response)` per page (~MB allocation per page on
+/// busy libraries — issue #347). The function exists so the cost shape
+/// is testable without exercising the full fetcher: a regression that
+/// hoists the response body back into the DEBUG event would be caught
+/// by the unit test next to this definition rather than only at scale.
+fn log_fetcher_response(album: &str, response: &Value) {
+    tracing::debug!(album = %album, "Fetcher response");
+    tracing::trace!(
+        album = %album,
+        response = %response,
+        "Fetcher response body",
+    );
+}
+
 /// Configuration for creating a `PhotoAlbum`, bundling all non-session fields.
 #[derive(Debug)]
 pub struct PhotoAlbumConfig {
@@ -588,15 +604,7 @@ impl PhotoAlbum {
                         return;
                     }
                 };
-                // Body emitted at TRACE only -- pretty-printing it at DEBUG
-                // ran `serde_json::to_string_pretty` per page (~MB allocation)
-                // because tracing field expressions are evaluated eagerly.
-                tracing::debug!(album = %name, "Fetcher response");
-                tracing::trace!(
-                    album = %name,
-                    response = %response,
-                    "Fetcher response body",
-                );
+                log_fetcher_response(&name, &response);
 
                 let query: super::cloudkit::QueryResponse = match serde_json::from_value(response) {
                     Ok(q) => q,
@@ -1754,5 +1762,103 @@ mod tests {
             }
             other => panic!("expected InvalidToken variant, got: {other:?}"),
         }
+    }
+
+    /// `log_fetcher_response` must not emit the raw CloudKit response
+    /// body at DEBUG. Issue #347's regression was a per-page
+    /// `tracing::debug!` whose field expression eagerly built a
+    /// pretty-printed string of the full response (~MB per page on
+    /// busy libraries). Operators set `--log-level debug` to see what
+    /// the fetcher was doing and got 1 MB of allocation per page in
+    /// return, on the same writer mutex everything else used. This
+    /// test asserts the body only appears at TRACE.
+    #[test]
+    fn fetcher_response_body_only_logs_at_trace() {
+        use std::io::Write;
+        use std::sync::Arc;
+
+        struct VecMakeWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+        struct VecWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+        impl Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for VecMakeWriter {
+            type Writer = VecWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                VecWriter(Arc::clone(&self.0))
+            }
+        }
+
+        // A unique marker buried in the response. If anything in the
+        // event includes the response value via Display/Debug, the
+        // marker leaks into the formatted output and the assertion
+        // fires.
+        const MARKER: &str = "FETCHER_RESPONSE_BODY_TEST_MARKER_xyz123";
+        let response = serde_json::json!({
+            "records": [{"recordName": "abc", "fields": {"value": MARKER}}],
+            "continuationMarker": MARKER,
+        });
+
+        let buf_debug = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sub_debug = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("debug"))
+            .with_writer(VecMakeWriter(Arc::clone(&buf_debug)))
+            .with_ansi(false)
+            .finish();
+        {
+            let _g = tracing::subscriber::set_default(sub_debug);
+            log_fetcher_response("TestAlbum", &response);
+        }
+        let out_debug = String::from_utf8_lossy(
+            &buf_debug
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+        .into_owned();
+        assert!(
+            out_debug.contains("Fetcher response"),
+            "DEBUG-level log should produce a Fetcher response event; got: {out_debug}",
+        );
+        assert!(
+            !out_debug.contains(MARKER),
+            "DEBUG-level log MUST NOT include the response body. The marker \
+             leaked into captured output, indicating the per-page log carries \
+             the full response value at DEBUG (issue #347 regression). \
+             Captured: {out_debug}",
+        );
+
+        let buf_trace = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sub_trace = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("trace"))
+            .with_writer(VecMakeWriter(Arc::clone(&buf_trace)))
+            .with_ansi(false)
+            .finish();
+        {
+            let _g = tracing::subscriber::set_default(sub_trace);
+            log_fetcher_response("TestAlbum", &response);
+        }
+        let out_trace = String::from_utf8_lossy(
+            &buf_trace
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+        .into_owned();
+        assert!(
+            out_trace.contains("Fetcher response body"),
+            "TRACE level should produce a 'Fetcher response body' event; got: {out_trace}",
+        );
+        assert!(
+            out_trace.contains(MARKER),
+            "TRACE level should include the response body in the event; got: {out_trace}",
+        );
     }
 }

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -63,13 +63,9 @@ fn determine_fetcher_count(total_items: u64, page_size: usize, concurrency: usiz
     pages_as_usize.min(concurrency).max(1)
 }
 
-/// Log a per-page Fetcher response. The metadata is at DEBUG; the raw
-/// body is gated behind TRACE because pretty-printing it at DEBUG ran a
-/// `to_string_pretty(&response)` per page (~MB allocation per page on
-/// busy libraries — issue #347). The function exists so the cost shape
-/// is testable without exercising the full fetcher: a regression that
-/// hoists the response body back into the DEBUG event would be caught
-/// by the unit test next to this definition rather than only at scale.
+/// Metadata at DEBUG; raw body only at TRACE. Including the body in
+/// the DEBUG event allocates ~MB per page on busy libraries (every
+/// fetched page formats the full response value).
 fn log_fetcher_response(album: &str, response: &Value) {
     tracing::debug!(album = %album, "Fetcher response");
     tracing::trace!(
@@ -1764,14 +1760,6 @@ mod tests {
         }
     }
 
-    /// `log_fetcher_response` must not emit the raw CloudKit response
-    /// body at DEBUG. Issue #347's regression was a per-page
-    /// `tracing::debug!` whose field expression eagerly built a
-    /// pretty-printed string of the full response (~MB per page on
-    /// busy libraries). Operators set `--log-level debug` to see what
-    /// the fetcher was doing and got 1 MB of allocation per page in
-    /// return, on the same writer mutex everything else used. This
-    /// test asserts the body only appears at TRACE.
     #[test]
     fn fetcher_response_body_only_logs_at_trace() {
         use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,57 @@ const EXIT_AUTH: u8 = 3;
 #[error("{0} downloads failed")]
 struct PartialSyncError(usize);
 
+/// How a fatal `Err` from `run` maps to an exit code and whether kei
+/// should emit a final `tracing::error!` + stderr line for it.
+///
+/// Kept as a typed dispatch table (rather than inline match arms in
+/// `main_inner`) so the policy is unit-testable without owning a tokio
+/// runtime, and so the non-obvious `TwoFactorRequired -> exit 0, no log`
+/// rule can't drift silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitClassification {
+    /// 2FA required: exit 0, suppress error log. kei already told the
+    /// user how to proceed; logging "kei exited with error" here would
+    /// be misleading and `restart: on-failure` would loop the auth
+    /// endpoint.
+    TwoFactorRequired,
+    /// Some downloads failed but the run was not a total failure.
+    Partial,
+    /// Auth failure other than 2FA-required.
+    Auth,
+    /// Any other error.
+    Other,
+}
+
+impl ExitClassification {
+    const fn exit_code(self) -> u8 {
+        match self {
+            Self::TwoFactorRequired => 0,
+            Self::Partial => EXIT_PARTIAL,
+            Self::Auth => EXIT_AUTH,
+            Self::Other => 1,
+        }
+    }
+
+    const fn should_log(self) -> bool {
+        !matches!(self, Self::TwoFactorRequired)
+    }
+}
+
+fn classify_exit_error(e: &anyhow::Error) -> ExitClassification {
+    if e.downcast_ref::<auth::error::AuthError>()
+        .is_some_and(auth::error::AuthError::is_two_factor_required)
+    {
+        ExitClassification::TwoFactorRequired
+    } else if e.downcast_ref::<PartialSyncError>().is_some() {
+        ExitClassification::Partial
+    } else if e.downcast_ref::<auth::error::AuthError>().is_some() {
+        ExitClassification::Auth
+    } else {
+        ExitClassification::Other
+    }
+}
+
 #[expect(
     clippy::string_slice,
     reason = "floor_char_boundary guarantees a valid char boundary"
@@ -429,14 +480,8 @@ pub fn main_inner() -> ExitCode {
     match rt.block_on(run(env_password)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            // 2FA required is not a failure — kei checked auth, told the user
-            // what to do, and is done. Exit 0 so `restart: on-failure` won't
-            // restart into a loop that hammers Apple's auth endpoints.
-            if e.downcast_ref::<auth::error::AuthError>()
-                .is_some_and(auth::error::AuthError::is_two_factor_required)
-            {
-                ExitCode::SUCCESS
-            } else {
+            let classification = classify_exit_error(&e);
+            if classification.should_log() {
                 // Route the final error through tracing so it carries the same
                 // timestamp + level prefix as the rest of the logs; makes
                 // `docker logs` / `journalctl` output correlate cleanly.
@@ -450,14 +495,8 @@ pub fn main_inner() -> ExitCode {
                 {
                     eprintln!("Error: {e:#}");
                 }
-                if e.downcast_ref::<PartialSyncError>().is_some() {
-                    ExitCode::from(EXIT_PARTIAL)
-                } else if e.downcast_ref::<auth::error::AuthError>().is_some() {
-                    ExitCode::from(EXIT_AUTH)
-                } else {
-                    ExitCode::FAILURE
-                }
             }
+            ExitCode::from(classification.exit_code())
         }
     }
 }
@@ -1200,6 +1239,99 @@ mod tests {
     fn check_min_disk_space_threshold_is_one_gib() {
         assert_eq!(MIN_FREE_BYTES, 1_073_741_824);
         assert_eq!(MIN_FREE_BYTES, 1024 * 1024 * 1024);
+    }
+
+    /// `classify_exit_error` is the dispatch table that decides what kei's
+    /// exit code is and whether it logs a final "kei exited with error"
+    /// line. The mapping is non-obvious in two places:
+    ///
+    /// 1. `AuthError::TwoFactorRequired` is *not* a failure — kei has
+    ///    already told the user how to proceed, exit 0 keeps `restart:
+    ///    on-failure` from looping the auth endpoint.
+    /// 2. `AuthError` (non-2FA) and `PartialSyncError` get distinct exit
+    ///    codes (3 and 2) so operators / supervisors can branch on them.
+    ///
+    /// A refactor that flips any of those mappings should fail one of these
+    /// tests rather than silently change operator-visible behavior.
+    #[test]
+    fn classify_exit_error_two_factor_required_is_suppressed_success() {
+        let e: anyhow::Error = auth::error::AuthError::TwoFactorRequired.into();
+        let c = classify_exit_error(&e);
+        assert_eq!(c, ExitClassification::TwoFactorRequired);
+        assert_eq!(c.exit_code(), 0);
+        assert!(
+            !c.should_log(),
+            "2FA-required must not emit a final error log; that path is the success branch"
+        );
+    }
+
+    #[test]
+    fn classify_exit_error_partial_sync_uses_exit_partial() {
+        let e: anyhow::Error = PartialSyncError(7).into();
+        let c = classify_exit_error(&e);
+        assert_eq!(c, ExitClassification::Partial);
+        assert_eq!(c.exit_code(), EXIT_PARTIAL);
+        assert_eq!(c.exit_code(), 2);
+        assert!(c.should_log());
+    }
+
+    #[test]
+    fn classify_exit_error_auth_non_2fa_uses_exit_auth() {
+        let e: anyhow::Error = auth::error::AuthError::FailedLogin("bad password".into()).into();
+        let c = classify_exit_error(&e);
+        assert_eq!(c, ExitClassification::Auth);
+        assert_eq!(c.exit_code(), EXIT_AUTH);
+        assert_eq!(c.exit_code(), 3);
+        assert!(c.should_log());
+    }
+
+    #[test]
+    fn classify_exit_error_generic_uses_failure() {
+        let e = anyhow::anyhow!("disk on fire");
+        let c = classify_exit_error(&e);
+        assert_eq!(c, ExitClassification::Other);
+        assert_eq!(c.exit_code(), 1);
+        assert!(c.should_log());
+    }
+
+    /// `PartialSyncError` and `AuthError` both downcast cleanly even when
+    /// wrapped in additional `anyhow` context — the dispatch must look
+    /// through `.context(...)` chains, not just at the leaf error.
+    #[test]
+    fn classify_exit_error_walks_anyhow_context() {
+        let e: anyhow::Error = anyhow::Error::from(auth::error::AuthError::TwoFactorRequired)
+            .context("while validating session")
+            .context("during startup");
+        assert_eq!(
+            classify_exit_error(&e),
+            ExitClassification::TwoFactorRequired,
+            "AuthError wrapped in .context() must still classify as 2FA-required; \
+             otherwise context-wrapping at any call site silently flips exit 0 -> exit 1"
+        );
+
+        let e: anyhow::Error =
+            anyhow::Error::from(PartialSyncError(3)).context("after final retry pass");
+        assert_eq!(classify_exit_error(&e), ExitClassification::Partial);
+    }
+
+    /// All four classifications must produce distinct exit codes — if two
+    /// collapse, operators lose the ability to branch on the cause.
+    #[test]
+    fn classify_exit_error_codes_are_distinct() {
+        let codes = [
+            ExitClassification::TwoFactorRequired.exit_code(),
+            ExitClassification::Partial.exit_code(),
+            ExitClassification::Auth.exit_code(),
+            ExitClassification::Other.exit_code(),
+        ];
+        let mut sorted: Vec<u8> = codes.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            codes.len(),
+            "every exit classification must map to a distinct code; got {codes:?}"
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,39 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter {
     }
 }
 
+/// Assemble the redacting log-writer pipeline that `run` installs.
+///
+/// Returns `(MakeWriter, WorkerGuard, password slot)`. Caller keeps the
+/// guard alive until events should be flushed; on drop it joins the
+/// background worker so the channel drains before teardown. The password
+/// slot starts empty and is populated once the password is known.
+///
+/// Sharing this assembly between `run` and tests is what lets a regression
+/// in the back-pressure shape (someone removes `lossy(true)`, swaps the
+/// non-blocking channel for the raw sink, hoists the guard back into a
+/// `static`) get caught: the `tests` module exercises this exact builder.
+pub(crate) fn build_redacting_writer<W>(
+    sink: W,
+) -> (
+    impl for<'a> tracing_subscriber::fmt::MakeWriter<'a> + 'static,
+    tracing_appender::non_blocking::WorkerGuard,
+    Arc<std::sync::Mutex<Option<SecretString>>>,
+)
+where
+    W: std::io::Write + Send + 'static,
+{
+    let password: Arc<std::sync::Mutex<Option<SecretString>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let (non_blocking, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+        .lossy(true)
+        .finish(sink);
+    let make_writer = RedactingMakeWriter {
+        password: Arc::clone(&password),
+        inner: non_blocking,
+    };
+    (make_writer, guard, password)
+}
+
 use cli::Command;
 use config::TomlConfig;
 
@@ -492,35 +525,14 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         types::LogLevel::Warn => "warn",
         types::LogLevel::Error => "error",
     };
-    // Password redaction: the password is set after config parsing,
-    // but tracing must be initialized earlier. Use a shared slot that
-    // starts as None and is populated once the password is known.
-    let redact_password: Arc<std::sync::Mutex<Option<SecretString>>> =
-        Arc::new(std::sync::Mutex::new(None));
-
-    // Non-blocking writer with `lossy(true)`: when the consumer of stderr
-    // (Docker stdout pipe, screen PTY, journald) drains slower than events
-    // are emitted, drop events instead of blocking the producing task.
-    // Without this, every tracing call parks on the writer mutex behind a
-    // synchronous `Stderr::write_all` and the runtime wedges while
-    // spawn-blocking workers continue. Silent log loss under saturation is
-    // strictly preferable to a hung scan loop.
-    //
     // `_writer_guard` MUST live until `run` returns: the guard's `Drop`
     // signals the background worker to flush remaining events before the
     // process exits. A `static`-stored guard would never drop (Rust skips
     // static destructors), so subprocess tests that read stderr after
     // kei exits would race against unflushed events on fast process
-    // teardown (observed on macOS CI).
-    let (non_blocking, _writer_guard) =
-        tracing_appender::non_blocking::NonBlockingBuilder::default()
-            .lossy(true)
-            .finish(std::io::stderr());
-
-    let make_writer = RedactingMakeWriter {
-        password: Arc::clone(&redact_password),
-        inner: non_blocking,
-    };
+    // teardown (observed on macOS CI). See `build_redacting_writer`
+    // for the back-pressure shape.
+    let (make_writer, _writer_guard, redact_password) = build_redacting_writer(std::io::stderr());
 
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -909,6 +921,131 @@ mod tests {
         let output = String::from_utf8_lossy(&buf).into_owned();
         assert!(!output.contains("s3cret"));
         assert!(output.contains("********"));
+    }
+
+    /// Reproduces the failure mode of issue #347: the producer must not
+    /// park on the sink mutex when the consumer drains slow. Without the
+    /// `tracing_appender::non_blocking` lossy channel that
+    /// `build_redacting_writer` installs, 200 events at 50 ms per write
+    /// would block the emitting task for ~10 s. With it, the bounded
+    /// channel absorbs the saturation and the producer returns in
+    /// milliseconds. A regression that drops the non-blocking layer or
+    /// swaps `lossy(true)` for the blocking variant fails this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_pipeline_does_not_back_pressure_producer() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        struct SlowSink {
+            delay: Duration,
+            bytes: Arc<AtomicUsize>,
+        }
+        impl Write for SlowSink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                std::thread::sleep(self.delay);
+                self.bytes.fetch_add(buf.len(), Ordering::Relaxed);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let bytes = Arc::new(AtomicUsize::new(0));
+        let sink = SlowSink {
+            delay: Duration::from_millis(50),
+            bytes: Arc::clone(&bytes),
+        };
+        let (make_writer, _guard, _pw) = build_redacting_writer(sink);
+
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::new("info"))
+            .with_writer(make_writer)
+            .finish();
+        let _g = tracing::subscriber::set_default(subscriber);
+
+        let start = Instant::now();
+        for i in 0..200 {
+            tracing::info!(i, "back-pressure test event");
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "producer blocked {elapsed:?} emitting 200 events through a 50ms-per-write sink; \
+             expected the lossy non-blocking channel to absorb the saturation",
+        );
+    }
+
+    /// Companion to issue #347's macOS CI flake: the `WorkerGuard` must
+    /// drop before the test asserts on captured output. With the guard
+    /// bound locally (rather than held in a `static OnceLock` whose
+    /// destructor never runs), drop joins the background worker and
+    /// drains the channel deterministically. A regression that hoists the
+    /// guard back into static storage races against the sink and loses
+    /// events on fast teardown.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_pipeline_flushes_all_events_before_guard_drops() {
+        use std::io::Write;
+
+        struct CollectingSink {
+            buf: Arc<std::sync::Mutex<Vec<u8>>>,
+        }
+        impl Write for CollectingSink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.buf
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = CollectingSink {
+            buf: Arc::clone(&buf),
+        };
+        let (make_writer, guard, _pw) = build_redacting_writer(sink);
+
+        // Disable ANSI so the assertion can match `seq=N` against a stable
+        // byte boundary. Default `tracing_subscriber::fmt()` emits color
+        // codes between fields, which would defeat a literal-substring
+        // assertion.
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::new("info"))
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+        {
+            let _g = tracing::subscriber::set_default(subscriber);
+            for i in 0..50 {
+                tracing::info!(seq = i, "completeness test event");
+            }
+        }
+        // Drop the guard explicitly (mirrors `run` returning) so the
+        // background flush thread drains before we read the sink.
+        drop(guard);
+
+        let captured = buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            !captured.is_empty(),
+            "guard drop completed but sink received no bytes; \
+             the non-blocking worker did not flush before drop returned",
+        );
+        let captured_str = String::from_utf8_lossy(&captured);
+        for i in 0..50 {
+            // `seq=N\n` anchors at end-of-line so seq=5 doesn't match seq=50.
+            assert!(
+                captured_str.contains(&format!("seq={i}\n")),
+                "event seq={i} missing from captured output after guard drop; \
+                 captured was: {captured_str}",
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,17 +125,13 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter {
     }
 }
 
-/// Assemble the redacting log-writer pipeline that `run` installs.
+/// Build the redacting log-writer pipeline `run` installs.
 ///
-/// Returns `(MakeWriter, WorkerGuard, password slot)`. Caller keeps the
-/// guard alive until events should be flushed; on drop it joins the
-/// background worker so the channel drains before teardown. The password
-/// slot starts empty and is populated once the password is known.
-///
-/// Sharing this assembly between `run` and tests is what lets a regression
-/// in the back-pressure shape (someone removes `lossy(true)`, swaps the
-/// non-blocking channel for the raw sink, hoists the guard back into a
-/// `static`) get caught: the `tests` module exercises this exact builder.
+/// `lossy(true)` so producers never park on the background writer; the
+/// returned `WorkerGuard` must outlive every `tracing::*` call so its
+/// `Drop` can join the worker and drain the channel before teardown.
+/// The password slot starts empty and is populated once the password
+/// is known.
 pub(crate) fn build_redacting_writer<W>(
     sink: W,
 ) -> (
@@ -197,25 +193,16 @@ const EXIT_AUTH: u8 = 3;
 #[error("{0} downloads failed")]
 struct PartialSyncError(usize);
 
-/// How a fatal `Err` from `run` maps to an exit code and whether kei
-/// should emit a final `tracing::error!` + stderr line for it.
-///
-/// Kept as a typed dispatch table (rather than inline match arms in
-/// `main_inner`) so the policy is unit-testable without owning a tokio
-/// runtime, and so the non-obvious `TwoFactorRequired -> exit 0, no log`
-/// rule can't drift silently.
+/// Maps a fatal `Err` from `run` to an exit code and decides whether to
+/// log it. `TwoFactorRequired` is the non-obvious case: exit 0, no log.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExitClassification {
-    /// 2FA required: exit 0, suppress error log. kei already told the
-    /// user how to proceed; logging "kei exited with error" here would
-    /// be misleading and `restart: on-failure` would loop the auth
-    /// endpoint.
+    /// Exit 0 with no error log: kei already told the user how to
+    /// proceed, and `restart: on-failure` would loop Apple's auth
+    /// endpoint if 2FA were treated as a failure.
     TwoFactorRequired,
-    /// Some downloads failed but the run was not a total failure.
     Partial,
-    /// Auth failure other than 2FA-required.
     Auth,
-    /// Any other error.
     Other,
 }
 
@@ -564,13 +551,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         types::LogLevel::Warn => "warn",
         types::LogLevel::Error => "error",
     };
-    // `_writer_guard` MUST live until `run` returns: the guard's `Drop`
-    // signals the background worker to flush remaining events before the
-    // process exits. A `static`-stored guard would never drop (Rust skips
-    // static destructors), so subprocess tests that read stderr after
-    // kei exits would race against unflushed events on fast process
-    // teardown (observed on macOS CI). See `build_redacting_writer`
-    // for the back-pressure shape.
+    // `_writer_guard` MUST live until `run` returns. A `static`-stored
+    // guard never drops (Rust skips static destructors), so subprocess
+    // tests reading stderr after kei exits race against unflushed events
+    // on fast teardown (observed on macOS CI).
     let (make_writer, _writer_guard, redact_password) = build_redacting_writer(std::io::stderr());
 
     tracing_subscriber::fmt()
@@ -962,14 +946,8 @@ mod tests {
         assert!(output.contains("********"));
     }
 
-    /// Reproduces the failure mode of issue #347: the producer must not
-    /// park on the sink mutex when the consumer drains slow. Without the
-    /// `tracing_appender::non_blocking` lossy channel that
-    /// `build_redacting_writer` installs, 200 events at 50 ms per write
-    /// would block the emitting task for ~10 s. With it, the bounded
-    /// channel absorbs the saturation and the producer returns in
-    /// milliseconds. A regression that drops the non-blocking layer or
-    /// swaps `lossy(true)` for the blocking variant fails this test.
+    /// 200 events at 50 ms per write would synchronously block the
+    /// producer for ~10 s without the lossy non-blocking channel.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn writer_pipeline_does_not_back_pressure_producer() {
         use std::io::Write;
@@ -1016,13 +994,9 @@ mod tests {
         );
     }
 
-    /// Companion to issue #347's macOS CI flake: the `WorkerGuard` must
-    /// drop before the test asserts on captured output. With the guard
-    /// bound locally (rather than held in a `static OnceLock` whose
-    /// destructor never runs), drop joins the background worker and
-    /// drains the channel deterministically. A regression that hoists the
-    /// guard back into static storage races against the sink and loses
-    /// events on fast teardown.
+    /// `WorkerGuard::drop` must flush every emitted event before
+    /// returning. Hoisting the guard into a `static` (whose destructor
+    /// never runs) silently re-introduces the race.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn writer_pipeline_flushes_all_events_before_guard_drops() {
         use std::io::Write;
@@ -1241,18 +1215,6 @@ mod tests {
         assert_eq!(MIN_FREE_BYTES, 1024 * 1024 * 1024);
     }
 
-    /// `classify_exit_error` is the dispatch table that decides what kei's
-    /// exit code is and whether it logs a final "kei exited with error"
-    /// line. The mapping is non-obvious in two places:
-    ///
-    /// 1. `AuthError::TwoFactorRequired` is *not* a failure — kei has
-    ///    already told the user how to proceed, exit 0 keeps `restart:
-    ///    on-failure` from looping the auth endpoint.
-    /// 2. `AuthError` (non-2FA) and `PartialSyncError` get distinct exit
-    ///    codes (3 and 2) so operators / supervisors can branch on them.
-    ///
-    /// A refactor that flips any of those mappings should fail one of these
-    /// tests rather than silently change operator-visible behavior.
     #[test]
     fn classify_exit_error_two_factor_required_is_suppressed_success() {
         let e: anyhow::Error = auth::error::AuthError::TwoFactorRequired.into();
@@ -1294,9 +1256,6 @@ mod tests {
         assert!(c.should_log());
     }
 
-    /// `PartialSyncError` and `AuthError` both downcast cleanly even when
-    /// wrapped in additional `anyhow` context — the dispatch must look
-    /// through `.context(...)` chains, not just at the leaf error.
     #[test]
     fn classify_exit_error_walks_anyhow_context() {
         let e: anyhow::Error = anyhow::Error::from(auth::error::AuthError::TwoFactorRequired)
@@ -1314,8 +1273,6 @@ mod tests {
         assert_eq!(classify_exit_error(&e), ExitClassification::Partial);
     }
 
-    /// All four classifications must produce distinct exit codes — if two
-    /// collapse, operators lose the ability to branch on the cause.
     #[test]
     fn classify_exit_error_codes_are_distinct() {
         let codes = [


### PR DESCRIPTION
## Summary

Tests for the bug class shipped in #349. No production behavior change.

Each test fails on a specific regression and passes on the merged fix:

- `writer_pipeline_does_not_back_pressure_producer` (src/lib.rs) - emits 200 events through a 50 ms-per-write sink and asserts the producer returns in under 2 s. Catches removing `tracing_appender::non_blocking` lossy mode (the original #347 stall).
- `heartbeat_fires_under_writer_load` (src/commands/import.rs) - spawns the production `HeartbeatGuard` with a fake scan loop emitting through a 5 ms-per-write sink and asserts the watchdog fires at least twice in 300 ms. Catches re-routing the watchdog through a synchronous chokepoint shared with the data plane.
- `fetcher_response_body_only_logs_at_trace` (src/icloud/photos/album.rs) - buries a unique marker in a fake CloudKit response and asserts the marker appears in captured output at TRACE but not DEBUG. Catches re-introducing the per-page pretty-print allocation that allocated 0.5-1 MB on every fetched page.
- `writer_pipeline_flushes_all_events_before_guard_drops` (src/lib.rs) - emits 50 events, drops the `WorkerGuard`, asserts all 50 events land in the sink. Catches hoisting the guard back into static storage (whose destructor never runs at process exit).

The audit also surfaced an untested branch in `main_inner`: the `Result -> ExitCode` dispatch (2FA-as-success, partial-sync, auth, generic) had zero coverage. Six new tests pin that table:

- `classify_exit_error_two_factor_required_is_suppressed_success` - 2FA exits 0 and does *not* emit `tracing::error!`. Catches anything that flips the "kei told the user, this is success" rule and starts looping `restart: on-failure` against Apple's auth endpoint.
- `classify_exit_error_partial_sync_uses_exit_partial` - partial sync maps to exit 2 (`EXIT_PARTIAL`).
- `classify_exit_error_auth_non_2fa_uses_exit_auth` - auth failures other than 2FA map to exit 3 (`EXIT_AUTH`).
- `classify_exit_error_generic_uses_failure` - any other `anyhow::Error` maps to exit 1.
- `classify_exit_error_walks_anyhow_context` - `.context(...)` wrapping at any call site doesn't silently re-route a 2FA or partial-sync error into the generic-failure bucket.
- `classify_exit_error_codes_are_distinct` - operators / supervisors can branch on each cause without two outcomes collapsing.

## Refactors

- `build_redacting_writer<W>` extracted from `run` so production and tests construct the pipeline through the same helper. Without this, a regression to the back-pressure shape only surfaces at scale.
- `log_fetcher_response` extracted from the inline album fetcher hot path so the DEBUG-vs-TRACE split is testable in isolation.
- `classify_exit_error` + `ExitClassification` extracted from `main_inner` so the exit-code policy is unit-testable without owning a tokio runtime. `main_inner` now branches on `should_log()` and `exit_code()` rather than an inline four-arm match; behavior is unchanged.

## Audit

A read-only audit of the rest of `src/` for the same bug patterns is saved in `.scratch/postmortem-347-class-audit.md`. Categories 4 (static-stored resources whose `Drop` matters) and 5 (watchdogs sharing data-plane chokepoints) came back clean. One borderline finding worth tracking but not fixing now: the per-asset `Mutex::lock` for `last_seen_id` in `src/commands/import.rs:336`, already justified by the existing comment.

## Test plan

- [x] `cargo test --lib writer_pipeline` - both lib.rs tests pass.
- [x] `cargo test --lib heartbeat_fires_under_writer_load` - passes.
- [x] `cargo test --lib fetcher_response_body_only_logs_at_trace` - passes.
- [x] `cargo test --lib classify_exit_error` - 6 new tests pass.
- [x] `just gate` clean (fmt, clippy, doc, audit, test, typos).