### PR TITLE
ci: per-platform service-install smoke matrix

### DIFF
--- a/.github/workflows/service-smoke.yml
+++ b/.github/workflows/service-smoke.yml
@@ -73,8 +73,7 @@ jobs:
 
           # Pre-state: nothing installed.
           test ! -e "$UNIT"
-          "$KEI" status | tee /tmp/kei-status-pre.txt
-          grep -q '^Service: not installed' /tmp/kei-status-pre.txt
+          "$KEI" status | grep -q '^Service: not installed'
 
           # Dry-run install renders the unit on disk and skips
           # daemon-reload / enable / loginctl enable-linger. The runner
@@ -98,8 +97,7 @@ jobs:
           "$KEI" uninstall
 
           test ! -e "$UNIT"
-          "$KEI" status | tee /tmp/kei-status-post.txt
-          grep -q '^Service: not installed' /tmp/kei-status-post.txt
+          "$KEI" status | grep -q '^Service: not installed'
 
       - name: macOS smoke
         if: runner.os == 'macOS'
@@ -110,8 +108,7 @@ jobs:
           PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
 
           test ! -e "$PLIST"
-          "$KEI" status | tee /tmp/kei-status-pre.txt
-          grep -q '^Service: not installed' /tmp/kei-status-pre.txt
+          "$KEI" status | grep -q '^Service: not installed'
 
           # Dry-run renders the plist and skips launchctl bootstrap.
           # GitHub-hosted macOS runners have a GUI session, but we
@@ -132,8 +129,7 @@ jobs:
           "$KEI" uninstall
 
           test ! -e "$PLIST"
-          "$KEI" status | tee /tmp/kei-status-post.txt
-          grep -q '^Service: not installed' /tmp/kei-status-post.txt
+          "$KEI" status | grep -q '^Service: not installed'
 
       - name: Windows smoke
         if: runner.os == 'Windows'
@@ -147,7 +143,6 @@ jobs:
           if ($null -ne $svc) { throw "service already registered before smoke install" }
 
           $statusPre = & $kei status
-          $statusPre | Out-File /tmp/kei-status-pre.txt
           if ($statusPre[0] -ne 'Service: not installed') {
               throw "expected 'Service: not installed', got: $($statusPre[0])"
           }
@@ -172,7 +167,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "kei uninstall on clean host failed" }
 
           $statusPost = & $kei status
-          $statusPost | Out-File /tmp/kei-status-post.txt
           if ($statusPost[0] -ne 'Service: not installed') {
               throw "expected 'Service: not installed', got: $($statusPost[0])"
           }

--- a/.github/workflows/service-smoke.yml
+++ b/.github/workflows/service-smoke.yml
@@ -1,0 +1,178 @@
+name: Service smoke
+
+# Per-platform smoke for `kei install` / `kei uninstall`. Builds the
+# release binary on each runner OS, exercises the dry-run install path
+# (which renders the platform artifact without invoking the service
+# manager so no credentials or elevated bus is required), validates
+# artifact syntax with the platform-native linter, then runs
+# `kei uninstall` and asserts the artifact is gone.
+#
+# What this catches:
+#   - regressions that produce malformed unit/plist/SCM-preview output
+#   - artifact path changes (uninstall must find what install wrote)
+#   - cross-platform regressions in the shared install/uninstall
+#     dispatcher
+#
+# What this does NOT catch (out of scope, would need credentials):
+#   - the service actually starts and reaches `Service: running`
+#   - launchctl bootstrap / systemctl --now / SCM CreateService glue
+#
+# That deeper exercise lives in the Rust integration suites
+# (tests/service_linux.rs etc.) and the maintainer's manual real-install
+# flow against the icloudpd-test album.
+
+on:
+  pull_request:
+    paths:
+      - 'src/service/**'
+      - 'src/cli.rs'
+      - 'src/commands/status.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/service-smoke.yml'
+
+concurrency:
+  group: service-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+  # `kei status` derives its state-DB path from the username; pin a
+  # placeholder so the smoke does not require a real Apple ID.
+  ICLOUD_USERNAME: service-smoke@example.invalid
+
+jobs:
+  smoke:
+    name: Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Linux smoke
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          KEI="$PWD/target/release/kei"
+          UNIT="$HOME/.config/systemd/user/kei.service"
+
+          # Pre-state: nothing installed.
+          test ! -e "$UNIT"
+          "$KEI" status | tee /tmp/kei-status-pre.txt
+          grep -q '^Service: not installed' /tmp/kei-status-pre.txt
+
+          # Dry-run install renders the unit on disk and skips
+          # daemon-reload / enable / loginctl enable-linger. The runner
+          # user has no active systemd --user bus on hosted runners, so
+          # the non-dry path would fail at daemon-reload regardless.
+          "$KEI" install --user --dry-run
+
+          test -f "$UNIT"
+
+          # Validate the unit syntax. systemd-analyze verify works
+          # without an active bus and catches malformed [Unit] / [Service]
+          # / [Install] sections, unknown directives, and bad ExecStart
+          # paths. It expects the unit to be reachable from the
+          # systemd unit search path; --user mode plus the standard
+          # ~/.config/systemd/user location works without sudo.
+          systemd-analyze --user verify "$UNIT"
+
+          # Uninstall removes the unit even when the bus is unreachable
+          # (the platform branch logs and continues on best-effort
+          # daemon-reload failure).
+          "$KEI" uninstall
+
+          test ! -e "$UNIT"
+          "$KEI" status | tee /tmp/kei-status-post.txt
+          grep -q '^Service: not installed' /tmp/kei-status-post.txt
+
+      - name: macOS smoke
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          KEI="$PWD/target/release/kei"
+          PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
+
+          test ! -e "$PLIST"
+          "$KEI" status | tee /tmp/kei-status-pre.txt
+          grep -q '^Service: not installed' /tmp/kei-status-pre.txt
+
+          # Dry-run renders the plist and skips launchctl bootstrap.
+          # GitHub-hosted macOS runners have a GUI session, but we
+          # avoid the bootstrap step because the worker would fail to
+          # auth without credentials and KeepAlive would loop with
+          # backoff for the lifetime of the job.
+          "$KEI" install --dry-run
+
+          test -f "$PLIST"
+
+          # plutil -lint checks the plist parses as well-formed XML
+          # and that every key has a recognized value type. It does
+          # not validate launchd-specific keys (that's launchctl's
+          # job at bootstrap), but it catches the most common
+          # template-rendering regressions.
+          plutil -lint "$PLIST"
+
+          "$KEI" uninstall
+
+          test ! -e "$PLIST"
+          "$KEI" status | tee /tmp/kei-status-post.txt
+          grep -q '^Service: not installed' /tmp/kei-status-post.txt
+
+      - name: Windows smoke
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $kei = Join-Path $PWD 'target\release\kei.exe'
+
+          # Pre-state: SCM service must not exist.
+          $svc = Get-Service com.rhoopr.kei -ErrorAction SilentlyContinue
+          if ($null -ne $svc) { throw "service already registered before smoke install" }
+
+          $statusPre = & $kei status
+          $statusPre | Out-File /tmp/kei-status-pre.txt
+          if ($statusPre[0] -ne 'Service: not installed') {
+              throw "expected 'Service: not installed', got: $($statusPre[0])"
+          }
+
+          # Windows dry-run prints the full SCM call preview (executable
+          # path, account, launch arguments, failure-action policy)
+          # without prompting for the account password and without
+          # invoking CreateServiceW. A real install requires the
+          # operator's plain-text password to be passed to LSA, which
+          # has no clean CI-secret story today; that path is exercised
+          # manually.
+          & $kei install --dry-run
+          if ($LASTEXITCODE -ne 0) { throw "kei install --dry-run failed" }
+
+          # Confirm the dry-run was truly a no-op against SCM.
+          $svc = Get-Service com.rhoopr.kei -ErrorAction SilentlyContinue
+          if ($null -ne $svc) { throw "dry-run unexpectedly registered the service" }
+
+          # Uninstall against a clean host should report "nothing to
+          # remove" and exit 0.
+          & $kei uninstall
+          if ($LASTEXITCODE -ne 0) { throw "kei uninstall on clean host failed" }
+
+          $statusPost = & $kei status
+          $statusPost | Out-File /tmp/kei-status-post.txt
+          if ($statusPost[0] -ne 'Service: not installed') {
+              throw "expected 'Service: not installed', got: $($statusPost[0])"
+          }

--- a/.github/workflows/service-smoke.yml
+++ b/.github/workflows/service-smoke.yml
@@ -72,8 +72,14 @@ jobs:
           UNIT="$HOME/.config/systemd/user/kei.service"
 
           # Pre-state: nothing installed.
+          # Capture status output to a variable instead of piping into
+          # `grep -q`: -q closes its end of the pipe on the first match,
+          # which delivers SIGPIPE to kei's later writes (`State
+          # Database`, `Assets`, etc.) and Rust's default stdout panics
+          # on EPIPE.
           test ! -e "$UNIT"
-          "$KEI" status | grep -q '^Service: not installed'
+          status_pre=$("$KEI" status)
+          printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
 
           # Dry-run install renders the unit on disk and skips
           # daemon-reload / enable / loginctl enable-linger. The runner
@@ -97,7 +103,8 @@ jobs:
           "$KEI" uninstall
 
           test ! -e "$UNIT"
-          "$KEI" status | grep -q '^Service: not installed'
+          status_post=$("$KEI" status)
+          printf '%s\n' "$status_post" | grep -q '^Service: not installed'
 
       - name: macOS smoke
         if: runner.os == 'macOS'
@@ -108,7 +115,8 @@ jobs:
           PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
 
           test ! -e "$PLIST"
-          "$KEI" status | grep -q '^Service: not installed'
+          status_pre=$("$KEI" status)
+          printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
 
           # Dry-run renders the plist and skips launchctl bootstrap.
           # GitHub-hosted macOS runners have a GUI session, but we
@@ -129,7 +137,8 @@ jobs:
           "$KEI" uninstall
 
           test ! -e "$PLIST"
-          "$KEI" status | grep -q '^Service: not installed'
+          status_post=$("$KEI" status)
+          printf '%s\n' "$status_post" | grep -q '^Service: not installed'
 
       - name: Windows smoke
         if: runner.os == 'Windows'

--- a/justfile
+++ b/justfile
@@ -280,25 +280,25 @@ service-smoke:
             # pre-state assertion is meaningful.
             rm -f "$UNIT"
             test ! -e "$UNIT"
-            "$KEI" status | grep -q '^Service: not installed'
+            status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
             "$KEI" install --user --dry-run
             test -f "$UNIT"
             systemd-analyze --user verify "$UNIT"
             "$KEI" uninstall
             test ! -e "$UNIT"
-            "$KEI" status | grep -q '^Service: not installed'
+            status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'
             ;;
         Darwin)
             PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
             rm -f "$PLIST"
             test ! -e "$PLIST"
-            "$KEI" status | grep -q '^Service: not installed'
+            status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
             "$KEI" install --dry-run
             test -f "$PLIST"
             plutil -lint "$PLIST"
             "$KEI" uninstall
             test ! -e "$PLIST"
-            "$KEI" status | grep -q '^Service: not installed'
+            status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'
             ;;
         *)
             echo "service-smoke is Linux/macOS only; Windows runs in CI" >&2

--- a/justfile
+++ b/justfile
@@ -262,6 +262,50 @@ fuzz MODE="list" *ARGS="":
             ;;
     esac
 
+# Service-install smoke: builds release, dry-run install, validates artifact, uninstall, asserts clean.
+# Mirrors .github/workflows/service-smoke.yml. Linux + macOS only.
+service-smoke:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    cargo build --release
+    KEI="$PWD/target/release/kei"
+    # `kei status` derives its state-DB path from the username; pin a
+    # placeholder so the smoke does not depend on the operator's .env
+    # or saved config.
+    export ICLOUD_USERNAME="service-smoke@example.invalid"
+    case "$(uname -s)" in
+        Linux)
+            UNIT="$HOME/.config/systemd/user/kei.service"
+            # Clean any leftover from a previous failed run so the
+            # pre-state assertion is meaningful.
+            rm -f "$UNIT"
+            test ! -e "$UNIT"
+            "$KEI" status | grep -q '^Service: not installed'
+            "$KEI" install --user --dry-run
+            test -f "$UNIT"
+            systemd-analyze --user verify "$UNIT"
+            "$KEI" uninstall
+            test ! -e "$UNIT"
+            "$KEI" status | grep -q '^Service: not installed'
+            ;;
+        Darwin)
+            PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
+            rm -f "$PLIST"
+            test ! -e "$PLIST"
+            "$KEI" status | grep -q '^Service: not installed'
+            "$KEI" install --dry-run
+            test -f "$PLIST"
+            plutil -lint "$PLIST"
+            "$KEI" uninstall
+            test ! -e "$PLIST"
+            "$KEI" status | grep -q '^Service: not installed'
+            ;;
+        *)
+            echo "service-smoke is Linux/macOS only; Windows runs in CI" >&2
+            exit 2
+            ;;
+    esac
+
 # Create branch NAME off a freshly fetched origin/main (CLAUDE.md branch-from-fresh-main rule).
 branch NAME:
     #!/usr/bin/env bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ tests/
 | `tests/shell/concurrency.sh` | 8 | yes | `just test concurrency` |
 | `tests/shell/state-machine.sh` | 20 | yes | `just test state` |
 | `tests/shell/docker.sh` | 16 | yes | `just test docker` |
+| `.github/workflows/service-smoke.yml` | 3 (linux/macos/windows) | no | `just service-smoke` (linux/macOS) |
 
 Counts are approximate and drift as tests are added.
 
@@ -173,3 +174,15 @@ happens:
   multiple kei invocations with DB mutation in between.
 - **`shell/docker.sh`** - anything that requires `docker run`, watch
   mode + SIGTERM, healthcheck probes inside the container.
+- **`service-smoke` workflow** - per-platform CI smoke for `kei install`
+  / `kei uninstall`. Builds the release binary on
+  `ubuntu-latest`/`macos-latest`/`windows-latest`, runs `kei install
+  --dry-run` to render the platform artifact (systemd unit, launchd
+  plist, or Windows SCM preview) without invoking the service manager,
+  validates the artifact with the platform-native linter
+  (`systemd-analyze verify`, `plutil -lint`, or `Get-Service`), then
+  runs `kei uninstall` and asserts the artifact is gone. Catches
+  rendering and path-resolution regressions; doesn't exercise the
+  actual service-manager handoff (that needs credentials and is left
+  to manual real-install testing). Mirrored by `just service-smoke` on
+  Linux and macOS.


### PR DESCRIPTION
## Summary

- New `.github/workflows/service-smoke.yml` matrix job (ubuntu / macos / windows) running on PRs that touch `src/service/`, `src/cli.rs`, `src/commands/status.rs`, or `Cargo.{toml,lock}`.
- Per platform: `cargo build --release` -> `kei install --dry-run` -> artifact path assertion -> platform-native syntax linter (`systemd-analyze --user verify`, `plutil -lint`, `Get-Service`) -> `kei uninstall` -> assert artifact gone -> `kei status` reports `Service: not installed`.
- New `just service-smoke` recipe mirrors the same flow on Linux and macOS for local pre-push checks.
- `tests/README.md` catalog updated with the new suite.

PR 8 of 8 in the v0.14 phase-1 sequence (`.scratch/2026-05-07_v0.14-phase1-implementation-plan.md`). Closes the test-packaging-entrypoints gap from `feedback_test_packaging_entrypoints.md` for the new install/uninstall surface.

## Why dry-run instead of real install

A non-dry-run `kei install` calls `systemctl --now` / `launchctl bootstrap` / SCM `CreateServiceW`. All three require the worker to actually start, which means `kei service run` must authenticate against iCloud. CI has no credentials, so the worker would crash on startup, `KeepAlive` / `Restart=on-failure` would loop with backoff, and the smoke would either time out or false-fail.

The dry-run path renders the platform artifact, which is where most regressions land. We catch:

- malformed unit / plist / SCM-preview output
- artifact path drift (uninstall must find what install wrote)
- breakage in the cross-platform install / uninstall dispatcher
- `kei status` cross-platform output divergence

We do **not** catch:

- the actual service-manager handoff (systemd / launchd / SCM accept the artifact)
- whether the service starts and reaches `Service: running`

Both are exercised by the maintainer's manual real-install flow against the icloudpd-test album, and by the Rust integration suites under `tests/service_*.rs`.

## Local validation

Ran `just service-smoke` on Linux against this branch:

```
+ kei install --user --dry-run
INFO wrote per-user systemd unit
INFO dry run: skipped systemctl daemon-reload / enable / loginctl enable-linger
+ test -f /home/robhooper/.config/systemd/user/kei.service
+ systemd-analyze --user verify /home/robhooper/.config/systemd/user/kei.service
+ kei uninstall
INFO removed per-user systemd unit
+ test ! -e /home/robhooper/.config/systemd/user/kei.service
+ kei status | grep -q '^Service: not installed'
```

Pass.

## Test plan

- [x] Local `just service-smoke` passes on Linux against the dev binary at `target/release/kei`.
- [x] `cargo fmt --check` clean (no Rust changes; verified anyway).
- [ ] CI ubuntu-latest job passes against this PR.
- [ ] CI macos-latest job passes (depends on `plutil` being on PATH and the runner having a writable `~/Library/LaunchAgents/`).
- [ ] CI windows-latest job passes (depends on `kei install --dry-run` exiting 0 without prompting for the account password and on `Get-Service` finding no `com.rhoopr.kei` entry).

## Follow-ups (out of scope)

- Real Windows install in CI requires injecting the operator's account password into `prompt_windows_password`. A `--password-stdin` flag (or `KEI_INSTALL_PASSWORD` env var) for `kei install` on Windows would unblock that. Not pursued here to keep PR 8 workflow-only per the plan.