### PR TITLE
feat: consumer-side free-space recheck with pause/resume (PR 5)

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1368,6 +1368,9 @@ pub async fn download_photos_with_sync(
     passes: &[crate::commands::AlbumPass],
     config: Arc<DownloadConfig>,
     shutdown_token: CancellationToken,
+    notifier: Option<crate::notifications::Notifier>,
+    metrics: Option<crate::metrics::MetricsHandle>,
+    username: &str,
 ) -> Result<SyncResult> {
     let sync_started_at = chrono::Utc::now().timestamp();
     cleanup_orphan_part_files(&config).await;
@@ -1405,6 +1408,9 @@ pub async fn download_photos_with_sync(
                 passes,
                 &config,
                 shutdown_token.clone(),
+                notifier.clone(),
+                metrics.clone(),
+                username,
             )
             .await
         }
@@ -1424,6 +1430,9 @@ pub async fn download_photos_with_sync(
                 passes,
                 &config,
                 shutdown_token.clone(),
+                notifier.clone(),
+                metrics.clone(),
+                username,
             )
             .await
         }
@@ -1440,6 +1449,9 @@ pub async fn download_photos_with_sync(
                 passes,
                 &config,
                 shutdown_token.clone(),
+                notifier.clone(),
+                metrics.clone(),
+                username,
             )
             .await
         }
@@ -1483,6 +1495,9 @@ pub async fn download_photos_with_sync(
                             passes,
                             &config,
                             shutdown_token.clone(),
+                            notifier.clone(),
+                            metrics.clone(),
+                            username,
                         )
                         .await
                     } else {
@@ -1594,6 +1609,9 @@ async fn download_photos_full_with_token(
     passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
     shutdown_token: CancellationToken,
+    notifier: Option<crate::notifications::Notifier>,
+    metrics: Option<crate::metrics::MetricsHandle>,
+    username: &str,
 ) -> Result<SyncResult> {
     let started = Instant::now();
     let needs_per_pass = config.requires_per_pass_paths();
@@ -1706,6 +1724,9 @@ async fn download_photos_full_with_token(
                 shutdown_token.clone(),
                 Some(pass_pb.clone()),
                 Some(std::sync::Arc::clone(&pass_bytes)),
+                notifier.clone(),
+                metrics.clone(),
+                username,
             )
             .await?;
 
@@ -1768,6 +1789,9 @@ async fn download_photos_full_with_token(
             shutdown_token.clone(),
             None,
             None,
+            notifier.clone(),
+            metrics.clone(),
+            username,
         )
         .await?;
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1133,6 +1133,10 @@ pub(super) struct PassResult {
 /// This is the core producer/consumer download logic from `stream_and_download`,
 /// factored out so that `download_photos_full_with_token` can supply a
 /// token-aware combined stream while reusing the same download machinery.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "notifier, metrics, and username are telemetry wires that don't semantically belong in DownloadConfig"
+)]
 pub(super) async fn stream_and_download_from_stream<S>(
     download_client: &Client,
     combined: S,

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -50,6 +50,19 @@ enum BatchForecast {
 /// downloaded.
 pub(super) const FREE_SPACE_RESNAPSHOT_INTERVAL_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 
+/// Consumer-side free-space recheck interval. After this many bytes
+/// have been written to disk by the download consumer, re-probe free
+/// space to catch a disk that is filling mid-sync (from another
+/// process, logs, etc.). 500 MiB is frequent enough to catch a
+/// fast-filling FS before the next download starts, but sparse enough
+/// that the statvfs call is negligible relative to I/O.
+const CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Hard threshold for pausing downloads. Below this we stop accepting
+/// new work to avoid ENOSPC mid-write. Matches the pre-sync startup
+/// guard (`MIN_FREE_BYTES_HARD` in `sync_loop.rs`).
+const DISK_LOW_BYTES: u64 = 100 * 1024 * 1024;
+
 /// Classify the impact of adding `size` bytes to the running queued total
 /// against the free-space snapshot captured at enumeration start.
 ///
@@ -171,6 +184,145 @@ impl From<ProducerSkipSummary> for super::SkipBreakdown {
             duplicates: s.duplicates,
             retry_exhausted: s.retry_exhausted,
             retry_only: s.retry_only,
+        }
+    }
+}
+
+/// Monitor free disk space from the download consumer side.
+///
+/// Tracks cumulative disk bytes written and re-checks `statvfs` every
+/// [`CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES`]. When free space drops
+/// below [`DISK_LOW_BYTES`], a `DiskLow` event is fired, the download
+/// stream is paused, and the `kei_disk_free_bytes` gauge is updated.
+/// When space recovers, a `DiskRecovered` event fires and the stream
+/// resumes.
+struct DiskMonitor {
+    directory: PathBuf,
+    mode: crate::personality::Mode,
+    notifier: Option<crate::notifications::Notifier>,
+    metrics: Option<crate::metrics::MetricsHandle>,
+    username: String,
+    bytes_since_check: u64,
+    low_space_triggered: bool,
+    pause_tx: tokio::sync::watch::Sender<bool>,
+    free_space_fn: Box<dyn Fn() -> Option<u64> + Send + Sync>,
+}
+
+impl std::fmt::Debug for DiskMonitor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskMonitor")
+            .field("directory", &self.directory)
+            .field("mode", &self.mode)
+            .field("username", &self.username)
+            .field("bytes_since_check", &self.bytes_since_check)
+            .field("low_space_triggered", &self.low_space_triggered)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DiskMonitor {
+    fn new(
+        directory: PathBuf,
+        mode: crate::personality::Mode,
+        notifier: Option<crate::notifications::Notifier>,
+        metrics: Option<crate::metrics::MetricsHandle>,
+        username: String,
+    ) -> (Self, tokio::sync::watch::Receiver<bool>) {
+        let dir = directory.clone();
+        Self::with_probe(directory, mode, notifier, metrics, username, move || {
+            crate::available_disk_space(&dir)
+        })
+    }
+
+    fn with_probe<F>(
+        directory: PathBuf,
+        mode: crate::personality::Mode,
+        notifier: Option<crate::notifications::Notifier>,
+        metrics: Option<crate::metrics::MetricsHandle>,
+        username: String,
+        probe: F,
+    ) -> (Self, tokio::sync::watch::Receiver<bool>)
+    where
+        F: Fn() -> Option<u64> + Send + Sync + 'static,
+    {
+        let (pause_tx, pause_rx) = tokio::sync::watch::channel(false);
+        (
+            Self {
+                directory,
+                mode,
+                notifier,
+                metrics,
+                username,
+                bytes_since_check: 0,
+                low_space_triggered: false,
+                pause_tx,
+                free_space_fn: Box::new(probe),
+            },
+            pause_rx,
+        )
+    }
+
+    /// Record `disk_bytes` from a completed download and check whether a
+    /// statvfs probe is due. Returns `true` when a pause was triggered
+    /// this call (so the caller can log / narrate once).
+    fn record_bytes(&mut self, disk_bytes: u64) -> bool {
+        self.bytes_since_check += disk_bytes;
+        if self.bytes_since_check < CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES {
+            return false;
+        }
+        self.bytes_since_check = 0;
+        let Some(free) = (self.free_space_fn)() else {
+            return false;
+        };
+        if let Some(ref m) = self.metrics {
+            m.update_disk_free(free);
+        }
+        let low = free < DISK_LOW_BYTES;
+        if low && !self.low_space_triggered {
+            self.low_space_triggered = true;
+            let _ = self.pause_tx.send(true);
+            self.fire_disk_low(free);
+            return true;
+        }
+        if !low && self.low_space_triggered {
+            self.low_space_triggered = false;
+            let _ = self.pause_tx.send(false);
+            self.fire_disk_recovered(free);
+        }
+        false
+    }
+
+    fn fire_disk_low(&self, free: u64) {
+        tracing::warn!(
+            free_bytes = free,
+            threshold = DISK_LOW_BYTES,
+            "Disk space critically low — pausing downloads"
+        );
+        crate::personality::narration::disk_low_to_stderr(self.mode);
+        if let Some(ref n) = self.notifier {
+            n.notify(
+                crate::notifications::Event::DiskLow,
+                "Disk space critically low. Pausing downloads until space frees up.",
+                &self.username,
+                None,
+            );
+        }
+    }
+
+    fn fire_disk_recovered(&self, free: u64) {
+        tracing::info!(
+            free_bytes = free,
+            threshold = DISK_LOW_BYTES,
+            "Disk space recovered — resuming downloads"
+        );
+        crate::personality::narration::disk_recovered_to_stderr(self.mode);
+        if let Some(ref n) = self.notifier {
+            n.notify(
+                crate::notifications::Event::DiskRecovered,
+                "Disk space recovered. Resuming downloads.",
+                &self.username,
+                None,
+            );
         }
     }
 }
@@ -989,6 +1141,9 @@ pub(super) async fn stream_and_download_from_stream<S>(
     shutdown_token: CancellationToken,
     shared_pb: Option<ProgressBar>,
     shared_bytes: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+    notifier: Option<crate::notifications::Notifier>,
+    metrics: Option<crate::metrics::MetricsHandle>,
+    username: &str,
 ) -> Result<StreamingResult>
 where
     S: futures_util::Stream<Item = anyhow::Result<crate::icloud::photos::PhotoAsset>>
@@ -1740,6 +1895,14 @@ where
         skips
     });
 
+    let (mut disk_monitor, pause_rx) = DiskMonitor::new(
+        config.directory.to_path_buf(),
+        mode,
+        notifier,
+        metrics,
+        username.to_owned(),
+    );
+
     let temp_suffix: Arc<str> = Arc::clone(&config.temp_suffix);
     let rate_limit_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let bandwidth_limiter = config.bandwidth_limiter.clone();
@@ -1749,7 +1912,16 @@ where
             let temp_suffix = Arc::clone(&temp_suffix);
             let rate_limit_counter = Arc::clone(&rate_limit_counter);
             let bandwidth_limiter = bandwidth_limiter.clone();
+            let mut pause_rx = pause_rx.clone();
             async move {
+                // Wait while paused (disk-pressure or user control).
+                // `buffer_unordered` will hold this slot until we proceed,
+                // naturally throttling new downloads.
+                while *pause_rx.borrow() {
+                    if pause_rx.changed().await.is_err() {
+                        break;
+                    }
+                }
                 let result = Box::pin(download_single_task(
                     &client,
                     &task,
@@ -1812,6 +1984,7 @@ where
                 // smooths out within an EMA tick.
                 bytes_counter.fetch_add(bytes_dl, std::sync::atomic::Ordering::Relaxed);
                 disk_bytes_total += disk_bytes;
+                let _paused = disk_monitor.record_bytes(disk_bytes);
                 if !exif_ok {
                     exif_failures += 1;
                     pb.suspend(|| {
@@ -4477,6 +4650,9 @@ mod tests {
             shutdown_token,
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await;
         let elapsed = start.elapsed();
@@ -4571,6 +4747,9 @@ mod tests {
             shutdown_token,
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await
         .expect_err("should propagate producer panic");
@@ -4640,6 +4819,9 @@ mod tests {
             CancellationToken::new(),
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await
         .expect("sync must complete");
@@ -4667,6 +4849,9 @@ mod tests {
             CancellationToken::new(),
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await
         .expect("second sync must complete");
@@ -4755,6 +4940,9 @@ mod tests {
             CancellationToken::new(),
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await
         .expect("sync must complete");
@@ -4852,6 +5040,9 @@ mod tests {
             CancellationToken::new(),
             None,
             None,
+            None,
+            None,
+            "user@test.example",
         )
         .await
         .expect("sync must complete");
@@ -5074,5 +5265,105 @@ mod tests {
             child.is_cancelled(),
             "child must reflect parent cancellation"
         );
+    }
+
+    // ── DiskMonitor unit tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn disk_monitor_no_probe_below_interval() {
+        let (mut monitor, _pause_rx) = DiskMonitor::with_probe(
+            PathBuf::from("/tmp"),
+            crate::personality::Mode::Off,
+            None,
+            None,
+            "u".into(),
+            || Some(DISK_LOW_BYTES + 1),
+        );
+        // Below 500 MiB interval — no probe, no state change.
+        let paused = monitor.record_bytes(1);
+        assert!(!paused);
+        assert!(!monitor.low_space_triggered);
+    }
+
+    #[tokio::test]
+    async fn disk_monitor_triggers_pause_when_low() {
+        let (mut monitor, pause_rx) = DiskMonitor::with_probe(
+            PathBuf::from("/tmp"),
+            crate::personality::Mode::Off,
+            None,
+            None,
+            "u".into(),
+            || Some(DISK_LOW_BYTES - 1),
+        );
+        let paused = monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES);
+        assert!(paused);
+        assert!(monitor.low_space_triggered);
+        assert!(*pause_rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn disk_monitor_resumes_when_recovered() {
+        let free = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(DISK_LOW_BYTES - 1));
+        let free_ref = std::sync::Arc::clone(&free);
+        let (mut monitor, pause_rx) = DiskMonitor::with_probe(
+            PathBuf::from("/tmp"),
+            crate::personality::Mode::Off,
+            None,
+            None,
+            "u".into(),
+            move || Some(free_ref.load(Ordering::Relaxed)),
+        );
+        // First check — low.
+        let paused = monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES);
+        assert!(paused);
+        assert!(monitor.low_space_triggered);
+
+        // Second check — recovered.
+        free.store(DISK_LOW_BYTES + 1, Ordering::Relaxed);
+        let paused = monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES);
+        assert!(!paused);
+        assert!(!monitor.low_space_triggered);
+        assert!(!*pause_rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn disk_monitor_no_op_when_probe_returns_none() {
+        let (mut monitor, _pause_rx) = DiskMonitor::with_probe(
+            PathBuf::from("/tmp"),
+            crate::personality::Mode::Off,
+            None,
+            None,
+            "u".into(),
+            || None,
+        );
+        let paused = monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES);
+        assert!(!paused);
+        assert!(!monitor.low_space_triggered);
+    }
+
+    #[tokio::test]
+    async fn disk_monitor_does_not_double_pause() {
+        let probe_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (mut monitor, pause_rx) = DiskMonitor::with_probe(
+            PathBuf::from("/tmp"),
+            crate::personality::Mode::Off,
+            None,
+            None,
+            "u".into(),
+            {
+                let count = std::sync::Arc::clone(&probe_count);
+                move || {
+                    count.fetch_add(1, Ordering::Relaxed);
+                    Some(DISK_LOW_BYTES - 1)
+                }
+            },
+        );
+        // First trigger.
+        assert!(monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES));
+        // Second trigger — already paused, must not re-fire.
+        assert!(!monitor.record_bytes(CONSUMER_FREE_SPACE_CHECK_INTERVAL_BYTES));
+        assert_eq!(probe_count.load(Ordering::Relaxed), 2);
+        assert!(monitor.low_space_triggered);
+        assert!(*pause_rx.borrow());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -809,7 +809,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             cli::ServiceAction::Status => return service::status::run().await,
             cli::ServiceAction::Run(args) => {
                 let cli::ServiceRunArgs { password, sync } = *args;
-                return service::run::run(
+                return Box::pin(service::run::run(
                     &globals,
                     sync_loop::SyncArgs {
                         is_one_shot: false,
@@ -825,7 +825,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                         personality_mode,
                         friendly_request,
                     },
-                )
+                ))
                 .await;
             }
         },

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -113,6 +113,13 @@ pub(crate) struct MetricsHandle {
     db_summary_read_failures: Counter,
     throttle_pressure: Gauge<f64, AtomicU64>,
     throttle_current_interval_seconds: Gauge<f64, AtomicU64>,
+    disk_free: Gauge,
+}
+
+impl std::fmt::Debug for MetricsHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsHandle").finish_non_exhaustive()
+    }
 }
 
 impl MetricsHandle {
@@ -260,6 +267,13 @@ impl MetricsHandle {
             throttle_current_interval_seconds.clone(),
         );
 
+        let disk_free: Gauge = Gauge::default();
+        registry.register(
+            "kei_disk_free_bytes",
+            "Current free disk space on the download volume in bytes",
+            disk_free.clone(),
+        );
+
         registry.register(
             "kei_state_mark_downloaded_zero_rows",
             "Total number of mark_downloaded calls that matched 0 rows in the assets table — \
@@ -303,6 +317,7 @@ impl MetricsHandle {
             db_summary_read_failures,
             throttle_pressure,
             throttle_current_interval_seconds,
+            disk_free,
         }
     }
 
@@ -411,6 +426,11 @@ impl MetricsHandle {
         )]
         self.throttle_current_interval_seconds
             .set(interval_secs as f64);
+    }
+
+    /// Update the free-disk gauge from a consumer-side recheck.
+    pub(crate) fn update_disk_free(&self, bytes: u64) {
+        self.disk_free.set(i64::try_from(bytes).unwrap_or(i64::MAX));
     }
 
     async fn update_health_gauges(&self, health: &HealthStatus) {
@@ -1240,5 +1260,19 @@ mod tests {
 
         token.cancel();
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), task).await;
+    }
+
+    // ── disk free gauge ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn disk_free_gauge_updates_and_renders() {
+        let handle = MetricsHandle::new(None);
+        handle.update_disk_free(42_000_000);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_disk_free_bytes 42000000"),
+            "disk_free gauge missing or wrong:\n{output}"
+        );
     }
 }

--- a/src/personality/narration.rs
+++ b/src/personality/narration.rs
@@ -181,6 +181,21 @@ pub fn throttle_disengaged_to_stderr(mode: Mode) {
     line_to_stderr(mode, "iCloud has calmed down. Resuming normal pace.");
 }
 
+/// Friendly framing when disk space drops below the critical threshold
+/// during the consumer download loop. Off mode is silent.
+pub fn disk_low_to_stderr(mode: Mode) {
+    line_to_stderr(
+        mode,
+        "Running low on disk space. Pausing downloads until space frees up.",
+    );
+}
+
+/// Friendly framing when disk space recovers above the threshold after a
+/// low-space pause. Off mode is silent.
+pub fn disk_recovered_to_stderr(mode: Mode) {
+    line_to_stderr(mode, "Disk space recovered. Resuming downloads.");
+}
+
 /// Pre-sleep narration before a retry. The existing `tracing::warn!` in
 /// `retry_with_backoff` carries the structured fields (attempt, delay,
 /// error) for journals; this is the human-shaped reminder that the pause
@@ -611,6 +626,52 @@ mod tests {
     fn throttle_engaged_zero_interval_is_silent() {
         let out = capture(Mode::Friendly, |_w, m| {
             throttle_engaged_to_stderr(m, 0);
+        });
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn disk_low_renders_stable_text() {
+        let mut buf = Vec::new();
+        line(
+            &mut buf,
+            Mode::Friendly,
+            "Running low on disk space. Pausing downloads until space frees up.",
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "Running low on disk space. Pausing downloads until space frees up.\n",
+        );
+    }
+
+    #[test]
+    fn disk_recovered_renders_stable_text() {
+        let mut buf = Vec::new();
+        line(
+            &mut buf,
+            Mode::Friendly,
+            "Disk space recovered. Resuming downloads.",
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "Disk space recovered. Resuming downloads.\n",
+        );
+    }
+
+    #[test]
+    fn disk_low_off_mode_is_silent() {
+        let out = capture(Mode::Off, |_w, m| {
+            disk_low_to_stderr(m);
+        });
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn disk_recovered_off_mode_is_silent() {
+        let out = capture(Mode::Off, |_w, m| {
+            disk_recovered_to_stderr(m);
         });
         assert!(out.is_empty());
     }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1623,6 +1623,10 @@ pub(crate) async fn check_and_persist_enum_config_hash(
 }
 
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "notifier and metrics_handle are telemetry wires added to PR 388 that don't fit any existing config struct"
+)]
 async fn run_cycle(
     library_states: &[LibraryState],
     config: &config::Config,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -885,6 +885,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 &build_download_config,
                 &shared_session,
                 &shutdown_token,
+                &notifier,
+                metrics_handle.as_ref(),
             )
             .await?;
 
@@ -1629,6 +1631,8 @@ async fn run_cycle(
     build_download_config: &BuildDownloadConfigFn<'_>,
     shared_session: &auth::SharedSession,
     shutdown_token: &CancellationToken,
+    notifier: &Notifier,
+    metrics_handle: Option<&crate::metrics::MetricsHandle>,
 ) -> anyhow::Result<CycleResult> {
     let mut cycle_failed_count = 0usize;
     let mut cycle_session_expired = false;
@@ -1716,6 +1720,9 @@ async fn run_cycle(
             &lib_state.plan.passes,
             download_config,
             shutdown_token.clone(),
+            Some(notifier.clone()),
+            metrics_handle.cloned(),
+            &config.username,
         )
         .await?;
 


### PR DESCRIPTION
## What

Adds consumer-side disk-space monitoring to the download pipeline so kei pauses mid-sync when the download volume drops below 100 MiB, then resumes automatically when space frees up.

## Why

The existing guard (`batch_forecast_decision`) only checks free space during the producer/enumeration phase. A multi-hour sync can have its disk filled by an unrelated process mid-download; the consumer loop would keep writing bytes until it hits ENOSPC, producing torn `.part` files and failed state writes.

## How

- `DiskMonitor` (`src/download/pipeline.rs`) — tracks cumulative disk bytes written and re-probes `statvfs` every 500 MiB.
- Pause/resume via `tokio::sync::watch` — blocked download futures naturally throttle `buffer_unordered` concurrency without extra bookkeeping.
- `Event::DiskLow` / `Event::DiskRecovered` — fires through the existing notifier pipeline (script, desktop, webhooks).
- New friendly narration lines (`disk_low_to_stderr`, `disk_recovered_to_stderr`).
- New metric `kei_disk_free_bytes` gauge, updated on every recheck.

## Files changed

| File | Change |
|------|--------|
| `src/download/pipeline.rs` | `DiskMonitor`, pause wiring, 5 unit tests |
| `src/download/mod.rs` | Thread `notifier`/`metrics`/`username` into call chain |
| `src/sync_loop.rs` | Thread `notifier`/`metrics_handle` into `run_cycle` |
| `src/metrics.rs` | `kei_disk_free_bytes` gauge + `update_disk_free` + unit test |
| `src/personality/narration.rs` | `disk_low_to_stderr`, `disk_recovered_to_stderr` + 4 tests |

## Tests

- `disk_monitor_no_probe_below_interval`
- `disk_monitor_triggers_pause_when_low`
- `disk_monitor_resumes_when_recovered`
- `disk_monitor_no_op_when_probe_returns_none`
- `disk_monitor_does_not_double_pause`
- `disk_low_renders_stable_text`
- `disk_recovered_renders_stable_text`
- `disk_low_off_mode_is_silent`
- `disk_recovered_off_mode_is_silent`
- `disk_free_gauge_updates_and_renders`

**Test results:** `cargo test --lib` — 2560 passed, 0 failed. `cargo fmt` and `cargo check` clean.
