### PR TITLE
chore(deps): bump rpassword to 7.5.2 (supersedes #353, #354)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,13 +2226,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -473,6 +473,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "kei"
-version = "0.12.3-dev"
+version = "0.13.4-dev"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1304,6 +1319,7 @@ dependencies = [
  "indicatif",
  "keyring",
  "libc",
+ "memchr",
  "mp4-atom",
  "num-bigint",
  "pbkdf2",
@@ -1326,6 +1342,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -2061,13 +2078,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2445,6 +2462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2759,6 +2782,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps rpassword from 7.4.0 to 7.5.2 in `Cargo.lock` and `fuzz/Cargo.lock`.

Supersedes #353 and #354.

## Why not just merge dependabot's #353

#353 is pinned at 7.5.0, which ships a cross-platform compilation regression that breaks the macOS build. Upstream fixed it in 7.5.1, then landed a Unicode parsing panic fix in 7.5.2. Going straight to 7.5.2 skips the broken intermediate.

#354 only touches `fuzz/Cargo.lock`. This PR covers both lockfiles in one go.

## What 7.5.x lands for us

- CVE-2025-64170 fix (affects 7.4.0 and below)
- More reliable multibyte / control-character handling in the password prompt
- Unicode parsing panic fix (7.5.2)

## Call-site impact

Two call sites, both using `rpassword::prompt_password`:

- `src/password.rs:372`
- `src/commands/password.rs:27`

That signature is unchanged across 7.5.x. Upstream release notes confirm backward compatibility.

## Local smoke

I'm on Linux, so the macOS-specific compile-bug-fix angle is not directly verifiable here. What I can confirm:

- `cargo build` clean with rpassword 7.5.2 resolved on Linux x86_64.
- `just gate` clean (fmt + clippy + lib + cli + behavioral + service_cli + service_linux + service_macos renderer/parser + doc + audit + typos + roundtrip).
- `cargo audit` clean against the new lockfile.

The macOS compile path is covered by CI's `Test (macos-latest)` job, which is the runner #353 would have failed on.

## Test plan

- [x] `just gate` clean
- [x] `cargo build` clean
- [x] `cargo audit` clean (no advisories on 7.5.2)
- [x] CI `Test (macos-latest)` green - the bit #353 couldn't pass
- [x] CI `Test (windows-latest)` green
- [x] CI `Test (ubuntu-latest)` green
