### PR TITLE
feat: Linux systemd backend for kei install / uninstall / service status

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ _default:
 gate:
     cargo fmt --all --check
     cargo clippy --all-targets --all-features -- -D warnings
-    cargo test --lib --test cli --test behavioral --test service_cli
+    cargo test --lib --test cli --test behavioral --test service_cli --test service_linux
     RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps --all-features
     cargo fetch --locked
     cargo audit --deny warnings
@@ -41,7 +41,7 @@ test MODE="":
             cargo test --all-features
             ;;
         fast)
-            cargo test --lib --test cli --test behavioral --test service_cli
+            cargo test --lib --test cli --test behavioral --test service_cli --test service_linux
             ;;
         live)
             _live_env

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1957,6 +1957,35 @@ mod tests {
     }
 
     #[test]
+    fn install_dry_run_parses_with_user_flag() {
+        let cli = Cli::try_parse_from(["kei", "install", "--user", "--dry-run"]).unwrap();
+        let args = match cli.effective_command() {
+            Command::Install(a) => a.clone(),
+            other => panic!("expected Install, got {other:?}"),
+        };
+        assert!(args.user);
+        assert!(args.dry_run);
+        assert!(!args.system);
+    }
+
+    #[test]
+    fn install_user_and_system_conflict_at_parse_time() {
+        // clap rejects mutually exclusive flags during parse; this guards
+        // the `conflicts_with` annotation on InstallArgs.
+        let err = Cli::try_parse_from(["kei", "install", "--user", "--system"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn uninstall_purge_parses_to_struct_field() {
+        let cli = Cli::try_parse_from(["kei", "uninstall", "--purge"]).unwrap();
+        assert!(matches!(
+            cli.effective_command(),
+            Command::Uninstall(UninstallArgs { purge: true })
+        ));
+    }
+
+    #[test]
     fn test_reset_sync_token() {
         let cli = Cli::try_parse_from(["kei", "reset", "sync-token"]).unwrap();
         assert!(matches!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -736,6 +736,13 @@ pub struct InstallArgs {
     /// Windows the per-platform default is used regardless of this flag.
     #[arg(long, conflicts_with = "user")]
     pub system: bool,
+
+    /// Render the service file and report what would happen, without
+    /// invoking the platform service manager (no `systemctl daemon-reload`,
+    /// no `launchctl bootstrap`, no SCM `CreateService`). The unit file is
+    /// still written to disk so it can be inspected.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 /// Arguments for `kei uninstall`.

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -2,8 +2,8 @@
 //!
 //! Routes to a per-platform backend (launchd on macOS, systemd on Linux,
 //! Windows SCM on Windows) that registers kei to start at boot and run
-//! continuously. PR 3 lands the Linux backend, PR 4 macOS, PR 5 Windows;
-//! until then every platform returns a clean "not yet implemented" error.
+//! continuously. Linux is wired up; macOS and Windows currently return
+//! a clean "not yet implemented" error.
 //!
 //! Inside containers the command short-circuits: Docker / Kubernetes /
 //! Podman supervise the process themselves, and writing a launchd plist
@@ -55,6 +55,6 @@ async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
     );
     Err(anyhow::anyhow!(
         "`kei install` is not yet implemented on this platform; \
-         macOS launchd lands in PR 4 and Windows SCM in PR 5"
+         macOS launchd and Windows SCM backends are still in flight"
     ))
 }

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -12,12 +12,10 @@
 
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::cli::InstallArgs;
-use crate::service::env::{
-    current_executable, is_in_container, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
-};
+use crate::service::env::is_in_container;
 
 pub(crate) async fn run(args: InstallArgs, config_path: &Path) -> Result<()> {
     if is_in_container() {
@@ -28,6 +26,22 @@ pub(crate) async fn run(args: InstallArgs, config_path: &Path) -> Result<()> {
         return Ok(());
     }
 
+    dispatch(args, config_path).await
+}
+
+#[cfg(target_os = "linux")]
+async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+    use crate::service::linux;
+    if args.system {
+        linux::install_system(&args, config_path).await
+    } else {
+        linux::install_user(&args, config_path).await
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+    use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
     let exe = current_executable()?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
@@ -36,11 +50,11 @@ pub(crate) async fn run(args: InstallArgs, config_path: &Path) -> Result<()> {
         config = %config_path.display(),
         user = args.user,
         system = args.system,
+        dry_run = args.dry_run,
         "preparing to install kei service",
     );
-
-    Err(anyhow!(
+    Err(anyhow::anyhow!(
         "`kei install` is not yet implemented on this platform; \
-         per-platform installers land in follow-up PRs (Linux first)"
+         macOS launchd lands in PR 4 and Windows SCM in PR 5"
     ))
 }

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -14,11 +14,15 @@
 //!   is the one who's expected to run with privilege.
 //!
 //! Unit-file rendering is split out as a pure function so tests can
-//! assert key shape without spawning systemd. The orchestrators
-//! [`install_user`] / [`install_system`] / [`uninstall`] / [`status`]
-//! handle the systemd command pipeline; they're covered by the PR 8
+//! assert key shape without spawning systemd. The systemd command
+//! pipeline (`daemon-reload`, `enable`, `disable`) is exercised by the
 //! per-platform smoke matrix, since faithful local mocking of
 //! `systemctl --user` requires an active user session.
+
+#![allow(
+    clippy::print_stdout,
+    reason = "kei service status renders human-readable output to stdout, matching kei status / kei verify."
+)]
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -29,8 +33,7 @@ use tokio::process::Command;
 use crate::cli::{InstallArgs, UninstallArgs};
 use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
 
-/// Unit-file basename written under the per-user / system systemd dirs.
-pub(crate) const UNIT_FILE_NAME: &str = "kei.service";
+const UNIT_FILE_NAME: &str = "kei.service";
 
 const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 
@@ -41,7 +44,7 @@ const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 /// stops arriving. `WantedBy=default.target` is the right install
 /// target for a user unit; `multi-user.target` is reserved for system
 /// units.
-pub(crate) fn render_user_unit(exec_path: &Path, config_path: &Path) -> String {
+fn render_user_unit(exec_path: &Path, config_path: &Path) -> String {
     render_unit(exec_path, config_path, UnitKind::User)
 }
 
@@ -51,7 +54,7 @@ pub(crate) fn render_user_unit(exec_path: &Path, config_path: &Path) -> String {
 /// uses that user's HOME (and thereby `~/.config/kei`) rather than
 /// running as root. `WantedBy=multi-user.target` is the boot-time
 /// target every non-graphical Linux server reaches.
-pub(crate) fn render_system_unit(exec_path: &Path, config_path: &Path, user: &str) -> String {
+fn render_system_unit(exec_path: &Path, config_path: &Path, user: &str) -> String {
     render_unit(
         exec_path,
         config_path,
@@ -104,14 +107,12 @@ fn render_unit(exec_path: &Path, config_path: &Path, kind: UnitKind) -> String {
 /// to `~/.config/systemd/user/kei.service`. Returns `None` when neither
 /// `XDG_CONFIG_HOME` nor `HOME` is set, which is the right answer
 /// because there's no reasonable place to write the file in that case.
-pub(crate) fn user_unit_path() -> Option<PathBuf> {
+fn user_unit_path() -> Option<PathBuf> {
     let dir = dirs::config_dir()?;
     Some(dir.join("systemd/user").join(UNIT_FILE_NAME))
 }
 
-/// Where the system-wide unit lives. Constant, but exposed as a
-/// function so tests can override against a tempdir via [`install_system_at`].
-pub(crate) fn system_unit_path() -> PathBuf {
+fn system_unit_path() -> PathBuf {
     Path::new(SYSTEM_UNIT_DIR).join(UNIT_FILE_NAME)
 }
 
@@ -192,48 +193,42 @@ pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Re
 /// path first; if no user unit exists, falls back to the system unit
 /// (which the operator will need root for).
 pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
-    let user_path = user_unit_path();
-    let system_path = system_unit_path();
+    let user_path = user_unit_path().filter(|p| p.exists());
+    let system_path = Some(system_unit_path()).filter(|p| p.exists());
 
-    let user_exists = user_path.as_ref().is_some_and(|p| p.exists());
-    let system_exists = system_path.exists();
-
-    if !user_exists && !system_exists {
+    if user_path.is_none() && system_path.is_none() {
         tracing::info!(
             "no kei.service unit file found at the per-user or system path; \
-             nothing to uninstall",
+             nothing to uninstall"
         );
     }
 
-    if user_exists {
-        if let Some(path) = user_path.as_ref() {
-            // disable + daemon-reload may legitimately fail in a
-            // non-systemd environment (a tempdir-only test, a chroot,
-            // or a host that uses sysvinit). The unit file removal is
-            // the load-bearing step; log the failures and proceed.
-            let _ = disable_now_user().await;
-            remove_unit_file(path)?;
-            let _ = daemon_reload_user().await;
-            tracing::info!(path = %path.display(), "removed per-user systemd unit");
-        }
+    if let Some(path) = user_path.as_ref() {
+        // disable + daemon-reload may legitimately fail in a non-systemd
+        // environment (tempdir-only test, chroot, sysvinit host). The
+        // unit-file removal is the load-bearing step; log+proceed.
+        let _ = disable_now_user().await;
+        remove_unit_file(path)?;
+        let _ = daemon_reload_user().await;
+        tracing::info!(path = %path.display(), "removed per-user systemd unit");
     }
 
-    if system_exists {
+    if let Some(path) = system_path.as_ref() {
         if !is_root() {
             bail!(
                 "system-wide kei.service is registered at {}; \
                  rerun `kei uninstall` as root to remove it",
-                system_path.display()
+                path.display()
             );
         }
         let _ = disable_now_system().await;
-        remove_unit_file(&system_path)?;
+        remove_unit_file(path)?;
         let _ = daemon_reload_system().await;
-        tracing::info!(path = %system_path.display(), "removed system-wide systemd unit");
+        tracing::info!(path = %path.display(), "removed system-wide systemd unit");
     }
 
     if args.purge {
-        purge_user_data()?;
+        purge_user_data().await?;
     }
 
     Ok(())
@@ -248,21 +243,19 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
 /// projection.
 pub(crate) async fn status() -> Result<()> {
     let line = render_status(probe_status_inputs().await?);
-    print_status(&line);
+    println!("{line}");
     Ok(())
 }
 
-#[allow(
-    clippy::print_stdout,
-    reason = "kei service status renders human-readable output to stdout, matching kei status / kei verify."
-)]
-fn print_status(line: &str) {
-    println!("{line}");
-}
-
-struct StatusInputs {
-    scope: Option<&'static str>,
-    probe: std::collections::BTreeMap<String, String>,
+enum StatusInputs {
+    NotInstalled,
+    BusUnavailable {
+        scope: &'static str,
+    },
+    Probed {
+        scope: &'static str,
+        probe: std::collections::BTreeMap<String, String>,
+    },
 }
 
 async fn probe_status_inputs() -> Result<StatusInputs> {
@@ -270,50 +263,41 @@ async fn probe_status_inputs() -> Result<StatusInputs> {
     let system_unit = system_unit_path().exists();
 
     if !user_unit && !system_unit {
-        return Ok(StatusInputs {
-            scope: None,
-            probe: std::collections::BTreeMap::new(),
-        });
+        return Ok(StatusInputs::NotInstalled);
     }
 
     let scope = if user_unit { "user" } else { "system" };
-    let probe = if user_unit {
-        show_unit(&["--user"]).await?
-    } else {
-        show_unit(&[]).await?
-    };
-    Ok(StatusInputs {
-        scope: Some(scope),
-        probe,
+    let scope_args: &[&str] = if user_unit { &["--user"] } else { &[] };
+    Ok(match show_unit(scope_args).await? {
+        ProbeOutcome::BusUnavailable => StatusInputs::BusUnavailable { scope },
+        ProbeOutcome::Properties(probe) => StatusInputs::Probed { scope, probe },
     })
 }
 
 fn render_status(inputs: StatusInputs) -> String {
-    let Some(scope) = inputs.scope else {
-        return "Service: not installed".to_string();
-    };
+    match inputs {
+        StatusInputs::NotInstalled => "Service: not installed".to_string(),
+        StatusInputs::BusUnavailable { scope } => {
+            // Unit file exists but we can't talk to systemd (no active
+            // session bus, e.g. SSH without `loginctl enable-linger`).
+            // Saying "not installed" would be wrong; surface the cause.
+            format!("Service: installed (systemd {scope}, bus unavailable)")
+        }
+        StatusInputs::Probed { scope, probe } => {
+            let active = probe.get("ActiveState").map(String::as_str).unwrap_or("?");
+            let sub = probe.get("SubState").map(String::as_str).unwrap_or("?");
+            let since = probe
+                .get("ActiveEnterTimestamp")
+                .filter(|s| !s.is_empty())
+                .map(String::as_str);
 
-    let active = inputs
-        .probe
-        .get("ActiveState")
-        .map(String::as_str)
-        .unwrap_or("?");
-    let sub = inputs
-        .probe
-        .get("SubState")
-        .map(String::as_str)
-        .unwrap_or("?");
-    let since = inputs
-        .probe
-        .get("ActiveEnterTimestamp")
-        .filter(|s| !s.is_empty())
-        .map(String::as_str);
-
-    if active == "active" {
-        let when = since.map(|s| format!(" since {s}")).unwrap_or_default();
-        format!("Service: running (systemd {scope}, {sub}{when})")
-    } else {
-        format!("Service: {active} (systemd {scope}, {sub})")
+            if active == "active" {
+                let when = since.map(|s| format!(" since {s}")).unwrap_or_default();
+                format!("Service: running (systemd {scope}, {sub}{when})")
+            } else {
+                format!("Service: {active} (systemd {scope}, {sub})")
+            }
+        }
     }
 }
 
@@ -336,11 +320,27 @@ fn remove_unit_file(path: &Path) -> Result<()> {
     }
 }
 
-fn purge_user_data() -> Result<()> {
-    let Some(home) = dirs::home_dir() else {
-        bail!("--purge requested but $HOME is not set; cannot locate ~/.config/kei");
+async fn purge_user_data() -> Result<()> {
+    let Some(config_dir) = dirs::config_dir() else {
+        bail!("--purge requested but no XDG config dir resolves; cannot locate kei state");
     };
-    let kei_dir = home.join(".config/kei");
+    let kei_dir = config_dir.join("kei");
+
+    // Read username out of the config before deleting, so the OS keyring
+    // entry kept by `CredentialStore` can be cleared too. Without this the
+    // credential survives `--purge`, contradicting the docs and leaving a
+    // password the user thinks they removed.
+    if let Some(username) = read_config_username(&kei_dir).await {
+        let store = crate::credential::CredentialStore::new(&username, &kei_dir);
+        if let Err(e) = store.delete() {
+            // delete() bails when neither backend has anything to remove,
+            // which is fine for purge (we're cleaning up regardless).
+            tracing::debug!(error = %e, "credential delete during purge: nothing to remove");
+        } else {
+            tracing::info!(username, "cleared stored credential");
+        }
+    }
+
     match std::fs::remove_dir_all(&kei_dir) {
         Ok(()) => {
             tracing::info!(path = %kei_dir.display(), "purged kei state directory");
@@ -353,6 +353,12 @@ fn purge_user_data() -> Result<()> {
         Err(e) => Err(e)
             .with_context(|| format!("failed to remove state directory {}", kei_dir.display())),
     }
+}
+
+async fn read_config_username(kei_dir: &Path) -> Option<String> {
+    let config_path = kei_dir.join("config.toml");
+    let toml = crate::config::load_toml_config(&config_path, false).ok()??;
+    toml.auth?.username.filter(|u| !u.is_empty())
 }
 
 fn is_root() -> bool {
@@ -453,7 +459,12 @@ where
     Ok(())
 }
 
-async fn show_unit(scope: &[&str]) -> Result<std::collections::BTreeMap<String, String>> {
+enum ProbeOutcome {
+    Properties(std::collections::BTreeMap<String, String>),
+    BusUnavailable,
+}
+
+async fn show_unit(scope: &[&str]) -> Result<ProbeOutcome> {
     let mut argv: Vec<&str> = scope.to_vec();
     argv.extend([
         "show",
@@ -467,9 +478,24 @@ async fn show_unit(scope: &[&str]) -> Result<std::collections::BTreeMap<String, 
         .context("failed to invoke `systemctl show`")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_session_bus_unavailable(&stderr) {
+            return Ok(ProbeOutcome::BusUnavailable);
+        }
         bail!("`systemctl show` failed: {}", stderr.trim());
     }
-    Ok(parse_show_output(&String::from_utf8_lossy(&output.stdout)))
+    Ok(ProbeOutcome::Properties(parse_show_output(
+        &String::from_utf8_lossy(&output.stdout),
+    )))
+}
+
+fn is_session_bus_unavailable(stderr: &str) -> bool {
+    // systemd / dbus emit one of these when there's no active user
+    // session to talk to. We treat that as "can't probe state" rather
+    // than "service is broken" so `kei service status` over SSH
+    // reports something useful instead of a hard error.
+    stderr.contains("Failed to connect to bus")
+        || stderr.contains("Failed to connect to user scope bus")
+        || stderr.contains("No medium found")
 }
 
 fn parse_show_output(stdout: &str) -> std::collections::BTreeMap<String, String> {
@@ -571,12 +597,17 @@ mod tests {
     }
 
     #[test]
-    fn render_status_reports_not_installed_without_scope() {
-        let inputs = StatusInputs {
-            scope: None,
-            probe: std::collections::BTreeMap::new(),
-        };
-        assert_eq!(render_status(inputs), "Service: not installed");
+    fn render_status_reports_not_installed() {
+        assert_eq!(
+            render_status(StatusInputs::NotInstalled),
+            "Service: not installed"
+        );
+    }
+
+    #[test]
+    fn render_status_reports_bus_unavailable_when_no_session() {
+        let line = render_status(StatusInputs::BusUnavailable { scope: "user" });
+        assert_eq!(line, "Service: installed (systemd user, bus unavailable)");
     }
 
     #[test]
@@ -588,8 +619,8 @@ mod tests {
             "ActiveEnterTimestamp".to_string(),
             "Thu 2026-05-07 14:32:01 UTC".to_string(),
         );
-        let line = render_status(StatusInputs {
-            scope: Some("user"),
+        let line = render_status(StatusInputs::Probed {
+            scope: "user",
             probe,
         });
         assert_eq!(
@@ -604,10 +635,23 @@ mod tests {
         probe.insert("ActiveState".to_string(), "inactive".to_string());
         probe.insert("SubState".to_string(), "dead".to_string());
         probe.insert("ActiveEnterTimestamp".to_string(), String::new());
-        let line = render_status(StatusInputs {
-            scope: Some("user"),
+        let line = render_status(StatusInputs::Probed {
+            scope: "user",
             probe,
         });
         assert_eq!(line, "Service: inactive (systemd user, dead)");
+    }
+
+    #[test]
+    fn detects_session_bus_unavailable_strings() {
+        assert!(is_session_bus_unavailable(
+            "Failed to connect to bus: No such file or directory\n"
+        ));
+        assert!(is_session_bus_unavailable(
+            "Failed to connect to user scope bus via local transport\n"
+        ));
+        assert!(!is_session_bus_unavailable(
+            "Unit kei.service could not be found.\n"
+        ));
     }
 }

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -1,0 +1,613 @@
+//! Linux backend for `kei install` / `kei uninstall` / `kei service status`.
+//!
+//! Two install paths land here:
+//!
+//! - `--user` (default): writes
+//!   `${XDG_CONFIG_HOME:-~/.config}/systemd/user/kei.service` and runs
+//!   `systemctl --user daemon-reload && systemctl --user enable --now`.
+//!   `loginctl enable-linger` is best-effort: a polkit denial logs a
+//!   warning and the install still succeeds, since the unit will work
+//!   for as long as the user is logged in.
+//! - `--system`: writes `/etc/systemd/system/kei.service` with `User=`
+//!   pointing at `$SUDO_USER`. Refuses without `EUID=0` rather than
+//!   shelling out to `sudo` itself; the operator who chose `--system`
+//!   is the one who's expected to run with privilege.
+//!
+//! Unit-file rendering is split out as a pure function so tests can
+//! assert key shape without spawning systemd. The orchestrators
+//! [`install_user`] / [`install_system`] / [`uninstall`] / [`status`]
+//! handle the systemd command pipeline; they're covered by the PR 8
+//! per-platform smoke matrix, since faithful local mocking of
+//! `systemctl --user` requires an active user session.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use tokio::process::Command;
+
+use crate::cli::{InstallArgs, UninstallArgs};
+use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
+
+/// Unit-file basename written under the per-user / system systemd dirs.
+pub(crate) const UNIT_FILE_NAME: &str = "kei.service";
+
+const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
+
+/// Renders the per-user `kei.service` body.
+///
+/// Uses `Type=notify` + `WatchdogSec=120` so systemd treats kei as a
+/// long-lived daemon and restarts it if the watchdog ping (sd-notify)
+/// stops arriving. `WantedBy=default.target` is the right install
+/// target for a user unit; `multi-user.target` is reserved for system
+/// units.
+pub(crate) fn render_user_unit(exec_path: &Path, config_path: &Path) -> String {
+    render_unit(exec_path, config_path, UnitKind::User)
+}
+
+/// Renders the system-wide `kei.service` body.
+///
+/// `User=` pins the daemon to a specific local account so the service
+/// uses that user's HOME (and thereby `~/.config/kei`) rather than
+/// running as root. `WantedBy=multi-user.target` is the boot-time
+/// target every non-graphical Linux server reaches.
+pub(crate) fn render_system_unit(exec_path: &Path, config_path: &Path, user: &str) -> String {
+    render_unit(
+        exec_path,
+        config_path,
+        UnitKind::System {
+            user: user.to_string(),
+        },
+    )
+}
+
+#[derive(Debug, Clone)]
+enum UnitKind {
+    User,
+    System { user: String },
+}
+
+fn render_unit(exec_path: &Path, config_path: &Path, kind: UnitKind) -> String {
+    let exec = exec_path.display();
+    let config = config_path.display();
+    let install_target = match &kind {
+        UnitKind::User => "default.target",
+        UnitKind::System { .. } => "multi-user.target",
+    };
+    let user_line = match &kind {
+        UnitKind::User => String::new(),
+        UnitKind::System { user } => format!("User={user}\n"),
+    };
+
+    format!(
+        "[Unit]\n\
+         Description={SERVICE_DESCRIPTION}\n\
+         Documentation=https://github.com/rhoopr/kei\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=notify\n\
+         {user_line}\
+         ExecStart={exec} service run --config {config}\n\
+         Restart=on-failure\n\
+         RestartSec=10s\n\
+         WatchdogSec=120\n\
+         NotifyAccess=main\n\
+         \n\
+         [Install]\n\
+         WantedBy={install_target}\n",
+    )
+}
+
+/// Where the per-user unit lives. Honors `XDG_CONFIG_HOME`; falls back
+/// to `~/.config/systemd/user/kei.service`. Returns `None` when neither
+/// `XDG_CONFIG_HOME` nor `HOME` is set, which is the right answer
+/// because there's no reasonable place to write the file in that case.
+pub(crate) fn user_unit_path() -> Option<PathBuf> {
+    let dir = dirs::config_dir()?;
+    Some(dir.join("systemd/user").join(UNIT_FILE_NAME))
+}
+
+/// Where the system-wide unit lives. Constant, but exposed as a
+/// function so tests can override against a tempdir via [`install_system_at`].
+pub(crate) fn system_unit_path() -> PathBuf {
+    Path::new(SYSTEM_UNIT_DIR).join(UNIT_FILE_NAME)
+}
+
+/// Top-level entry for `kei install --user` (and the bare `kei install`
+/// default on Linux).
+pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
+    let exe = current_executable()?;
+    let unit_path =
+        user_unit_path().ok_or_else(|| anyhow!("could not resolve XDG_CONFIG_HOME or $HOME"))?;
+    let contents = render_user_unit(&exe, config_path);
+    write_unit(&unit_path, &contents)?;
+    tracing::info!(
+        service = SERVICE_IDENTIFIER,
+        path = %unit_path.display(),
+        executable = %exe.display(),
+        config = %config_path.display(),
+        dry_run = args.dry_run,
+        "wrote per-user systemd unit",
+    );
+
+    if args.dry_run {
+        tracing::info!(
+            "dry run: skipped systemctl daemon-reload / enable / loginctl enable-linger"
+        );
+        return Ok(());
+    }
+
+    daemon_reload_user().await?;
+    enable_now_user().await?;
+    enable_linger_best_effort().await;
+
+    tracing::info!(
+        "kei is now running as a per-user systemd service; \
+         check `systemctl --user status {SERVICE_IDENTIFIER}.service` to verify",
+    );
+    Ok(())
+}
+
+/// Top-level entry for `kei install --system`.
+pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Result<()> {
+    if !is_root() {
+        bail!(
+            "`kei install --system` must be run as root (EUID=0); \
+             rerun under sudo or use `kei install --user` for a per-user install"
+        );
+    }
+    let user = sudo_user_or_bail()?;
+    let exe = current_executable()?;
+    let unit_path = system_unit_path();
+    let contents = render_system_unit(&exe, config_path, &user);
+    write_unit(&unit_path, &contents)?;
+    tracing::info!(
+        service = SERVICE_IDENTIFIER,
+        path = %unit_path.display(),
+        executable = %exe.display(),
+        config = %config_path.display(),
+        run_as_user = user,
+        dry_run = args.dry_run,
+        "wrote system-wide systemd unit",
+    );
+
+    if args.dry_run {
+        tracing::info!("dry run: skipped systemctl daemon-reload / enable");
+        return Ok(());
+    }
+
+    daemon_reload_system().await?;
+    enable_now_system().await?;
+
+    tracing::info!(
+        "kei is now running as a system-wide systemd service; \
+         check `systemctl status {SERVICE_IDENTIFIER}.service` to verify",
+    );
+    Ok(())
+}
+
+/// Top-level entry for `kei uninstall` on Linux. Tries the per-user
+/// path first; if no user unit exists, falls back to the system unit
+/// (which the operator will need root for).
+pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
+    let user_path = user_unit_path();
+    let system_path = system_unit_path();
+
+    let user_exists = user_path.as_ref().is_some_and(|p| p.exists());
+    let system_exists = system_path.exists();
+
+    if !user_exists && !system_exists {
+        tracing::info!(
+            "no kei.service unit file found at the per-user or system path; \
+             nothing to uninstall",
+        );
+    }
+
+    if user_exists {
+        if let Some(path) = user_path.as_ref() {
+            // disable + daemon-reload may legitimately fail in a
+            // non-systemd environment (a tempdir-only test, a chroot,
+            // or a host that uses sysvinit). The unit file removal is
+            // the load-bearing step; log the failures and proceed.
+            let _ = disable_now_user().await;
+            remove_unit_file(path)?;
+            let _ = daemon_reload_user().await;
+            tracing::info!(path = %path.display(), "removed per-user systemd unit");
+        }
+    }
+
+    if system_exists {
+        if !is_root() {
+            bail!(
+                "system-wide kei.service is registered at {}; \
+                 rerun `kei uninstall` as root to remove it",
+                system_path.display()
+            );
+        }
+        let _ = disable_now_system().await;
+        remove_unit_file(&system_path)?;
+        let _ = daemon_reload_system().await;
+        tracing::info!(path = %system_path.display(), "removed system-wide systemd unit");
+    }
+
+    if args.purge {
+        purge_user_data()?;
+    }
+
+    Ok(())
+}
+
+/// Implementation for `kei service status` on Linux.
+///
+/// Calls `systemctl --user show kei.service` and parses the resulting
+/// key=value pairs. We do not read the full status output (`systemctl
+/// status`) because it embeds escape codes and free-form journal lines
+/// that complicate parsing; `show` returns a clean machine-readable
+/// projection.
+pub(crate) async fn status() -> Result<()> {
+    let line = render_status(probe_status_inputs().await?);
+    print_status(&line);
+    Ok(())
+}
+
+#[allow(
+    clippy::print_stdout,
+    reason = "kei service status renders human-readable output to stdout, matching kei status / kei verify."
+)]
+fn print_status(line: &str) {
+    println!("{line}");
+}
+
+struct StatusInputs {
+    scope: Option<&'static str>,
+    probe: std::collections::BTreeMap<String, String>,
+}
+
+async fn probe_status_inputs() -> Result<StatusInputs> {
+    let user_unit = user_unit_path().is_some_and(|p| p.exists());
+    let system_unit = system_unit_path().exists();
+
+    if !user_unit && !system_unit {
+        return Ok(StatusInputs {
+            scope: None,
+            probe: std::collections::BTreeMap::new(),
+        });
+    }
+
+    let scope = if user_unit { "user" } else { "system" };
+    let probe = if user_unit {
+        show_unit(&["--user"]).await?
+    } else {
+        show_unit(&[]).await?
+    };
+    Ok(StatusInputs {
+        scope: Some(scope),
+        probe,
+    })
+}
+
+fn render_status(inputs: StatusInputs) -> String {
+    let Some(scope) = inputs.scope else {
+        return "Service: not installed".to_string();
+    };
+
+    let active = inputs
+        .probe
+        .get("ActiveState")
+        .map(String::as_str)
+        .unwrap_or("?");
+    let sub = inputs
+        .probe
+        .get("SubState")
+        .map(String::as_str)
+        .unwrap_or("?");
+    let since = inputs
+        .probe
+        .get("ActiveEnterTimestamp")
+        .filter(|s| !s.is_empty())
+        .map(String::as_str);
+
+    if active == "active" {
+        let when = since.map(|s| format!(" since {s}")).unwrap_or_default();
+        format!("Service: running (systemd {scope}, {sub}{when})")
+    } else {
+        format!("Service: {active} (systemd {scope}, {sub})")
+    }
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+fn write_unit(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create unit directory {}", parent.display()))?;
+    }
+    std::fs::write(path, contents)
+        .with_context(|| format!("failed to write unit file {}", path.display()))
+}
+
+fn remove_unit_file(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e).with_context(|| format!("failed to remove unit file {}", path.display())),
+    }
+}
+
+fn purge_user_data() -> Result<()> {
+    let Some(home) = dirs::home_dir() else {
+        bail!("--purge requested but $HOME is not set; cannot locate ~/.config/kei");
+    };
+    let kei_dir = home.join(".config/kei");
+    match std::fs::remove_dir_all(&kei_dir) {
+        Ok(()) => {
+            tracing::info!(path = %kei_dir.display(), "purged kei state directory");
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!(path = %kei_dir.display(), "no kei state directory to purge");
+            Ok(())
+        }
+        Err(e) => Err(e)
+            .with_context(|| format!("failed to remove state directory {}", kei_dir.display())),
+    }
+}
+
+fn is_root() -> bool {
+    // SAFETY: libc::geteuid() is a stateless POSIX FFI call with no
+    // preconditions, no side effects, and a uid_t return value; it cannot
+    // violate Rust memory safety. Same pattern as src/state/db.rs.
+    unsafe { libc::geteuid() == 0 }
+}
+
+fn sudo_user_or_bail() -> Result<String> {
+    match std::env::var("SUDO_USER") {
+        Ok(u) if !u.is_empty() && u != "root" => Ok(u),
+        _ => bail!(
+            "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
+             can be configured to run as your account rather than root"
+        ),
+    }
+}
+
+async fn daemon_reload_user() -> Result<()> {
+    run_systemctl(&["--user", "daemon-reload"]).await
+}
+
+async fn enable_now_user() -> Result<()> {
+    run_systemctl(&["--user", "enable", "--now", UNIT_FILE_NAME]).await
+}
+
+async fn disable_now_user() -> Result<()> {
+    run_systemctl(&["--user", "disable", "--now", UNIT_FILE_NAME]).await
+}
+
+async fn daemon_reload_system() -> Result<()> {
+    run_systemctl(&["daemon-reload"]).await
+}
+
+async fn enable_now_system() -> Result<()> {
+    run_systemctl(&["enable", "--now", UNIT_FILE_NAME]).await
+}
+
+async fn disable_now_system() -> Result<()> {
+    run_systemctl(&["disable", "--now", UNIT_FILE_NAME]).await
+}
+
+async fn enable_linger_best_effort() {
+    let user = match std::env::var("USER") {
+        Ok(u) if !u.is_empty() => u,
+        _ => {
+            tracing::warn!("$USER not set; skipping `loginctl enable-linger`");
+            return;
+        }
+    };
+    let status = Command::new("loginctl")
+        .arg("enable-linger")
+        .arg(&user)
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => {
+            tracing::info!(
+                user,
+                "enabled loginctl linger so the service survives logout"
+            );
+        }
+        Ok(s) => {
+            tracing::warn!(
+                user,
+                code = s.code().unwrap_or(-1),
+                "loginctl enable-linger failed; service will only run while {user} is logged in. \
+                 Run `sudo loginctl enable-linger {user}` to enable it manually."
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "loginctl not found; skipping enable-linger");
+        }
+    }
+}
+
+async fn run_systemctl<I, S>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args: Vec<_> = args.into_iter().collect();
+    let output = Command::new("systemctl")
+        .args(&args)
+        .output()
+        .await
+        .context("failed to invoke `systemctl` (is systemd installed and on PATH?)")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let argv = args
+            .iter()
+            .map(|a| a.as_ref().to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        bail!("`systemctl {argv}` failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+async fn show_unit(scope: &[&str]) -> Result<std::collections::BTreeMap<String, String>> {
+    let mut argv: Vec<&str> = scope.to_vec();
+    argv.extend([
+        "show",
+        UNIT_FILE_NAME,
+        "--property=ActiveState,SubState,ActiveEnterTimestamp",
+    ]);
+    let output = Command::new("systemctl")
+        .args(&argv)
+        .output()
+        .await
+        .context("failed to invoke `systemctl show`")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`systemctl show` failed: {}", stderr.trim());
+    }
+    Ok(parse_show_output(&String::from_utf8_lossy(&output.stdout)))
+}
+
+fn parse_show_output(stdout: &str) -> std::collections::BTreeMap<String, String> {
+    stdout
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn user_unit_contains_required_sections_and_keys() {
+        let unit = render_user_unit(
+            &PathBuf::from("/usr/local/bin/kei"),
+            &PathBuf::from("/home/alice/.config/kei/config.toml"),
+        );
+        assert!(unit.contains("[Unit]"));
+        assert!(unit.contains("[Service]"));
+        assert!(unit.contains("[Install]"));
+        assert!(unit.contains(&format!("Description={SERVICE_DESCRIPTION}")));
+        assert!(unit.contains("Type=notify"));
+        assert!(unit.contains("WatchdogSec=120"));
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains(
+            "ExecStart=/usr/local/bin/kei service run --config /home/alice/.config/kei/config.toml"
+        ));
+        assert!(unit.contains("WantedBy=default.target"));
+        // Per-user unit must not pin a User= (it inherits from the
+        // user-systemd-instance owner).
+        assert!(
+            !unit.contains("\nUser="),
+            "per-user unit must not declare User=:\n{unit}"
+        );
+    }
+
+    #[test]
+    fn system_unit_pins_user_and_targets_multi_user() {
+        let unit = render_system_unit(
+            &PathBuf::from("/opt/kei/bin/kei"),
+            &PathBuf::from("/etc/kei/config.toml"),
+            "alice",
+        );
+        assert!(unit.contains("User=alice"));
+        assert!(unit.contains("WantedBy=multi-user.target"));
+        assert!(
+            unit.contains("ExecStart=/opt/kei/bin/kei service run --config /etc/kei/config.toml")
+        );
+        assert!(unit.contains("Type=notify"));
+    }
+
+    #[test]
+    fn parse_show_output_extracts_known_keys() {
+        let raw = "ActiveState=active\nSubState=running\nActiveEnterTimestamp=Thu 2026-05-07 14:32:01 UTC\n";
+        let parsed = parse_show_output(raw);
+        assert_eq!(
+            parsed.get("ActiveState").map(String::as_str),
+            Some("active")
+        );
+        assert_eq!(parsed.get("SubState").map(String::as_str), Some("running"));
+        assert_eq!(
+            parsed.get("ActiveEnterTimestamp").map(String::as_str),
+            Some("Thu 2026-05-07 14:32:01 UTC"),
+        );
+    }
+
+    #[test]
+    fn parse_show_output_handles_blank_timestamp() {
+        let raw = "ActiveState=inactive\nSubState=dead\nActiveEnterTimestamp=\n";
+        let parsed = parse_show_output(raw);
+        assert_eq!(
+            parsed.get("ActiveEnterTimestamp").map(String::as_str),
+            Some(""),
+        );
+    }
+
+    #[test]
+    fn user_unit_path_is_under_config_dir() {
+        // Result depends on $HOME / $XDG_CONFIG_HOME, but if either is
+        // set the path must end with systemd/user/kei.service.
+        if let Some(p) = user_unit_path() {
+            assert!(
+                p.ends_with("systemd/user/kei.service"),
+                "expected systemd user path, got {}",
+                p.display()
+            );
+            assert!(p.is_absolute());
+        }
+    }
+
+    #[test]
+    fn system_unit_path_is_etc_systemd_system() {
+        let p = system_unit_path();
+        assert_eq!(p, Path::new("/etc/systemd/system/kei.service"));
+    }
+
+    #[test]
+    fn render_status_reports_not_installed_without_scope() {
+        let inputs = StatusInputs {
+            scope: None,
+            probe: std::collections::BTreeMap::new(),
+        };
+        assert_eq!(render_status(inputs), "Service: not installed");
+    }
+
+    #[test]
+    fn render_status_includes_active_enter_timestamp() {
+        let mut probe = std::collections::BTreeMap::new();
+        probe.insert("ActiveState".to_string(), "active".to_string());
+        probe.insert("SubState".to_string(), "running".to_string());
+        probe.insert(
+            "ActiveEnterTimestamp".to_string(),
+            "Thu 2026-05-07 14:32:01 UTC".to_string(),
+        );
+        let line = render_status(StatusInputs {
+            scope: Some("user"),
+            probe,
+        });
+        assert_eq!(
+            line,
+            "Service: running (systemd user, running since Thu 2026-05-07 14:32:01 UTC)"
+        );
+    }
+
+    #[test]
+    fn render_status_handles_inactive_with_blank_timestamp() {
+        let mut probe = std::collections::BTreeMap::new();
+        probe.insert("ActiveState".to_string(), "inactive".to_string());
+        probe.insert("SubState".to_string(), "dead".to_string());
+        probe.insert("ActiveEnterTimestamp".to_string(), String::new());
+        let line = render_status(StatusInputs {
+            scope: Some("user"),
+            probe,
+        });
+        assert_eq!(line, "Service: inactive (systemd user, dead)");
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -13,3 +13,6 @@ pub(crate) mod install;
 pub(crate) mod run;
 pub(crate) mod status;
 pub(crate) mod uninstall;
+
+#[cfg(target_os = "linux")]
+pub(crate) mod linux;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,10 +3,10 @@
 //!
 //! Cross-platform plumbing (container detection, branding constants,
 //! executable canonicalization) lives in `env`. The four dispatchers
-//! (`install`, `uninstall`, `run`, `status`) currently route through
-//! `cfg(target_os = ...)` to per-platform backends that do not yet
-//! exist; they return a clean "not yet implemented" error until PR 3+
-//! land launchd / systemd / Windows SCM support.
+//! (`install`, `uninstall`, `run`, `status`) route through
+//! `cfg(target_os = ...)` to per-platform backends. Linux dispatches
+//! to `linux`; macOS and Windows currently return a clean "not yet
+//! implemented" error until those backends ship.
 
 pub(crate) mod env;
 pub(crate) mod install;

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -6,11 +6,21 @@
 //! backend modules introduced by PR 3+; until those land this command
 //! returns a placeholder error rather than a misleading "not installed".
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 pub(crate) async fn run() -> Result<()> {
-    Err(anyhow!(
-        "`kei service status` is not yet implemented; \
-         status reporting lands alongside the per-platform install backends"
+    dispatch().await
+}
+
+#[cfg(target_os = "linux")]
+async fn dispatch() -> Result<()> {
+    crate::service::linux::status().await
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn dispatch() -> Result<()> {
+    Err(anyhow::anyhow!(
+        "`kei service status` is not yet implemented on this platform; \
+         macOS launchd lands in PR 4 and Windows SCM in PR 5"
     ))
 }

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -1,10 +1,10 @@
 //! `kei service status` dispatcher.
 //!
 //! Reports whether kei is registered as a service on this host and how
-//! long it has been running. The platform queries (`systemctl --user
+//! long it has been running. Per-platform queries (`systemctl --user
 //! show`, `launchctl print`, `Get-Service`) live in the per-platform
-//! backend modules introduced by PR 3+; until those land this command
-//! returns a placeholder error rather than a misleading "not installed".
+//! backend modules. Linux is wired up; macOS and Windows currently
+//! return a placeholder error rather than a misleading "not installed".
 
 use anyhow::Result;
 
@@ -21,6 +21,6 @@ async fn dispatch() -> Result<()> {
 async fn dispatch() -> Result<()> {
     Err(anyhow::anyhow!(
         "`kei service status` is not yet implemented on this platform; \
-         macOS launchd lands in PR 4 and Windows SCM in PR 5"
+         macOS launchd and Windows SCM backends are still in flight"
     ))
 }

--- a/src/service/uninstall.rs
+++ b/src/service/uninstall.rs
@@ -5,10 +5,10 @@
 //! configuration, and stored credentials. Container short-circuit
 //! matches install — compose-managed deployments aren't touched.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::cli::UninstallArgs;
-use crate::service::env::{is_in_container, SERVICE_IDENTIFIER};
+use crate::service::env::is_in_container;
 
 pub(crate) async fn run(args: UninstallArgs) -> Result<()> {
     if is_in_container() {
@@ -19,14 +19,24 @@ pub(crate) async fn run(args: UninstallArgs) -> Result<()> {
         return Ok(());
     }
 
+    dispatch(args).await
+}
+
+#[cfg(target_os = "linux")]
+async fn dispatch(args: UninstallArgs) -> Result<()> {
+    crate::service::linux::uninstall(&args).await
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn dispatch(args: UninstallArgs) -> Result<()> {
+    use crate::service::env::SERVICE_IDENTIFIER;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
         purge = args.purge,
         "preparing to uninstall kei service",
     );
-
-    Err(anyhow!(
+    Err(anyhow::anyhow!(
         "`kei uninstall` is not yet implemented on this platform; \
-         per-platform support lands alongside `kei install` in follow-up PRs"
+         macOS launchd lands in PR 4 and Windows SCM in PR 5"
     ))
 }

--- a/src/service/uninstall.rs
+++ b/src/service/uninstall.rs
@@ -37,6 +37,6 @@ async fn dispatch(args: UninstallArgs) -> Result<()> {
     );
     Err(anyhow::anyhow!(
         "`kei uninstall` is not yet implemented on this platform; \
-         macOS launchd lands in PR 4 and Windows SCM in PR 5"
+         macOS launchd and Windows SCM backends are still in flight"
     ))
 }

--- a/tests/service_cli.rs
+++ b/tests/service_cli.rs
@@ -2,11 +2,11 @@
 //! and `kei service {run,status}`.
 //!
 //! Tests in this file must hold on every target. Platform-specific
-//! behavior — actually writing a unit file or invoking systemctl — lives
-//! in `tests/service_linux.rs` (and analogous suites for macOS / Windows
-//! once PRs 4-5 land). The "not yet implemented" assertions for macOS /
-//! Windows are gated to those targets so PR 3's Linux backend doesn't
-//! make them lie.
+//! behavior (actually writing a unit file or invoking systemctl) lives
+//! in `tests/service_linux.rs` and analogous suites for the other
+//! platforms. The "not yet implemented" assertions are gated to
+//! targets without a backend so they auto-deactivate as each platform
+//! ships.
 
 #![allow(
     clippy::unwrap_used,
@@ -103,37 +103,11 @@ fn install_user_and_system_are_mutually_exclusive() {
         .stderr(predicate::str::contains("cannot be used with"));
 }
 
-#[test]
-fn uninstall_accepts_purge_flag_via_clap() {
-    // Cross-platform check: clap parses `--purge` as a known flag (no
-    // exit-2 parse error). The actual uninstall behavior is asserted
-    // per-platform; here we just confirm the surface accepts the flag
-    // without flagging it as unknown.
-    cmd()
-        .args(["uninstall", "--purge", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("--purge"));
-}
-
-#[test]
-fn install_accepts_dry_run_flag_via_clap() {
-    // Same shape as --purge: assert clap recognizes `--dry-run` rather
-    // than executing the install. The Linux backend exercises the
-    // dry-run end-to-end in tests/service_linux.rs.
-    cmd()
-        .args(["install", "--dry-run", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("--dry-run"));
-}
-
 // ── Stub error contract (non-Linux only) ────────────────────────────────
 //
-// PR 3 lands the Linux backend, so on Linux these no longer return a
-// "not yet implemented" error. PRs 4 (macOS) and 5 (Windows) replace
-// the stubs on those targets too — the cfg gate auto-deactivates each
-// test as its platform's backend lands.
+// On targets where the platform backend has shipped, these tests
+// auto-deactivate via cfg. They guard the macOS / Windows stubs until
+// those backends land.
 
 #[cfg(not(target_os = "linux"))]
 #[test]

--- a/tests/service_cli.rs
+++ b/tests/service_cli.rs
@@ -1,11 +1,12 @@
-//! CLI parsing + container-guard tests for `kei install`, `kei uninstall`,
+//! Cross-platform CLI parsing tests for `kei install`, `kei uninstall`,
 //! and `kei service {run,status}`.
 //!
-//! The per-platform install backends (launchd, systemd, Windows SCM) land
-//! in PRs 3-5; until then `install` / `uninstall` / `service status`
-//! return a clean "not yet implemented" error and the tests below assert
-//! the contract: subcommand parsing, `--help` rendering, mutually
-//! exclusive flags, and a friendly stub error rather than a panic.
+//! Tests in this file must hold on every target. Platform-specific
+//! behavior — actually writing a unit file or invoking systemctl — lives
+//! in `tests/service_linux.rs` (and analogous suites for macOS / Windows
+//! once PRs 4-5 land). The "not yet implemented" assertions for macOS /
+//! Windows are gated to those targets so PR 3's Linux backend doesn't
+//! make them lie.
 
 #![allow(
     clippy::unwrap_used,
@@ -103,19 +104,38 @@ fn install_user_and_system_are_mutually_exclusive() {
 }
 
 #[test]
-fn uninstall_accepts_purge_flag() {
-    // Stub returns NotImplemented (exit 1); the relevant assertion is
-    // that --purge parses cleanly, which the failure mode at exit 1
-    // (vs. a clap parse error at exit 2) confirms.
+fn uninstall_accepts_purge_flag_via_clap() {
+    // Cross-platform check: clap parses `--purge` as a known flag (no
+    // exit-2 parse error). The actual uninstall behavior is asserted
+    // per-platform; here we just confirm the surface accepts the flag
+    // without flagging it as unknown.
     cmd()
-        .args(["uninstall", "--purge"])
+        .args(["uninstall", "--purge", "--help"])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("not yet implemented"));
+        .success()
+        .stdout(predicate::str::contains("--purge"));
 }
 
-// ── Stub error contract ─────────────────────────────────────────────────
+#[test]
+fn install_accepts_dry_run_flag_via_clap() {
+    // Same shape as --purge: assert clap recognizes `--dry-run` rather
+    // than executing the install. The Linux backend exercises the
+    // dry-run end-to-end in tests/service_linux.rs.
+    cmd()
+        .args(["install", "--dry-run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--dry-run"));
+}
 
+// ── Stub error contract (non-Linux only) ────────────────────────────────
+//
+// PR 3 lands the Linux backend, so on Linux these no longer return a
+// "not yet implemented" error. PRs 4 (macOS) and 5 (Windows) replace
+// the stubs on those targets too — the cfg gate auto-deactivates each
+// test as its platform's backend lands.
+
+#[cfg(not(target_os = "linux"))]
 #[test]
 fn install_returns_clean_not_implemented_error() {
     cmd()
@@ -125,6 +145,7 @@ fn install_returns_clean_not_implemented_error() {
         .stderr(predicate::str::contains("not yet implemented"));
 }
 
+#[cfg(not(target_os = "linux"))]
 #[test]
 fn uninstall_returns_clean_not_implemented_error() {
     cmd()
@@ -134,6 +155,7 @@ fn uninstall_returns_clean_not_implemented_error() {
         .stderr(predicate::str::contains("not yet implemented"));
 }
 
+#[cfg(not(target_os = "linux"))]
 #[test]
 fn service_status_returns_clean_not_implemented_error() {
     cmd()

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -25,10 +25,14 @@ const TIMEOUT: Duration = Duration::from_secs(20);
 fn cmd_with_home(home: &TempDir) -> assert_cmd::Command {
     let mut cmd = common::cmd();
     cmd.timeout(TIMEOUT);
-    // Scrub inherited XDG_/HOME so the test is deterministic regardless
-    // of the developer's shell environment, then point at the tempdir.
+    // Scrub inherited environment so the test can't reach the developer's
+    // real systemd user session: XDG_RUNTIME_DIR + DBUS_SESSION_BUS_ADDRESS
+    // are how `systemctl --user` finds the live user-bus, so removing them
+    // makes the (best-effort) disable / daemon-reload calls fail fast in
+    // the tempdir instead of touching the host's running services.
     cmd.env_remove("XDG_CONFIG_HOME");
     cmd.env_remove("XDG_RUNTIME_DIR");
+    cmd.env_remove("DBUS_SESSION_BUS_ADDRESS");
     cmd.env_remove("SUDO_USER");
     cmd.env("HOME", home.path());
     cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
@@ -96,6 +100,8 @@ fn dry_run_install_user_writes_to_xdg_config_home_override() {
     let xdg = TempDir::new().unwrap();
     let mut cmd = common::cmd();
     cmd.timeout(TIMEOUT);
+    cmd.env_remove("XDG_RUNTIME_DIR");
+    cmd.env_remove("DBUS_SESSION_BUS_ADDRESS");
     cmd.env_remove("SUDO_USER");
     cmd.env("HOME", home.path());
     cmd.env("XDG_CONFIG_HOME", xdg.path());
@@ -185,6 +191,41 @@ fn uninstall_purge_removes_kei_state_dir_when_present() {
         !kei_dir.exists(),
         "--purge should remove ~/.config/kei (was at {})",
         kei_dir.display()
+    );
+}
+
+#[test]
+fn uninstall_purge_clears_encrypted_credential_file() {
+    // --purge must wipe stored credentials, not just the on-disk state.
+    // The encrypted-file backend is the only one we can exercise
+    // hermetically: the keyring backend would otherwise dispatch through
+    // libsecret to the dev's real OS keyring. cmd_with_home scrubs
+    // DBUS_SESSION_BUS_ADDRESS specifically so that backend can't reach
+    // anything live, leaving CredentialStore::delete to land its
+    // file-side cleanup inside the tempdir.
+    let home = TempDir::new().unwrap();
+    let kei_dir = home.path().join(".config/kei");
+    std::fs::create_dir_all(&kei_dir).unwrap();
+    std::fs::write(
+        kei_dir.join("config.toml"),
+        "[auth]\nusername = \"kei-purge-test@example.invalid\"\n",
+    )
+    .unwrap();
+    let cred_file = kei_dir.join("credentials.enc");
+    std::fs::write(&cred_file, b"opaque-ciphertext-bytes").unwrap();
+
+    cmd_with_home(&home)
+        .args(["uninstall", "--purge"])
+        .assert()
+        .success();
+
+    assert!(
+        !cred_file.exists(),
+        "--purge should remove the encrypted credential file"
+    );
+    assert!(
+        !kei_dir.exists(),
+        "--purge should also remove the kei state directory"
     );
 }
 

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -1,0 +1,199 @@
+//! Linux-specific integration tests for `kei install` / `kei uninstall`.
+//!
+//! Exercises the unit-file rendering pipeline end-to-end via `--dry-run`,
+//! which writes the systemd unit file but skips the `systemctl` /
+//! `loginctl` side effects. Faithful coverage of the daemon-reload /
+//! enable / linger steps requires an active user session, so those land
+//! in PR 8's per-platform smoke matrix instead of here.
+
+#![cfg(target_os = "linux")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stderr
+)]
+
+mod common;
+
+use predicates::prelude::*;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const TIMEOUT: Duration = Duration::from_secs(20);
+
+fn cmd_with_home(home: &TempDir) -> assert_cmd::Command {
+    let mut cmd = common::cmd();
+    cmd.timeout(TIMEOUT);
+    // Scrub inherited XDG_/HOME so the test is deterministic regardless
+    // of the developer's shell environment, then point at the tempdir.
+    cmd.env_remove("XDG_CONFIG_HOME");
+    cmd.env_remove("XDG_RUNTIME_DIR");
+    cmd.env_remove("SUDO_USER");
+    cmd.env("HOME", home.path());
+    cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
+    cmd
+}
+
+fn user_unit_path(home: &TempDir) -> std::path::PathBuf {
+    home.path().join(".config/systemd/user/kei.service")
+}
+
+#[test]
+fn dry_run_install_user_writes_unit_file_with_expected_keys() {
+    let home = TempDir::new().unwrap();
+    cmd_with_home(&home)
+        .args(["install", "--user", "--dry-run"])
+        .assert()
+        .success();
+
+    let unit = user_unit_path(&home);
+    assert!(unit.exists(), "expected unit at {}", unit.display());
+    let body = std::fs::read_to_string(&unit).unwrap();
+
+    // Spot-check the load-bearing keys; the renderer's full shape is
+    // covered by unit tests in src/service/linux.rs.
+    assert!(body.contains("[Unit]"), "missing [Unit]:\n{body}");
+    assert!(body.contains("[Service]"), "missing [Service]:\n{body}");
+    assert!(body.contains("[Install]"), "missing [Install]:\n{body}");
+    assert!(body.contains("Type=notify"), "missing Type=notify:\n{body}");
+    assert!(
+        body.contains("Description=kei Media Sync Engine"),
+        "missing Description:\n{body}"
+    );
+    assert!(
+        body.contains("WantedBy=default.target"),
+        "missing WantedBy:\n{body}"
+    );
+
+    // ExecStart must point at an absolute path (the actual kei binary
+    // canonicalized by current_executable). Verifying the prefix is
+    // enough — the path itself is environment-dependent.
+    assert!(
+        body.contains("ExecStart=/") && body.contains(" service run --config "),
+        "ExecStart not absolute or missing flags:\n{body}"
+    );
+}
+
+#[test]
+fn dry_run_install_user_is_idempotent() {
+    let home = TempDir::new().unwrap();
+    for _ in 0..2 {
+        cmd_with_home(&home)
+            .args(["install", "--user", "--dry-run"])
+            .assert()
+            .success();
+    }
+    assert!(user_unit_path(&home).exists());
+}
+
+#[test]
+fn dry_run_install_user_writes_to_xdg_config_home_override() {
+    // Ensures we honor XDG_CONFIG_HOME rather than always landing under
+    // $HOME/.config — the systemd convention is XDG-first, and a user
+    // who relocates their config would expect kei to follow.
+    let home = TempDir::new().unwrap();
+    let xdg = TempDir::new().unwrap();
+    let mut cmd = common::cmd();
+    cmd.timeout(TIMEOUT);
+    cmd.env_remove("SUDO_USER");
+    cmd.env("HOME", home.path());
+    cmd.env("XDG_CONFIG_HOME", xdg.path());
+
+    cmd.args(["install", "--user", "--dry-run"])
+        .assert()
+        .success();
+
+    let xdg_unit = xdg.path().join("systemd/user/kei.service");
+    let home_unit = home.path().join(".config/systemd/user/kei.service");
+    assert!(
+        xdg_unit.exists(),
+        "expected unit under XDG_CONFIG_HOME at {}",
+        xdg_unit.display()
+    );
+    assert!(
+        !home_unit.exists(),
+        "must not fall through to $HOME/.config when XDG_CONFIG_HOME is set"
+    );
+}
+
+#[test]
+fn install_system_without_root_fails_clearly() {
+    // CI runs as a non-root user, which is exactly the condition this
+    // test wants to exercise. Skipping when EUID==0 (rare local-dev
+    // case) keeps the assertion meaningful without false negatives.
+    // SAFETY: stateless POSIX FFI call, no memory-safety preconditions.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping non-root assertion: running as root");
+        return;
+    }
+
+    let home = TempDir::new().unwrap();
+    cmd_with_home(&home)
+        .args(["install", "--system", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be run as root"));
+}
+
+#[test]
+fn uninstall_removes_unit_file_after_dry_run_install() {
+    let home = TempDir::new().unwrap();
+    cmd_with_home(&home)
+        .args(["install", "--user", "--dry-run"])
+        .assert()
+        .success();
+    let unit = user_unit_path(&home);
+    assert!(unit.exists(), "precondition: unit file written");
+
+    // Bare `uninstall` (no --purge) should remove the unit file. It
+    // also tries `systemctl --user disable --now`, which is a no-op /
+    // failure in a tempdir-only environment — the function swallows
+    // that and proceeds to delete the file.
+    cmd_with_home(&home).arg("uninstall").assert().success();
+    assert!(!unit.exists(), "uninstall should remove {}", unit.display());
+}
+
+#[test]
+fn uninstall_with_no_unit_files_is_a_clean_no_op() {
+    let home = TempDir::new().unwrap();
+    cmd_with_home(&home).arg("uninstall").assert().success();
+    assert!(!user_unit_path(&home).exists());
+}
+
+#[test]
+fn uninstall_purge_removes_kei_state_dir_when_present() {
+    let home = TempDir::new().unwrap();
+    let kei_dir = home.path().join(".config/kei");
+    std::fs::create_dir_all(&kei_dir).unwrap();
+    std::fs::write(kei_dir.join("config.toml"), "[auth]\n").unwrap();
+    std::fs::write(kei_dir.join("state.db"), b"\x00").unwrap();
+
+    // Install a unit so uninstall has something to do too — but the
+    // assertion is on the purge path.
+    cmd_with_home(&home)
+        .args(["install", "--user", "--dry-run"])
+        .assert()
+        .success();
+
+    cmd_with_home(&home)
+        .args(["uninstall", "--purge"])
+        .assert()
+        .success();
+
+    assert!(
+        !kei_dir.exists(),
+        "--purge should remove ~/.config/kei (was at {})",
+        kei_dir.display()
+    );
+}
+
+#[test]
+fn service_status_with_no_unit_reports_not_installed() {
+    let home = TempDir::new().unwrap();
+    cmd_with_home(&home)
+        .args(["service", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Service: not installed"));
+}


### PR DESCRIPTION
PR 3 of the v0.14 service phase. The CLI surface from #352 now does something on Linux.

## Summary

- `kei install` writes a per-user systemd unit at `${XDG_CONFIG_HOME:-~/.config}/systemd/user/kei.service`, runs `systemctl --user daemon-reload && enable --now`, and best-effort `loginctl enable-linger` (polkit denial logs a warning, install still succeeds).
- `kei install --system` writes `/etc/systemd/system/kei.service` with `User=$SUDO_USER`. Refuses without `EUID=0` rather than calling sudo itself.
- `kei uninstall` removes the unit file and disables it. With `--purge`, also wipes `~/.config/kei/` and clears the OS keyring entry.
- `kei service status` reports `running (systemd user, running since ...)` / `inactive (...)` / `not installed` via `systemctl --user show`. Falls back to `installed (systemd user, bus unavailable)` when there's no active session bus (e.g. SSH without linger).
- Adds `--dry-run` to `InstallArgs`. Renders and writes the unit file but skips the systemctl/loginctl side effects, so users can preview the result and tests can drive the install path end-to-end.

## Design notes

Unit-file rendering is a pure function (`render_user_unit` / `render_system_unit`) so tests can assert key shape without spawning systemd. The orchestrators use `tokio::process::Command` to shell out; their daemon-reload / enable side effects are covered by PR 8's per-platform smoke matrix, since faithful local mocking of `systemctl --user` needs an active user session.

The "not yet implemented" assertions in `tests/service_cli.rs` are now `#[cfg(not(target_os = "linux"))]`. PRs 4 and 5 will auto-deactivate them on macOS / Windows as those backends ship.

## Local smoke

- `kei install --user --dry-run` against tempdir HOME wrote the expected unit file with `Type=notify`, `WatchdogSec=120`, `Restart=on-failure`, `WantedBy=default.target`, and an absolute `ExecStart=` pointing at the real binary.
- `kei install --system --dry-run` from a non-root shell errored with the friendly "must be run as root" message.
- `kei service status` against an empty tempdir HOME reported `Service: not installed`; against an installed unit with no session bus reported `Service: installed (systemd user, bus unavailable)`.
- Full real-systemctl roundtrip against the `icloudpd-test` album: `install --user` -> `systemctl --user is-active` returned `active` (auth resumed from cached session, sd_notify ready fired) -> `kei service status` reported `running` with start timestamp -> `uninstall` -> post-uninstall `is-enabled` returned `not-found` and `is-active` returned `inactive`. Unit file and wantedlink both gone.
- `just gate` clean (2293 lib + 9 service_linux + 7 service_cli + 163 behavioral + 115 cli tests).

## Test plan

- [x] `just gate` (fmt + clippy + lib + cli + behavioral + service_cli + service_linux + doc + audit + typos + roundtrip)
- [x] Dry-run install round-trip in tempdir
- [x] `--system` without root rejected
- [x] Idempotent re-install
- [x] Full `install --user` -> `systemctl --user is-active` -> `uninstall` validated locally; PR 8's CI matrix replays it on a hosted runner
- [ ] macOS launchd backend (PR 4)
- [ ] Windows SCM backend (PR 5)
