### PR TITLE
docs: per-platform install + service guides for v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Docker image now honors `PUID` and `PGID` environment variables.** When both are set, the container's entrypoint chowns ownership-mismatched files in `/config` and `/photos` to that UID:GID and drops privileges via `gosu` before running kei. Setting only one is rejected; setting neither preserves the prior root-default. The chown uses `find -not -uid` so a multi-TB volume only pays for stragglers, not the full tree, on every restart. Unblocks NAS deployments (Synology Container Manager, Unraid, TrueNAS Scale) where downstream indexers like Synology Photos can't see root-owned files. ([Synology wiki](https://github.com/rhoopr/kei/wiki/Synology), [Docker wiki](https://github.com/rhoopr/kei/wiki/Docker))
+- **`kei install` registers kei as a long-running service on Linux, macOS, and Windows.** Renders the platform-native artifact (systemd unit, launchd plist, or Service Control Manager entry) and hands it to the platform's service manager. Defaults to per-user on Linux and macOS; Windows is per-user only and needs an elevated prompt. Inside Docker / Kubernetes / Podman the command is a no-op so existing compose workflows are unchanged. The service runs `kei service run`, which is `kei sync` with a once-per-day watch interval default. ([#351], [#352], [#355], [#356], [#358])
+- **`kei uninstall` removes the service.** Reverses `kei install` on every platform. Pass `--purge` to also delete the state database, configuration, and stored credentials; default keeps your data. ([#352], [#355], [#356], [#358])
+- **`kei service status` reports per-platform service state.** Surfaces the systemd `SubState`, launchd lifecycle, or SCM `current_state` in the platform's own terms for finer-grained debugging than the cross-platform line in `kei status`. ([#352], [#355], [#356], [#358])
+- **`kei status` leads with a `Service:` summary line.** Cross-platform one-liner (`Service: running (systemd user, pid 12345, since 2026-05-08 14:32 UTC)`, `Service: not installed`, `Service: running in container (process supervisor: docker)`, etc.) so you can script against a single output regardless of host. ([#359])
+
+[#351]: https://github.com/rhoopr/kei/pull/351
+[#352]: https://github.com/rhoopr/kei/pull/352
+[#355]: https://github.com/rhoopr/kei/pull/355
+[#356]: https://github.com/rhoopr/kei/pull/356
+[#358]: https://github.com/rhoopr/kei/pull/358
+[#359]: https://github.com/rhoopr/kei/pull/359
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,29 @@ For a guided walkthrough, run `kei config setup` instead.
 
 ---
 
+## Run as a service
+
+Register kei to start at boot and keep syncing in the background. One command per platform:
+
+```sh
+kei install --user            # Linux (systemd user unit)
+kei install                   # macOS (launchd agent)
+kei install                   # Windows (run from elevated PowerShell)
+```
+
+Inside Docker the command is a no-op; the container runtime is the supervisor. Keep using `docker compose up -d`.
+
+Verify with `kei status` (the first line reports the service state) or `kei service status` for the platform-tuned view. To remove: `kei uninstall` (add `--purge` to also wipe state, config, and credentials).
+
+Full per-platform guide including troubleshooting: [docs/install.md](docs/install.md). What the service runs once registered: [docs/service.md](docs/service.md).
+
+---
+
 ## Docs
 
 Everything lives on the [wiki](https://github.com/rhoopr/kei/wiki): full CLI reference, filtering and folder templates, watch mode, Docker Compose, credentials, troubleshooting, and more.
 
-- [Commands](https://github.com/rhoopr/kei/wiki/Home#commands) - `sync`, `login`, `list`, `password`, `config`, `reset`, `status`, `verify`, `import-existing`
+- [Commands](https://github.com/rhoopr/kei/wiki/Home#commands) - `sync`, `install`, `uninstall`, `service`, `login`, `list`, `password`, `config`, `reset`, `status`, `verify`, `import-existing`
 - [Configuration](https://github.com/rhoopr/kei/wiki/Configuration) - TOML file, env vars, precedence
 - [Docker](https://github.com/rhoopr/kei/wiki/Docker) - Compose files and headless 2FA
 - [Synology](https://github.com/rhoopr/kei/wiki/Synology) - Container Manager setup, PUID/PGID, Synology Photos integration

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,9 @@ Linux supports both per-user (default) and system-wide installs.
 kei install --user
 ```
 
-Writes `~/.config/systemd/user/kei.service`, runs `systemctl --user daemon-reload`, and enables the unit so it starts immediately and on every login. kei also tries `loginctl enable-linger $USER` so the service keeps running when you log out; this step needs polkit and is best-effort. If linger fails, the service runs only while you're logged in.
+Writes `~/.config/systemd/user/kei.service`, runs `systemctl --user daemon-reload`, and enables the unit so it starts immediately and on every login.
+
+kei also attempts `loginctl enable-linger $USER` so the service keeps running after you log out. That call goes through polkit and may be denied; if it fails, the unit still works while you're logged in but stops when your session ends. Re-run `sudo loginctl enable-linger $USER` manually to enable lingering, or accept the per-session lifetime.
 
 Verify with:
 
@@ -79,7 +81,7 @@ kei install
 
 Run this from an **elevated** PowerShell prompt (right-click PowerShell -> Run as administrator). Service Control Manager `CreateService` requires admin rights, and a non-elevated install fails with `Access is denied`.
 
-`kei install` registers `com.rhoopr.kei` with SCM, set to run as your Windows user account. You'll be prompted for your account password during install: SCM stores it in LSA so the service can start under your identity at boot, and so it can read your Credential Manager vault for the iCloud password.
+`kei install` registers `com.rhoopr.kei` with SCM, set to run as your Windows user account. You'll be prompted for your account password during install: SCM stores it in the Local Security Authority (LSA) so the service can start under your identity at boot, and so it can read your iCloud password from Credential Manager. See [credential-storage.md](credential-storage.md) for how kei stores the iCloud password itself.
 
 Per-user services aren't a Windows concept; `--user` and `--system` are both ignored. There is one install per machine.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,136 @@
+# Install kei
+
+This guide covers installing kei on each supported platform and registering it as a long-running service. For the brief one-liners, see the project README. For what the service does once registered, see [service.md](service.md).
+
+The flow is the same everywhere: install the binary, then run `kei install` to register the service.
+
+## macOS
+
+```sh
+brew install rhoopr/kei/kei
+kei install
+```
+
+`kei install` writes a per-user LaunchAgent to `~/Library/LaunchAgents/com.rhoopr.kei.plist` and bootstraps it via `launchctl`. The agent runs in your login session and writes logs to `~/Library/Logs/kei/`. There's no system-wide install on macOS in v0.14: `--system` returns an error pointing at the per-user form.
+
+If the binary won't launch with a "cannot be opened because the developer cannot be verified" dialog, strip the gatekeeper quarantine bit:
+
+```sh
+xattr -dr com.apple.quarantine "$(which kei)"
+```
+
+`brew install` clears the bit on its own outputs, so this only matters if you grabbed a release tarball directly.
+
+To uninstall:
+
+```sh
+kei uninstall            # remove the LaunchAgent
+kei uninstall --purge    # also remove ~/.config/kei (state DB, config, credentials)
+```
+
+## Linux
+
+Linux supports both per-user (default) and system-wide installs.
+
+### Per-user (recommended)
+
+```sh
+kei install --user
+```
+
+Writes `~/.config/systemd/user/kei.service`, runs `systemctl --user daemon-reload`, and enables the unit so it starts immediately and on every login. kei also tries `loginctl enable-linger $USER` so the service keeps running when you log out; this step needs polkit and is best-effort. If linger fails, the service runs only while you're logged in.
+
+Verify with:
+
+```sh
+systemctl --user status kei.service
+```
+
+### System-wide
+
+```sh
+sudo kei install --system
+```
+
+Writes `/etc/systemd/system/kei.service`, sets `User=` to the user named in `$SUDO_USER`, and enables the unit. The service runs as that user (not root) but is supervised by the system manager, so it survives logout without linger.
+
+Status check:
+
+```sh
+systemctl status kei.service
+```
+
+### Distro packaging
+
+There's no apt/dnf repo yet. Use the static binary tarball from [Releases](https://github.com/rhoopr/kei/releases) and drop it into `/usr/local/bin/`, then run `kei install --user`.
+
+### Uninstall
+
+```sh
+kei uninstall            # tries per-user first, then system (root needed for the latter)
+kei uninstall --purge    # also wipes ~/.config/kei
+```
+
+## Windows
+
+```powershell
+kei install
+```
+
+Run this from an **elevated** PowerShell prompt (right-click PowerShell -> Run as administrator). Service Control Manager `CreateService` requires admin rights, and a non-elevated install fails with `Access is denied`.
+
+`kei install` registers `com.rhoopr.kei` with SCM, set to run as your Windows user account. You'll be prompted for your account password during install: SCM stores it in LSA so the service can start under your identity at boot, and so it can read your Credential Manager vault for the iCloud password.
+
+Per-user services aren't a Windows concept; `--user` and `--system` are both ignored. There is one install per machine.
+
+Verify with:
+
+```powershell
+Get-Service com.rhoopr.kei
+```
+
+To uninstall:
+
+```powershell
+kei uninstall            # also from an elevated prompt
+kei uninstall --purge    # also wipes %USERPROFILE%\.config\kei
+```
+
+## Docker
+
+`kei install` is a no-op inside containers. Docker, Kubernetes, Podman, and similar runtimes already supervise the process; writing a launchd plist or systemd unit on the container's rootfs would never be invoked.
+
+Existing `docker compose up -d` workflows are unchanged. The container's default `CMD` runs `kei sync --watch-with-interval 86400`, which gives the same once-a-day poll behavior `kei install` produces on a bare host. See the [Docker wiki page](https://github.com/rhoopr/kei/wiki/Docker) for compose examples and the [Synology guide](https://github.com/rhoopr/kei/wiki/Synology) for NAS setups.
+
+## What `kei install` actually does
+
+The command renders one platform-native artifact and hands it to the platform's service manager:
+
+| Platform | Artifact | Manager |
+|---|---|---|
+| Linux (user)   | `~/.config/systemd/user/kei.service`     | `systemctl --user` |
+| Linux (system) | `/etc/systemd/system/kei.service`         | `systemctl` |
+| macOS          | `~/Library/LaunchAgents/com.rhoopr.kei.plist` | `launchctl` |
+| Windows        | SCM entry `com.rhoopr.kei`                | Service Control Manager |
+
+The service runs `kei service run`, which is `kei sync` with a watch interval default of once per day (86400 seconds). Override with the standard `--watch-with-interval` flag in your config. See [service.md](service.md) for what the worker does once running.
+
+## Verifying the install
+
+After `kei install` succeeds:
+
+```sh
+kei status
+```
+
+The first line is the `Service:` summary. On a bare host with the service running you'll see something like:
+
+```
+Service: running (systemd user, pid 12345, since 2026-05-08 14:32 UTC)
+```
+
+The exact backend label varies (`systemd user`, `systemd system`, `launchd user`, `windows scm`, or `running in container (process supervisor: docker)`). `not installed` means `kei install` hasn't run yet.
+
+## Dry runs
+
+`kei install --dry-run` writes the unit/plist to disk so you can inspect it but skips `daemon-reload` / `bootstrap` / `CreateService`. Useful when you want to see exactly what kei will register before committing. Windows `--dry-run` prints the SCM call it would make and skips the password prompt.

--- a/docs/service.md
+++ b/docs/service.md
@@ -40,7 +40,7 @@ systemctl --user restart kei.service
 
 Drop the `--user` for system-wide installs.
 
-The unit notifies systemd of readiness and watchdog pings via `sd_notify`, so `Type=notify` and `WatchdogSec=` work out of the box. The PID file is `~/.config/kei/kei.pid` (or `/run/kei.pid` for system installs).
+The unit is `Type=notify` with `WatchdogSec=120`, so kei sends `sd_notify` readiness and watchdog pings; systemd manages the PID directly and no `PIDFile=` is set. `Restart=on-failure` with `RestartSec=10s` keeps the worker alive across crashes.
 
 ### macOS (launchd)
 
@@ -77,11 +77,13 @@ sc.exe qc com.rhoopr.kei
 Start-Service com.rhoopr.kei
 Stop-Service  com.rhoopr.kei
 
-# Logs go to the Windows Event Log under "Application"; filter by source name `kei`
-Get-EventLog -LogName Application -Source kei -Newest 50
+# SCM lifecycle events (start, stop, crash) under source "Service Control Manager"
+Get-EventLog -LogName System -Source "Service Control Manager" -Newest 50 | Where-Object { $_.Message -like "*com.rhoopr.kei*" }
 ```
 
-The service is configured `start= auto` so it runs at every boot.
+The service is configured `start= auto` so it runs at every boot. Failure actions: SCM restarts the worker up to three times with a 10-second delay between attempts; the failure counter resets after 24 hours of clean uptime.
+
+kei's own log output (the `tracing` lines you see when running `kei sync` in a terminal) goes to stderr, which SCM discards. There is no first-class log-file destination configured by `kei install` on Windows in v0.14. To inspect kei's runtime behavior, run `kei sync` directly from PowerShell with the same flags rather than relying on the SCM-managed worker.
 
 ## Checking status
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -1,0 +1,126 @@
+# Running kei as a service
+
+`kei install` registers kei to start at boot and run continuously. This page explains what runs once the service is up, what each platform's artifact looks like, and how to inspect or control it from the platform's native tools.
+
+For installing the service, see [install.md](install.md).
+
+## What `kei service run` does
+
+The command launched by every platform's service manager is `kei service run`. That's `kei sync` with one default change: when nothing else sets a watch interval, it polls iCloud once per day (86400 seconds) instead of running once and exiting.
+
+Override the interval the same way you would for any sync:
+
+- CLI flag in the config: `--watch-with-interval 3600` (every hour)
+- Config file: `[watch] interval_seconds = 3600`
+- Env var (Docker): `KEI_WATCH_WITH_INTERVAL=3600`
+
+Resolution order is the standard CLI > env > TOML > default chain.
+
+The worker handles 2FA, session refresh, and graceful shutdown the same way `kei sync --watch` does in the foreground. SIGINT/SIGTERM (Linux/macOS) and SCM stop requests (Windows) flush in-flight downloads, persist the sync state, and exit cleanly.
+
+## Per-platform artifacts
+
+### Linux (systemd)
+
+The unit file is plain `[Service] ExecStart=/path/to/kei service run`. Per-user installs land at `~/.config/systemd/user/kei.service`; system-wide at `/etc/systemd/system/kei.service` with `User=` set to the operator account.
+
+```sh
+# View the unit
+systemctl --user cat kei.service
+
+# Live status
+systemctl --user status kei.service
+
+# Logs (follow)
+journalctl --user -u kei.service -f
+
+# Restart after a config change
+systemctl --user restart kei.service
+```
+
+Drop the `--user` for system-wide installs.
+
+The unit notifies systemd of readiness and watchdog pings via `sd_notify`, so `Type=notify` and `WatchdogSec=` work out of the box. The PID file is `~/.config/kei/kei.pid` (or `/run/kei.pid` for system installs).
+
+### macOS (launchd)
+
+The plist is `~/Library/LaunchAgents/com.rhoopr.kei.plist`. It runs as your user and writes stdout/stderr to `~/Library/Logs/kei/stdout.log` and `~/Library/Logs/kei/stderr.log`.
+
+```sh
+# Confirm it's loaded
+launchctl list com.rhoopr.kei
+
+# Tail logs
+tail -f ~/Library/Logs/kei/stderr.log
+
+# Stop without uninstalling
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.rhoopr.kei.plist
+
+# Start it again
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rhoopr.kei.plist
+```
+
+`KeepAlive` is set, so launchd restarts the worker if it exits non-zero. `RunAtLoad` is true, so the worker starts the moment the agent loads (which means at every login, since LaunchAgents follow the GUI session).
+
+### Windows (SCM)
+
+The service name is `com.rhoopr.kei`. It runs as your Windows user account, with the password stored in LSA at install time.
+
+```powershell
+# Service summary
+Get-Service com.rhoopr.kei
+
+# Detailed view including binary path and account
+sc.exe qc com.rhoopr.kei
+
+# Start / stop without uninstalling
+Start-Service com.rhoopr.kei
+Stop-Service  com.rhoopr.kei
+
+# Logs go to the Windows Event Log under "Application"; filter by source name `kei`
+Get-EventLog -LogName Application -Source kei -Newest 50
+```
+
+The service is configured `start= auto` so it runs at every boot.
+
+## Checking status
+
+Two commands report on the service. Pick whichever fits the question.
+
+### `kei status`
+
+The first line of `kei status` is the cross-platform service summary. This is the right thing to script against:
+
+```
+Service: running (systemd user, pid 12345, since 2026-05-08 14:32 UTC)
+```
+
+Variants:
+
+- `Service: not installed` -> `kei install` hasn't run.
+- `Service: running (<backend>, pid <n>, since <utc>)` -> healthy.
+- `Service: <state> (<backend>, ...)` -> registered but not currently running. `<state>` is the platform's own term (`inactive`, `failed`, `stopped`).
+- `Service: installed (<backend>, <reason>)` -> registered, but kei couldn't reach the manager to ask for a state (typically a missing systemd user bus over SSH). Treat as "registered, status unknown".
+- `Service: running in container (process supervisor: docker)` -> kei is inside a container; the container runtime is the supervisor.
+
+The line is best-effort: a probe failure renders `Service: status unavailable` rather than blocking the rest of `kei status`.
+
+### `kei service status`
+
+The platform-tuned form. On Linux it surfaces the systemd `SubState` (`running`/`dead`/`failed`/...) for finer-grained debugging. On macOS and Windows it's similar to the line above. Use this when you want to see all the per-backend detail kei has, rather than the cross-platform summary.
+
+## Updating after a kei upgrade
+
+`brew upgrade rhoopr/kei/kei`, replacing the binary in `/usr/local/bin/`, or `cargo install kei` will all replace the binary in place. The unit/plist/SCM entry continues to point at the same path, so the next service restart picks up the new binary.
+
+To force a restart:
+
+- **Linux**: `systemctl --user restart kei.service`
+- **macOS**: `launchctl kickstart -k gui/$(id -u)/com.rhoopr.kei`
+- **Windows**: `Restart-Service com.rhoopr.kei`
+
+If the binary moved (e.g. you switched from the homebrew install to a manually placed binary at a different path), run `kei uninstall && kei install` to re-render the artifact at the new path.
+
+## Removing the service
+
+`kei uninstall` removes only the platform artifact. State (DB, config, credentials) is preserved by default; pass `--purge` to wipe `~/.config/kei` along with the service entry. See [install.md](install.md) for the per-platform commands.


### PR DESCRIPTION
## Summary

- New `docs/install.md` and `docs/service.md` with per-platform install paths (macOS, Linux, Windows, Docker), troubleshooting, and runtime/inspection guidance.
- README gets a `Run as a service` section pointing at the new guides; `Commands` line in Docs adds `install`, `uninstall`, `service`.
- `CHANGELOG.md` Unreleased rolls up the v0.14 service surface across #351, #352, #355, #356, #358, #359.

PR 7 of 8 in the v0.14 phase-1 sequence (`.scratch/2026-05-07_v0.14-phase1-implementation-plan.md`).

## Follow-ups (separate PRs, not this one)

- **Brew tap caveats**: open a sibling PR against `rhoopr/homebrew-kei` adding a post-install `caveats` block pointing at `kei install`.
- **Wiki sync**: copy the install/service guidance into the wiki (Install / Configuration pages); this repo PR ships the canonical version under `docs/`.
- **PR 8** (next): CI service-smoke matrix exercising `kei install` -> `kei status` -> `kei uninstall` on ubuntu / macOS / windows runners.

## Test plan

- [x] `cargo fmt --check` clean (no Rust changes; verified anyway)
- [x] Em-dash audit: `grep -nE "—|–"` against the four touched files only flags pre-existing entries in the frozen released CHANGELOG history. New content is em-dash-free per `feedback_no_emdashes.md`.
- [x] Docs-writing skill banned-word audit: clean. The two `elevated` hits in `docs/install.md` refer to the Windows admin-prompt term, not the AI banned word.
- [x] CLI surface verified against `src/cli.rs` and `src/service/{install,uninstall}.rs`: per-user / per-system defaults per platform, `--dry-run`, `--purge`, container no-op all match the real implementation.
- [ ] Render check on GitHub once the PR is open (relative links between README -> `docs/install.md` -> `docs/service.md` resolve correctly).