### PR TITLE
feat: cross-platform Service section in `kei status`

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ _default:
 gate:
     cargo fmt --all --check
     cargo clippy --all-targets --all-features -- -D warnings
-    cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows
+    cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows --test service_status
     RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps --all-features
     cargo fetch --locked
     cargo audit --deny warnings
@@ -41,7 +41,7 @@ test MODE="":
             cargo test --all-features
             ;;
         fast)
-            cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows
+            cargo test --lib --test cli --test behavioral --test service_cli --test service_linux --test service_macos --test service_windows --test service_status
             ;;
         live)
             _live_env

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -5,6 +5,7 @@
 
 use crate::cli;
 use crate::config;
+use crate::service::status as service_status;
 use crate::state;
 use crate::state::{AssetRecord, StateDb};
 
@@ -16,6 +17,8 @@ pub(crate) async fn run_status(
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<()> {
+    print_service_section().await;
+
     let db_path = super::super::get_db_path(globals, toml)?;
 
     if !db_path.exists() {
@@ -71,6 +74,24 @@ pub(crate) async fn run_status(
     }
 
     Ok(())
+}
+
+/// Prints the `Service:` line at the top of `kei status`. Errors from
+/// the per-platform probe (no systemd, headless macOS, locked-down SCM)
+/// are absorbed so a probe failure never poisons the rest of the status
+/// command -- the state DB summary is the load-bearing output.
+async fn print_service_section() {
+    let state = match service_status::service_state().await {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::debug!(error = %e, "service_state probe failed; rendering placeholder");
+            println!("Service: status unavailable");
+            println!();
+            return;
+        }
+    };
+    println!("{}", service_status::render_oneline(&state));
+    println!();
 }
 
 /// Which `kei status` listing is being paginated. Picks the state-DB page

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -5,7 +5,7 @@
 
 use crate::cli;
 use crate::config;
-use crate::service::status as service_status;
+use crate::service::status::{render_oneline, service_state};
 use crate::state;
 use crate::state::{AssetRecord, StateDb};
 
@@ -81,7 +81,7 @@ pub(crate) async fn run_status(
 /// are absorbed so a probe failure never poisons the rest of the status
 /// command -- the state DB summary is the load-bearing output.
 async fn print_service_section() {
-    let state = match service_status::service_state().await {
+    let state = match service_state().await {
         Ok(state) => state,
         Err(e) => {
             tracing::debug!(error = %e, "service_state probe failed; rendering placeholder");
@@ -90,7 +90,7 @@ async fn print_service_section() {
             return;
         }
     };
-    println!("{}", service_status::render_oneline(&state));
+    println!("{}", render_oneline(&state));
     println!();
 }
 

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -40,26 +40,35 @@ pub(crate) const SERVICE_IDENTIFIER: &str = if cfg!(target_os = "linux") {
 
 /// Returns `true` when the current process is running inside a container.
 ///
-/// Two-signal probe: the marker file Docker drops at `/.dockerenv`, then
-/// the cgroup membership of PID 1 (covers Podman, containerd, Kubernetes,
-/// LXC). Cgroup parsing is Linux-only; on macOS and Windows only the
-/// marker-file check runs, which catches Docker Desktop edge cases
-/// without needing platform-specific container APIs.
+/// Thin wrapper over [`container_supervisor`] for the boolean callers
+/// (`kei install` no-op gate). Returns the same answer as
+/// `container_supervisor().is_some()`.
 pub(crate) fn is_in_container() -> bool {
-    is_in_container_at(
+    container_supervisor().is_some()
+}
+
+/// Returns the name of the container supervisor when running inside a
+/// container, or `None` on the bare host.
+///
+/// Used by `kei status` to render `Service: running in container
+/// (process supervisor: docker)` instead of `not installed`, which would
+/// mislead operators on a Docker / Kubernetes host where service
+/// management is the host's job. Two-signal probe: the marker file
+/// Docker drops at `/.dockerenv` (always reads as "docker"), then the
+/// cgroup membership of PID 1 (returns the matched marker). Cgroup
+/// parsing is Linux-only; on macOS/Windows only the marker-file check
+/// runs.
+pub(crate) fn container_supervisor() -> Option<&'static str> {
+    container_supervisor_at(
         Path::new(DEFAULT_DOCKERENV_PATH),
         Path::new(DEFAULT_CGROUP_PATH),
     )
 }
 
-/// Path-injecting form of [`is_in_container`] used by unit tests.
-///
-/// Production callers go through [`is_in_container`]; tests pass tempdir
-/// paths so the result is deterministic regardless of where the test
-/// binary runs.
-pub(crate) fn is_in_container_at(dockerenv: &Path, cgroup: &Path) -> bool {
+/// Path-injecting form of [`container_supervisor`].
+pub(crate) fn container_supervisor_at(dockerenv: &Path, cgroup: &Path) -> Option<&'static str> {
     if dockerenv.exists() {
-        return true;
+        return Some("docker");
     }
 
     #[cfg(target_os = "linux")]
@@ -67,15 +76,16 @@ pub(crate) fn is_in_container_at(dockerenv: &Path, cgroup: &Path) -> bool {
         match std::fs::read_to_string(cgroup) {
             Ok(contents) => CONTAINER_CGROUP_MARKERS
                 .iter()
-                .any(|marker| contents.contains(marker)),
-            Err(_) => false,
+                .find(|marker| contents.contains(*marker))
+                .copied(),
+            Err(_) => None,
         }
     }
 
     #[cfg(not(target_os = "linux"))]
     {
         let _ = cgroup;
-        false
+        None
     }
 }
 
@@ -205,7 +215,7 @@ mod tests {
         fs::write(&dockerenv, "").unwrap();
         let cgroup = tmp.path().join("cgroup");
         fs::write(&cgroup, "").unwrap();
-        assert!(is_in_container_at(&dockerenv, &cgroup));
+        assert!(container_supervisor_at(&dockerenv, &cgroup).is_some());
     }
 
     #[test]
@@ -214,7 +224,7 @@ mod tests {
         let dockerenv = tmp.path().join("dockerenv-missing");
         let cgroup = tmp.path().join("cgroup");
         fs::write(&cgroup, "0::/user.slice/user-1000.slice\n").unwrap();
-        assert!(!is_in_container_at(&dockerenv, &cgroup));
+        assert!(container_supervisor_at(&dockerenv, &cgroup).is_none());
     }
 
     #[cfg(target_os = "linux")]
@@ -242,11 +252,31 @@ mod tests {
             let dockerenv = tmp.path().join("dockerenv-missing");
             let cgroup = tmp.path().join("cgroup");
             fs::write(&cgroup, contents).unwrap();
-            assert!(
-                is_in_container_at(&dockerenv, &cgroup),
-                "expected container detection for {name} cgroup contents",
+            assert_eq!(
+                container_supervisor_at(&dockerenv, &cgroup),
+                Some(*name),
+                "expected supervisor {name} from cgroup contents",
             );
         }
+    }
+
+    #[test]
+    fn container_supervisor_dockerenv_marker_returns_docker() {
+        let tmp = TempDir::new().unwrap();
+        let dockerenv = tmp.path().join("dockerenv");
+        fs::write(&dockerenv, "").unwrap();
+        let cgroup = tmp.path().join("cgroup");
+        fs::write(&cgroup, "").unwrap();
+        assert_eq!(container_supervisor_at(&dockerenv, &cgroup), Some("docker"),);
+    }
+
+    #[test]
+    fn container_supervisor_returns_none_on_clean_host() {
+        let tmp = TempDir::new().unwrap();
+        let dockerenv = tmp.path().join("dockerenv-missing");
+        let cgroup = tmp.path().join("cgroup");
+        fs::write(&cgroup, "0::/user.slice/user-1000.slice\n").unwrap();
+        assert_eq!(container_supervisor_at(&dockerenv, &cgroup), None);
     }
 
     #[cfg(target_os = "linux")]
@@ -257,7 +287,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dockerenv = tmp.path().join("dockerenv-missing");
         let cgroup = tmp.path().join("cgroup-does-not-exist");
-        assert!(!is_in_container_at(&dockerenv, &cgroup));
+        assert!(container_supervisor_at(&dockerenv, &cgroup).is_none());
     }
 
     #[test]

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -28,12 +28,14 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Utc};
 use tokio::process::Command;
 
 use crate::cli::{InstallArgs, UninstallArgs};
 use crate::service::env::{
     current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
 };
+use crate::service::status::ServiceState;
 
 const UNIT_FILE_NAME: &str = "kei.service";
 
@@ -306,6 +308,80 @@ fn render_status(inputs: StatusInputs) -> String {
     }
 }
 
+/// Cross-platform `service_state()` for the new `Service:` section in
+/// `kei status`. Reuses [`probe_status_inputs`] and converts the raw
+/// systemctl key/value map into the platform-agnostic [`ServiceState`].
+pub(crate) async fn service_state() -> Result<ServiceState> {
+    Ok(match probe_status_inputs().await? {
+        StatusInputs::NotInstalled => ServiceState::NotInstalled,
+        StatusInputs::BusUnavailable { scope } => ServiceState::BackendUnavailable {
+            backend: backend_label(scope),
+            reason: "bus unavailable",
+        },
+        StatusInputs::Probed { scope, probe } => probe_to_state(scope, &probe),
+    })
+}
+
+fn backend_label(scope: &'static str) -> &'static str {
+    match scope {
+        "user" => "systemd user",
+        "system" => "systemd system",
+        _ => "systemd",
+    }
+}
+
+fn probe_to_state(
+    scope: &'static str,
+    probe: &std::collections::BTreeMap<String, String>,
+) -> ServiceState {
+    let active = probe.get("ActiveState").map(String::as_str).unwrap_or("?");
+    let running = active == "active";
+    let state_label: &'static str = match active {
+        "active" => "running",
+        "inactive" => "stopped",
+        "failed" => "failed",
+        "activating" => "starting",
+        "deactivating" => "stopping",
+        "reloading" => "reloading",
+        _ => "unknown",
+    };
+    let since = probe
+        .get("ActiveEnterTimestamp")
+        .and_then(|s| parse_systemd_timestamp(s));
+    let pid = probe
+        .get("MainPID")
+        .and_then(|s| s.parse::<u32>().ok())
+        .filter(|&p| p != 0);
+    ServiceState::Installed {
+        backend: backend_label(scope),
+        running,
+        state_label,
+        since,
+        pid,
+    }
+}
+
+/// Parses systemd's `ActiveEnterTimestamp` into a UTC `DateTime`.
+///
+/// systemd formats the timestamp as `<weekday-abbrev> YYYY-MM-DD
+/// HH:MM:SS <TZ>` where the timezone defaults to the host's local zone
+/// unless `LC_ALL=C` or similar is in effect. Service units run with
+/// the host's tzdata, so the value is usually `UTC` on servers and the
+/// local zone on workstations. Only the UTC form is parsed here -- other
+/// zones return `None` so the renderer omits the `since` clause rather
+/// than guessing wrong. The returned timestamp is informational; missing
+/// it is preferable to misleading the operator.
+fn parse_systemd_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // `Thu 2026-05-07 14:32:01 UTC` -- weekday is decorative; chrono
+    // matches `%a` against any 3-letter abbrev.
+    let parsed = chrono::NaiveDateTime::parse_from_str(trimmed, "%a %Y-%m-%d %H:%M:%S UTC").ok()?;
+    Some(DateTime::<Utc>::from_naive_utc_and_offset(parsed, Utc))
+}
+
 // ── Internals ───────────────────────────────────────────────────────────
 
 fn write_unit(path: &Path, contents: &str) -> Result<()> {
@@ -430,7 +506,7 @@ async fn show_unit(scope: &[&str]) -> Result<ProbeOutcome> {
     argv.extend([
         "show",
         UNIT_FILE_NAME,
-        "--property=ActiveState,SubState,ActiveEnterTimestamp",
+        "--property=ActiveState,SubState,ActiveEnterTimestamp,MainPID",
     ]);
     let output = Command::new("systemctl")
         .args(&argv)
@@ -601,6 +677,86 @@ mod tests {
             probe,
         });
         assert_eq!(line, "Service: inactive (systemd user, dead)");
+    }
+
+    #[test]
+    fn parse_systemd_timestamp_accepts_utc_form() {
+        let parsed = parse_systemd_timestamp("Thu 2026-05-07 14:32:01 UTC")
+            .expect("UTC-form timestamp must parse");
+        assert_eq!(
+            parsed,
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 5, 7, 14, 32, 1).unwrap(),
+        );
+    }
+
+    #[test]
+    fn parse_systemd_timestamp_rejects_local_tz_and_blank() {
+        // Anything other than "UTC" returns None so we don't render a
+        // misleading "since X UTC" against a local-zone wall clock.
+        assert_eq!(parse_systemd_timestamp(""), None);
+        assert_eq!(parse_systemd_timestamp("Thu 2026-05-07 14:32:01 EDT"), None);
+        assert_eq!(parse_systemd_timestamp("not a timestamp"), None);
+    }
+
+    #[test]
+    fn probe_to_state_running_with_main_pid() {
+        let mut probe = std::collections::BTreeMap::new();
+        probe.insert("ActiveState".to_string(), "active".to_string());
+        probe.insert("SubState".to_string(), "running".to_string());
+        probe.insert(
+            "ActiveEnterTimestamp".to_string(),
+            "Thu 2026-05-07 14:32:01 UTC".to_string(),
+        );
+        probe.insert("MainPID".to_string(), "12345".to_string());
+        match probe_to_state("user", &probe) {
+            ServiceState::Installed {
+                backend,
+                running,
+                state_label,
+                since,
+                pid,
+            } => {
+                assert_eq!(backend, "systemd user");
+                assert!(running);
+                assert_eq!(state_label, "running");
+                assert!(since.is_some());
+                assert_eq!(pid, Some(12345));
+            }
+            other => panic!("expected Installed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_to_state_inactive_drops_zero_main_pid() {
+        // systemd reports `MainPID=0` for inactive units; do not
+        // surface that as a real PID in the rendered status line.
+        let mut probe = std::collections::BTreeMap::new();
+        probe.insert("ActiveState".to_string(), "inactive".to_string());
+        probe.insert("SubState".to_string(), "dead".to_string());
+        probe.insert("ActiveEnterTimestamp".to_string(), String::new());
+        probe.insert("MainPID".to_string(), "0".to_string());
+        match probe_to_state("user", &probe) {
+            ServiceState::Installed {
+                running,
+                state_label,
+                pid,
+                since,
+                ..
+            } => {
+                assert!(!running);
+                assert_eq!(state_label, "stopped");
+                assert_eq!(pid, None);
+                assert_eq!(since, None);
+            }
+            other => panic!("expected Installed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn backend_label_distinguishes_user_and_system_scopes() {
+        assert_eq!(backend_label("user"), "systemd user");
+        assert_eq!(backend_label("system"), "systemd system");
+        assert_eq!(backend_label("other"), "systemd");
     }
 
     #[test]

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -308,9 +308,9 @@ fn render_status(inputs: StatusInputs) -> String {
     }
 }
 
-/// Cross-platform `service_state()` for the new `Service:` section in
-/// `kei status`. Reuses [`probe_status_inputs`] and converts the raw
-/// systemctl key/value map into the platform-agnostic [`ServiceState`].
+/// `service_state()` for the `Service:` section in `kei status`. Reuses
+/// [`probe_status_inputs`] and converts the raw systemctl key/value map
+/// into the platform-agnostic [`ServiceState`].
 pub(crate) async fn service_state() -> Result<ServiceState> {
     Ok(match probe_status_inputs().await? {
         StatusInputs::NotInstalled => ServiceState::NotInstalled,
@@ -322,11 +322,18 @@ pub(crate) async fn service_state() -> Result<ServiceState> {
     })
 }
 
+// probe_status_inputs only ever passes "user" or "system"; the unreachable!
+// arm is a refactor tripwire, not a runtime concern, hence the allow.
+#[allow(
+    clippy::unreachable,
+    reason = "scope strings are produced by probe_status_inputs; \
+              third value would be a refactor bug worth panicking on"
+)]
 fn backend_label(scope: &'static str) -> &'static str {
     match scope {
         "user" => "systemd user",
         "system" => "systemd system",
-        _ => "systemd",
+        other => unreachable!("unexpected systemd scope: {other:?}"),
     }
 }
 
@@ -335,9 +342,8 @@ fn probe_to_state(
     probe: &std::collections::BTreeMap<String, String>,
 ) -> ServiceState {
     let active = probe.get("ActiveState").map(String::as_str).unwrap_or("?");
-    let running = active == "active";
     let state_label: &'static str = match active {
-        "active" => "running",
+        "active" => crate::service::status::RUNNING_LABEL,
         "inactive" => "stopped",
         "failed" => "failed",
         "activating" => "starting",
@@ -354,7 +360,6 @@ fn probe_to_state(
         .filter(|&p| p != 0);
     ServiceState::Installed {
         backend: backend_label(scope),
-        running,
         state_label,
         since,
         pid,
@@ -711,13 +716,11 @@ mod tests {
         match probe_to_state("user", &probe) {
             ServiceState::Installed {
                 backend,
-                running,
                 state_label,
                 since,
                 pid,
             } => {
                 assert_eq!(backend, "systemd user");
-                assert!(running);
                 assert_eq!(state_label, "running");
                 assert!(since.is_some());
                 assert_eq!(pid, Some(12345));
@@ -737,13 +740,11 @@ mod tests {
         probe.insert("MainPID".to_string(), "0".to_string());
         match probe_to_state("user", &probe) {
             ServiceState::Installed {
-                running,
                 state_label,
                 pid,
                 since,
                 ..
             } => {
-                assert!(!running);
                 assert_eq!(state_label, "stopped");
                 assert_eq!(pid, None);
                 assert_eq!(since, None);
@@ -756,7 +757,15 @@ mod tests {
     fn backend_label_distinguishes_user_and_system_scopes() {
         assert_eq!(backend_label("user"), "systemd user");
         assert_eq!(backend_label("system"), "systemd system");
-        assert_eq!(backend_label("other"), "systemd");
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected systemd scope")]
+    fn backend_label_panics_on_unknown_scope() {
+        // probe_status_inputs only emits "user" or "system" today; if a
+        // future refactor adds a third scope without updating
+        // backend_label, the panic surfaces it loud.
+        let _ = backend_label("other");
     }
 
     #[test]

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -38,6 +38,7 @@ use crate::cli::{InstallArgs, UninstallArgs};
 use crate::service::env::{
     current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
 };
+use crate::service::status::ServiceState;
 
 const PLIST_FILE_NAME: &str = "com.rhoopr.kei.plist";
 
@@ -268,6 +269,35 @@ fn render_status(inputs: StatusInputs) -> String {
                 format!("Service: {state} (launchd user{pid_suffix})")
             }
         }
+    }
+}
+
+/// Cross-platform `service_state()` for the new `Service:` section in
+/// `kei status`. `launchctl print` exposes state and pid but no start
+/// time, so `since` is always `None` on macOS in v0.14.
+pub(crate) async fn service_state() -> Result<ServiceState> {
+    Ok(match probe_status_inputs().await? {
+        StatusInputs::NotInstalled => ServiceState::NotInstalled,
+        StatusInputs::DomainUnavailable => ServiceState::BackendUnavailable {
+            backend: "launchd user",
+            reason: "domain unavailable",
+        },
+        StatusInputs::Probed { state, pid } => probed_to_state(&state, pid.as_deref()),
+    })
+}
+
+fn probed_to_state(state: &str, pid: Option<&str>) -> ServiceState {
+    let running = state == LAUNCHD_STATE_RUNNING;
+    let state_label: &'static str = if running { "running" } else { "stopped" };
+    let pid = pid
+        .filter(|p| !p.is_empty() && *p != LAUNCHD_PID_NONE)
+        .and_then(|p| p.parse::<u32>().ok());
+    ServiceState::Installed {
+        backend: "launchd user",
+        running,
+        state_label,
+        since: None,
+        pid,
     }
 }
 
@@ -665,6 +695,49 @@ com.rhoopr.kei = {
         assert!(is_not_loaded("No such process"));
         assert!(is_not_loaded("Could not find specified service"));
         assert!(!is_not_loaded("Bootstrap failed"));
+    }
+
+    #[test]
+    fn probed_to_state_running_with_pid() {
+        match probed_to_state(LAUNCHD_STATE_RUNNING, Some("4321")) {
+            ServiceState::Installed {
+                backend,
+                running,
+                state_label,
+                since,
+                pid,
+            } => {
+                assert_eq!(backend, "launchd user");
+                assert!(running);
+                assert_eq!(state_label, "running");
+                assert_eq!(since, None);
+                assert_eq!(pid, Some(4321));
+            }
+            other => panic!("expected Installed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probed_to_state_drops_dash_pid() {
+        match probed_to_state(LAUNCHD_STATE_RUNNING, Some(LAUNCHD_PID_NONE)) {
+            ServiceState::Installed { pid, .. } => assert_eq!(pid, None),
+            other => panic!("expected Installed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probed_to_state_non_running_label() {
+        match probed_to_state("not running", None) {
+            ServiceState::Installed {
+                running,
+                state_label,
+                ..
+            } => {
+                assert!(!running);
+                assert_eq!(state_label, "stopped");
+            }
+            other => panic!("expected Installed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -272,9 +272,9 @@ fn render_status(inputs: StatusInputs) -> String {
     }
 }
 
-/// Cross-platform `service_state()` for the new `Service:` section in
-/// `kei status`. `launchctl print` exposes state and pid but no start
-/// time, so `since` is always `None` on macOS in v0.14.
+/// `service_state()` for the `Service:` section in `kei status`.
+/// `launchctl print` exposes state and pid but no start time, so
+/// `since` is always `None` on macOS.
 pub(crate) async fn service_state() -> Result<ServiceState> {
     Ok(match probe_status_inputs().await? {
         StatusInputs::NotInstalled => ServiceState::NotInstalled,
@@ -287,14 +287,16 @@ pub(crate) async fn service_state() -> Result<ServiceState> {
 }
 
 fn probed_to_state(state: &str, pid: Option<&str>) -> ServiceState {
-    let running = state == LAUNCHD_STATE_RUNNING;
-    let state_label: &'static str = if running { "running" } else { "stopped" };
+    let state_label: &'static str = if state == LAUNCHD_STATE_RUNNING {
+        crate::service::status::RUNNING_LABEL
+    } else {
+        "stopped"
+    };
     let pid = pid
         .filter(|p| !p.is_empty() && *p != LAUNCHD_PID_NONE)
         .and_then(|p| p.parse::<u32>().ok());
     ServiceState::Installed {
         backend: "launchd user",
-        running,
         state_label,
         since: None,
         pid,
@@ -702,13 +704,11 @@ com.rhoopr.kei = {
         match probed_to_state(LAUNCHD_STATE_RUNNING, Some("4321")) {
             ServiceState::Installed {
                 backend,
-                running,
                 state_label,
                 since,
                 pid,
             } => {
                 assert_eq!(backend, "launchd user");
-                assert!(running);
                 assert_eq!(state_label, "running");
                 assert_eq!(since, None);
                 assert_eq!(pid, Some(4321));
@@ -728,12 +728,7 @@ com.rhoopr.kei = {
     #[test]
     fn probed_to_state_non_running_label() {
         match probed_to_state("not running", None) {
-            ServiceState::Installed {
-                running,
-                state_label,
-                ..
-            } => {
-                assert!(!running);
+            ServiceState::Installed { state_label, .. } => {
                 assert_eq!(state_label, "stopped");
             }
             other => panic!("expected Installed, got {other:?}"),

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -1,9 +1,9 @@
 //! `kei service status` dispatcher and the cross-platform `ServiceState`
-//! data type that backs the new `Service:` section in `kei status`.
+//! data type that backs the `Service:` section in `kei status`.
 //!
-//! `run()` continues to power `kei service status`: it delegates to the
-//! per-platform `status()` function, which prints a single line tuned to
-//! that platform's vocabulary (`systemctl --user`, `launchctl print`,
+//! `run()` powers `kei service status`: it delegates to the per-platform
+//! `status()` function, which prints a single line tuned to that
+//! platform's vocabulary (`systemctl --user`, `launchctl print`,
 //! `sc.exe query`).
 //!
 //! [`service_state`] is the data-only counterpart used by `kei status`:
@@ -51,14 +51,12 @@ async fn dispatch() -> Result<()> {
 pub(crate) enum ServiceState {
     /// No service file / SCM entry / launchd plist registered for kei.
     NotInstalled,
-    /// Service is registered. `running` distinguishes the running case
-    /// from any non-running state (stopped, paused, failed, etc.). The
-    /// `state_label` carries the platform-native verdict so we can print
-    /// `Service: stopped (...)` rather than collapsing every non-running
-    /// case to a single string.
+    /// Service is registered. `state_label` carries the lifecycle
+    /// verdict (`"running"`, `"stopped"`, `"failed"`, ...); `since`
+    /// renders only when the label is `"running"` so a stale
+    /// activation timestamp on a stopped unit cannot mislead.
     Installed {
         backend: &'static str,
-        running: bool,
         state_label: &'static str,
         since: Option<DateTime<Utc>>,
         pid: Option<u32>,
@@ -76,6 +74,12 @@ pub(crate) enum ServiceState {
     /// process supervisor is what restarts kei.
     InContainer { supervisor: &'static str },
 }
+
+/// Lifecycle label used by [`ServiceState::Installed`] for a running
+/// service. The renderer compares against this constant to decide
+/// whether to attach the `since` clause; per-platform adapters set
+/// `state_label` to this string when the service is actively running.
+pub(crate) const RUNNING_LABEL: &str = "running";
 
 /// Cross-platform `service_state()` dispatcher used by `kei status`.
 ///
@@ -122,7 +126,6 @@ pub(crate) fn render_oneline(state: &ServiceState) -> String {
         }
         ServiceState::Installed {
             backend,
-            running,
             state_label,
             since,
             pid,
@@ -131,10 +134,7 @@ pub(crate) fn render_oneline(state: &ServiceState) -> String {
             if let Some(pid) = pid {
                 detail.push_str(&format!(", pid {pid}"));
             }
-            // `since` only renders for the running state. A stopped
-            // service may still have ActiveEnterTimestamp populated from
-            // its last activation; printing it would mislead.
-            if *running {
+            if *state_label == RUNNING_LABEL {
                 if let Some(since) = since {
                     detail.push_str(&format!(", since {}", since.format("%Y-%m-%d %H:%M UTC")));
                 }
@@ -187,8 +187,7 @@ mod tests {
     fn renders_running_with_pid_and_since() {
         let line = render_oneline(&ServiceState::Installed {
             backend: "systemd user",
-            running: true,
-            state_label: "running",
+            state_label: RUNNING_LABEL,
             since: Some(fixed_since()),
             pid: Some(12345),
         });
@@ -202,8 +201,7 @@ mod tests {
     fn renders_running_without_since_or_pid() {
         let line = render_oneline(&ServiceState::Installed {
             backend: "windows scm",
-            running: true,
-            state_label: "running",
+            state_label: RUNNING_LABEL,
             since: None,
             pid: None,
         });
@@ -215,8 +213,7 @@ mod tests {
         // macOS path: launchctl print exposes the PID but no start time.
         let line = render_oneline(&ServiceState::Installed {
             backend: "launchd user",
-            running: true,
-            state_label: "running",
+            state_label: RUNNING_LABEL,
             since: None,
             pid: Some(4321),
         });
@@ -225,13 +222,11 @@ mod tests {
 
     #[test]
     fn renders_stopped_state_without_since() {
-        // Even when ActiveEnterTimestamp is populated by an older run,
-        // we don't dangle "since X" off a stopped service line -- the
-        // timestamp would refer to the previous activation, not the
-        // current state.
+        // ActiveEnterTimestamp may carry over from an earlier activation
+        // on a now-stopped unit; the renderer must not dangle "since X"
+        // off the stopped line.
         let line = render_oneline(&ServiceState::Installed {
             backend: "systemd user",
-            running: false,
             state_label: "stopped",
             since: Some(fixed_since()),
             pid: None,

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -1,12 +1,20 @@
-//! `kei service status` dispatcher.
+//! `kei service status` dispatcher and the cross-platform `ServiceState`
+//! data type that backs the new `Service:` section in `kei status`.
 //!
-//! Reports whether kei is registered as a service on this host and how
-//! long it has been running. Per-platform queries (`systemctl --user
-//! show`, `launchctl print`, `Get-Service`) live in the per-platform
-//! backend modules. Linux and macOS are wired up; Windows currently
-//! returns a placeholder error rather than a misleading "not installed".
+//! `run()` continues to power `kei service status`: it delegates to the
+//! per-platform `status()` function, which prints a single line tuned to
+//! that platform's vocabulary (`systemctl --user`, `launchctl print`,
+//! `sc.exe query`).
+//!
+//! [`service_state`] is the data-only counterpart used by `kei status`:
+//! each backend reports back as a [`ServiceState`] so the renderer in
+//! [`render_oneline`] is platform-agnostic and can be unit-tested without
+//! shelling out. Container hosts short-circuit to
+//! [`ServiceState::InContainer`] before any platform query, so docker /
+//! kubernetes deployments never see a misleading `not installed`.
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 
 pub(crate) async fn run() -> Result<()> {
     dispatch().await
@@ -32,4 +40,202 @@ async fn dispatch() -> Result<()> {
     Err(anyhow::anyhow!(
         "`kei service status` is not implemented on this platform"
     ))
+}
+
+/// Cross-platform view of "is kei registered as a service on this host".
+///
+/// Each backend exposes a `service_state()` that returns one of these
+/// variants. The renderer in [`render_oneline`] is the single source of
+/// truth for the `Service:` line in `kei status` output.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ServiceState {
+    /// No service file / SCM entry / launchd plist registered for kei.
+    NotInstalled,
+    /// Service is registered. `running` distinguishes the running case
+    /// from any non-running state (stopped, paused, failed, etc.). The
+    /// `state_label` carries the platform-native verdict so we can print
+    /// `Service: stopped (...)` rather than collapsing every non-running
+    /// case to a single string.
+    Installed {
+        backend: &'static str,
+        running: bool,
+        state_label: &'static str,
+        since: Option<DateTime<Utc>>,
+        pid: Option<u32>,
+    },
+    /// The service is registered but the platform's query surface is
+    /// unavailable: no session bus on linux SSH-without-linger, no GUI
+    /// domain on a headless macOS CI runner, non-elevated SCM on
+    /// Windows.
+    BackendUnavailable {
+        backend: &'static str,
+        reason: &'static str,
+    },
+    /// Running inside a container (Docker, Kubernetes, Podman, ...).
+    /// kei's service-management surface is a no-op here: the container's
+    /// process supervisor is what restarts kei.
+    InContainer { supervisor: &'static str },
+}
+
+/// Cross-platform `service_state()` dispatcher used by `kei status`.
+///
+/// Container detection is checked first so `kei status` inside Docker
+/// reports the supervisor rather than running a per-platform probe that
+/// would (correctly) say "not installed" and confuse the operator.
+pub(crate) async fn service_state() -> Result<ServiceState> {
+    if let Some(supervisor) = crate::service::env::container_supervisor() {
+        return Ok(ServiceState::InContainer { supervisor });
+    }
+    platform_service_state().await
+}
+
+#[cfg(target_os = "linux")]
+async fn platform_service_state() -> Result<ServiceState> {
+    crate::service::linux::service_state().await
+}
+
+#[cfg(target_os = "macos")]
+async fn platform_service_state() -> Result<ServiceState> {
+    crate::service::macos::service_state().await
+}
+
+#[cfg(target_os = "windows")]
+async fn platform_service_state() -> Result<ServiceState> {
+    crate::service::windows::service_state().await
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+async fn platform_service_state() -> Result<ServiceState> {
+    Ok(ServiceState::NotInstalled)
+}
+
+/// Renders a [`ServiceState`] as the single `Service: ...` line that
+/// `kei status` emits. Pure function; tests cover every variant.
+pub(crate) fn render_oneline(state: &ServiceState) -> String {
+    match state {
+        ServiceState::NotInstalled => "Service: not installed".to_string(),
+        ServiceState::InContainer { supervisor } => {
+            format!("Service: running in container (process supervisor: {supervisor})")
+        }
+        ServiceState::BackendUnavailable { backend, reason } => {
+            format!("Service: installed ({backend}, {reason})")
+        }
+        ServiceState::Installed {
+            backend,
+            running,
+            state_label,
+            since,
+            pid,
+        } => {
+            let mut detail = format!("Service: {state_label} ({backend}");
+            if let Some(pid) = pid {
+                detail.push_str(&format!(", pid {pid}"));
+            }
+            // `since` only renders for the running state. A stopped
+            // service may still have ActiveEnterTimestamp populated from
+            // its last activation; printing it would mislead.
+            if *running {
+                if let Some(since) = since {
+                    detail.push_str(&format!(", since {}", since.format("%Y-%m-%d %H:%M UTC")));
+                }
+            }
+            detail.push(')');
+            detail
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_since() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 7, 14, 32, 1).unwrap()
+    }
+
+    #[test]
+    fn renders_not_installed() {
+        assert_eq!(
+            render_oneline(&ServiceState::NotInstalled),
+            "Service: not installed",
+        );
+    }
+
+    #[test]
+    fn renders_in_container() {
+        assert_eq!(
+            render_oneline(&ServiceState::InContainer {
+                supervisor: "docker",
+            }),
+            "Service: running in container (process supervisor: docker)",
+        );
+    }
+
+    #[test]
+    fn renders_backend_unavailable() {
+        assert_eq!(
+            render_oneline(&ServiceState::BackendUnavailable {
+                backend: "systemd user",
+                reason: "bus unavailable",
+            }),
+            "Service: installed (systemd user, bus unavailable)",
+        );
+    }
+
+    #[test]
+    fn renders_running_with_pid_and_since() {
+        let line = render_oneline(&ServiceState::Installed {
+            backend: "systemd user",
+            running: true,
+            state_label: "running",
+            since: Some(fixed_since()),
+            pid: Some(12345),
+        });
+        assert_eq!(
+            line,
+            "Service: running (systemd user, pid 12345, since 2026-05-07 14:32 UTC)",
+        );
+    }
+
+    #[test]
+    fn renders_running_without_since_or_pid() {
+        let line = render_oneline(&ServiceState::Installed {
+            backend: "windows scm",
+            running: true,
+            state_label: "running",
+            since: None,
+            pid: None,
+        });
+        assert_eq!(line, "Service: running (windows scm)");
+    }
+
+    #[test]
+    fn renders_running_with_pid_only_when_since_missing() {
+        // macOS path: launchctl print exposes the PID but no start time.
+        let line = render_oneline(&ServiceState::Installed {
+            backend: "launchd user",
+            running: true,
+            state_label: "running",
+            since: None,
+            pid: Some(4321),
+        });
+        assert_eq!(line, "Service: running (launchd user, pid 4321)");
+    }
+
+    #[test]
+    fn renders_stopped_state_without_since() {
+        // Even when ActiveEnterTimestamp is populated by an older run,
+        // we don't dangle "since X" off a stopped service line -- the
+        // timestamp would refer to the previous activation, not the
+        // current state.
+        let line = render_oneline(&ServiceState::Installed {
+            backend: "systemd user",
+            running: false,
+            state_label: "stopped",
+            since: Some(fixed_since()),
+            pid: None,
+        });
+        assert_eq!(line, "Service: stopped (systemd user)");
+    }
 }

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -35,6 +35,7 @@ use crate::service::env::{
     current_executable, kei_state_dir_dotted, purge_kei_state, SERVICE_DESCRIPTION,
     SERVICE_IDENTIFIER,
 };
+use crate::service::status::ServiceState;
 
 /// SCM service name (matches `SERVICE_IDENTIFIER` so `sc.exe query
 /// com.rhoopr.kei` works for ad-hoc inspection).
@@ -130,6 +131,28 @@ pub(crate) async fn status() -> Result<()> {
     let line = render_status(scm_impl::probe().await?);
     println!("{line}");
     Ok(())
+}
+
+/// Cross-platform `service_state()` for the new `Service:` section in
+/// `kei status`. SCM does not expose a service-start timestamp via
+/// `QueryServiceStatusEx`, so `since` is always `None` on Windows in
+/// v0.14; the running flag and PID are sufficient signal for the
+/// status line.
+pub(crate) async fn service_state() -> Result<ServiceState> {
+    Ok(match scm_impl::probe().await? {
+        StatusInputs::NotInstalled => ServiceState::NotInstalled,
+        StatusInputs::ScmUnavailable => ServiceState::BackendUnavailable {
+            backend: "windows scm",
+            reason: "SCM unavailable",
+        },
+        StatusInputs::Probed { state, pid } => ServiceState::Installed {
+            backend: "windows scm",
+            running: state == ServiceStateView::Running,
+            state_label: state.label(),
+            since: None,
+            pid,
+        },
+    })
 }
 
 /// `kei service run` entry on Windows.

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -133,11 +133,10 @@ pub(crate) async fn status() -> Result<()> {
     Ok(())
 }
 
-/// Cross-platform `service_state()` for the new `Service:` section in
-/// `kei status`. SCM does not expose a service-start timestamp via
-/// `QueryServiceStatusEx`, so `since` is always `None` on Windows in
-/// v0.14; the running flag and PID are sufficient signal for the
-/// status line.
+/// `service_state()` for the `Service:` section in `kei status`. SCM
+/// does not expose a service-start timestamp via `QueryServiceStatusEx`,
+/// so `since` is always `None`; the lifecycle label and PID are
+/// sufficient signal for the status line.
 pub(crate) async fn service_state() -> Result<ServiceState> {
     Ok(match scm_impl::probe().await? {
         StatusInputs::NotInstalled => ServiceState::NotInstalled,
@@ -147,7 +146,6 @@ pub(crate) async fn service_state() -> Result<ServiceState> {
         },
         StatusInputs::Probed { state, pid } => ServiceState::Installed {
             backend: "windows scm",
-            running: state == ServiceStateView::Running,
             state_label: state.label(),
             since: None,
             pid,

--- a/tests/service_status.rs
+++ b/tests/service_status.rs
@@ -1,0 +1,79 @@
+//! Integration coverage for the new `Service:` section in `kei status`.
+//!
+//! These tests run on every host the rest of the suite runs on (linux,
+//! macOS, Windows) because the Service line is now the *first* line of
+//! `kei status` output regardless of platform. The platform-native
+//! detail (`systemd user`, `launchd user`, `windows scm`,
+//! `running in container (...)`) is determined at runtime by the
+//! per-platform `service_state()` and is not asserted here -- the
+//! per-platform integration suites (`service_linux.rs` /
+//! `service_macos.rs` / `service_windows.rs`) cover that.
+//!
+//! What we do guarantee here:
+//!
+//! - `kei status` against a host with no kei service registered
+//!   (the test harness's CI runner) prints a `Service:` line and exits
+//!   successfully.
+//! - The Service line is emitted even when no state DB exists, so
+//!   `kei install` followed by `kei status` works on a fresh host.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stderr,
+    reason = "test harness; permissive lints accepted to keep assertions readable"
+)]
+
+mod common;
+
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Returns a `kei status` command bound to a fresh tempdir, with the
+/// username pinned to a placeholder so the resolver doesn't fail.
+/// `kei status` only uses the username to derive the per-account state
+/// DB path -- no network call is made -- so any non-empty value works.
+fn status_cmd(tmp: &TempDir) -> assert_cmd::Command {
+    let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", "service-status-test@example.invalid")
+        .args(["--data-dir"])
+        .arg(tmp.path())
+        .arg("status");
+    cmd
+}
+
+#[test]
+fn status_prints_service_line_with_no_state_db() {
+    // Fresh tempdir = no state.db. Status must still succeed and lead
+    // with a Service: line, since the user just ran `kei install` and
+    // is checking whether the service registered.
+    let tmp = TempDir::new().expect("tempdir");
+    status_cmd(&tmp)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Service:"));
+}
+
+#[test]
+fn status_emits_service_line_before_assets_section() {
+    // The Service line must come before the State Database / Assets
+    // block; an out-of-order emission would mean the section was wired
+    // into the wrong branch of run_status.
+    let tmp = TempDir::new().expect("tempdir");
+    let assert = status_cmd(&tmp).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let service_idx = stdout
+        .find("Service:")
+        .expect("Service: line must be present in status output");
+    // No state DB on a fresh tempdir, so the next section is the
+    // "No state database found" notice rather than the Assets block.
+    let next_idx = stdout
+        .find("No state database found")
+        .or_else(|| stdout.find("State Database:"))
+        .expect("status must surface either a missing-DB notice or the State Database line");
+    assert!(
+        service_idx < next_idx,
+        "Service line ({service_idx}) must come before the DB section ({next_idx}); got:\n{stdout}",
+    );
+}

--- a/tests/service_status.rs
+++ b/tests/service_status.rs
@@ -1,7 +1,7 @@
-//! Integration coverage for the new `Service:` section in `kei status`.
+//! Integration coverage for the `Service:` section in `kei status`.
 //!
 //! These tests run on every host the rest of the suite runs on (linux,
-//! macOS, Windows) because the Service line is now the *first* line of
+//! macOS, Windows) because the Service line is the first line of
 //! `kei status` output regardless of platform. The platform-native
 //! detail (`systemd user`, `launchd user`, `windows scm`,
 //! `running in container (...)`) is determined at runtime by the
@@ -17,18 +17,24 @@
 //! - The Service line is emitted even when no state DB exists, so
 //!   `kei install` followed by `kei status` works on a fresh host.
 
+// `mod common` pulls in tests/common/mod.rs which uses eprintln!, unwrap,
+// expect, and panic; the file-level allow propagates into that module so
+// the shared test harness keeps compiling without per-call attributes.
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
-    clippy::print_stderr,
-    reason = "test harness; permissive lints accepted to keep assertions readable"
+    clippy::print_stderr
 )]
 
 mod common;
 
+use std::time::Duration;
+
 use predicates::prelude::*;
 use tempfile::TempDir;
+
+const TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Returns a `kei status` command bound to a fresh tempdir, with the
 /// username pinned to a placeholder so the resolver doesn't fail.
@@ -36,7 +42,8 @@ use tempfile::TempDir;
 /// DB path -- no network call is made -- so any non-empty value works.
 fn status_cmd(tmp: &TempDir) -> assert_cmd::Command {
     let mut cmd = common::cmd();
-    cmd.env("ICLOUD_USERNAME", "service-status-test@example.invalid")
+    cmd.timeout(TIMEOUT)
+        .env("ICLOUD_USERNAME", "service-status-test@example.invalid")
         .args(["--data-dir"])
         .arg(tmp.path())
         .arg("status");


### PR DESCRIPTION
## Summary

Phase 1 of the v0.14 service work delivered `kei install` / `kei uninstall` / `kei service status` across linux, macOS, and Windows. This PR closes the loop by surfacing the same data inside the existing `kei status` command, so a freshly-installed user runs `kei status` and immediately sees whether the service registered and is running.

```
$ kei status
Service: running (systemd user, pid 12345, since 2026-05-07 14:32 UTC)

State Database: /home/alice/.config/kei/alice.db
Assets:
  Total:      4321
  ...
```

- Adds a cross-platform `ServiceState` data type in `src/service/status.rs` with a pure renderer (`render_oneline`) and a dispatcher that container-detects first.
- Each platform's existing probe path (`systemctl --user show`, `launchctl print`, SCM `QueryServiceStatusEx`) gets a `service_state()` adapter that returns `ServiceState`.
- Linux extends the systemctl property list with `MainPID` and parses the UTC form of `ActiveEnterTimestamp` into `DateTime<Utc>`. Non-UTC timestamps return `None` so the line is never silently wrong.
- Container hosts (Docker / containerd / kubepods / podman / lxc / `/.dockerenv`) short-circuit to `Service: running in container (process supervisor: docker)` rather than reporting `not installed`. Detection reuses the existing cgroup marker scan; `is_in_container()` is now a thin wrapper over the new `container_supervisor()`.

`kei service status` is unchanged: it still prints its platform-specific line; the new path is data-only and powers `kei status` only.

## Test plan

- [x] `just gate` clean (fmt, clippy, doc, audit, typos, roundtrip; full offline test set including the new `service_status` integration suite).
- [x] Pure renderer covers every `ServiceState` variant (NotInstalled, InContainer, BackendUnavailable, Installed running with/without since/pid, Installed stopped).
- [x] Linux `probe_to_state` + `parse_systemd_timestamp` covered with table tests; rejects non-UTC and blank timestamps.
- [x] macOS `probed_to_state` covered including the `pid = -` loaded-but-stopped edge case.
- [x] Container-supervisor detection table-test covers docker/containerd/kubepods/podman/lxc cgroup marker shapes plus `/.dockerenv` short-circuit.
- [x] `tests/service_status.rs` exercises the real `kei status` binary against a tempdir state DB; asserts the `Service:` line is present and emitted before the State Database section. CI-safe: pins `ICLOUD_USERNAME` via `Command::env` so the test doesn't depend on `.env`.
- [x] Local smoke: `cargo run -- --data-dir /tmp/kei-smoke status` on this host prints `Service: not installed` followed by the existing DB section.
- [ ] CI: ubuntu / macOS / windows-latest runners exercise the new code; per-platform smoke matrix lands in PR 8.

## Phase 1 progress

- [x] PR 1 — install/uninstall/service CLI (#352)
- [x] PR 2 — kei service run / sync_loop split (already on main)
- [x] PR 3 — Linux systemd backend (#355)
- [x] PR 4 — macOS launchd backend (#356)
- [x] PR 5 — Windows SCM backend (#358)
- [x] **PR 6 — kei status augmentation (this PR)**
- [ ] PR 7 — docs + brew tap caveat
- [ ] PR 8 — CI service-smoke matrix