### PR TITLE
refactor: move sync filesystem ops off tokio worker threads

### DIFF
--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -356,7 +356,11 @@ impl Session {
         let cookie_jar = Arc::new(reqwest::cookie::Jar::default());
 
         let cookiejar_path = cookie_dir.join(sanitized);
-        if cookiejar_path.is_file() {
+        let cookiejar_is_file = match tokio::fs::metadata(&cookiejar_path).await {
+            Ok(m) => m.is_file(),
+            Err(_) => false,
+        };
+        if cookiejar_is_file {
             match fs::read_to_string(&cookiejar_path).await {
                 Ok(contents) => {
                     let now = chrono::Utc::now();
@@ -409,7 +413,8 @@ impl Session {
         let (client, download_client) = build_clients(&cookie_jar, home_endpoint, timeout)?;
 
         let session_path = cookie_dir.join(format!("{sanitized}.session"));
-        let session_data = if session_path.exists() {
+        let session_exists = tokio::fs::try_exists(&session_path).await.unwrap_or(false);
+        let session_data = if session_exists {
             match fs::read_to_string(&session_path).await {
                 Ok(contents) => match serde_json::from_str::<HashMap<String, Value>>(&contents) {
                     Ok(map) => {
@@ -697,7 +702,10 @@ impl Session {
 
         // Check if the cookie file already has the same content to avoid
         // redundant disk writes during high-frequency API calls.
-        if cookiejar_path.exists() {
+        let cookiejar_exists = tokio::fs::try_exists(&cookiejar_path)
+            .await
+            .unwrap_or(false);
+        if cookiejar_exists {
             if let Ok(contents) = fs::read_to_string(&cookiejar_path).await {
                 if let Ok(existing) = serde_json::from_str::<Vec<CookieEntry>>(&contents) {
                     if existing == entries {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ impl Drop for PidFileGuard {
     fn drop(&mut self) {
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             let path = self.path.clone();
-            let _ = handle.spawn_blocking(move || {
+            let _handle = handle.spawn_blocking(move || {
                 if let Err(e) = std::fs::remove_file(&path) {
                     tracing::debug!(path = %path.display(), error = %e, "Failed to remove PID file");
                 }
@@ -558,7 +558,6 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         tokio::task::spawn_blocking({
             let expanded = expanded.clone();
             let docker_fallback = docker_fallback.clone();
-            let config_explicitly_set = config_explicitly_set;
             move || {
                 if !config_explicitly_set && !expanded.exists() && docker_fallback.exists() {
                     (docker_fallback, true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,8 +459,17 @@ fn pid_is_alive(_pid: i32) -> bool {
 
 impl Drop for PidFileGuard {
     fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(&self.path) {
-            tracing::debug!(path = %self.path.display(), error = %e, "Failed to remove PID file");
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let path = self.path.clone();
+            let _ = handle.spawn_blocking(move || {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    tracing::debug!(path = %path.display(), error = %e, "Failed to remove PID file");
+                }
+            });
+        } else {
+            if let Err(e) = std::fs::remove_file(&self.path) {
+                tracing::debug!(path = %self.path.display(), error = %e, "Failed to remove PID file");
+            }
         }
     }
 }
@@ -523,7 +532,12 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 
     // Migrate legacy icloudpd-rs paths before loading config, so the
     // copied config.toml is found at the new location.
-    let migration_report = migration::migrate_legacy_paths();
+    let migration_report = tokio::task::spawn_blocking(migration::migrate_legacy_paths)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "Legacy path migration task panicked");
+            None
+        });
 
     // Load TOML config early so it can influence log level.
     // If the user explicitly set --config, the file must exist.
@@ -539,26 +553,38 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         cli.config != "~/.config/kei/config.toml" && cli.config != DOCKER_FALLBACK_CONFIG;
     let (config_path, used_docker_fallback) = {
         let expanded = config::expand_tilde(&cli.config);
-        if !config_explicitly_set && !expanded.exists() {
-            let docker = PathBuf::from(DOCKER_FALLBACK_CONFIG);
-            if docker.exists() {
-                (docker, true)
-            } else {
-                (expanded, false)
+        let docker_fallback = PathBuf::from(DOCKER_FALLBACK_CONFIG);
+        tokio::task::spawn_blocking({
+            let expanded = expanded.clone();
+            let docker_fallback = docker_fallback.clone();
+            let config_explicitly_set = config_explicitly_set;
+            move || {
+                if !config_explicitly_set && !expanded.exists() && docker_fallback.exists() {
+                    (docker_fallback, true)
+                } else {
+                    (expanded, false)
+                }
             }
-        } else {
-            (expanded, false)
-        }
+        })
+        .await
+        .unwrap_or((expanded, false))
     };
     // When --config is explicitly set but the file doesn't exist, allow it
     // if the parent directory exists (auto-config will create the file).
     // Otherwise require the file to exist so typos in --config paths error.
     // When --config is explicit but the file doesn't exist and the parent
     // dir does exist, allow it (auto-config will create the file).
-    let can_auto_create =
-        !config_path.exists() && config_path.parent().is_some_and(std::path::Path::is_dir);
-    let config_required = config_explicitly_set && !can_auto_create;
-    let mut toml_config = config::load_toml_config(&config_path, config_required)?;
+    let config_path_for_load = config_path.clone();
+    let mut toml_config = tokio::task::spawn_blocking(move || {
+        let can_auto_create = !config_path_for_load.exists()
+            && config_path_for_load
+                .parent()
+                .is_some_and(std::path::Path::is_dir);
+        let config_required = config_explicitly_set && !can_auto_create;
+        config::load_toml_config(&config_path_for_load, config_required)
+    })
+    .await
+    .unwrap_or_else(|e| Err(anyhow::anyhow!("config load task panicked: {e}")))?;
 
     // Resolve log level: --log-level > --verbose > TOML > default (info).
     // `--verbose` is a friendlier alias for `--log-level info` and is
@@ -720,7 +746,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             }
             cli::ConfigAction::Setup { output } => {
                 let path = output.map_or_else(|| config_path.clone(), |o| config::expand_tilde(&o));
-                match setup::run_setup(&path)? {
+                let setup_result = tokio::task::spawn_blocking(move || setup::run_setup(&path))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("setup task panicked: {e}"))??;
+                match setup_result {
                     setup::SetupResult::SyncNow {
                         config_path: cfg_path,
                         env_path,

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -127,7 +127,7 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
     let unit_path =
         user_unit_path().ok_or_else(|| anyhow!("could not resolve XDG_CONFIG_HOME or $HOME"))?;
     let contents = render_user_unit(&exe, config_path);
-    write_unit(&unit_path, &contents)?;
+    write_unit(&unit_path, &contents).await?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
         path = %unit_path.display(),
@@ -170,7 +170,7 @@ pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Re
     let exe = current_executable()?;
     let unit_path = system_unit_path();
     let contents = render_system_unit(&exe, config_path, &user);
-    write_unit(&unit_path, &contents)?;
+    write_unit(&unit_path, &contents).await?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
         path = %unit_path.display(),
@@ -215,7 +215,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
         // environment (tempdir-only test, chroot, sysvinit host). The
         // unit-file removal is the load-bearing step; log+proceed.
         let _ = disable_now_user().await;
-        remove_unit_file(path)?;
+        remove_unit_file(path).await?;
         let _ = daemon_reload_user().await;
         tracing::info!(path = %path.display(), "removed per-user systemd unit");
     }
@@ -229,7 +229,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
             );
         }
         let _ = disable_now_system().await;
-        remove_unit_file(path)?;
+        remove_unit_file(path).await?;
         let _ = daemon_reload_system().await;
         tracing::info!(path = %path.display(), "removed system-wide systemd unit");
     }
@@ -238,7 +238,10 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
         let Some(config_dir) = dirs::config_dir() else {
             bail!("--purge requested but no XDG config dir resolves; cannot locate kei state");
         };
-        purge_kei_state(&config_dir.join("kei"), &[])?;
+        let kei_dir = config_dir.join("kei");
+        tokio::task::spawn_blocking(move || purge_kei_state(&kei_dir, &[]))
+            .await
+            .map_err(|e| anyhow::anyhow!("purge task panicked: {e}"))??;
     }
 
     Ok(())
@@ -392,17 +395,19 @@ fn parse_systemd_timestamp(raw: &str) -> Option<DateTime<Utc>> {
 
 // ── Internals ───────────────────────────────────────────────────────────
 
-fn write_unit(path: &Path, contents: &str) -> Result<()> {
+async fn write_unit(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
+        tokio::fs::create_dir_all(parent)
+            .await
             .with_context(|| format!("failed to create unit directory {}", parent.display()))?;
     }
-    std::fs::write(path, contents)
+    tokio::fs::write(path, contents)
+        .await
         .with_context(|| format!("failed to write unit file {}", path.display()))
 }
 
-fn remove_unit_file(path: &Path) -> Result<()> {
-    match std::fs::remove_file(path) {
+async fn remove_unit_file(path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e).with_context(|| format!("failed to remove unit file {}", path.display())),

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -142,7 +142,8 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
     let plist_path = home.join(LAUNCH_AGENTS_SUBDIR).join(PLIST_FILE_NAME);
     let log_dir = home.join(LOG_SUBDIR);
 
-    std::fs::create_dir_all(&log_dir)
+    tokio::fs::create_dir_all(&log_dir)
+        .await
         .with_context(|| format!("failed to create log directory {}", log_dir.display()))?;
 
     let dict = render_user_plist(PlistInputs {
@@ -152,7 +153,7 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
         home: &home,
     });
     let xml = serialize_plist(&dict)?;
-    write_plist(&plist_path, &xml)?;
+    write_plist(&plist_path, &xml).await?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
         path = %plist_path.display(),
@@ -206,7 +207,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
         // mac, plist-not-loaded-but-present). The plist removal is the
         // load-bearing step; log+proceed.
         let _ = bootout_or_unload(path).await;
-        remove_plist_file(path)?;
+        remove_plist_file(path).await?;
         tracing::info!(path = %path.display(), "removed per-user launchd plist");
     }
 
@@ -215,7 +216,13 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
             bail!("--purge requested but $HOME does not resolve; cannot locate kei state");
         };
         let extras: Vec<PathBuf> = user_log_dir().into_iter().collect();
-        purge_kei_state(&kei_dir, &extras)?;
+        tokio::task::spawn_blocking({
+            let kei_dir = kei_dir.clone();
+            let extras = extras.clone();
+            move || purge_kei_state(&kei_dir, &extras)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("purge task panicked: {e}"))??;
     }
 
     Ok(())
@@ -303,21 +310,22 @@ fn probed_to_state(state: &str, pid: Option<&str>) -> ServiceState {
 
 // ── Internals ───────────────────────────────────────────────────────────
 
-fn write_plist(path: &Path, contents: &str) -> Result<()> {
+async fn write_plist(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
             format!(
                 "failed to create LaunchAgents directory {}",
                 parent.display()
             )
         })?;
     }
-    std::fs::write(path, contents)
+    tokio::fs::write(path, contents)
+        .await
         .with_context(|| format!("failed to write plist {}", path.display()))
 }
 
-fn remove_plist_file(path: &Path) -> Result<()> {
-    match std::fs::remove_file(path) {
+async fn remove_plist_file(path: &Path) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e).with_context(|| format!("failed to remove plist {}", path.display())),

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -121,7 +121,12 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
         let kei_dir = kei_state_dir().ok_or_else(|| {
             anyhow!("--purge requested but USERPROFILE is not set; cannot locate kei state")
         })?;
-        purge_kei_state(&kei_dir, &[])?;
+        tokio::task::spawn_blocking({
+            let kei_dir = kei_dir.clone();
+            move || purge_kei_state(&kei_dir, &[])
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("purge task panicked: {e}"))??;
     }
 
     Ok(())

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -258,15 +258,26 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .data_dir
         .clone()
         .or_else(|| globals.cookie_directory.clone());
-    let mut config = config::Config::build_inner(
-        globals,
-        &pw,
-        sync,
-        toml_config.as_ref(),
-        config::parse_env_watch_interval(std::env::var(config::ENV_WATCH_INTERVAL))?,
-        personality_mode,
-        friendly_request,
-    )?;
+    let mut config = tokio::task::spawn_blocking({
+        let globals = globals.clone();
+        let pw = pw.clone();
+        let sync = sync.clone();
+        let toml_config = toml_config.clone();
+        let env_watch_interval =
+            config::parse_env_watch_interval(std::env::var(config::ENV_WATCH_INTERVAL))?;
+        move || {
+            config::Config::build_inner(
+                &globals,
+                &pw,
+                sync,
+                toml_config.as_ref(),
+                env_watch_interval,
+                personality_mode,
+                friendly_request,
+            )
+        }
+    })
+    .await??;
 
     // On first run (no config file), persist CLI-provided values so
     // subsequent runs don't need the same flags again. Only when the
@@ -310,11 +321,15 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     crate::harden_process();
 
     // Write PID file if requested (before auth so the PID is visible immediately)
-    let _pid_guard = config
-        .pid_file
-        .as_ref()
-        .map(|p| PidFileGuard::new(p.clone()))
-        .transpose()?;
+    let _pid_guard = match config.pid_file.clone() {
+        Some(p) => {
+            let guard = tokio::task::spawn_blocking(move || PidFileGuard::new(p))
+                .await
+                .map_err(|e| anyhow::anyhow!("PID file task panicked: {e}"))??;
+            Some(guard)
+        }
+        None => None,
+    };
 
     let sd_notifier = SystemdNotifier::new(config.notify_systemd);
     let notifier = Notifier::new(config.notification_script.clone(), &config.notifications);


### PR DESCRIPTION
## Summary

Audit for blocking I/O called directly inside `async fn` bodies and replace with `tokio::task::spawn_blocking` or `tokio::fs` async equivalents.

## Changes

### `src/lib.rs` (async `run`)
- `migration::migrate_legacy_paths()` → `spawn_blocking`
- `config::load_toml_config()` → `spawn_blocking`
- `setup::run_setup()` → `spawn_blocking`
- `PidFileGuard::Drop` → `spawn_blocking` when inside runtime, sync fallback otherwise

### `src/sync_loop.rs` (async `run_sync`)
- `Config::build_inner()` → `spawn_blocking` (internally calls `std::fs::create_dir_all`)
- `PidFileGuard::new()` → `spawn_blocking`

### `src/auth/session.rs` (async `build` / `persist_jar_cookies`)
- `cookiejar_path.is_file()` → `tokio::fs::metadata().await`
- `session_path.exists()` → `tokio::fs::try_exists().await`
- `cookiejar_path.exists()` → `tokio::fs::try_exists().await`

### `src/service/linux.rs`
- `write_unit()` / `remove_unit_file()` → `async fn` via `tokio::fs`
- `purge_kei_state()` → `spawn_blocking` at call site

### `src/service/macos.rs`
- `install_user`: `std::fs::create_dir_all` → `tokio::fs::create_dir_all`
- `write_plist()` / `remove_plist_file()` → `async fn` via `tokio::fs`
- `purge_kei_state()` → `spawn_blocking` at call site

### `src/service/windows.rs`
- `purge_kei_state()` → `spawn_blocking` at call site

## Verification
- `cargo check` — clean
- `cargo test --lib` — 2532 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy` — no new warnings

No public API changes. The codebase already uses `tokio::task::spawn_blocking` extensively (38+ call sites) for SQLite ops, SHA-256 hashing, fsync, and password prompting — this PR extends the same pattern to config loading, service installation, session file checks, and PID file management.