### PR TITLE
fix: thread personality_mode into Config::build_inner instead of mutating after build

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1175,6 +1175,7 @@ impl Config {
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
         let env_watch_interval = parse_env_watch_interval(std::env::var(ENV_WATCH_INTERVAL))?;
+        let friendly_request = toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly);
         Self::build_inner(
             globals,
             pw,
@@ -1182,7 +1183,7 @@ impl Config {
             toml,
             env_watch_interval,
             crate::personality::Mode::Off,
-            None,
+            friendly_request,
         )
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1142,13 +1142,13 @@ pub(crate) fn resolve_password_command(
         .or_else(|| toml_auth.and_then(|a| a.password_command.clone()))
 }
 
-const ENV_WATCH_INTERVAL: &str = "KEI_WATCH_WITH_INTERVAL";
+pub(crate) const ENV_WATCH_INTERVAL: &str = "KEI_WATCH_WITH_INTERVAL";
 
 /// Parse `KEI_WATCH_WITH_INTERVAL` into an `Option<u64>`. Takes the raw
 /// `Result` so tests can exercise it without mutating the process env (which
 /// would race other `Config::build` callers under `--test-threads > 1`).
 /// Range validation lives in `Config::build_inner` so CLI/TOML/env share it.
-fn parse_env_watch_interval(
+pub(crate) fn parse_env_watch_interval(
     raw: Result<String, std::env::VarError>,
 ) -> anyhow::Result<Option<u64>> {
     match raw {
@@ -1175,7 +1175,15 @@ impl Config {
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
         let env_watch_interval = parse_env_watch_interval(std::env::var(ENV_WATCH_INTERVAL))?;
-        Self::build_inner(globals, pw, sync, toml, env_watch_interval)
+        Self::build_inner(
+            globals,
+            pw,
+            sync,
+            toml,
+            env_watch_interval,
+            crate::personality::Mode::Off,
+            None,
+        )
     }
 
     pub(crate) fn build_inner(
@@ -1184,6 +1192,8 @@ impl Config {
         sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
         env_watch_interval: Option<u64>,
+        personality_mode: crate::personality::Mode,
+        friendly_request: Option<bool>,
     ) -> anyhow::Result<Self> {
         let toml_auth = toml.and_then(|t| t.auth.as_ref());
 
@@ -1879,14 +1889,13 @@ impl Config {
             xmp_sidecar,
             dry_run: sync.dry_run,
             no_progress_bar,
-            // Resolved at startup in lib.rs and threaded into Config via the
-            // `friendly` flag. Defaults to Off here; lib.rs overwrites with
-            // the resolved Mode after Config::build returns. The TOML
-            // preference (when present) is captured here so `kei config show`
-            // round-trips the user's intent without seeing the CLI; lib.rs
-            // overrides this when `--friendly` / `--no-friendly` is passed.
-            personality_mode: crate::personality::Mode::Off,
-            friendly_request: toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly),
+            // Supplied by the caller. Config::build() (used by tests and
+            // non-sync commands) defaults to Off/None; sync_loop::run_sync
+            // calls build_inner() directly with the resolved Mode from
+            // lib.rs's gate (CLI > TOML > default-on-for-TTY, then
+            // environmental hard-off check).
+            personality_mode,
+            friendly_request,
             keep_unicode_in_filenames,
             only_print_filenames: sync.only_print_filenames,
             no_incremental: sync.no_incremental,
@@ -5384,6 +5393,8 @@ mod tests {
             sync,
             toml.as_ref(),
             env_watch_interval,
+            crate::personality::Mode::Off,
+            None,
         )
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -263,9 +263,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         &pw,
         sync,
         toml_config.as_ref(),
-        config::parse_env_watch_interval(
-            std::env::var(config::ENV_WATCH_INTERVAL),
-        )?,
+        config::parse_env_watch_interval(std::env::var(config::ENV_WATCH_INTERVAL))?,
         personality_mode,
         friendly_request,
     )?;

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -258,16 +258,17 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .data_dir
         .clone()
         .or_else(|| globals.cookie_directory.clone());
-    let mut config = config::Config::build(globals, &pw, sync, toml_config.as_ref())?;
-    // Stamp the resolved Mode onto Config so build_download_config below picks
-    // it up via `config.personality_mode`. Config::build defaults to Off; the
-    // CLI flag and gate logic live up in lib.rs.
-    config.personality_mode = personality_mode;
-    // Same story for the user-stated preference: Config::build pulled the
-    // TOML value (if any), and lib.rs has already merged the CLI flag on
-    // top. Stamp the merged result so `to_toml` and any downstream consumer
-    // sees the canonical post-resolution intent.
-    config.friendly_request = friendly_request;
+    let mut config = config::Config::build_inner(
+        globals,
+        &pw,
+        sync,
+        toml_config.as_ref(),
+        config::parse_env_watch_interval(
+            std::env::var(config::ENV_WATCH_INTERVAL),
+        )?,
+        personality_mode,
+        friendly_request,
+    )?;
 
     // On first run (no config file), persist CLI-provided values so
     // subsequent runs don't need the same flags again. Only when the


### PR DESCRIPTION
## What

Fixes a quality issue flagged in the v0.13.3 → v0.13.4-dev audit: `Config::build()` was setting `personality_mode` to `Mode::Off` as a placeholder, then `sync_loop::run_sync` was overwriting it after the fact. This two-phase init was fragile — any caller going through `Config::build()` without the post-hoc overwrite would silently get Off mode.

## Changes

- `Config::build_inner()` now accepts `personality_mode` and `friendly_request` parameters so the resolved values are set directly at construction time
- `Config::build()` remains a convenience wrapper that passes `Mode::Off` / `None` — preserving backward compat for all existing tests and non-sync commands (`kei config show`, etc.)
- `sync_loop::run_sync` now calls `build_inner()` directly with the resolved values from `lib.rs`'s startup gate instead of calling `build()` then mutating
- Made `parse_env_watch_interval` and `ENV_WATCH_INTERVAL` `pub(crate)` so `sync_loop` can pass the parsed env value through

## Not fixed

The audit also flagged `current_executable()` unwraps, but that function already returns `Result<PathBuf>` and all production callers use `?`. The 14 `.unwrap()` hits were all in test code (which already has `#[cfg_attr(test, allow(...))]`).