### PR TITLE
feat: Windows SCM backend for kei install / uninstall / service status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "windows-service",
  "wiremock",
  "xmp_toolkit",
 ]
@@ -3328,6 +3329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "windows-service",
+ "windows-sys 0.52.0",
  "wiremock",
  "xmp_toolkit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ keyring = { version = "3", features = ["sync-secret-service"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+windows-service = "0.7"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,10 @@ keyring = { version = "3", features = ["sync-secret-service"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
 windows-service = "0.7"
+# Used only for the named ERROR_* constants returned by windows-service
+# error variants (1060, 1063). 0.52 matches the version windows-service
+# 0.7 already brings in transitively, so no extra version in the build.
+windows-sys = { version = "0.52", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ _default:
 gate:
     cargo fmt --all --check
     cargo clippy --all-targets --all-features -- -D warnings
-    cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos
+    cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows
     RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps --all-features
     cargo fetch --locked
     cargo audit --deny warnings
@@ -41,7 +41,7 @@ test MODE="":
             cargo test --all-features
             ;;
         fast)
-            cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos
+            cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows
             ;;
         live)
             _live_env

--- a/src/config.rs
+++ b/src/config.rs
@@ -948,7 +948,7 @@ pub(crate) fn resolve_path_derivation_fields(
 ///
 /// Bundles the fields that moved from per-command `AuthArgs` to
 /// global options on `Cli`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct GlobalArgs {
     pub username: Option<String>,
     pub domain: Option<Domain>,

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -149,6 +149,18 @@ pub(crate) fn purge_kei_state(kei_dir: &Path, extra_dirs: &[PathBuf]) -> Result<
     }
 }
 
+/// kei state directory at the dotted-config convention.
+///
+/// macOS and Windows both bypass `dirs::config_dir()` (which returns
+/// `~/Library/Application Support` and `%APPDATA%\Roaming` respectively)
+/// so the data dir matches the rest of the codebase, where
+/// `~/.config/kei` is hard-coded in `setup.rs` and `migration.rs`.
+/// Linux honours XDG via `dirs::config_dir().join("kei")` and resolves
+/// its own path -- this helper is for the platforms that don't.
+pub(crate) fn kei_state_dir_dotted() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".config/kei"))
+}
+
 /// Canonical absolute path to the running `kei` executable.
 ///
 /// Service unit files / launchd plists / SCM entries reference an

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -83,7 +83,7 @@ pub(crate) fn is_in_container_at(dockerenv: &Path, cgroup: &Path) -> bool {
 ///
 /// Centralises the one `unsafe` block per backend that wraps
 /// `libc::geteuid` so each platform module doesn't carry its own copy
-/// with a duplicated SAFETY comment. POSIX-only — Windows uses access
+/// with a duplicated SAFETY comment. POSIX-only -- Windows uses access
 /// tokens rather than UIDs, and the linux + macOS service backends are
 /// the only callers.
 #[cfg(unix)]
@@ -97,11 +97,9 @@ pub(crate) fn effective_uid() -> u32 {
 /// Reads `auth.username` out of `kei_dir/config.toml`.
 ///
 /// Returns `None` when the file is missing, malformed, or has no
-/// non-empty username — `--purge` callers treat any of those as "no
-/// credential to clear" and proceed. `cfg(unix)` until the Windows SCM
-/// backend (PR 5) wires up `kei uninstall --purge`; the function itself
-/// uses no unix-only APIs.
-#[cfg(unix)]
+/// non-empty username -- `--purge` callers treat any of those as "no
+/// credential to clear" and proceed. Cross-platform: Linux + macOS +
+/// Windows backends all share this helper.
 pub(crate) fn read_config_username(kei_dir: &Path) -> Option<String> {
     let config_path = kei_dir.join("config.toml");
     let toml = crate::config::load_toml_config(&config_path, false).ok()??;
@@ -111,10 +109,8 @@ pub(crate) fn read_config_username(kei_dir: &Path) -> Option<String> {
 /// Wipes `kei_dir` plus any platform-specific extras after clearing the
 /// stored credential. Each platform's `--purge` path resolves the kei
 /// state directory however it wants (linux honours `XDG_CONFIG_HOME`;
-/// macOS hard-codes `~/.config/kei` rather than `~/Library/Application
-/// Support`) and passes the resolved path here. Same `cfg(unix)` story
-/// as [`read_config_username`].
-#[cfg(unix)]
+/// macOS and Windows hard-code `~/.config/kei` rather than the platform
+/// default config dir) and passes the resolved path here.
 pub(crate) fn purge_kei_state(kei_dir: &Path, extra_dirs: &[PathBuf]) -> Result<()> {
     if let Some(username) = read_config_username(kei_dir) {
         let store = crate::credential::CredentialStore::new(&username, kei_dir);

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -1,9 +1,8 @@
 //! `kei install` dispatcher.
 //!
-//! Routes to a per-platform backend (launchd on macOS, systemd on Linux,
+//! Routes to a per-platform backend (systemd on Linux, launchd on macOS,
 //! Windows SCM on Windows) that registers kei to start at boot and run
-//! continuously. Linux and macOS are wired up; Windows currently returns
-//! a clean "not yet implemented" error.
+//! continuously.
 //!
 //! Inside containers the command short-circuits: Docker / Kubernetes /
 //! Podman supervise the process themselves, and writing a launchd plist
@@ -49,7 +48,17 @@ async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(target_os = "windows")]
+async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+    use crate::service::windows;
+    if args.system {
+        windows::install_system(&args, config_path).await
+    } else {
+        windows::install_user(&args, config_path).await
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
     use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
     let exe = current_executable()?;
@@ -64,7 +73,6 @@ async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
         "preparing to install kei service",
     );
     Err(anyhow::anyhow!(
-        "`kei install` is not yet implemented on this platform; \
-         the Windows SCM backend is still in flight"
+        "`kei install` is not implemented on this platform"
     ))
 }

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -126,12 +126,11 @@ fn user_log_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(LOG_SUBDIR))
 }
 
-/// kei state directory on macOS: `~/.config/kei`, matching linux. This
-/// deliberately does *not* use `dirs::config_dir()` because that resolves
-/// to `~/Library/Application Support` on macOS, which conflicts with the
-/// rest of the codebase (config.rs / setup.rs hard-code the dotted path).
+/// kei state directory on macOS: `~/.config/kei`, matching linux. Just
+/// re-exports `env::kei_state_dir_dotted` so the macOS uninstall path
+/// reads the same way the Windows one does.
 fn kei_state_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".config/kei"))
+    crate::service::env::kei_state_dir_dotted()
 }
 
 pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,9 +4,8 @@
 //! Cross-platform plumbing (container detection, branding constants,
 //! executable canonicalization) lives in `env`. The four dispatchers
 //! (`install`, `uninstall`, `run`, `status`) route through
-//! `cfg(target_os = ...)` to per-platform backends. Linux and macOS
-//! dispatch to `linux` and `macos`; Windows currently returns a clean
-//! "not yet implemented" error until the SCM backend ships.
+//! `cfg(target_os = ...)` to per-platform backends -- linux, macos, or
+//! windows.
 
 pub(crate) mod env;
 pub(crate) mod install;
@@ -17,13 +16,21 @@ pub(crate) mod uninstall;
 #[cfg(target_os = "linux")]
 pub(crate) mod linux;
 
-// Compiled on every unix target (linux + macOS) — the renderer + parser
+// Compiled on every unix target (linux + macOS) -- the renderer + parser
 // are pure and their inline unit tests pick up regressions on linux CI
 // before macos-latest ever sees them. Windows is excluded because
 // `effective_uid` (POSIX `geteuid`) and `tokio::process::Command` calls
 // to `launchctl` have no analogue there. Only the `kei install` /
 // `kei uninstall` / `kei service status` dispatchers are runtime-gated
-// to macOS — see install.rs / uninstall.rs / status.rs.
+// to macOS -- see install.rs / uninstall.rs / status.rs.
 #[cfg(unix)]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) mod macos;
+
+// Compiled on every target -- pure renderer / formatter helpers carry
+// inline unit tests that run on linux + macOS, and only the
+// windows-service FFI surface is `#[cfg(target_os = "windows")]`-gated
+// inside the module. As with macos, the dispatchers in install.rs /
+// uninstall.rs / status.rs / run.rs runtime-gate to Windows targets.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) mod windows;

--- a/src/service/run.rs
+++ b/src/service/run.rs
@@ -10,6 +10,11 @@
 //! - The canonical executable path is logged on entry. Service files
 //!   reference an absolute exec path; surfacing it in the log lets
 //!   operators confirm the registered binary is the one running.
+//! - On Windows the entry double-dispatches: SCM-launched invocations
+//!   route through [`crate::service::windows::run_under_scm_or_foreground`]
+//!   so `StartServiceCtrlDispatcher` fires within the 30s SCM watchdog;
+//!   foreground invocations fall through to the same `sync_loop::run_sync`
+//!   path other platforms use.
 
 use anyhow::Result;
 
@@ -24,5 +29,12 @@ pub(crate) async fn run(globals: &config::GlobalArgs, args: sync_loop::SyncArgs)
         executable = %exe.display(),
         "starting kei service worker",
     );
+
+    #[cfg(target_os = "windows")]
+    {
+        return crate::service::windows::run_under_scm_or_foreground(globals.clone(), args).await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
     sync_loop::run_sync(globals, args).await
 }

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -22,10 +22,14 @@ async fn dispatch() -> Result<()> {
     crate::service::macos::status().await
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(target_os = "windows")]
+async fn dispatch() -> Result<()> {
+    crate::service::windows::status().await
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 async fn dispatch() -> Result<()> {
     Err(anyhow::anyhow!(
-        "`kei service status` is not yet implemented on this platform; \
-         the Windows SCM backend is still in flight"
+        "`kei service status` is not implemented on this platform"
     ))
 }

--- a/src/service/uninstall.rs
+++ b/src/service/uninstall.rs
@@ -32,7 +32,12 @@ async fn dispatch(args: UninstallArgs) -> Result<()> {
     crate::service::macos::uninstall(&args).await
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(target_os = "windows")]
+async fn dispatch(args: UninstallArgs) -> Result<()> {
+    crate::service::windows::uninstall(&args).await
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 async fn dispatch(args: UninstallArgs) -> Result<()> {
     use crate::service::env::SERVICE_IDENTIFIER;
     tracing::info!(
@@ -41,7 +46,6 @@ async fn dispatch(args: UninstallArgs) -> Result<()> {
         "preparing to uninstall kei service",
     );
     Err(anyhow::anyhow!(
-        "`kei uninstall` is not yet implemented on this platform; \
-         the Windows SCM backend is still in flight"
+        "`kei uninstall` is not implemented on this platform"
     ))
 }

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -7,23 +7,17 @@
 //! login password via rpassword and pass it to `CreateServiceW` as the
 //! LSA secret; SCM launches the daemon under that user's profile so the
 //! Credential Manager vault and `~/.config/kei` data dir match the
-//! interactive login. Same convention as the macOS / linux backends.
+//! interactive login.
 //!
-//! Domain users / roaming profiles are documented as a v0.14 limitation
-//! (the `.\<user>` LSA-secret form covers local-machine accounts only).
+//! Domain-user / roaming-profile accounts are out of scope: the
+//! `.\<user>` LSA-secret form covers local-machine accounts only.
 //!
-//! `kei service run` on Windows does double duty: when SCM launches the
-//! binary it must call `StartServiceCtrlDispatcher` within 30s or SCM
-//! kills the process. [`run_under_scm_or_foreground`] tries the
+//! `kei service run` on Windows double-dispatches: when SCM launches
+//! the binary, `StartServiceCtrlDispatcher` must be called within 30s
+//! or SCM kills the process. [`run_under_scm_or_foreground`] tries the
 //! dispatcher first; on `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` it
 //! falls through to a foreground sync-loop run for `kei service run`
 //! invoked from a terminal.
-//!
-//! The PR 8 smoke matrix is what exercises a full install -> stop ->
-//! uninstall round-trip on a real Windows runner. Locally on linux/macOS
-//! only the renderer + status-formatter helpers compile and run; those
-//! carry inline unit tests so a regression in their shape is caught
-//! before the windows-latest job ever sees the change.
 
 #![allow(
     clippy::print_stdout,
@@ -38,7 +32,8 @@ use anyhow::{anyhow, bail, Context, Result};
 
 use crate::cli::{InstallArgs, UninstallArgs};
 use crate::service::env::{
-    current_executable, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
+    current_executable, kei_state_dir_dotted, purge_kei_state, SERVICE_DESCRIPTION,
+    SERVICE_IDENTIFIER,
 };
 
 /// SCM service name (matches `SERVICE_IDENTIFIER` so `sc.exe query
@@ -48,14 +43,11 @@ pub(crate) const SERVICE_NAME: &str = SERVICE_IDENTIFIER;
 /// Restart-on-failure cadence applied via `ChangeServiceConfig2W`.
 const RESTART_DELAY: Duration = Duration::from_secs(10);
 
+/// Number of times SCM should restart kei after a crash before giving up.
+const RESTART_COUNT: usize = 3;
+
 /// Window over which SCM counts crashes against the failure action list.
 const FAILURE_RESET_PERIOD: Duration = Duration::from_secs(86_400);
-
-/// Subdirectory used everywhere: linux honours XDG, macOS hard-codes
-/// `~/.config/kei`, Windows mirrors macOS so the operator sees a
-/// consistent path across platforms (and so `kei uninstall --purge`
-/// removes the same tree `kei sync` populated).
-const KEI_STATE_SUBDIR: &str = ".config/kei";
 
 // ── Public surface ──────────────────────────────────────────────────────
 
@@ -101,11 +93,10 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
     Ok(())
 }
 
-/// `--system` is rejected here for the same reason as macOS: a true
-/// system-wide install would mean LocalSystem (no user keyring) or a
-/// virtual `NT SERVICE\kei` account (no Credential Manager). Both
-/// would break the cross-platform "credentials follow the operator"
-/// promise from the v0.14 phase-1 plan.
+/// `--system` is rejected: a system-wide install would mean LocalSystem
+/// (no user keyring) or a virtual `NT SERVICE\kei` account (no
+/// Credential Manager). Both break the "credentials follow the
+/// operator" contract the per-user form provides.
 pub(crate) async fn install_system(_args: &InstallArgs, _config_path: &Path) -> Result<()> {
     bail!(
         "`kei install --system` is not supported on Windows; \
@@ -203,12 +194,42 @@ fn render_service_info_preview(inputs: &ServiceInfoInputs<'_>) -> String {
          Service type        : OWN_PROCESS\n\
          Start type          : AUTO_START\n\
          Error control       : NORMAL\n\
-         Failure actions     : restart x3, delay {delay}s, reset after {reset}s\n\
+         Failure actions     : restart x{count}, delay {delay}s, reset after {reset}s\n\
          Binary path         : {argv}",
         account = inputs.account_name(),
+        count = RESTART_COUNT,
         delay = RESTART_DELAY.as_secs(),
         reset = FAILURE_RESET_PERIOD.as_secs(),
     )
+}
+
+/// Mirror of `windows_service::service::ServiceState` that compiles on
+/// every target. The runtime arm in `scm_impl` maps the windows-service
+/// enum into this view so the renderer + its tests stay reachable from
+/// linux/macOS hosts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ServiceStateView {
+    Running,
+    Stopped,
+    StartPending,
+    StopPending,
+    ContinuePending,
+    PausePending,
+    Paused,
+}
+
+impl ServiceStateView {
+    fn label(self) -> &'static str {
+        match self {
+            ServiceStateView::Running => "running",
+            ServiceStateView::Stopped => "stopped",
+            ServiceStateView::StartPending => "start-pending",
+            ServiceStateView::StopPending => "stop-pending",
+            ServiceStateView::ContinuePending => "continue-pending",
+            ServiceStateView::PausePending => "pause-pending",
+            ServiceStateView::Paused => "paused",
+        }
+    }
 }
 
 /// Inputs the status renderer accepts. Decoupled from the
@@ -219,7 +240,7 @@ enum StatusInputs {
     NotInstalled,
     ScmUnavailable,
     Probed {
-        state: &'static str,
+        state: ServiceStateView,
         pid: Option<u32>,
     },
 }
@@ -227,17 +248,21 @@ enum StatusInputs {
 fn render_status(inputs: StatusInputs) -> String {
     match inputs {
         StatusInputs::NotInstalled => "Service: not installed".to_string(),
+        // SCM is unavailable when called from a non-elevated shell or
+        // (rare) when the Service Control Manager itself is down.
+        // Surface the cause; "not installed" would lie.
         StatusInputs::ScmUnavailable => {
-            // SCM is unavailable when called from a non-elevated shell or
-            // (rare) when the Service Control Manager itself is down.
-            // Either way, surface the cause; "not installed" would lie.
             "Service: SCM unavailable (run from an elevated PowerShell to query state)".to_string()
         }
-        StatusInputs::Probed { state, pid } => match (state, pid) {
-            ("running", Some(pid)) => format!("Service: running (windows scm, pid {pid})"),
-            ("running", None) => "Service: running (windows scm)".to_string(),
-            (state, _) => format!("Service: {state} (windows scm)"),
-        },
+        StatusInputs::Probed {
+            state: ServiceStateView::Running,
+            pid: Some(pid),
+        } => format!("Service: running (windows scm, pid {pid})"),
+        StatusInputs::Probed {
+            state: ServiceStateView::Running,
+            pid: None,
+        } => "Service: running (windows scm)".to_string(),
+        StatusInputs::Probed { state, .. } => format!("Service: {} (windows scm)", state.label()),
     }
 }
 
@@ -257,7 +282,7 @@ fn current_user_name() -> Option<String> {
 }
 
 fn kei_state_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(KEI_STATE_SUBDIR))
+    kei_state_dir_dotted()
 }
 
 fn prompt_windows_password(user: &str) -> Result<String> {
@@ -278,7 +303,7 @@ fn prompt_windows_password(user: &str) -> Result<String> {
 #[cfg(target_os = "windows")]
 mod scm_impl {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::Mutex;
     use windows_service::{
         define_windows_service,
         service::{
@@ -290,75 +315,77 @@ mod scm_impl {
         service_dispatcher,
         service_manager::{ServiceManager, ServiceManagerAccess},
     };
-
-    /// 1060 = ERROR_SERVICE_DOES_NOT_EXIST.
-    const WINAPI_SERVICE_DOES_NOT_EXIST: i32 = 1060;
-    /// 1063 = ERROR_FAILED_SERVICE_CONTROLLER_CONNECT — what
-    /// `StartServiceCtrlDispatcher` returns when the binary is run from a
-    /// terminal instead of by SCM.
-    const WINAPI_NOT_RUNNING_AS_SERVICE: i32 = 1063;
+    use windows_sys::Win32::Foundation::{
+        ERROR_FAILED_SERVICE_CONTROLLER_CONNECT, ERROR_SERVICE_DOES_NOT_EXIST,
+    };
 
     /// Bridge between the async caller in `service::run::run` and the
     /// SCM service-main callback that runs on a thread spawned by the
     /// windows-service dispatcher. The OS thread that `kei_service_main`
     /// runs on cannot capture our async-context payload by closure (the
     /// callback signature is fixed by the FFI contract), so we stash it
-    /// in this static, take it inside the callback, and the foreground
-    /// fall-through path takes it back when the dispatcher refuses.
-    static SCM_PAYLOAD: OnceLock<Mutex<Option<ScmPayload>>> = OnceLock::new();
+    /// here, the callback takes it, and the foreground fall-through
+    /// path takes it back when the dispatcher refuses.
+    static SCM_PAYLOAD: Mutex<Option<ScmPayload>> = Mutex::new(None);
 
-    /// Channel sender published by the service-main thread once it has
-    /// registered its event handler. The SCM stop event is delivered on
-    /// a separate OS thread, so the handler signals shutdown by sending
-    /// on this channel which the sync-loop runtime observes via select!.
-    static SCM_SHUTDOWN_TX: OnceLock<Mutex<Option<tokio::sync::oneshot::Sender<()>>>> =
-        OnceLock::new();
+    /// SCM stop is delivered on a thread separate from the one running
+    /// `service_main_inner`; the handler signals shutdown by sending
+    /// on this oneshot which the sync-loop runtime observes via select!.
+    static SCM_SHUTDOWN_TX: Mutex<Option<tokio::sync::oneshot::Sender<()>>> = Mutex::new(None);
 
     struct ScmPayload {
         globals: crate::config::GlobalArgs,
         sync: crate::sync_loop::SyncArgs,
     }
 
-    fn payload_slot() -> &'static Mutex<Option<ScmPayload>> {
-        SCM_PAYLOAD.get_or_init(|| Mutex::new(None))
+    /// Owned form of [`ServiceInfoInputs`] -- crosses the spawn_blocking
+    /// boundary, so cannot borrow from the async caller.
+    struct OwnedServiceInfoInputs {
+        exec: PathBuf,
+        config: PathBuf,
+        account_user: String,
     }
 
-    fn shutdown_slot() -> &'static Mutex<Option<tokio::sync::oneshot::Sender<()>>> {
-        SCM_SHUTDOWN_TX.get_or_init(|| Mutex::new(None))
+    impl OwnedServiceInfoInputs {
+        fn as_borrowed(&self) -> ServiceInfoInputs<'_> {
+            ServiceInfoInputs {
+                exec: &self.exec,
+                config: &self.config,
+                account_user: &self.account_user,
+            }
+        }
+    }
+
+    fn raw_os_error(e: &windows_service::Error) -> Option<u32> {
+        match e {
+            windows_service::Error::Winapi(io) => io.raw_os_error().map(|n| n as u32),
+            _ => None,
+        }
     }
 
     pub(super) async fn install(inputs: &ServiceInfoInputs<'_>, password: &str) -> Result<()> {
-        let exec = inputs.exec.to_path_buf();
-        let config = inputs.config.to_path_buf();
-        let account_user = inputs.account_user.to_string();
+        let owned = OwnedServiceInfoInputs {
+            exec: inputs.exec.to_path_buf(),
+            config: inputs.config.to_path_buf(),
+            account_user: inputs.account_user.to_string(),
+        };
         let password = password.to_owned();
-        tokio::task::spawn_blocking(move || {
-            install_blocking(&exec, &config, &account_user, &password)
-        })
-        .await
-        .context("install task panicked")?
+        tokio::task::spawn_blocking(move || install_blocking(&owned, &password))
+            .await
+            .context("install task panicked")?
     }
 
-    fn install_blocking(
-        exec: &Path,
-        config: &Path,
-        account_user: &str,
-        password: &str,
-    ) -> Result<()> {
+    fn install_blocking(owned: &OwnedServiceInfoInputs, password: &str) -> Result<()> {
         let manager =
             open_manager(ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE)?;
-        let inputs = ServiceInfoInputs {
-            exec,
-            config,
-            account_user,
-        };
+        let inputs = owned.as_borrowed();
         let info = ServiceInfo {
             name: OsString::from(SERVICE_NAME),
             display_name: OsString::from(SERVICE_DESCRIPTION),
             service_type: ServiceType::OWN_PROCESS,
             start_type: ServiceStartType::AutoStart,
             error_control: ServiceErrorControl::Normal,
-            executable_path: exec.to_path_buf(),
+            executable_path: owned.exec.clone(),
             launch_arguments: inputs.launch_arguments(),
             dependencies: Vec::new(),
             account_name: Some(OsString::from(inputs.account_name())),
@@ -383,7 +410,7 @@ mod scm_impl {
                         action_type: ServiceActionType::Restart,
                         delay: RESTART_DELAY,
                     };
-                    3
+                    RESTART_COUNT
                 ]),
             })
             .context("ChangeServiceConfig2W (failure actions) failed")?;
@@ -403,9 +430,7 @@ mod scm_impl {
         let access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
         let service = match manager.open_service(SERVICE_NAME, access) {
             Ok(s) => s,
-            Err(windows_service::Error::Winapi(ref e))
-                if e.raw_os_error() == Some(WINAPI_SERVICE_DOES_NOT_EXIST) =>
-            {
+            Err(ref e) if raw_os_error(e) == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {
                 return Ok(false);
             }
             Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
@@ -445,9 +470,7 @@ mod scm_impl {
         };
         let service = match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
             Ok(s) => s,
-            Err(windows_service::Error::Winapi(ref e))
-                if e.raw_os_error() == Some(WINAPI_SERVICE_DOES_NOT_EXIST) =>
-            {
+            Err(ref e) if raw_os_error(e) == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {
                 return Ok(StatusInputs::NotInstalled);
             }
             Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
@@ -456,7 +479,7 @@ mod scm_impl {
             .query_status()
             .context("QueryServiceStatusEx failed")?;
         Ok(StatusInputs::Probed {
-            state: scm_state_label(status.current_state),
+            state: service_state_view(status.current_state),
             pid: status.process_id,
         })
     }
@@ -468,15 +491,15 @@ mod scm_impl {
         )
     }
 
-    fn scm_state_label(state: ServiceState) -> &'static str {
+    fn service_state_view(state: ServiceState) -> ServiceStateView {
         match state {
-            ServiceState::Running => "running",
-            ServiceState::Stopped => "stopped",
-            ServiceState::StartPending => "start-pending",
-            ServiceState::StopPending => "stop-pending",
-            ServiceState::ContinuePending => "continue-pending",
-            ServiceState::PausePending => "pause-pending",
-            ServiceState::Paused => "paused",
+            ServiceState::Running => ServiceStateView::Running,
+            ServiceState::Stopped => ServiceStateView::Stopped,
+            ServiceState::StartPending => ServiceStateView::StartPending,
+            ServiceState::StopPending => ServiceStateView::StopPending,
+            ServiceState::ContinuePending => ServiceStateView::ContinuePending,
+            ServiceState::PausePending => ServiceStateView::PausePending,
+            ServiceState::Paused => ServiceStateView::Paused,
         }
     }
 
@@ -488,10 +511,9 @@ mod scm_impl {
         globals: crate::config::GlobalArgs,
         sync: crate::sync_loop::SyncArgs,
     ) -> Result<()> {
-        // Stash payload so the SCM-spawned service-main thread can take
-        // it; this happens *before* the dispatcher attempt so the OS
-        // thread can never observe an empty slot.
-        *payload_slot().lock().unwrap() = Some(ScmPayload { globals, sync });
+        // Stash payload before the dispatcher attempt so the SCM-spawned
+        // service-main thread cannot observe an empty slot.
+        *SCM_PAYLOAD.lock().unwrap() = Some(ScmPayload { globals, sync });
 
         let dispatcher_result = tokio::task::spawn_blocking(|| {
             service_dispatcher::start(SERVICE_NAME, ffi_service_main)
@@ -501,22 +523,16 @@ mod scm_impl {
 
         match dispatcher_result {
             Ok(()) => {
-                // SCM took over and the service ran to completion.
                 tracing::info!(service = SERVICE_NAME, "SCM-managed service exited cleanly");
                 Ok(())
             }
-            Err(windows_service::Error::Winapi(ref e))
-                if e.raw_os_error() == Some(WINAPI_NOT_RUNNING_AS_SERVICE) =>
-            {
-                // Foreground invocation -- e.g. operator running
-                // `kei service run` from PowerShell. Recover the
-                // payload and run the sync loop directly.
+            Err(ref e) if raw_os_error(e) == Some(ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) => {
                 tracing::info!(
                     service = SERVICE_NAME,
                     "kei service run invoked outside SCM; running in foreground"
                 );
                 let payload =
-                    payload_slot().lock().unwrap().take().ok_or_else(|| {
+                    SCM_PAYLOAD.lock().unwrap().take().ok_or_else(|| {
                         anyhow!("internal: SCM payload missing on foreground path")
                     })?;
                 crate::sync_loop::run_sync(&payload.globals, payload.sync).await
@@ -533,12 +549,12 @@ mod scm_impl {
 
     fn service_main_inner() -> Result<()> {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-        *shutdown_slot().lock().unwrap() = Some(shutdown_tx);
+        *SCM_SHUTDOWN_TX.lock().unwrap() = Some(shutdown_tx);
 
         let event_handler = move |control_event| -> ServiceControlHandlerResult {
             match control_event {
                 ServiceControl::Stop | ServiceControl::Shutdown => {
-                    if let Some(tx) = shutdown_slot().lock().unwrap().take() {
+                    if let Some(tx) = SCM_SHUTDOWN_TX.lock().unwrap().take() {
                         let _ = tx.send(());
                     }
                     ServiceControlHandlerResult::NoError
@@ -552,33 +568,34 @@ mod scm_impl {
             .context("RegisterServiceCtrlHandlerExW failed")?;
 
         status_handle
-            .set_service_status(running_status())
+            .set_service_status(service_status(ServiceState::Running, 0))
             .context("set_service_status(running) failed")?;
 
         let outcome = run_payload_under_scm(shutdown_rx);
 
         // Always report Stopped, even on error -- otherwise SCM keeps
-        // the service in StartPending until the wait_hint elapses and
-        // then force-kills the process, which is a worse signal than a
-        // clean stop with a non-zero exit code.
-        let report_result = status_handle.set_service_status(stopped_status(outcome.is_ok()));
-        if let Err(e) = report_result {
+        // the service in StartPending until wait_hint elapses and then
+        // force-kills the process, which is a worse signal than a clean
+        // stop with a non-zero exit code.
+        let exit_code = if outcome.is_ok() { 0 } else { 1 };
+        let report =
+            status_handle.set_service_status(service_status(ServiceState::Stopped, exit_code));
+        if let Err(e) = report {
             tracing::error!(error = %e, "failed to report Stopped to SCM");
         }
         outcome
     }
 
     fn run_payload_under_scm(mut shutdown_rx: tokio::sync::oneshot::Receiver<()>) -> Result<()> {
-        let payload = payload_slot()
+        let payload = SCM_PAYLOAD
             .lock()
             .unwrap()
             .take()
             .ok_or_else(|| anyhow!("kei service main started without a stashed payload"))?;
 
         // Dedicated single-thread runtime for the sync loop. Lives on
-        // this OS thread (the one SCM spawned for service main); the
-        // foreground caller's runtime, if any, is on a different thread
-        // and unaffected.
+        // the OS thread SCM spawned for service main; the foreground
+        // caller's runtime, if any, is on a different thread.
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -595,24 +612,21 @@ mod scm_impl {
         })
     }
 
-    fn running_status() -> ServiceStatus {
+    /// Builds a `ServiceStatus` for the two states this backend reports.
+    /// `Running` accepts STOP/SHUTDOWN; `Stopped` accepts nothing and
+    /// carries the exit code. Other states (StartPending, etc.) would
+    /// need additional shape (`checkpoint`, `wait_hint`) so they are
+    /// not built here.
+    fn service_status(state: ServiceState, exit_code: u32) -> ServiceStatus {
+        let controls_accepted = match state {
+            ServiceState::Running => ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+            _ => ServiceControlAccept::empty(),
+        };
         ServiceStatus {
             service_type: ServiceType::OWN_PROCESS,
-            current_state: ServiceState::Running,
-            controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
-            exit_code: ServiceExitCode::Win32(0),
-            checkpoint: 0,
-            wait_hint: Duration::default(),
-            process_id: None,
-        }
-    }
-
-    fn stopped_status(success: bool) -> ServiceStatus {
-        ServiceStatus {
-            service_type: ServiceType::OWN_PROCESS,
-            current_state: ServiceState::Stopped,
-            controls_accepted: ServiceControlAccept::empty(),
-            exit_code: ServiceExitCode::Win32(if success { 0 } else { 1 }),
+            current_state: state,
+            controls_accepted,
+            exit_code: ServiceExitCode::Win32(exit_code),
             checkpoint: 0,
             wait_hint: Duration::default(),
             process_id: None,
@@ -632,11 +646,17 @@ mod scm_impl {
     }
 
     pub(super) async fn uninstall_existing() -> Result<bool> {
-        Ok(false)
+        bail!(
+            "internal error: Windows uninstall path reached on a non-Windows target; \
+             this is a build configuration bug"
+        )
     }
 
     pub(super) async fn probe() -> Result<StatusInputs> {
-        Ok(StatusInputs::NotInstalled)
+        bail!(
+            "internal error: Windows status path reached on a non-Windows target; \
+             this is a build configuration bug"
+        )
     }
 }
 
@@ -651,21 +671,32 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn sample_inputs() -> ServiceInfoInputs<'static> {
-        static EXE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-        static CFG: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-        let exe = EXE.get_or_init(|| PathBuf::from(r"C:\Program Files\kei\kei.exe"));
-        let cfg = CFG.get_or_init(|| PathBuf::from(r"C:\Users\Alice\.config\kei\config.toml"));
-        ServiceInfoInputs {
-            exec: exe.as_path(),
-            config: cfg.as_path(),
-            account_user: "Alice",
+    struct SampleFixture {
+        exe: PathBuf,
+        cfg: PathBuf,
+    }
+
+    impl SampleFixture {
+        fn new() -> Self {
+            Self {
+                exe: PathBuf::from(r"C:\Program Files\kei\kei.exe"),
+                cfg: PathBuf::from(r"C:\Users\Alice\.config\kei\config.toml"),
+            }
+        }
+
+        fn inputs(&self) -> ServiceInfoInputs<'_> {
+            ServiceInfoInputs {
+                exec: &self.exe,
+                config: &self.cfg,
+                account_user: "Alice",
+            }
         }
     }
 
     #[test]
     fn launch_arguments_pass_service_run_with_config() {
-        let argv = sample_inputs().launch_arguments();
+        let fixture = SampleFixture::new();
+        let argv = fixture.inputs().launch_arguments();
         let strs: Vec<String> = argv
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
@@ -678,20 +709,20 @@ mod tests {
 
     #[test]
     fn account_name_uses_local_machine_prefix() {
-        // `.\Alice` is the SCM "local machine, account Alice" form.
-        // Domain users (`DOMAIN\Alice`) are out of scope for v0.14.
-        assert_eq!(sample_inputs().account_name(), r".\Alice");
+        // `.\Alice` is the SCM "local machine, account Alice" form;
+        // domain accounts (`DOMAIN\Alice`) are out of scope.
+        let fixture = SampleFixture::new();
+        assert_eq!(fixture.inputs().account_name(), r".\Alice");
     }
 
     #[test]
     fn render_service_info_preview_lists_every_field() {
         // SERVICE_NAME / SERVICE_DESCRIPTION are platform-resolved
         // constants -- on linux SERVICE_IDENTIFIER is "kei", on
-        // macOS/Windows it is "com.rhoopr.kei". Reference the constant
-        // in the assertion so the test passes on every host that runs
-        // it (linux + macOS + windows; the Windows-resolved string is
-        // what the smoke matrix verifies against `sc.exe qc`).
-        let preview = render_service_info_preview(&sample_inputs());
+        // macOS/Windows it is "com.rhoopr.kei". Reference the constants
+        // in the assertion so the test passes on every host.
+        let fixture = SampleFixture::new();
+        let preview = render_service_info_preview(&fixture.inputs());
         for needle in [
             format!("Service name        : {SERVICE_NAME}"),
             format!("Display name        : {SERVICE_DESCRIPTION}"),
@@ -700,7 +731,11 @@ mod tests {
             "Service type        : OWN_PROCESS".to_string(),
             "Start type          : AUTO_START".to_string(),
             "Error control       : NORMAL".to_string(),
-            "Failure actions     : restart x3, delay 10s, reset after 86400s".to_string(),
+            format!(
+                "Failure actions     : restart x{RESTART_COUNT}, delay {}s, reset after {}s",
+                RESTART_DELAY.as_secs(),
+                FAILURE_RESET_PERIOD.as_secs(),
+            ),
             r"Binary path         : C:\Program Files\kei\kei.exe service run --config C:\Users\Alice\.config\kei\config.toml".to_string(),
         ] {
             assert!(
@@ -723,14 +758,14 @@ mod tests {
         let line = render_status(StatusInputs::ScmUnavailable);
         assert!(line.starts_with("Service: SCM unavailable"));
         // Operator hint about elevation belongs in the same line so a
-        // tail -f / log-collector picks it up alongside the verdict.
+        // tail -f / log collector picks it up alongside the verdict.
         assert!(line.contains("elevated PowerShell"));
     }
 
     #[test]
     fn render_status_includes_pid_when_running() {
         let line = render_status(StatusInputs::Probed {
-            state: "running",
+            state: ServiceStateView::Running,
             pid: Some(4321),
         });
         assert_eq!(line, "Service: running (windows scm, pid 4321)");
@@ -742,7 +777,7 @@ mod tests {
         // start-pending -> running transition; we should not lose the
         // "running" verdict just because the pid was racing.
         let line = render_status(StatusInputs::Probed {
-            state: "running",
+            state: ServiceStateView::Running,
             pid: None,
         });
         assert_eq!(line, "Service: running (windows scm)");
@@ -750,42 +785,20 @@ mod tests {
 
     #[test]
     fn render_status_renders_non_running_states() {
-        for state in [
-            "stopped",
-            "start-pending",
-            "stop-pending",
-            "paused",
-            "continue-pending",
-            "pause-pending",
-        ] {
+        let cases = [
+            (ServiceStateView::Stopped, "stopped"),
+            (ServiceStateView::StartPending, "start-pending"),
+            (ServiceStateView::StopPending, "stop-pending"),
+            (ServiceStateView::Paused, "paused"),
+            (ServiceStateView::ContinuePending, "continue-pending"),
+            (ServiceStateView::PausePending, "pause-pending"),
+        ];
+        for (state, expected) in cases {
             let line = render_status(StatusInputs::Probed {
                 state,
                 pid: Some(1),
             });
-            assert_eq!(line, format!("Service: {state} (windows scm)"));
+            assert_eq!(line, format!("Service: {expected} (windows scm)"));
         }
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn current_user_falls_back_to_userprofile_basename() {
-        // Direct unit test of the parsing shape used by the fallback
-        // path. We don't mutate process env on every CI host; this
-        // covers the basename extraction independently. Gated to
-        // Windows because `Path::file_name` only treats '\' as a
-        // separator on Windows targets -- on linux the same input
-        // round-trips as a single filename.
-        let basename = Path::new(r"C:\Users\Alice")
-            .file_name()
-            .map(|f| f.to_string_lossy().into_owned());
-        assert_eq!(basename.as_deref(), Some("Alice"));
-    }
-
-    #[test]
-    fn kei_state_subdir_matches_macos_and_linux_convention() {
-        // The other backends hard-code `~/.config/kei`. Regression-guard
-        // against a casual edit that would split Windows off into
-        // `%APPDATA%\kei`.
-        assert_eq!(KEI_STATE_SUBDIR, ".config/kei");
     }
 }

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -1,0 +1,791 @@
+//! Windows backend for `kei install` / `kei uninstall` /
+//! `kei service status` plus the SCM service-main bridge for
+//! `kei service run`.
+//!
+//! Registers kei with the Windows Service Control Manager (SCM) under a
+//! per-user account. On install we prompt for the operator's Windows
+//! login password via rpassword and pass it to `CreateServiceW` as the
+//! LSA secret; SCM launches the daemon under that user's profile so the
+//! Credential Manager vault and `~/.config/kei` data dir match the
+//! interactive login. Same convention as the macOS / linux backends.
+//!
+//! Domain users / roaming profiles are documented as a v0.14 limitation
+//! (the `.\<user>` LSA-secret form covers local-machine accounts only).
+//!
+//! `kei service run` on Windows does double duty: when SCM launches the
+//! binary it must call `StartServiceCtrlDispatcher` within 30s or SCM
+//! kills the process. [`run_under_scm_or_foreground`] tries the
+//! dispatcher first; on `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` it
+//! falls through to a foreground sync-loop run for `kei service run`
+//! invoked from a terminal.
+//!
+//! The PR 8 smoke matrix is what exercises a full install -> stop ->
+//! uninstall round-trip on a real Windows runner. Locally on linux/macOS
+//! only the renderer + status-formatter helpers compile and run; those
+//! carry inline unit tests so a regression in their shape is caught
+//! before the windows-latest job ever sees the change.
+
+#![allow(
+    clippy::print_stdout,
+    reason = "kei service status renders human-readable output to stdout, matching kei status / kei verify."
+)]
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::cli::{InstallArgs, UninstallArgs};
+use crate::service::env::{
+    current_executable, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
+};
+
+/// SCM service name (matches `SERVICE_IDENTIFIER` so `sc.exe query
+/// com.rhoopr.kei` works for ad-hoc inspection).
+pub(crate) const SERVICE_NAME: &str = SERVICE_IDENTIFIER;
+
+/// Restart-on-failure cadence applied via `ChangeServiceConfig2W`.
+const RESTART_DELAY: Duration = Duration::from_secs(10);
+
+/// Window over which SCM counts crashes against the failure action list.
+const FAILURE_RESET_PERIOD: Duration = Duration::from_secs(86_400);
+
+/// Subdirectory used everywhere: linux honours XDG, macOS hard-codes
+/// `~/.config/kei`, Windows mirrors macOS so the operator sees a
+/// consistent path across platforms (and so `kei uninstall --purge`
+/// removes the same tree `kei sync` populated).
+const KEI_STATE_SUBDIR: &str = ".config/kei";
+
+// ── Public surface ──────────────────────────────────────────────────────
+
+/// Top-level entry for `kei install` (also the bare default; on Windows
+/// `--user` and the default both produce the same per-user SCM entry).
+pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
+    let exe = current_executable()?;
+    let user = current_user_name()
+        .context("could not resolve current Windows user (USERNAME / USERPROFILE unset?)")?;
+
+    let inputs = ServiceInfoInputs {
+        exec: &exe,
+        config: config_path,
+        account_user: &user,
+    };
+
+    if args.dry_run {
+        let preview = render_service_info_preview(&inputs);
+        tracing::info!(
+            service = SERVICE_NAME,
+            executable = %exe.display(),
+            config = %config_path.display(),
+            account = %inputs.account_name(),
+            dry_run = true,
+            "previewing kei service registration",
+        );
+        for line in preview.lines() {
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
+    let password = prompt_windows_password(&user)?;
+    scm_impl::install(&inputs, &password).await?;
+
+    tracing::info!(
+        service = SERVICE_NAME,
+        executable = %exe.display(),
+        config = %config_path.display(),
+        account = %inputs.account_name(),
+        "registered kei with the Windows Service Control Manager",
+    );
+    Ok(())
+}
+
+/// `--system` is rejected here for the same reason as macOS: a true
+/// system-wide install would mean LocalSystem (no user keyring) or a
+/// virtual `NT SERVICE\kei` account (no Credential Manager). Both
+/// would break the cross-platform "credentials follow the operator"
+/// promise from the v0.14 phase-1 plan.
+pub(crate) async fn install_system(_args: &InstallArgs, _config_path: &Path) -> Result<()> {
+    bail!(
+        "`kei install --system` is not supported on Windows; \
+         use `kei install` (per-user) so the service shares your Credential Manager vault \
+         and `~/.config/kei` state directory"
+    )
+}
+
+/// Top-level entry for `kei uninstall`.
+pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
+    match scm_impl::uninstall_existing().await? {
+        true => tracing::info!(service = SERVICE_NAME, "removed kei from SCM"),
+        false => tracing::info!(
+            service = SERVICE_NAME,
+            "no kei service registered with SCM; nothing to remove",
+        ),
+    }
+
+    if args.purge {
+        let kei_dir = kei_state_dir().ok_or_else(|| {
+            anyhow!("--purge requested but USERPROFILE is not set; cannot locate kei state")
+        })?;
+        purge_kei_state(&kei_dir, &[])?;
+    }
+
+    Ok(())
+}
+
+/// `kei service status` implementation.
+pub(crate) async fn status() -> Result<()> {
+    let line = render_status(scm_impl::probe().await?);
+    println!("{line}");
+    Ok(())
+}
+
+/// `kei service run` entry on Windows.
+///
+/// Tries SCM dispatcher first. When the binary is launched by SCM, the
+/// dispatcher attaches and blocks here for the lifetime of the service;
+/// when launched from a terminal, dispatcher returns
+/// `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` immediately and we fall
+/// through to a foreground `sync_loop::run_sync` so `kei service run`
+/// stays useful for local testing.
+#[cfg(target_os = "windows")]
+pub(crate) async fn run_under_scm_or_foreground(
+    globals: crate::config::GlobalArgs,
+    args: crate::sync_loop::SyncArgs,
+) -> Result<()> {
+    scm_impl::run_or_foreground(globals, args).await
+}
+
+// ── Inputs / pure renderers (testable on every target) ──────────────────
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ServiceInfoInputs<'a> {
+    pub exec: &'a Path,
+    pub config: &'a Path,
+    pub account_user: &'a str,
+}
+
+impl ServiceInfoInputs<'_> {
+    fn launch_arguments(&self) -> Vec<OsString> {
+        vec![
+            OsString::from("service"),
+            OsString::from("run"),
+            OsString::from("--config"),
+            self.config.as_os_str().to_owned(),
+        ]
+    }
+
+    fn account_name(&self) -> String {
+        format!(r".\{}", self.account_user)
+    }
+}
+
+/// Human-readable preview of the registration `--dry-run` would create.
+/// Same lines `sc.exe qc com.rhoopr.kei` would surface post-install, in
+/// the same order, so the operator can eyeball the install before
+/// committing.
+fn render_service_info_preview(inputs: &ServiceInfoInputs<'_>) -> String {
+    let argv = std::iter::once(inputs.exec.display().to_string())
+        .chain(
+            inputs
+                .launch_arguments()
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned()),
+        )
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "Service name        : {SERVICE_NAME}\n\
+         Display name        : {SERVICE_DESCRIPTION}\n\
+         Description         : {SERVICE_DESCRIPTION}\n\
+         Account             : {account}\n\
+         Service type        : OWN_PROCESS\n\
+         Start type          : AUTO_START\n\
+         Error control       : NORMAL\n\
+         Failure actions     : restart x3, delay {delay}s, reset after {reset}s\n\
+         Binary path         : {argv}",
+        account = inputs.account_name(),
+        delay = RESTART_DELAY.as_secs(),
+        reset = FAILURE_RESET_PERIOD.as_secs(),
+    )
+}
+
+/// Inputs the status renderer accepts. Decoupled from the
+/// windows-service crate's `ServiceStatus` so the formatter stays
+/// testable on linux/macOS hosts where that type does not compile.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StatusInputs {
+    NotInstalled,
+    ScmUnavailable,
+    Probed {
+        state: &'static str,
+        pid: Option<u32>,
+    },
+}
+
+fn render_status(inputs: StatusInputs) -> String {
+    match inputs {
+        StatusInputs::NotInstalled => "Service: not installed".to_string(),
+        StatusInputs::ScmUnavailable => {
+            // SCM is unavailable when called from a non-elevated shell or
+            // (rare) when the Service Control Manager itself is down.
+            // Either way, surface the cause; "not installed" would lie.
+            "Service: SCM unavailable (run from an elevated PowerShell to query state)".to_string()
+        }
+        StatusInputs::Probed { state, pid } => match (state, pid) {
+            ("running", Some(pid)) => format!("Service: running (windows scm, pid {pid})"),
+            ("running", None) => "Service: running (windows scm)".to_string(),
+            (state, _) => format!("Service: {state} (windows scm)"),
+        },
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn current_user_name() -> Option<String> {
+    if let Ok(u) = std::env::var("USERNAME") {
+        if !u.is_empty() {
+            return Some(u);
+        }
+    }
+    // USERPROFILE is `C:\Users\Alice`; the basename is the account name.
+    let profile = std::env::var("USERPROFILE").ok()?;
+    Path::new(&profile)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+}
+
+fn kei_state_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(KEI_STATE_SUBDIR))
+}
+
+fn prompt_windows_password(user: &str) -> Result<String> {
+    let prompt = format!(
+        "Windows password for {user} (used by SCM to launch kei under your account; \
+         stored as an LSA secret, not in kei): "
+    );
+    rpassword::prompt_password(prompt).context("failed to read Windows password from stdin")
+}
+
+// ── SCM glue ───────────────────────────────────────────────────────────
+//
+// The real impl is `#[cfg(target_os = "windows")]`. Stubs on the other
+// arms exist so the renderer/tests above compile and run on linux/macOS;
+// the runtime arm bails because the dispatch tables in install.rs /
+// uninstall.rs / status.rs route only Windows targets here.
+
+#[cfg(target_os = "windows")]
+mod scm_impl {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+    use windows_service::{
+        define_windows_service,
+        service::{
+            ServiceAccess, ServiceAction, ServiceActionType, ServiceControl, ServiceControlAccept,
+            ServiceErrorControl, ServiceExitCode, ServiceFailureActions, ServiceFailureResetPeriod,
+            ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+        },
+        service_control_handler::{self, ServiceControlHandlerResult},
+        service_dispatcher,
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
+
+    /// 1060 = ERROR_SERVICE_DOES_NOT_EXIST.
+    const WINAPI_SERVICE_DOES_NOT_EXIST: i32 = 1060;
+    /// 1063 = ERROR_FAILED_SERVICE_CONTROLLER_CONNECT — what
+    /// `StartServiceCtrlDispatcher` returns when the binary is run from a
+    /// terminal instead of by SCM.
+    const WINAPI_NOT_RUNNING_AS_SERVICE: i32 = 1063;
+
+    /// Bridge between the async caller in `service::run::run` and the
+    /// SCM service-main callback that runs on a thread spawned by the
+    /// windows-service dispatcher. The OS thread that `kei_service_main`
+    /// runs on cannot capture our async-context payload by closure (the
+    /// callback signature is fixed by the FFI contract), so we stash it
+    /// in this static, take it inside the callback, and the foreground
+    /// fall-through path takes it back when the dispatcher refuses.
+    static SCM_PAYLOAD: OnceLock<Mutex<Option<ScmPayload>>> = OnceLock::new();
+
+    /// Channel sender published by the service-main thread once it has
+    /// registered its event handler. The SCM stop event is delivered on
+    /// a separate OS thread, so the handler signals shutdown by sending
+    /// on this channel which the sync-loop runtime observes via select!.
+    static SCM_SHUTDOWN_TX: OnceLock<Mutex<Option<tokio::sync::oneshot::Sender<()>>>> =
+        OnceLock::new();
+
+    struct ScmPayload {
+        globals: crate::config::GlobalArgs,
+        sync: crate::sync_loop::SyncArgs,
+    }
+
+    fn payload_slot() -> &'static Mutex<Option<ScmPayload>> {
+        SCM_PAYLOAD.get_or_init(|| Mutex::new(None))
+    }
+
+    fn shutdown_slot() -> &'static Mutex<Option<tokio::sync::oneshot::Sender<()>>> {
+        SCM_SHUTDOWN_TX.get_or_init(|| Mutex::new(None))
+    }
+
+    pub(super) async fn install(inputs: &ServiceInfoInputs<'_>, password: &str) -> Result<()> {
+        let exec = inputs.exec.to_path_buf();
+        let config = inputs.config.to_path_buf();
+        let account_user = inputs.account_user.to_string();
+        let password = password.to_owned();
+        tokio::task::spawn_blocking(move || {
+            install_blocking(&exec, &config, &account_user, &password)
+        })
+        .await
+        .context("install task panicked")?
+    }
+
+    fn install_blocking(
+        exec: &Path,
+        config: &Path,
+        account_user: &str,
+        password: &str,
+    ) -> Result<()> {
+        let manager =
+            open_manager(ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE)?;
+        let inputs = ServiceInfoInputs {
+            exec,
+            config,
+            account_user,
+        };
+        let info = ServiceInfo {
+            name: OsString::from(SERVICE_NAME),
+            display_name: OsString::from(SERVICE_DESCRIPTION),
+            service_type: ServiceType::OWN_PROCESS,
+            start_type: ServiceStartType::AutoStart,
+            error_control: ServiceErrorControl::Normal,
+            executable_path: exec.to_path_buf(),
+            launch_arguments: inputs.launch_arguments(),
+            dependencies: Vec::new(),
+            account_name: Some(OsString::from(inputs.account_name())),
+            account_password: Some(OsString::from(password)),
+        };
+        let service = manager
+            .create_service(
+                &info,
+                ServiceAccess::CHANGE_CONFIG | ServiceAccess::START | ServiceAccess::QUERY_STATUS,
+            )
+            .context("CreateServiceW failed (run from an elevated PowerShell?)")?;
+        service
+            .set_description(SERVICE_DESCRIPTION)
+            .context("ChangeServiceConfig2W (description) failed")?;
+        service
+            .update_failure_actions(ServiceFailureActions {
+                reset_period: ServiceFailureResetPeriod::After(FAILURE_RESET_PERIOD),
+                reboot_msg: None,
+                command: None,
+                actions: Some(vec![
+                    ServiceAction {
+                        action_type: ServiceActionType::Restart,
+                        delay: RESTART_DELAY,
+                    };
+                    3
+                ]),
+            })
+            .context("ChangeServiceConfig2W (failure actions) failed")?;
+        let no_args: &[&str] = &[];
+        service.start(no_args).context("StartServiceW failed")?;
+        Ok(())
+    }
+
+    pub(super) async fn uninstall_existing() -> Result<bool> {
+        tokio::task::spawn_blocking(uninstall_blocking)
+            .await
+            .context("uninstall task panicked")?
+    }
+
+    fn uninstall_blocking() -> Result<bool> {
+        let manager = open_manager(ServiceManagerAccess::CONNECT)?;
+        let access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
+        let service = match manager.open_service(SERVICE_NAME, access) {
+            Ok(s) => s,
+            Err(windows_service::Error::Winapi(ref e))
+                if e.raw_os_error() == Some(WINAPI_SERVICE_DOES_NOT_EXIST) =>
+            {
+                return Ok(false);
+            }
+            Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
+        };
+
+        if let Ok(status) = service.query_status() {
+            if status.current_state != ServiceState::Stopped {
+                let _ = service.stop();
+                wait_for_stop(&service, Duration::from_secs(30));
+            }
+        }
+        service.delete().context("DeleteService failed")?;
+        Ok(true)
+    }
+
+    fn wait_for_stop(service: &windows_service::service::Service, timeout: Duration) {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            match service.query_status() {
+                Ok(status) if status.current_state == ServiceState::Stopped => return,
+                Ok(_) => std::thread::sleep(Duration::from_millis(250)),
+                Err(_) => return,
+            }
+        }
+    }
+
+    pub(super) async fn probe() -> Result<StatusInputs> {
+        tokio::task::spawn_blocking(probe_blocking)
+            .await
+            .context("status probe task panicked")?
+    }
+
+    fn probe_blocking() -> Result<StatusInputs> {
+        let manager = match open_manager(ServiceManagerAccess::CONNECT) {
+            Ok(m) => m,
+            Err(_) => return Ok(StatusInputs::ScmUnavailable),
+        };
+        let service = match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
+            Ok(s) => s,
+            Err(windows_service::Error::Winapi(ref e))
+                if e.raw_os_error() == Some(WINAPI_SERVICE_DOES_NOT_EXIST) =>
+            {
+                return Ok(StatusInputs::NotInstalled);
+            }
+            Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
+        };
+        let status = service
+            .query_status()
+            .context("QueryServiceStatusEx failed")?;
+        Ok(StatusInputs::Probed {
+            state: scm_state_label(status.current_state),
+            pid: status.process_id,
+        })
+    }
+
+    fn open_manager(access: ServiceManagerAccess) -> Result<ServiceManager> {
+        ServiceManager::local_computer(None::<&str>, access).context(
+            "OpenSCManagerW failed -- `kei install` and `kei uninstall` on Windows require an \
+             elevated PowerShell or Command Prompt",
+        )
+    }
+
+    fn scm_state_label(state: ServiceState) -> &'static str {
+        match state {
+            ServiceState::Running => "running",
+            ServiceState::Stopped => "stopped",
+            ServiceState::StartPending => "start-pending",
+            ServiceState::StopPending => "stop-pending",
+            ServiceState::ContinuePending => "continue-pending",
+            ServiceState::PausePending => "pause-pending",
+            ServiceState::Paused => "paused",
+        }
+    }
+
+    // -- Service main / SCM event handler --------------------------------
+
+    define_windows_service!(ffi_service_main, kei_service_main);
+
+    pub(super) async fn run_or_foreground(
+        globals: crate::config::GlobalArgs,
+        sync: crate::sync_loop::SyncArgs,
+    ) -> Result<()> {
+        // Stash payload so the SCM-spawned service-main thread can take
+        // it; this happens *before* the dispatcher attempt so the OS
+        // thread can never observe an empty slot.
+        *payload_slot().lock().unwrap() = Some(ScmPayload { globals, sync });
+
+        let dispatcher_result = tokio::task::spawn_blocking(|| {
+            service_dispatcher::start(SERVICE_NAME, ffi_service_main)
+        })
+        .await
+        .context("SCM dispatcher task panicked")?;
+
+        match dispatcher_result {
+            Ok(()) => {
+                // SCM took over and the service ran to completion.
+                tracing::info!(service = SERVICE_NAME, "SCM-managed service exited cleanly");
+                Ok(())
+            }
+            Err(windows_service::Error::Winapi(ref e))
+                if e.raw_os_error() == Some(WINAPI_NOT_RUNNING_AS_SERVICE) =>
+            {
+                // Foreground invocation -- e.g. operator running
+                // `kei service run` from PowerShell. Recover the
+                // payload and run the sync loop directly.
+                tracing::info!(
+                    service = SERVICE_NAME,
+                    "kei service run invoked outside SCM; running in foreground"
+                );
+                let payload =
+                    payload_slot().lock().unwrap().take().ok_or_else(|| {
+                        anyhow!("internal: SCM payload missing on foreground path")
+                    })?;
+                crate::sync_loop::run_sync(&payload.globals, payload.sync).await
+            }
+            Err(e) => Err(anyhow!("StartServiceCtrlDispatcher failed: {e}")),
+        }
+    }
+
+    fn kei_service_main(_arguments: Vec<OsString>) {
+        if let Err(e) = service_main_inner() {
+            tracing::error!(error = %e, "kei SCM service main failed");
+        }
+    }
+
+    fn service_main_inner() -> Result<()> {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        *shutdown_slot().lock().unwrap() = Some(shutdown_tx);
+
+        let event_handler = move |control_event| -> ServiceControlHandlerResult {
+            match control_event {
+                ServiceControl::Stop | ServiceControl::Shutdown => {
+                    if let Some(tx) = shutdown_slot().lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    ServiceControlHandlerResult::NoError
+                }
+                ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+                _ => ServiceControlHandlerResult::NotImplemented,
+            }
+        };
+
+        let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)
+            .context("RegisterServiceCtrlHandlerExW failed")?;
+
+        status_handle
+            .set_service_status(running_status())
+            .context("set_service_status(running) failed")?;
+
+        let outcome = run_payload_under_scm(shutdown_rx);
+
+        // Always report Stopped, even on error -- otherwise SCM keeps
+        // the service in StartPending until the wait_hint elapses and
+        // then force-kills the process, which is a worse signal than a
+        // clean stop with a non-zero exit code.
+        let report_result = status_handle.set_service_status(stopped_status(outcome.is_ok()));
+        if let Err(e) = report_result {
+            tracing::error!(error = %e, "failed to report Stopped to SCM");
+        }
+        outcome
+    }
+
+    fn run_payload_under_scm(mut shutdown_rx: tokio::sync::oneshot::Receiver<()>) -> Result<()> {
+        let payload = payload_slot()
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| anyhow!("kei service main started without a stashed payload"))?;
+
+        // Dedicated single-thread runtime for the sync loop. Lives on
+        // this OS thread (the one SCM spawned for service main); the
+        // foreground caller's runtime, if any, is on a different thread
+        // and unaffected.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to build SCM-mode tokio runtime")?;
+
+        runtime.block_on(async move {
+            tokio::select! {
+                result = crate::sync_loop::run_sync(&payload.globals, payload.sync) => result,
+                _ = &mut shutdown_rx => {
+                    tracing::info!(service = SERVICE_NAME, "SCM stop received; shutting down sync loop");
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    fn running_status() -> ServiceStatus {
+        ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: ServiceState::Running,
+            controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint: Duration::default(),
+            process_id: None,
+        }
+    }
+
+    fn stopped_status(success: bool) -> ServiceStatus {
+        ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: ServiceState::Stopped,
+            controls_accepted: ServiceControlAccept::empty(),
+            exit_code: ServiceExitCode::Win32(if success { 0 } else { 1 }),
+            checkpoint: 0,
+            wait_hint: Duration::default(),
+            process_id: None,
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod scm_impl {
+    use super::*;
+
+    pub(super) async fn install(_inputs: &ServiceInfoInputs<'_>, _password: &str) -> Result<()> {
+        bail!(
+            "internal error: Windows install path reached on a non-Windows target; \
+             this is a build configuration bug"
+        )
+    }
+
+    pub(super) async fn uninstall_existing() -> Result<bool> {
+        Ok(false)
+    }
+
+    pub(super) async fn probe() -> Result<StatusInputs> {
+        Ok(StatusInputs::NotInstalled)
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+//
+// Pure renderer / formatter coverage. These run on every unix host as
+// well as on Windows so a regression in shape (preview lines, status
+// strings) is caught on linux CI before windows-latest sees the change.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample_inputs() -> ServiceInfoInputs<'static> {
+        static EXE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        static CFG: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        let exe = EXE.get_or_init(|| PathBuf::from(r"C:\Program Files\kei\kei.exe"));
+        let cfg = CFG.get_or_init(|| PathBuf::from(r"C:\Users\Alice\.config\kei\config.toml"));
+        ServiceInfoInputs {
+            exec: exe.as_path(),
+            config: cfg.as_path(),
+            account_user: "Alice",
+        }
+    }
+
+    #[test]
+    fn launch_arguments_pass_service_run_with_config() {
+        let argv = sample_inputs().launch_arguments();
+        let strs: Vec<String> = argv
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(strs[0], "service");
+        assert_eq!(strs[1], "run");
+        assert_eq!(strs[2], "--config");
+        assert_eq!(strs[3], r"C:\Users\Alice\.config\kei\config.toml");
+    }
+
+    #[test]
+    fn account_name_uses_local_machine_prefix() {
+        // `.\Alice` is the SCM "local machine, account Alice" form.
+        // Domain users (`DOMAIN\Alice`) are out of scope for v0.14.
+        assert_eq!(sample_inputs().account_name(), r".\Alice");
+    }
+
+    #[test]
+    fn render_service_info_preview_lists_every_field() {
+        // SERVICE_NAME / SERVICE_DESCRIPTION are platform-resolved
+        // constants -- on linux SERVICE_IDENTIFIER is "kei", on
+        // macOS/Windows it is "com.rhoopr.kei". Reference the constant
+        // in the assertion so the test passes on every host that runs
+        // it (linux + macOS + windows; the Windows-resolved string is
+        // what the smoke matrix verifies against `sc.exe qc`).
+        let preview = render_service_info_preview(&sample_inputs());
+        for needle in [
+            format!("Service name        : {SERVICE_NAME}"),
+            format!("Display name        : {SERVICE_DESCRIPTION}"),
+            format!("Description         : {SERVICE_DESCRIPTION}"),
+            r"Account             : .\Alice".to_string(),
+            "Service type        : OWN_PROCESS".to_string(),
+            "Start type          : AUTO_START".to_string(),
+            "Error control       : NORMAL".to_string(),
+            "Failure actions     : restart x3, delay 10s, reset after 86400s".to_string(),
+            r"Binary path         : C:\Program Files\kei\kei.exe service run --config C:\Users\Alice\.config\kei\config.toml".to_string(),
+        ] {
+            assert!(
+                preview.contains(&needle),
+                "expected preview to contain {needle:?}; got:\n{preview}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_status_reports_not_installed() {
+        assert_eq!(
+            render_status(StatusInputs::NotInstalled),
+            "Service: not installed"
+        );
+    }
+
+    #[test]
+    fn render_status_reports_scm_unavailable() {
+        let line = render_status(StatusInputs::ScmUnavailable);
+        assert!(line.starts_with("Service: SCM unavailable"));
+        // Operator hint about elevation belongs in the same line so a
+        // tail -f / log-collector picks it up alongside the verdict.
+        assert!(line.contains("elevated PowerShell"));
+    }
+
+    #[test]
+    fn render_status_includes_pid_when_running() {
+        let line = render_status(StatusInputs::Probed {
+            state: "running",
+            pid: Some(4321),
+        });
+        assert_eq!(line, "Service: running (windows scm, pid 4321)");
+    }
+
+    #[test]
+    fn render_status_running_without_pid_is_still_running() {
+        // SCM occasionally returns process_id = None during the
+        // start-pending -> running transition; we should not lose the
+        // "running" verdict just because the pid was racing.
+        let line = render_status(StatusInputs::Probed {
+            state: "running",
+            pid: None,
+        });
+        assert_eq!(line, "Service: running (windows scm)");
+    }
+
+    #[test]
+    fn render_status_renders_non_running_states() {
+        for state in [
+            "stopped",
+            "start-pending",
+            "stop-pending",
+            "paused",
+            "continue-pending",
+            "pause-pending",
+        ] {
+            let line = render_status(StatusInputs::Probed {
+                state,
+                pid: Some(1),
+            });
+            assert_eq!(line, format!("Service: {state} (windows scm)"));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn current_user_falls_back_to_userprofile_basename() {
+        // Direct unit test of the parsing shape used by the fallback
+        // path. We don't mutate process env on every CI host; this
+        // covers the basename extraction independently. Gated to
+        // Windows because `Path::file_name` only treats '\' as a
+        // separator on Windows targets -- on linux the same input
+        // round-trips as a single filename.
+        let basename = Path::new(r"C:\Users\Alice")
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned());
+        assert_eq!(basename.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn kei_state_subdir_matches_macos_and_linux_convention() {
+        // The other backends hard-code `~/.config/kei`. Regression-guard
+        // against a casual edit that would split Windows off into
+        // `%APPDATA%\kei`.
+        assert_eq!(KEI_STATE_SUBDIR, ".config/kei");
+    }
+}

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -208,6 +208,7 @@ pub(crate) fn service_mode_default_interval(
 }
 
 /// Arguments that [`run_sync`] needs from the CLI dispatch layer.
+#[derive(Clone)]
 pub(crate) struct SyncArgs {
     pub is_one_shot: bool,
     /// True when invoked via `kei service run`. After [`Config::build`]

--- a/tests/service_cli.rs
+++ b/tests/service_cli.rs
@@ -109,7 +109,7 @@ fn install_user_and_system_are_mutually_exclusive() {
 // auto-deactivate via cfg. They guard the macOS / Windows stubs until
 // those backends land.
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 #[test]
 fn install_returns_clean_not_implemented_error() {
     cmd()
@@ -119,7 +119,7 @@ fn install_returns_clean_not_implemented_error() {
         .stderr(predicate::str::contains("not yet implemented"));
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 #[test]
 fn uninstall_returns_clean_not_implemented_error() {
     cmd()
@@ -129,7 +129,7 @@ fn uninstall_returns_clean_not_implemented_error() {
         .stderr(predicate::str::contains("not yet implemented"));
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 #[test]
 fn service_status_returns_clean_not_implemented_error() {
     cmd()

--- a/tests/service_windows.rs
+++ b/tests/service_windows.rs
@@ -1,9 +1,8 @@
 //! Windows-only integration tests for `kei install` / `kei uninstall` /
-//! `kei service status`. The full SCM round-trip lands in PR 8's smoke
-//! matrix (which runs on a real elevated Windows runner). What this file
-//! covers is the surface the smoke matrix can't easily probe: dry-run
-//! preview output, `--system` rejection, friendly error when running
-//! non-elevated, and `kei uninstall` on a host with no kei service.
+//! `kei service status`. Covers the surface the cross-platform smoke
+//! matrix cannot easily probe: dry-run preview output, `--system`
+//! rejection, and clean no-op behaviour on a host with no kei service
+//! registered.
 //!
 //! Gated to Windows so the file is a no-op on linux/macOS hosts. The
 //! cross-platform CLI parsing is covered separately in `service_cli.rs`.

--- a/tests/service_windows.rs
+++ b/tests/service_windows.rs
@@ -1,0 +1,95 @@
+//! Windows-only integration tests for `kei install` / `kei uninstall` /
+//! `kei service status`. The full SCM round-trip lands in PR 8's smoke
+//! matrix (which runs on a real elevated Windows runner). What this file
+//! covers is the surface the smoke matrix can't easily probe: dry-run
+//! preview output, `--system` rejection, friendly error when running
+//! non-elevated, and `kei uninstall` on a host with no kei service.
+//!
+//! Gated to Windows so the file is a no-op on linux/macOS hosts. The
+//! cross-platform CLI parsing is covered separately in `service_cli.rs`.
+
+#![cfg(target_os = "windows")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stderr
+)]
+
+mod common;
+
+use predicates::prelude::*;
+use std::time::Duration;
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+fn cmd() -> assert_cmd::Command {
+    let mut cmd = common::cmd();
+    cmd.timeout(TIMEOUT);
+    cmd
+}
+
+#[test]
+fn install_system_is_rejected_with_pointer_to_user_install() {
+    cmd()
+        .args(["install", "--system"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("not supported on Windows")
+                .and(predicate::str::contains("per-user")),
+        );
+}
+
+#[test]
+fn dry_run_install_emits_full_preview_without_touching_scm() {
+    // `--dry-run` must not require elevation: it does not call SCM, so
+    // it must succeed inside this test process even though the test
+    // runner may not be elevated. The preview must list every field
+    // SCM would have configured so an operator can eyeball the install.
+    let assert = cmd().args(["install", "--user", "--dry-run"]).assert();
+    let output = assert.get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected --dry-run install to succeed without elevation; \
+         stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    for needle in [
+        "Service name        : com.rhoopr.kei",
+        "Display name        : kei Media Sync Engine",
+        "Account             : .\\",
+        "Service type        : OWN_PROCESS",
+        "Start type          : AUTO_START",
+        "Failure actions     : restart x3",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected preview to contain {needle:?}; got:\n{stdout}",
+        );
+    }
+}
+
+#[test]
+fn status_on_host_without_kei_service_reports_not_installed_or_scm_unavailable() {
+    // CI windows-latest runs as Administrator so SCM is reachable; the
+    // status output for a host with no kei registered is "not
+    // installed". Local non-elevated runs see "SCM unavailable" -- both
+    // are valid for this test, since the assertion is "kei service
+    // status returns 0 and emits a Service: line", not which verdict.
+    cmd()
+        .args(["service", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Service:"));
+}
+
+#[test]
+fn uninstall_on_host_without_kei_service_is_a_clean_no_op() {
+    // Mirrors the linux/macOS contract: `kei uninstall` on a host with
+    // no kei registered must succeed (with a "nothing to remove" log
+    // line) rather than error out. Without --purge the call cannot
+    // touch the user's state directory.
+    cmd().args(["uninstall"]).assert().success();
+}


### PR DESCRIPTION
PR 5 of the v0.14 service phase. Windows now does what linux (#355) and macOS (#356) do.

## Summary

- `kei install` calls `OpenSCManagerW` + `CreateServiceW` to register `com.rhoopr.kei` with the Service Control Manager under the operator's local account (`.\<user>`). Failure actions: restart x3 with a 10s delay, reset window 24h. Sets the SCM description and starts the service. Requires an elevated PowerShell or Command Prompt; non-elevated invocations fail clearly at `OpenSCManagerW` with a pointer at the elevation requirement.
- `kei install --system` is rejected with a friendly message pointing at the per-user form. v0.14 deliberately does not ship a LocalSystem / virtual `NT SERVICE\kei` path; both would break the cross-platform "credentials follow the operator" promise from the phase-1 plan.
- `kei uninstall` opens the existing service, sends `ControlService(STOP)` if it is running, waits up to 30s for SCM to confirm Stopped, then `DeleteService`. With `--purge`, also wipes the keychain credential and removes `~/.config/kei`. A host with no kei service is a clean no-op rather than an error, matching linux/macOS.
- `kei service status` calls `QueryServiceStatusEx` and reports `running (windows scm, pid 12345)`, `stopped (windows scm)`, `not installed`, or `SCM unavailable (run from an elevated PowerShell to query state)`.
- `kei service run` on Windows double-dispatches: when SCM launches the binary, `service_dispatcher::start` attaches inside the 30s SCM watchdog and runs the sync loop on a dedicated tokio runtime. When the binary is run from a terminal, the dispatcher returns `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` and we fall through to the same `sync_loop::run_sync` path used by linux/macOS. SCM Stop signals a oneshot channel that the sync loop observes via `select!`, honouring the existing graceful-shutdown invariants.
- `--dry-run` (from #352) writes a preview of every SCM field (display name, account, failure actions, binary path) without invoking SCM. Runs without elevation so operators can sanity-check the install before committing.

## Design notes

The plan body specified `NT AUTHORITY\\LocalSystem` as the default account, but the Decisions section of the plan (locked 2026-05-07) settled on per-user. This PR follows the Decisions section: SCM-launched kei runs as the operator under `.\<user>`, sharing their Credential Manager vault and `~/.config/kei` data dir. Domain-user / roaming-profile installs are documented as a v0.14 limitation.

State directory stays at `~/.config/kei` rather than `%APPDATA%\kei`, matching the rest of the codebase (linux uses `dirs::config_dir()`, macOS hard-codes the dotted path). The Windows backend resolves through `dirs::home_dir()` to keep `kei uninstall --purge` removing the same tree `kei sync` populated.

Display name uses the existing `SERVICE_DESCRIPTION` constant ("kei Media Sync Engine") instead of the spec-body string ("kei iCloud Photo Sync") so all three backends share one branding string.

Renderer (`render_service_info_preview`) and status formatter (`render_status`) are pure functions compiled on every target. Their inline unit tests (8 cases) run on linux CI before windows-latest ever sees the change. Only the windows-service FFI surface is `#[cfg(target_os = "windows")]`-gated. The dispatcher table arms in install.rs / uninstall.rs / status.rs / run.rs route only Windows targets through to the SCM impl.

Drops the `#[cfg(unix)]` gates that #356 added on `read_config_username` + `purge_kei_state` in `service::env`. The Windows uninstall `--purge` path now wires both helpers up, so the gates are no longer load-bearing.

## Local smoke

I'm on Linux, so I cannot drive `sc.exe` or `Get-Service` against this branch. What I can verify:

- `cargo build` clean. The Windows-only `windows-service = "0.7"` dep gates correctly behind `[target.'cfg(target_os = "windows")']` and does not leak into the linux build graph.
- `cargo test --lib service::windows` runs 8 inline renderer / status-formatter / launch-argument tests on linux. The renderer test uses the platform-resolved `SERVICE_NAME` constant so it adapts to the linux `"kei"` value as well as the macOS / Windows `"com.rhoopr.kei"` value.
- `just gate` clean (2321 lib + 7 service_cli + 9 service_linux + 0 service_macos + 0 service_windows + behavioral + 115 cli; service_windows runs 4 integration tests on the Windows runner).
- Verified the windows-service 0.7.0 API surface against the local cargo registry source: `ServiceFailureActions`, `ServiceFailureResetPeriod::After`, `Service::update_failure_actions`, `service_dispatcher::start`, `service_control_handler::register`, `define_windows_service!` macro shape.

The full `kei install -> sc query -> kei uninstall` round-trip lands in PR 8's smoke matrix on the elevated windows-latest runner.

## Test plan

- [x] `just gate` (fmt + clippy + lib + cli + behavioral + service_cli + service_linux + service_macos + service_windows + doc + audit + typos + roundtrip)
- [x] Renderer + status-formatter unit tests pass on linux (8/8)
- [x] `cargo build` clean with `windows-service` cfg-gated to Windows targets only
- [x] `--system` rejected with friendly message (linux + macOS already; Windows test in `service_windows.rs`)
- [ ] CI Windows runner: `cargo test --target x86_64-pc-windows-msvc` builds the SCM module
- [ ] CI Windows runner: `service_windows.rs` integration tests pass (`--dry-run` preview, `--system` rejection, status no-op, uninstall no-op)
- [ ] Full SCM round-trip: install --user -> `sc query com.rhoopr.kei` -> stop -> uninstall (lands in PR 8's smoke matrix)
