### PR TITLE
Document legacy command deprecations

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -20,19 +20,29 @@ See [CHANGELOG.md](CHANGELOG.md) for the release where each item was first marke
 - `--no-incremental` CLI flag. Use `kei reset sync-token` before the sync for the same effect (both trigger a full enumeration and store a fresh token for subsequent incremental runs).
 - `KEI_METRICS_PORT` env var and `[metrics] port` TOML section. Use `KEI_HTTP_PORT` / `[server] port` instead. Both were renamed in 0.11.0 but didn't have a removal deadline; fixing that now.
 - Hidden compat flags on `kei sync`, superseded by dedicated subcommands:
-  - `--auth-only` — use `kei login`.
-  - `--list-albums` (and its short form `-l`) — use `kei list albums`.
-  - `--list-libraries` — use `kei list libraries`.
-  - `--reset-sync-token` — use `kei reset sync-token`.
+  - `--auth-only` - use `kei login`.
+  - `--list-albums` (and its short form `-l`) - use `kei list albums`.
+  - `--list-libraries` - use `kei list libraries`.
+  - `--reset-sync-token` - use `kei reset sync-token`.
 
   All four have existed as hidden compat flags since the subcommand refactor. They were missing an explicit removal target; v0.20.0 aligns them with the rest of the cleanup. Each now emits a deprecation warning at runtime naming v0.20.0.
+- Hidden legacy top-level subcommands, superseded by the nested command tree:
+  - `kei get-code` - use `kei login get-code`.
+  - `kei submit-code` - use `kei login submit-code`.
+  - `kei credential` - use `kei password`.
+  - `kei retry-failed` - use `kei sync --retry-failed`.
+  - `kei reset-state` - use `kei reset state`.
+  - `kei reset-sync-token` - use `kei reset sync-token`.
+  - `kei setup` - use `kei config setup`.
 
-## v0.20.0 — `sync_report.json` schema v2
+  These hidden aliases emit the same v0.20.0 deprecation warning path as the compat flags above.
+
+## v0.20.0 - `sync_report.json` schema v2
 
 Bump `SyncReport.version` from `"1"` to `"2"` alongside the flag removals above and apply these `RunOptions` field renames at the same time (one breaking schema change instead of three):
 
-- `options.directory` → `options.download_dir` (matches `--download-dir`)
-- `options.threads_num` → `options.threads` (matches `--threads`)
-- `options.no_incremental` → removed (`--no-incremental` is gone)
+- `options.directory` -> `options.download_dir` (matches `--download-dir`)
+- `options.threads_num` -> `options.threads` (matches `--threads`)
+- `options.no_incremental` -> removed (`--no-incremental` is gone)
 
 Until v0.20.0 the schema stays at `"1"` and the old field names are retained in the report even though the CLI flags they came from are deprecated.


### PR DESCRIPTION
## Summary
- document hidden legacy top-level commands in `DEPRECATED.md`
- normalize the touched deprecation list to plain ASCII separators

## Test
- `cargo check`
- `cargo run -- --help`
- `target/debug/kei <legacy-command> --help` for each documented legacy alias
