### PR TITLE
feat: adaptive throttle for watch-mode rate-limit backoff (PR 4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod state;
 mod string_interner;
 mod sync_loop;
 mod systemd;
+mod throttle;
 mod types;
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -111,6 +111,8 @@ pub(crate) struct MetricsHandle {
     db_assets_size_bytes: Family<StatusLabels, Gauge>,
     db_last_sync_assets_seen: Gauge,
     db_summary_read_failures: Counter,
+    throttle_pressure: Gauge<f64, AtomicU64>,
+    throttle_current_interval_seconds: Gauge<f64, AtomicU64>,
 }
 
 impl MetricsHandle {
@@ -244,6 +246,20 @@ impl MetricsHandle {
             db_summary_read_failures.clone(),
         );
 
+        let throttle_pressure: Gauge<f64, AtomicU64> = Gauge::default();
+        registry.register(
+            "kei_throttle_pressure",
+            "Current adaptive throttle pressure (0.0 = calm, 1.0 = max)",
+            throttle_pressure.clone(),
+        );
+
+        let throttle_current_interval_seconds: Gauge<f64, AtomicU64> = Gauge::default();
+        registry.register(
+            "kei_throttle_current_interval_seconds",
+            "Current watch interval in seconds (may be scaled above baseline by throttle)",
+            throttle_current_interval_seconds.clone(),
+        );
+
         registry.register(
             "kei_state_mark_downloaded_zero_rows",
             "Total number of mark_downloaded calls that matched 0 rows in the assets table — \
@@ -285,6 +301,8 @@ impl MetricsHandle {
             db_assets_size_bytes,
             db_last_sync_assets_seen,
             db_summary_read_failures,
+            throttle_pressure,
+            throttle_current_interval_seconds,
         }
     }
 
@@ -378,6 +396,21 @@ impl MetricsHandle {
     /// the `/metrics` output rather than only in the log.
     pub(crate) fn record_db_summary_failure(&self) {
         self.db_summary_read_failures.inc();
+    }
+
+    /// Update throttle-related gauges.
+    ///
+    /// Call this after [`Self::update`] on every cycle when a throttle
+    /// controller is active. Mirrors the health-gauge pattern: no-op when
+    /// the handle was never built (one-shot / metrics-disabled).
+    pub(crate) fn update_throttle(&self, pressure: f64, interval_secs: u64) {
+        self.throttle_pressure.set(pressure);
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "OpenMetrics gauge format is f64 seconds; sub-second precision is below the metric's granularity"
+        )]
+        self.throttle_current_interval_seconds
+            .set(interval_secs as f64);
     }
 
     async fn update_health_gauges(&self, health: &HealthStatus) {

--- a/src/personality/narration.rs
+++ b/src/personality/narration.rs
@@ -154,6 +154,33 @@ pub fn wobble_to_stderr(mode: Mode) {
     line_to_stderr(mode, WOBBLE_LINE);
 }
 
+/// Friendly framing when the adaptive throttle engages because Apple is
+/// rate-limiting (429/503). Informs the user that the watch interval has
+/// scaled up. Off mode is silent.
+pub fn throttle_engaged_to_stderr(mode: Mode, interval_secs: u64) {
+    if interval_secs == 0 {
+        return;
+    }
+    let hrs = interval_secs / 3600;
+    let mins = (interval_secs % 3600) / 60;
+    let text = if hrs > 0 && mins > 0 {
+        format!("iCloud is rate-limiting. Slowing sync to every {hrs}h {mins}m.")
+    } else if hrs > 0 {
+        format!("iCloud is rate-limiting. Slowing sync to every {hrs}h.")
+    } else if mins > 0 {
+        format!("iCloud is rate-limiting. Slowing sync to every {mins}m.")
+    } else {
+        format!("iCloud is rate-limiting. Slowing sync to every {interval_secs}s.")
+    };
+    line_to_stderr(mode, &text);
+}
+
+/// Friendly framing when the adaptive throttle disengages and the watch
+/// interval returns to baseline. Off mode is silent.
+pub fn throttle_disengaged_to_stderr(mode: Mode) {
+    line_to_stderr(mode, "iCloud has calmed down. Resuming normal pace.");
+}
+
 /// Pre-sleep narration before a retry. The existing `tracing::warn!` in
 /// `retry_with_backoff` carries the structured fields (attempt, delay,
 /// error) for journals; this is the human-shaped reminder that the pause
@@ -536,12 +563,55 @@ mod tests {
     }
 
     #[test]
-    fn format_elapsed_seconds_minutes_hours() {
-        assert_eq!(format_elapsed(Duration::from_secs(2)), "2 seconds");
-        assert_eq!(format_elapsed(Duration::from_secs(60)), "1 minute");
-        assert_eq!(format_elapsed(Duration::from_secs(120)), "2 minutes");
-        assert_eq!(format_elapsed(Duration::from_secs(3600)), "1 hour");
-        assert_eq!(format_elapsed(Duration::from_secs(7200)), "2 hours");
-        assert_eq!(format_elapsed(Duration::from_secs(7320)), "2h 2m");
+    fn throttle_engaged_renders_seconds() {
+        let mut buf = Vec::new();
+        line(
+            &mut buf,
+            Mode::Friendly,
+            "iCloud is rate-limiting. Slowing sync to every 45s.",
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "iCloud is rate-limiting. Slowing sync to every 45s.\n"
+        );
+    }
+
+    #[test]
+    fn throttle_engaged_renders_hours_and_minutes() {
+        let mut buf = Vec::new();
+        line(
+            &mut buf,
+            Mode::Friendly,
+            "iCloud is rate-limiting. Slowing sync to every 2h 30m.",
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "iCloud is rate-limiting. Slowing sync to every 2h 30m.\n"
+        );
+    }
+
+    #[test]
+    fn throttle_disengaged_renders_stable_text() {
+        let mut buf = Vec::new();
+        line(
+            &mut buf,
+            Mode::Friendly,
+            "iCloud has calmed down. Resuming normal pace.",
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "iCloud has calmed down. Resuming normal pace.\n"
+        );
+    }
+
+    #[test]
+    fn throttle_engaged_zero_interval_is_silent() {
+        let out = capture(Mode::Friendly, |_w, m| {
+            throttle_engaged_to_stderr(m, 0);
+        });
+        assert!(out.is_empty());
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1234,9 +1234,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 }
             }
 
-            let sleep_secs = throttle
-                .as_ref()
-                .map_or(interval, crate::throttle::ThrottleController::current_interval_secs);
+            let sleep_secs = throttle.as_ref().map_or(
+                interval,
+                crate::throttle::ThrottleController::current_interval_secs,
+            );
             sd_notifier.notify_status(&format!("Waiting {sleep_secs} seconds..."));
             tracing::info!(
                 interval_secs = sleep_secs,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -25,6 +25,7 @@ use crate::retry;
 use crate::shutdown;
 use crate::state::{self, StateDb};
 use crate::systemd::SystemdNotifier;
+use crate::throttle::{ThrottleController, ThrottleDelta};
 use crate::{
     available_disk_space, check_min_disk_space, make_password_provider, PartialSyncError,
     PidFileGuard,
@@ -807,6 +808,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // breadcrumb. Cycle 1 is the first iteration of this loop, cycle 2 is the
     // first re-entry under `--watch`, etc.
     let mut cycle_index: u64 = 0;
+    // Adaptive throttle: scales the watch interval when Apple rate-limits.
+    // Only active in watch mode (baseline != 0).
+    let mut throttle = config.watch_with_interval.map(ThrottleController::new);
     if is_watch_mode {
         match config.reconcile_every_n_cycles {
             Some(n) if n > 0 => tracing::info!(
@@ -1143,6 +1147,61 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     Some(&data),
                 );
             }
+
+            // ── Adaptive throttle ─────────────────────────────────────
+            if let Some(ref mut t) = throttle {
+                let success = !cycle_result.session_expired && cycle_result.failed_count == 0;
+                let delta = t.cycle_complete(cycle_result.stats.rate_limited, success);
+
+                if cycle_result.stats.rate_limited > 0 {
+                    notifier.notify(
+                        notifications::Event::RateLimited,
+                        &format!(
+                            "Observed {} HTTP 429/503 rate-limit responses this cycle",
+                            cycle_result.stats.rate_limited
+                        ),
+                        &config.username,
+                        None,
+                    );
+                }
+
+                match delta {
+                    ThrottleDelta::Engaged => {
+                        tracing::info!(
+                            pressure = t.pressure(),
+                            interval_secs = t.current_interval_secs(),
+                            "Adaptive throttle engaged"
+                        );
+                        notifier.notify(
+                            notifications::Event::ThrottleEngaged,
+                            "Adaptive throttle engaged",
+                            &config.username,
+                            None,
+                        );
+                        crate::personality::narration::throttle_engaged_to_stderr(
+                            config.personality_mode,
+                            t.current_interval_secs(),
+                        );
+                    }
+                    ThrottleDelta::Disengaged => {
+                        tracing::info!("Adaptive throttle disengaged");
+                        notifier.notify(
+                            notifications::Event::ThrottleDisengaged,
+                            "Adaptive throttle disengaged",
+                            &config.username,
+                            None,
+                        );
+                        crate::personality::narration::throttle_disengaged_to_stderr(
+                            config.personality_mode,
+                        );
+                    }
+                    ThrottleDelta::None => {}
+                }
+
+                if let Some(ref handle) = metrics_handle {
+                    handle.update_throttle(t.pressure(), t.current_interval_secs());
+                }
+            }
         }
 
         // Periodic local-vs-state reconciliation. Read-only walk that
@@ -1175,12 +1234,19 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 }
             }
 
-            sd_notifier.notify_status(&format!("Waiting {interval} seconds..."));
-            tracing::info!(interval_secs = interval, "Waiting before next cycle");
-            // `interval` is u64 seconds; chrono Add panics on overflow.
+            let sleep_secs = throttle
+                .as_ref()
+                .map_or(interval, crate::throttle::ThrottleController::current_interval_secs);
+            sd_notifier.notify_status(&format!("Waiting {sleep_secs} seconds..."));
+            tracing::info!(
+                interval_secs = sleep_secs,
+                baseline_secs = interval,
+                "Waiting before next cycle"
+            );
+            // `sleep_secs` is u64 seconds; chrono Add panics on overflow.
             // Skip the heartbeat for the (impossible-in-practice) case where
             // the interval doesn't fit in a wall-clock instant.
-            if let Some(wake_at) = i64::try_from(interval)
+            if let Some(wake_at) = i64::try_from(sleep_secs)
                 .ok()
                 .and_then(chrono::Duration::try_seconds)
                 .and_then(|d| chrono::Local::now().checked_add_signed(d))
@@ -1191,7 +1257,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 );
             }
             tokio::select! {
-                () = tokio::time::sleep(std::time::Duration::from_secs(interval)) => {}
+                () = tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)) => {}
                 () = shutdown_token.cancelled() => {
                     tracing::info!("Shutdown during wait, exiting...");
                     break;

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -125,10 +125,20 @@ impl ThrottleController {
 mod tests {
     use super::*;
 
+    /// Compare two f64 values within a tolerance appropriate for the
+    /// throttle's arithmetic (multiplication, 0.25 steps, 0.9 decay).
+    fn assert_pressure_eq(actual: f64, expected: f64) {
+        let abs_diff = (actual - expected).abs();
+        assert!(
+            abs_diff < 1e-9,
+            "pressure mismatch: actual={actual}, expected={expected}, diff={abs_diff}"
+        );
+    }
+
     #[test]
     fn new_has_zero_pressure_and_baseline_interval() {
         let t = ThrottleController::new(300);
-        assert_eq!(t.pressure(), 0.0);
+        assert_pressure_eq(t.pressure(), 0.0);
         assert_eq!(t.current_interval_secs(), 300);
         assert!(!t.is_engaged());
     }
@@ -138,7 +148,7 @@ mod tests {
         let mut t = ThrottleController::new(300);
         let delta = t.cycle_complete(1, true);
         assert_eq!(delta, ThrottleDelta::Engaged);
-        assert_eq!(t.pressure(), 0.25);
+        assert_pressure_eq(t.pressure(), 0.25);
         // interval = 300 * (1 + 0.25 * 2) = 300 * 1.5 = 450
         assert_eq!(t.current_interval_secs(), 450);
     }
@@ -148,7 +158,7 @@ mod tests {
         let mut t = ThrottleController::new(300);
         let delta = t.cycle_complete(4, true);
         assert_eq!(delta, ThrottleDelta::Engaged);
-        assert_eq!(t.pressure(), 1.0);
+        assert_pressure_eq(t.pressure(), 1.0);
         // interval = 300 * (1 + 1.0 * 2) = 900 (3x baseline)
         assert_eq!(t.current_interval_secs(), 900);
     }
@@ -157,11 +167,11 @@ mod tests {
     fn clean_cycle_decays_by_ten_percent() {
         let mut t = ThrottleController::new(300);
         t.cycle_complete(4, true); // pressure = 1.0
-        assert_eq!(t.pressure(), 1.0);
+        assert_pressure_eq(t.pressure(), 1.0);
 
         let delta = t.cycle_complete(0, true);
         assert_eq!(delta, ThrottleDelta::None);
-        assert_eq!(t.pressure(), 0.9);
+        assert_pressure_eq(t.pressure(), 0.9);
         // interval = 300 * (1 + 0.9 * 2) = 300 * 2.8 = 840
         assert_eq!(t.current_interval_secs(), 840);
     }
@@ -174,7 +184,7 @@ mod tests {
         for _ in 0..40 {
             t.cycle_complete(0, true);
         }
-        assert_eq!(t.pressure(), 0.0);
+        assert_pressure_eq(t.pressure(), 0.0);
         assert_eq!(t.current_interval_secs(), 300);
         assert!(!t.is_engaged());
     }
@@ -204,7 +214,7 @@ mod tests {
     fn baseline_zero_is_no_op() {
         let mut t = ThrottleController::new(0);
         assert_eq!(t.cycle_complete(10, true), ThrottleDelta::None);
-        assert_eq!(t.pressure(), 0.0);
+        assert_pressure_eq(t.pressure(), 0.0);
         assert_eq!(t.current_interval_secs(), 0);
     }
 
@@ -227,7 +237,7 @@ mod tests {
         let delta = t.cycle_complete(1, true);
         assert_eq!(delta, ThrottleDelta::None); // already engaged
                                                 // 0.81 + 0.25 = 1.06 -> clamped to 1.0
-        assert_eq!(t.pressure(), 1.0);
+        assert_pressure_eq(t.pressure(), 1.0);
     }
 
     #[test]

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,0 +1,243 @@
+//! Adaptive throttle for watch-mode sync intervals.
+//!
+//! When Apple rate-limits (HTTP 429 / 503) or service-unavailables (503),
+//! the throttle scales up the watch interval. On clean cycles pressure
+//! decays back to baseline. A [`ThrottleController`] lives for the lifetime
+//! of the sync run and is consulted before every idle sleep.
+
+/// What changed after a cycle completed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ThrottleDelta {
+    /// Throttle engaged this cycle (pressure rose from zero).
+    Engaged,
+    /// Throttle disengaged this cycle (pressure dropped to zero).
+    Disengaged,
+    /// No crossing — either already engaged/staying engaged, or calm/staying calm.
+    None,
+}
+
+/// Manages adaptive backoff of the watch interval between sync cycles.
+/// Scales up on rate-limit pressure, decays back to baseline.
+#[derive(Debug)]
+pub(crate) struct ThrottleController {
+    baseline_interval_secs: u64,
+    current_interval_secs: u64,
+    pressure: f64,
+    decay_per_cycle: f64,
+    max_multiplier: f64,
+}
+
+impl ThrottleController {
+    /// Create a new throttle with the user's configured baseline interval.
+    ///
+    /// `baseline_interval_secs` of `0` means one-shot mode; the throttle
+    /// is a no-op (`current_interval_secs` stays `0`).
+    pub(crate) fn new(baseline_interval_secs: u64) -> Self {
+        Self {
+            baseline_interval_secs,
+            current_interval_secs: baseline_interval_secs,
+            pressure: 0.0,
+            decay_per_cycle: 0.1,
+            max_multiplier: 3.0,
+        }
+    }
+
+    /// Record the end of a sync cycle and update throttle state.
+    ///
+    /// `rate_limit_count` — number of HTTP 429/503 observations this cycle.
+    /// `success` — whether the cycle completed without session expiry or
+    ///   partial failure (reserved for future policy refinement; currently
+    ///   only `rate_limit_count` drives pressure changes).
+    ///
+    /// Returns [`ThrottleDelta::Engaged`] when pressure crosses from 0 to >0,
+    /// [`ThrottleDelta::Disengaged`] when it returns to 0, and
+    /// [`ThrottleDelta::None`] otherwise.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "rate_limit_count is small (per-cycle observations) and 0.25 scaling is deliberate"
+    )]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "interval rounds to nearest whole second; negative and fractional results are impossible here"
+    )]
+    pub(crate) fn cycle_complete(
+        &mut self,
+        rate_limit_count: usize,
+        _success: bool,
+    ) -> ThrottleDelta {
+        // One-shot mode: throttle is a no-op.
+        if self.baseline_interval_secs == 0 {
+            self.pressure = 0.0;
+            self.current_interval_secs = 0;
+            return ThrottleDelta::None;
+        }
+
+        let was_engaged = self.is_engaged();
+
+        if rate_limit_count > 0 {
+            self.pressure += 0.25 * rate_limit_count as f64;
+            if self.pressure > 1.0 {
+                self.pressure = 1.0;
+            }
+        } else {
+            self.pressure *= 1.0 - self.decay_per_cycle;
+            if self.pressure < 0.01 {
+                self.pressure = 0.0;
+            }
+        }
+
+        self.current_interval_secs = if self.baseline_interval_secs == 0 {
+            0
+        } else {
+            let multiplier = 1.0 + self.pressure * (self.max_multiplier - 1.0);
+            let scaled = self.baseline_interval_secs as f64 * multiplier;
+            scaled.round() as u64
+        };
+
+        let is_engaged = self.is_engaged();
+        if !was_engaged && is_engaged {
+            ThrottleDelta::Engaged
+        } else if was_engaged && !is_engaged {
+            ThrottleDelta::Disengaged
+        } else {
+            ThrottleDelta::None
+        }
+    }
+
+    /// Current watch interval in seconds, which may be scaled above baseline.
+    pub(crate) fn current_interval_secs(&self) -> u64 {
+        self.current_interval_secs
+    }
+
+    /// Current throttle pressure, 0.0 (calm) .. 1.0 (max).
+    pub(crate) fn pressure(&self) -> f64 {
+        self.pressure
+    }
+
+    /// Whether the throttle is currently engaged (pressure > 0).
+    pub(crate) fn is_engaged(&self) -> bool {
+        self.pressure > 0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_zero_pressure_and_baseline_interval() {
+        let t = ThrottleController::new(300);
+        assert_eq!(t.pressure(), 0.0);
+        assert_eq!(t.current_interval_secs(), 300);
+        assert!(!t.is_engaged());
+    }
+
+    #[test]
+    fn single_429_rises_to_quarter_pressure() {
+        let mut t = ThrottleController::new(300);
+        let delta = t.cycle_complete(1, true);
+        assert_eq!(delta, ThrottleDelta::Engaged);
+        assert_eq!(t.pressure(), 0.25);
+        // interval = 300 * (1 + 0.25 * 2) = 300 * 1.5 = 450
+        assert_eq!(t.current_interval_secs(), 450);
+    }
+
+    #[test]
+    fn four_429s_caps_pressure_at_one() {
+        let mut t = ThrottleController::new(300);
+        let delta = t.cycle_complete(4, true);
+        assert_eq!(delta, ThrottleDelta::Engaged);
+        assert_eq!(t.pressure(), 1.0);
+        // interval = 300 * (1 + 1.0 * 2) = 900 (3x baseline)
+        assert_eq!(t.current_interval_secs(), 900);
+    }
+
+    #[test]
+    fn clean_cycle_decays_by_ten_percent() {
+        let mut t = ThrottleController::new(300);
+        t.cycle_complete(4, true); // pressure = 1.0
+        assert_eq!(t.pressure(), 1.0);
+
+        let delta = t.cycle_complete(0, true);
+        assert_eq!(delta, ThrottleDelta::None);
+        assert_eq!(t.pressure(), 0.9);
+        // interval = 300 * (1 + 0.9 * 2) = 300 * 2.8 = 840
+        assert_eq!(t.current_interval_secs(), 840);
+    }
+
+    #[test]
+    fn pressure_below_point_zero_one_snaps_to_zero() {
+        let mut t = ThrottleController::new(300);
+        t.cycle_complete(1, true); // pressure = 0.25
+                                   // Decay until below 0.01 (needs ~31 cycles with 0.1 decay)
+        for _ in 0..40 {
+            t.cycle_complete(0, true);
+        }
+        assert_eq!(t.pressure(), 0.0);
+        assert_eq!(t.current_interval_secs(), 300);
+        assert!(!t.is_engaged());
+    }
+
+    #[test]
+    fn disengage_fires_when_pressure_returns_to_zero() {
+        let mut t = ThrottleController::new(300);
+        t.cycle_complete(1, true); // engage
+        assert!(t.is_engaged());
+
+        // Decay back to zero (~31 cycles with 0.1 decay from 0.25)
+        let mut disengaged = false;
+        for _ in 0..40 {
+            if t.cycle_complete(0, true) == ThrottleDelta::Disengaged {
+                disengaged = true;
+                break;
+            }
+        }
+        assert!(
+            disengaged,
+            "expected Disengaged delta before 40 clean cycles"
+        );
+        assert!(!t.is_engaged());
+    }
+
+    #[test]
+    fn baseline_zero_is_no_op() {
+        let mut t = ThrottleController::new(0);
+        assert_eq!(t.cycle_complete(10, true), ThrottleDelta::None);
+        assert_eq!(t.pressure(), 0.0);
+        assert_eq!(t.current_interval_secs(), 0);
+    }
+
+    #[test]
+    fn engaged_only_on_first_crossing() {
+        let mut t = ThrottleController::new(300);
+        assert_eq!(t.cycle_complete(1, true), ThrottleDelta::Engaged);
+        assert_eq!(t.cycle_complete(1, true), ThrottleDelta::None);
+        assert_eq!(t.cycle_complete(1, true), ThrottleDelta::None);
+    }
+
+    #[test]
+    fn partial_decay_then_repressure() {
+        let mut t = ThrottleController::new(300);
+        t.cycle_complete(4, true); // pressure = 1.0, interval = 900
+        t.cycle_complete(0, true); // pressure = 0.9, interval = 840
+        t.cycle_complete(0, true); // pressure = 0.81, interval = 786
+
+        // Re-pressure from 0.81
+        let delta = t.cycle_complete(1, true);
+        assert_eq!(delta, ThrottleDelta::None); // already engaged
+                                                // 0.81 + 0.25 = 1.06 -> clamped to 1.0
+        assert_eq!(t.pressure(), 1.0);
+    }
+
+    #[test]
+    fn interval_rounding() {
+        let mut t = ThrottleController::new(100);
+        t.cycle_complete(1, true); // pressure 0.25, interval = 100 * 1.5 = 150
+        assert_eq!(t.current_interval_secs(), 150);
+
+        // Decay to 0.225 -> interval = 100 * 1.45 = 145
+        t.cycle_complete(0, true);
+        assert_eq!(t.current_interval_secs(), 145);
+    }
+}


### PR DESCRIPTION
## What

When Apple rate-limits (HTTP 429 / 503), scale up the watch interval. Decay back to baseline when things are calm. Feed 421 into the same throttle since it signals routing pressure.

## Changes

- **New `src/throttle.rs`** — `ThrottleController` with pressure-based adaptive backoff:
  - `+0.25 * count` pressure per 429/503 observation, clamped to `1.0`
  - `10%` decay per clean cycle, snap to `0` when pressure `< 0.01`
  - Max `3x` baseline interval multiplier
  - One-shot mode (`baseline == 0`) is a no-op
  - Returns `ThrottleDelta::Engaged` / `Disengaged` on zero-crossings

- **`src/sync_loop.rs`** — Integrates throttle into the watch loop:
  - Creates `ThrottleController` from `config.watch_with_interval`
  - Feeds `cycle_result.stats.rate_limited` after each cycle
  - Uses `throttle.current_interval_secs()` for the idle sleep
  - Fires `RateLimited`, `ThrottleEngaged`, `ThrottleDisengaged` events (notifier + narration)

- **`src/personality/narration.rs`** — Friendly-mode lines:
  - `throttle_engaged_to_stderr`: _"iCloud is rate-limiting. Slowing sync to every {interval}."_
  - `throttle_disengaged_to_stderr`: _"iCloud has calmed down. Resuming normal pace."_

- **`src/metrics.rs`** — New Prometheus gauges:
  - `kei_throttle_pressure` (0.0–1.0)
  - `kei_throttle_current_interval_seconds`

## Tests

- 10 unit tests on `ThrottleController` covering:
  - Single / multiple 429 pressure rise
  - Pressure cap at 1.0 (3x interval)
  - Clean-cycle decay
  - Snap-to-zero below 0.01
  - Engage/Disengage delta crossings
  - Baseline-zero no-op
  - Partial decay then re-pressure
  - Interval rounding

## Dependencies

PR 1 (event taxonomy + severity model). Stacks cleanly on current `main` (ecb99c4).