### PR TITLE
Make sync config TOML-first

### DIFF
--- a/.github/workflows/service-smoke.yml
+++ b/.github/workflows/service-smoke.yml
@@ -19,7 +19,7 @@ name: Service smoke
 #
 # That deeper exercise lives in the Rust integration suites
 # (tests/service_linux.rs etc.) and the maintainer's manual real-install
-# flow against the icloudpd-test album.
+# flow against the kei-test album.
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,5 @@ HEALTHCHECK --interval=60s --timeout=5s --start-period=15m --retries=3 \
 # deployments where files must be host-user-owned (Synology Photos,
 # Unraid, TrueNAS Scale).
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["service", "run", "--config", "/config/config.toml", "--data-dir", "/config"]
+ENV KEI_DATA_DIR=/config
+CMD ["service", "run", "--config", "/config/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,19 +67,15 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 VOLUME ["/config", "/photos"]
 
 # Always-on HTTP server: /healthz (health check) and /metrics (Prometheus).
-# Default port 9090; override with --http-port / KEI_HTTP_PORT.
+# Default port 9090; override with [server] port in TOML.
 EXPOSE 9090
 
 HEALTHCHECK --interval=60s --timeout=5s --start-period=15m --retries=3 \
   CMD curl -f http://localhost:9090/healthz || exit 1
-
-# Default watch interval (24h). Lower precedence than `[watch] interval`
-# in TOML so users can shorten the cycle without overriding `command:` (#293).
-ENV KEI_WATCH_WITH_INTERVAL=86400
 
 # entrypoint.sh drops to PUID:PGID when those env vars are set; otherwise
 # exec's kei as root (preserves prior behavior). Required for NAS
 # deployments where files must be host-user-owned (Synology Photos,
 # Unraid, TrueNAS Scale).
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["sync", "--config", "/config/config.toml", "--data-dir", "/config", "--download-dir", "/photos"]
+CMD ["service", "run", "--config", "/config/config.toml", "--data-dir", "/config"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     #     sync
     #     --config /config/config.toml
     #     --data-dir /config
-    #     --download-dir /photos
     #     --password-file /run/secrets/icloud_password
     #
     # Option 4: External secret manager (zero password on host)
@@ -45,7 +44,6 @@ services:
     #     sync
     #     --config /config/config.toml
     #     --data-dir /config
-    #     --download-dir /photos
     #     --password-command "cat /run/secrets/icloud_password"
 
 # Uncomment for Docker secrets (Option 3):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     stop_grace_period: 30s
     environment:
       - ICLOUD_USERNAME=${ICLOUD_USERNAME}
+      - KEI_DATA_DIR=/config
       - TZ=${TZ:-UTC}
       # Option 1: Password via environment variable (least secure — visible in
       # `docker inspect`). Removed by kei from the process environment after
@@ -34,16 +35,14 @@ services:
     #   secrets:
     #     - icloud_password
     #   command: >-
-    #     sync
+    #     service run
     #     --config /config/config.toml
-    #     --data-dir /config
     #     --password-file /run/secrets/icloud_password
     #
     # Option 4: External secret manager (zero password on host)
     #   command: >-
-    #     sync
+    #     service run
     #     --config /config/config.toml
-    #     --data-dir /config
     #     --password-command "cat /run/secrets/icloud_password"
 
 # Uncomment for Docker secrets (Option 3):

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,7 @@ elif [ "${1#-}" != "$1" ]; then
     set -- kei "$@"
 else
     case "$1" in
-        sync|login|list|password|reset|config|status|verify|import-existing|reconcile)
+        sync|login|list|password|reset|config|status|verify|import-existing|reconcile|service)
             set -- kei "$@"
             ;;
         *)

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -21,7 +21,7 @@ fresh Apple login and 2FA approval. Your local photo files can stay in place.
 Point kei at the directory that `icloudpd` has been writing to:
 
 ```sh
-kei import-existing --username you@example.com --download-dir ~/Photos/iCloud
+ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud
 ```
 
 `import-existing` signs in, enumerates the selected iCloud libraries, computes
@@ -32,7 +32,7 @@ those adopted files and downloads only new or previously failed assets.
 Run a dry import first when you're not sure the flags are right:
 
 ```sh
-kei import-existing --username you@example.com --download-dir ~/Photos/iCloud --dry-run
+ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud --dry-run
 ```
 
 If most files show as unmatched, stop and fix the path options before running a
@@ -68,7 +68,7 @@ If your Python tree included album names, put the album template on
 `--folder-structure-albums`:
 
 ```sh
-kei import-existing --username you@example.com --download-dir ~/Photos/iCloud \
+ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud \
   --folder-structure-albums "{album}/%Y/%m/%d"
 ```
 
@@ -133,25 +133,36 @@ config file for sync selection, pass that same `--config` during import.
 After the import looks good:
 
 ```sh
-kei sync --username you@example.com --download-dir ~/Photos/iCloud
+kei sync --config ~/.config/kei/config.toml
 ```
 
-After the first 2FA approval, kei stores session state under `--data-dir`
-(default `~/.config/kei`). Run `kei password set` or `kei sync --save-password`
-if you want kei to store the password for future runs.
+Put the account and sync directory in TOML:
+
+```toml
+[auth]
+username = "you@example.com"
+
+[download]
+directory = "~/Photos/iCloud"
+```
+
+After the first 2FA approval, kei stores session state under `data_dir`
+(default `~/.config/kei`; `KEI_DATA_DIR` can override it for automation). Run
+`kei password set` or `kei sync --save-password` if you want kei to store the
+password for future runs.
 
 ## Common flag mapping
 
 | `icloudpd` | kei | Notes |
 |---|---|---|
-| `-u`, `--username` | Same | Also `ICLOUD_USERNAME`. |
+| `-u`, `--username` | `[auth].username` | `ICLOUD_USERNAME` still works for automation. |
 | `-p`, `--password` | Same | Works, but process lists can expose it. Prefer `kei password set`, `--password-file`, or `--password-command`. |
 | `-d`, `--directory` | `-d`, `--download-dir` | `--directory` was removed in v0.20. |
 | `-a`, `--album` | Same | Repeatable. Default is `all`; use `--album '!Name'` for exclusions. |
 | `--exclude-album NAME` | `--album '!NAME'` | Removed in v0.20. |
 | `--list-albums` | `kei list albums` | The old flag was removed in v0.20. |
 | `--list-libraries` | `kei list libraries` | The old flag was removed in v0.20. |
-| `--cookie-directory` | `--data-dir` | The old flag was removed in v0.20. New default is `~/.config/kei`. |
+| `--cookie-directory` | `data_dir` | The old flag was removed in v0.20. New default is `~/.config/kei`; `KEI_DATA_DIR` still works for automation. |
 | `--folder-structure "{:%Y/%m/%d}"` | `--folder-structure "%Y/%m/%d"` | Python wrapper syntax is still accepted. Album and smart-folder templates now have separate flags. |
 | `--size original` | Same | Values: `original`, `medium`, `thumb`, `adjusted`, `alternative`. kei accepts one size per run. |
 | `--threads-num` | `--threads` | The old flag was removed in v0.20. Default is 10. With `--bandwidth-limit` and no explicit thread count, default drops to 1. |
@@ -163,7 +174,7 @@ if you want kei to store the password for future runs.
 | `--keep-unicode-in-filenames` | Same | Must match during import. |
 | `--live-photo-mov-filename-policy` | Same | `suffix` or `original`. |
 | `--file-match-policy` | Same | `name-size-dedup-with-suffix` or `name-id7`. |
-| `--domain` | Same | `com` or `cn`. |
+| `--domain` | `[auth].domain` | `com` or `cn`. |
 | `--watch-with-interval` | Same | Built-in watch mode. |
 | `--log-level` | Same | `debug`, `info`, `warn`, `error`. |
 | `--only-print-filenames` | Same | Prints paths and doesn't download. |
@@ -229,9 +240,9 @@ v0.20 removed the remaining v0.13 compatibility aliases:
 ## Docker migration
 
 The official image is `ghcr.io/rhoopr/kei:latest`. It uses `/config` and
-`/photos` volumes. The image runs `kei sync --config /config/config.toml
---data-dir /config --download-dir /photos` by default, with a 24-hour watch
-interval from `KEI_WATCH_WITH_INTERVAL=86400`.
+`/photos` volumes. The image runs `kei service run --config /config/config.toml`
+by default, with `KEI_DATA_DIR=/config`. Set `[download].directory = "/photos"`
+in the config file.
 
 A minimal compose file:
 

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -1,11 +1,11 @@
 # Migrating from `icloudpd`
 
-> Last updated on 5-16-26 for v0.14.2.
+> Last updated on 5-17-26 for v0.20.
 
 This guide is for moving an existing
 [`icloud-photos-downloader`](https://github.com/icloud-photos-downloader/icloud_photos_downloader)
 (`icloudpd`) library to kei without downloading everything again. It matches
-kei 0.14.x.
+kei v0.20.
 
 The short version:
 
@@ -107,11 +107,21 @@ kei import-existing --download-dir ~/Photos/iCloud \
 ### Libraries and albums
 
 kei defaults to the primary iCloud Photos library. If you want shared libraries
-too, import and sync with the same library selector:
+too, import with the same library selector that sync will read from TOML:
 
 ```sh
-kei import-existing --library all --download-dir ~/Photos/iCloud
-kei sync --library all --download-dir ~/Photos/iCloud
+kei import-existing --library all --download-dir ~/Photos/iCloud --config ~/.config/kei/config.toml
+```
+
+```toml
+[filters]
+libraries = ["all"]
+```
+
+Then run sync with that config:
+
+```sh
+kei sync --config ~/.config/kei/config.toml
 ```
 
 For multi-library trees, add `{library}` to the active templates if you want
@@ -156,30 +166,30 @@ password for future runs.
 | `icloudpd` | kei | Notes |
 |---|---|---|
 | `-u`, `--username` | `[auth].username` | `ICLOUD_USERNAME` still works for automation. |
-| `-p`, `--password` | Same | Works, but process lists can expose it. Prefer `kei password set`, `--password-file`, or `--password-command`. |
-| `-d`, `--directory` | `-d`, `--download-dir` | `--directory` was removed in v0.20. |
-| `-a`, `--album` | Same | Repeatable. Default is `all`; use `--album '!Name'` for exclusions. |
-| `--exclude-album NAME` | `--album '!NAME'` | Removed in v0.20. |
+| `-p`, `--password` | `--password`, `[auth].password_file`, `[auth].password_command`, or `kei password set` | Avoid putting passwords in process lists when you can. |
+| `-d`, `--directory` | `import-existing --download-dir`; sync uses `[download].directory` | `--directory` was removed in v0.20. |
+| `-a`, `--album` | `[filters].albums = ["Name"]` | Use `["!Name"]` for exclusions. |
+| `--exclude-album NAME` | `[filters].albums = ["!NAME"]` | Removed in v0.20. |
 | `--list-albums` | `kei list albums` | The old flag was removed in v0.20. |
 | `--list-libraries` | `kei list libraries` | The old flag was removed in v0.20. |
 | `--cookie-directory` | `data_dir` | The old flag was removed in v0.20. New default is `~/.config/kei`; `KEI_DATA_DIR` still works for automation. |
-| `--folder-structure "{:%Y/%m/%d}"` | `--folder-structure "%Y/%m/%d"` | Python wrapper syntax is still accepted. Album and smart-folder templates now have separate flags. |
-| `--size original` | Same | Values: `original`, `medium`, `thumb`, `adjusted`, `alternative`. kei accepts one size per run. |
-| `--threads-num` | `--threads` | The old flag was removed in v0.20. Default is 10. With `--bandwidth-limit` and no explicit thread count, default drops to 1. |
-| `--skip-videos`, `--skip-photos` | Same | Boolean flags also accept explicit false when overriding config. |
-| `--skip-live-photos` | `--live-photo-mode skip` | The old flag was removed in v0.20. |
-| `--recent 100` | Same | Count form works for sync and import. |
-| `--recent 30d` | Same for sync | Import rejects the days form. |
-| `--set-exif-datetime` | Same | kei also has EXIF rating, GPS, and description flags. |
-| `--keep-unicode-in-filenames` | Same | Must match during import. |
-| `--live-photo-mov-filename-policy` | Same | `suffix` or `original`. |
-| `--file-match-policy` | Same | `name-size-dedup-with-suffix` or `name-id7`. |
+| `--folder-structure "{:%Y/%m/%d}"` | `[download].folder_structure = "%Y/%m/%d"` | Python wrapper syntax is still accepted. Use `folder_structure_albums` and `folder_structure_smart_folders` for the other passes. |
+| `--size original` | `[photos].size = "original"` | Values: `original`, `medium`, `thumb`, `adjusted`, `alternative`. kei accepts one size per run. |
+| `--threads-num` | `[download].threads` | Default is 10. With `[download].bandwidth_limit` and no explicit thread count, default drops to 1. |
+| `--skip-videos`, `--skip-photos` | `[filters].skip_videos`, `[filters].skip_photos` | Boolean TOML settings replace the sync flags. |
+| `--skip-live-photos` | `[photos].live_photo_mode = "skip"` | The old flag was removed in v0.20. |
+| `--recent 100` | `--recent 100` | Count form works for sync and import. |
+| `--recent 30d` | `--recent 30d` for sync | Import rejects the days form. |
+| `--set-exif-datetime` | `[download].set_exif_datetime = true` | kei also has EXIF rating, GPS, and description settings. |
+| `--keep-unicode-in-filenames` | `[photos].keep_unicode_in_filenames = true` | Match this during import. |
+| `--live-photo-mov-filename-policy` | `[photos].live_photo_mov_filename_policy` | `suffix` or `original`. |
+| `--file-match-policy` | `[photos].file_match_policy` | `name-size-dedup-with-suffix` or `name-id7`. |
 | `--domain` | `[auth].domain` | `com` or `cn`. |
-| `--watch-with-interval` | Same | Built-in watch mode. |
-| `--log-level` | Same | `debug`, `info`, `warn`, `error`. |
-| `--only-print-filenames` | Same | Prints paths and doesn't download. |
-| `--dry-run` | Same | Doesn't modify local state or iCloud. |
-| `--notification-script` | Same flag | kei sends `KEI_EVENT`, `KEI_MESSAGE`, and `KEI_ICLOUD_USERNAME`. |
+| `--watch-with-interval` | `[watch].interval`; Docker uses `kei service run` | Built-in watch mode moved to durable config and service commands. |
+| `--log-level` | `--log-level` or `log_level` | `debug`, `info`, `warn`, `error`. |
+| `--only-print-filenames` | `--only-print-filenames` | Per-run flag that prints paths and doesn't download. |
+| `--dry-run` | `--dry-run` | Per-run flag that doesn't modify local state or iCloud. |
+| `--notification-script` | `[notifications].script` | kei sends `KEI_EVENT`, `KEI_MESSAGE`, and `KEI_ICLOUD_USERNAME`. |
 
 ## Python flags without a kei equivalent
 
@@ -194,8 +204,9 @@ password for future runs.
 | `--password-provider` | Use `--password-file`, `--password-command`, or `kei password set`. |
 | `--mfa-provider` | Not applicable. Use trusted-device 2FA with `kei login get-code` and `kei login submit-code`. |
 
-`--xmp-sidecar` is implemented in kei, along with `--embed-xmp`. They write
-iCloud metadata that Python didn't handle the same way.
+`[download].xmp_sidecar` is implemented in kei, along with
+`[download].embed_xmp`. They write iCloud metadata that Python didn't handle
+the same way.
 
 ## Useful kei-only options
 
@@ -208,22 +219,22 @@ iCloud metadata that Python didn't handle the same way.
 | `--password-command <cmd>` | Read the password from a shell command. |
 | `kei password set` | Store the password in the OS keyring or encrypted file backend. |
 | `--save-password` | Save the password after a successful auth. |
-| `--library` | Select primary, shared, all, named, or excluded iCloud libraries. |
-| `--smart-folder` | Sync Favorites, Screenshots, Hidden, Recently Deleted, and other Apple smart folders. |
-| `--unfiled false` | Disable the separate pass for photos not in any user album. |
-| `--filename-exclude` | Skip files by glob, such as `*.AAE` or `Screenshot*`. |
-| `--bandwidth-limit` | Cap total download throughput, for example `10M` or `1.5Mi`. |
-| `--set-exif-rating`, `--set-exif-gps`, `--set-exif-description` | Write more iCloud metadata into downloaded media. |
-| `--embed-xmp`, `--xmp-sidecar` | Embed XMP or write `.xmp` sidecars. |
-| `--max-retries` | Retry downloads. Default is 3. |
-| `--temp-suffix` | Temp file suffix for partial downloads. Default is `.kei-tmp`. |
-| `--report-json` | Write the latest sync report atomically as JSON. |
-| `--http-bind`, `--http-port` | Serve `/healthz` and `/metrics` during watch mode. |
+| `[filters].libraries` | Select primary, shared, all, named, or excluded iCloud libraries. |
+| `[filters].smart_folders` | Sync Favorites, Screenshots, Hidden, Recently Deleted, and other Apple smart folders. |
+| `[filters].unfiled = false` | Disable the separate pass for photos not in any user album. |
+| `[filters].filename_exclude` | Skip files by glob, such as `*.AAE` or `Screenshot*`. |
+| `[download].bandwidth_limit` | Cap total download throughput, for example `10M` or `1.5Mi`. |
+| `[download].set_exif_rating`, `.set_exif_gps`, `.set_exif_description` | Write more iCloud metadata into downloaded media. |
+| `[download].embed_xmp`, `[download].xmp_sidecar` | Embed XMP or write `.xmp` sidecars. |
+| `[download.retry].max_retries` | Retry downloads. Default is 3. |
+| `[download].temp_suffix` | Temp file suffix for partial downloads. Default is `.kei-tmp`. |
+| `[report].json` | Write the latest sync report atomically as JSON. |
+| `[server].bind`, `[server].port` | Serve `/healthz` and `/metrics` during watch mode. |
+| `[watch].reconcile_every_n_cycles` | Periodic read-only reconciliation warning pass during watch mode. |
 | `--friendly`, `--no-friendly` | Control the interactive progress UI. |
 | `kei status` | Show database and sync status. |
 | `kei verify` | Check downloaded files exist, with optional checksums. |
 | `kei reconcile` | Mark missing local files as failed so the next sync re-downloads them. |
-| `--reconcile-every-n-cycles` | Periodic read-only reconciliation warning pass during watch mode. |
 
 ## Removed kei compatibility aliases
 
@@ -231,8 +242,8 @@ v0.20 removed the remaining v0.13 compatibility aliases:
 
 | Deprecated | Use |
 |---|---|
-| `--exclude-album`, `KEI_EXCLUDE_ALBUM` | `--album '!NAME'` |
-| `{album}` inside `--folder-structure` | `--folder-structure-albums "{album}/..."` |
+| `--exclude-album`, `KEI_EXCLUDE_ALBUM` | `[filters].albums = ["!NAME"]` |
+| `{album}` inside `--folder-structure` | `[download].folder_structure_albums = "{album}/..."` |
 | `[filters].album` | `[filters].albums = ["NAME"]` |
 | `[filters].exclude_albums` | `[filters].albums = ["!NAME"]` |
 | `[filters].library` | `[filters].libraries` |
@@ -290,8 +301,8 @@ docker exec --user $(id -u):$(id -g) kei kei login submit-code 123456
   lowercased extensions.
 - If Apple doesn't send an original filename, kei falls back to a sanitized
   title when available, then the record name.
-- `--embed-xmp` and `--xmp-sidecar` add metadata that Python-created files
-  won't have.
+- `[download].embed_xmp` and `[download].xmp_sidecar` add metadata that
+  Python-created files won't have.
 
 ## What you don't need to worry about
 

--- a/justfile
+++ b/justfile
@@ -163,10 +163,11 @@ dev CMD *ARGS:
     if [ -f .env ]; then
         set -a; source .env; set +a
     fi
-    cargo run -- {{CMD}} \
-        --data-dir "${KEI_DEV_DATA_DIR:-$HOME/.config/kei}" \
-        --download-dir "${KEI_DEV_PHOTOS_DIR:-/tmp/kei-dev-photos}" \
-        {{ARGS}}
+    export KEI_DATA_DIR="${KEI_DEV_DATA_DIR:-$HOME/.config/kei}"
+    cfg="$(mktemp)"
+    trap 'rm -f "$cfg"' EXIT
+    printf 'data_dir = "%s"\n[download]\ndirectory = "%s"\n' "$KEI_DATA_DIR" "${KEI_DEV_PHOTOS_DIR:-/tmp/kei-dev-photos}" > "$cfg"
+    cargo run -- {{CMD}} --config "$cfg" {{ARGS}}
 
 # Docker: build | multiarch | run | shell | health.
 docker MODE:

--- a/scripts/full-test/run_all.sh
+++ b/scripts/full-test/run_all.sh
@@ -75,7 +75,7 @@ current_phase="prereqs"
 
 # Live env exports (lib.sh + just both consult these)
 export ICLOUD_TEST_COOKIE_DIR="$repo_root/.test-cookies"
-export KEI_TEST_ALBUM="${KEI_TEST_ALBUM:-icloudpd-test}"
+export KEI_TEST_ALBUM="${KEI_TEST_ALBUM:-kei-test}"
 export KEI_DOCKER_IMAGE="${KEI_DOCKER_IMAGE:-kei:dev}"
 
 tp() { "$script_dir/time_phase.sh" "$@"; }

--- a/scripts/full-test/run_live_smokes.sh
+++ b/scripts/full-test/run_live_smokes.sh
@@ -8,7 +8,7 @@
 #
 # Optional env:
 #   KEI_TEST_DATA_DIR  cookie / db dir (default .test-cookies under repo)
-#   KEI_TEST_ALBUM     album name for sync dry-run (default icloudpd-test)
+#   KEI_TEST_ALBUM     album name for sync dry-run (default kei-test)
 #   KEI_TEST_DOWNLOAD_DIR  scratch dir for sync/import dry-run (default /tmp/codex/photos-test)
 #
 # Adding a new CLI subcommand: add a smoke line below. Don't add destructive
@@ -28,9 +28,26 @@ fi
 
 USR="${ICLOUD_USERNAME:-missing@example.invalid}"
 DD="${KEI_TEST_DATA_DIR:-$repo_root/.test-cookies}"
-ALBUM="${KEI_TEST_ALBUM:-icloudpd-test}"
+ALBUM="${KEI_TEST_ALBUM:-kei-test}"
 DOWNLOAD_DIR="${KEI_TEST_DOWNLOAD_DIR:-/tmp/codex/photos-test}"
 mkdir -p "$DOWNLOAD_DIR"
+
+toml_string() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '"%s"' "$s"
+}
+
+sync_config="$DD/.kei-live-smoke-sync.toml"
+mkdir -p "$DD"
+{
+  echo "[download]"
+  printf 'directory = %s\n' "$(toml_string "$DOWNLOAD_DIR")"
+  echo "[filters]"
+  printf 'albums = [%s]\n' "$(toml_string "$ALBUM")"
+  echo "unfiled = false"
+} > "$sync_config"
 
 run() {
   local phase="$1"; shift
@@ -53,7 +70,7 @@ export USR DD binary
 run live_status            "$binary" status                       --username "$USR" --data-dir "$DD"
 run live_libraries         "$binary" list libraries               --username "$USR" --data-dir "$DD"
 run live_albums            "$binary" list albums                  --username "$USR" --data-dir "$DD"
-run live_dryrun            "$binary" sync --dry-run --recent 5 -a "$ALBUM" --download-dir "$DOWNLOAD_DIR" --username "$USR" --data-dir "$DD"
+run live_dryrun            "$binary" sync --dry-run --recent 5 --config "$sync_config" --username "$USR" --data-dir "$DD"
 run live_config_show       "$binary" config show                  --username "$USR" --data-dir "$DD"
 run live_verify            bash -c verify_wrapper
 run live_reconcile_dryrun  "$binary" reconcile --dry-run          --username "$USR" --data-dir "$DD"

--- a/scripts/full-test/run_live_smokes.sh
+++ b/scripts/full-test/run_live_smokes.sh
@@ -57,7 +57,7 @@ run() {
 # Wrappers for commands that need shell composition (rc check, etc.).
 verify_wrapper() {
   set +e
-  "$binary" verify --username "$USR" --data-dir "$DD"
+  env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" verify
   rc=$?
   set -e
   # rc=2 is clap parse error; everything else (including non-zero data
@@ -67,12 +67,12 @@ verify_wrapper() {
 export -f verify_wrapper
 export USR DD binary
 
-run live_status            "$binary" status                       --username "$USR" --data-dir "$DD"
-run live_libraries         "$binary" list libraries               --username "$USR" --data-dir "$DD"
-run live_albums            "$binary" list albums                  --username "$USR" --data-dir "$DD"
-run live_dryrun            "$binary" sync --dry-run --recent 5 --config "$sync_config" --username "$USR" --data-dir "$DD"
-run live_config_show       "$binary" config show                  --username "$USR" --data-dir "$DD"
+run live_status            env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" status
+run live_libraries         env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" list libraries
+run live_albums            env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" list albums
+run live_dryrun            env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" sync --dry-run --recent 5 --config "$sync_config"
+run live_config_show       env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" config show
 run live_verify            bash -c verify_wrapper
-run live_reconcile_dryrun  "$binary" reconcile --dry-run          --username "$USR" --data-dir "$DD"
-run live_password_backend  "$binary" password backend             --username "$USR" --data-dir "$DD"
-run live_import_dryrun     "$binary" import-existing --dry-run --recent 5 --download-dir "$DOWNLOAD_DIR" --username "$USR" --data-dir "$DD"
+run live_reconcile_dryrun  env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" reconcile --dry-run
+run live_password_backend  env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" password backend
+run live_import_dryrun     env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" import-existing --dry-run --recent 5 --download-dir "$DOWNLOAD_DIR"

--- a/scripts/full-test/run_live_smokes.sh
+++ b/scripts/full-test/run_live_smokes.sh
@@ -17,9 +17,12 @@
 set -euo pipefail
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PROJECT_DIR="$repo_root"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 time_phase="$script_dir/time_phase.sh"
 binary="$repo_root/target/release/kei"
+# shellcheck disable=SC1091
+source "$repo_root/tests/shell/lib.sh"
 
 if [[ ! -x "$binary" ]]; then
   echo "run_live_smokes: missing release binary at $binary (run Phase 1 first)" >&2
@@ -28,26 +31,10 @@ fi
 
 USR="${ICLOUD_USERNAME:-missing@example.invalid}"
 DD="${KEI_TEST_DATA_DIR:-$repo_root/.test-cookies}"
-ALBUM="${KEI_TEST_ALBUM:-kei-test}"
 DOWNLOAD_DIR="${KEI_TEST_DOWNLOAD_DIR:-/tmp/codex/photos-test}"
 mkdir -p "$DOWNLOAD_DIR"
 
-toml_string() {
-  local s="$1"
-  s="${s//\\/\\\\}"
-  s="${s//\"/\\\"}"
-  printf '"%s"' "$s"
-}
-
-sync_config="$DD/.kei-live-smoke-sync.toml"
-mkdir -p "$DD"
-{
-  echo "[download]"
-  printf 'directory = %s\n' "$(toml_string "$DOWNLOAD_DIR")"
-  echo "[filters]"
-  printf 'albums = [%s]\n' "$(toml_string "$ALBUM")"
-  echo "unfiled = false"
-} > "$sync_config"
+sync_config="$(kei_write_sync_config "$DD" "$DOWNLOAD_DIR")"
 
 run() {
   local phase="$1"; shift

--- a/scripts/full-test/run_shell_suites.sh
+++ b/scripts/full-test/run_shell_suites.sh
@@ -4,7 +4,7 @@
 # name is test_shell_<basename-with-dashes-as-underscores>.
 #
 # Required env (set by the orchestrator):
-#   KEI_TEST_ALBUM     default icloudpd-test
+#   KEI_TEST_ALBUM     default kei-test
 #   KEI_DOCKER_IMAGE   default kei:dev (must match Phase 2 build tag)
 #
 # Each shell suite hits Apple via the live binary, so they run as --live
@@ -22,7 +22,7 @@ if [[ ! -d "$shell_dir" ]]; then
   exit 1
 fi
 
-album="${KEI_TEST_ALBUM:-icloudpd-test}"
+album="${KEI_TEST_ALBUM:-kei-test}"
 image="${KEI_DOCKER_IMAGE:-kei:dev}"
 
 for sh in "$shell_dir"/*.sh; do

--- a/scripts/just/live-env.sh
+++ b/scripts/just/live-env.sh
@@ -12,4 +12,4 @@ if [ -z "${ICLOUD_USERNAME:-}" ] && [ -f .env ]; then
 fi
 
 : "${ICLOUD_USERNAME:?ICLOUD_USERNAME must be set (via .env or environment)}"
-export KEI_TEST_ALBUM="${KEI_TEST_ALBUM:-icloudpd-test}"
+export KEI_TEST_ALBUM="${KEI_TEST_ALBUM:-kei-test}"

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -495,10 +495,10 @@ pub async fn authenticate_with_token(
     body.check_errors()?;
 
     // Apple redirects China mainland accounts to .com.cn — users must
-    // re-run with --domain cn to use the correct regional endpoint.
+    // re-run with auth.domain = "cn" to use the correct regional endpoint.
     if let Some(domain_to_use) = &body.domain_to_use {
         return Err(anyhow::anyhow!(
-            "Apple insists on using {domain_to_use} for your request. Please use --domain parameter"
+            "Apple insists on using {domain_to_use} for your request. Please set auth.domain in config"
         ));
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,246 +198,31 @@ pub struct PasswordArgs {
 /// Arguments for the sync command (also used as default when no subcommand).
 #[derive(Parser, Debug, Clone, Default)]
 pub struct SyncArgs {
-    /// Local directory for downloads
-    #[arg(short = 'd', long = "download-dir", env = "KEI_DOWNLOAD_DIR", value_parser = non_empty_string)]
-    pub download_dir: Option<String>,
-
-    /// Album(s) to download. Repeatable; default `all` (every user-created
-    /// album, plus an unfiled pass for photos not in any album). Accepts a
-    /// literal name, the sentinels `all` / `none`, or `!name` to exclude.
-    /// Apple's smart folders like "Favorites" are skipped under `all`; use
-    /// `--smart-folder` to opt them in. `all` cannot be combined with
-    /// specific album names; mix exclusions instead (`--album all '!Foo'`).
-    #[arg(short = 'a', long = "album", env = "KEI_ALBUM", value_parser = non_empty_string)]
-    pub albums: Vec<String>,
-
-    /// Smart folder(s) to download. Repeatable; default `none` (smart folders
-    /// are skipped unless opted in). Accepts the same value grammar as
-    /// `--album`: a name, the sentinel `all` (every smart folder except
-    /// Hidden / Recently Deleted), `all-with-sensitive` (include those two),
-    /// `none`, or `!name` to exclude. Available names: Favorites, Videos,
-    /// Live, Panoramas, Screenshots, Bursts, Slo-mo, Time-lapse, Hidden,
-    /// Recently Deleted.
-    #[arg(long = "smart-folder", env = "KEI_SMART_FOLDER", value_parser = non_empty_string)]
-    pub smart_folders: Vec<String>,
-
-    /// Run a separate pass for photos not in any user album. Default: `true`.
-    /// Pass `--unfiled false` to skip the unfiled pass (e.g. when you only
-    /// want named album passes). Independent of `--album`: `--album Vacation`
-    /// still runs the unfiled pass unless this flag is explicitly disabled.
-    #[arg(long, env = "KEI_UNFILED", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub unfiled: Option<bool>,
-
-    /// Exclude files matching glob pattern(s) (e.g. "*.AAE", "Screenshot*")
-    #[arg(long = "filename-exclude", env = "KEI_FILENAME_EXCLUDE", value_delimiter = ',', value_parser = non_empty_string)]
-    pub filename_exclude: Vec<String>,
-
-    /// Library/libraries to download. Repeatable; default `primary` (the
-    /// PrimarySync zone). Accepts the same value grammar as `--album`: a
-    /// CloudKit zone name (full UUID or the truncated 8-char `SharedSync-`
-    /// prefix that `{library}` renders into paths), the sentinels
-    /// `primary` / `shared` / `all` / `none`, or `!name` to exclude.
-    #[arg(long = "library", env = "KEI_LIBRARY", value_parser = non_empty_string)]
-    pub libraries: Vec<String>,
-
-    /// Image size to download
-    #[arg(long, env = "KEI_SIZE", value_enum)]
-    pub size: Option<VersionSize>,
-
-    /// Live photo video size
-    #[arg(long, env = "KEI_LIVE_PHOTO_SIZE", value_enum)]
-    pub live_photo_size: Option<LivePhotoSize>,
-
     /// Number of recent photos to download (e.g. `--recent 100`) or a recency
     /// window in days (e.g. `--recent 30d`). Days form maps to
     /// `--skip-created-before` internally.
-    #[arg(long, env = "KEI_RECENT", value_parser = parse_recent_limit)]
+    #[arg(long, value_parser = parse_recent_limit)]
     pub recent: Option<RecentLimit>,
 
-    /// Number of concurrent download threads (default: 10)
-    #[arg(long = "threads", env = "KEI_THREADS", value_parser = clap::value_parser!(u16).range(1..=64))]
-    pub threads: Option<u16>,
-
-    /// Cap total download throughput across all concurrent downloads.
-    /// Accepts human-readable values: `10M` (10 MB/s), `500K` (500 KB/s),
-    /// `1Mi` (1 MiB/s), bare integer = bytes/s. When set without an explicit
-    /// `--threads`, concurrency defaults to 1 to avoid fragmenting the
-    /// capped pipe across many starved connections.
-    #[arg(long = "bandwidth-limit", env = "KEI_BANDWIDTH_LIMIT", value_parser = parse_bandwidth_limit)]
-    pub bandwidth_limit: Option<u64>,
-
-    /// Don't download videos (pass `false` to override config file)
-    #[arg(long, env = "KEI_SKIP_VIDEOS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub skip_videos: Option<bool>,
-
-    /// Don't download photos (pass `false` to override config file)
-    #[arg(long, env = "KEI_SKIP_PHOTOS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub skip_photos: Option<bool>,
-
-    /// Live photo handling: both, image-only, video-only, skip
-    #[arg(long, env = "KEI_LIVE_PHOTO_MODE", value_enum)]
-    pub live_photo_mode: Option<LivePhotoMode>,
-
-    /// Only download requested size (don't fall back to original)
-    #[arg(long, env = "KEI_FORCE_SIZE", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub force_size: Option<bool>,
-
-    /// Folder structure for the unfiled pass (default `%Y/%m/%d`; pass
-    /// "none" for a flat layout). Album passes use
-    /// `--folder-structure-albums` (default `{album}`); smart-folder
-    /// passes use `--folder-structure-smart-folders` (default
-    /// `{smart-folder}`). Legacy `{album}` in this template auto-migrates
-    /// to `--folder-structure-albums` with a deprecation warning; that
-    /// compat path is removed in v0.20.
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE")]
-    pub folder_structure: Option<String>,
-
-    /// Folder structure used by every album pass. Default `{album}` (flat
-    /// per-album folders, no inherited date hierarchy). Set to e.g.
-    /// `"{album}/%Y/%m/%d"` to add a date hierarchy inside each album
-    /// folder.
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE_ALBUMS")]
-    pub folder_structure_albums: Option<String>,
-
-    /// Folder structure used by every smart-folder pass. Default
-    /// `{smart-folder}` (flat per-smart-folder folders). Set to e.g.
-    /// `"{smart-folder}/%Y/%m/%d"` to add a date hierarchy.
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE_SMART_FOLDERS")]
-    pub folder_structure_smart_folders: Option<String>,
-
-    /// Write `DateTimeOriginal` EXIF tag if missing
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_SET_EXIF_DATETIME", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub set_exif_datetime: Option<bool>,
-
-    /// Write EXIF `Rating` tag (0x4746) for favorited photos (1-5 scale)
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_SET_EXIF_RATING", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub set_exif_rating: Option<bool>,
-
-    /// Write EXIF GPS tags from iCloud location metadata (only when the file lacks GPS)
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_SET_EXIF_GPS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub set_exif_gps: Option<bool>,
-
-    /// Write EXIF `ImageDescription` tag from iCloud description / title
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_SET_EXIF_DESCRIPTION", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub set_exif_description: Option<bool>,
-
-    /// Embed a full XMP packet (title, keywords, album memberships, people,
-    /// hidden/archived, media subtype, burst id) into downloaded media bytes
-    /// on supported formats (JPEG/HEIC/PNG/TIFF/MP4/MOV)
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_EMBED_XMP", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub embed_xmp: Option<bool>,
-
-    /// Write a `.xmp` sidecar file next to each downloaded media file with
-    /// every available metadata field
-    #[cfg(feature = "xmp")]
-    #[arg(long, env = "KEI_XMP_SIDECAR", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub xmp_sidecar: Option<bool>,
-
     /// Do not modify local system or iCloud
-    #[arg(long, conflicts_with = "watch_with_interval")]
+    #[arg(long)]
     pub dry_run: bool,
 
-    /// Run continuously, waiting N seconds between runs (60..=86400).
-    /// Resolution order: this flag > `[watch] interval` in TOML >
-    /// `KEI_WATCH_WITH_INTERVAL` env > unset (single-shot).
-    //
-    // No clap `env =` attribute on purpose. clap collapses env into the
-    // CLI tier, which would override TOML, but the docker image bakes
-    // `KEI_WATCH_WITH_INTERVAL=86400` as a default and we want a user's
-    // TOML to win. The env is parsed manually in `Config::build`.
-    // Regression: #293.
-    #[arg(long, value_parser = clap::value_parser!(u64).range(60..=86400))]
-    pub watch_with_interval: Option<u64>,
-
     /// Disable progress bar
-    #[arg(long, env = "KEI_NO_PROGRESS_BAR", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub no_progress_bar: Option<bool>,
 
-    /// Keep Unicode in filenames
-    #[arg(long, env = "KEI_KEEP_UNICODE_IN_FILENAMES", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub keep_unicode_in_filenames: Option<bool>,
-
-    /// Live photo MOV filename policy
-    #[arg(long, env = "KEI_LIVE_PHOTO_MOV_FILENAME_POLICY", value_enum)]
-    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
-
-    /// RAW treatment policy
-    #[arg(long, env = "KEI_ALIGN_RAW", value_enum)]
-    pub align_raw: Option<RawTreatmentPolicy>,
-
-    /// File matching and dedup policy
-    #[arg(long, env = "KEI_FILE_MATCH_POLICY", value_enum)]
-    pub file_match_policy: Option<FileMatchPolicy>,
-
     /// Skip assets created before this ISO date or interval (e.g., 2025-01-02 or 20d)
-    #[arg(long, env = "KEI_SKIP_CREATED_BEFORE")]
+    #[arg(long)]
     pub skip_created_before: Option<String>,
 
     /// Skip assets created after this ISO date or interval (e.g., 2025-01-02 or 20d)
-    #[arg(long, env = "KEI_SKIP_CREATED_AFTER")]
+    #[arg(long)]
     pub skip_created_after: Option<String>,
 
     /// Only print filenames without downloading
-    #[arg(long, conflicts_with = "watch_with_interval")]
+    #[arg(long)]
     pub only_print_filenames: bool,
-
-    /// Max retries per download (default: 3, 0 = no retries, max: 100)
-    #[arg(long, env = "KEI_MAX_RETRIES", value_parser = clap::value_parser!(u32).range(0..=100))]
-    pub max_retries: Option<u32>,
-
-    /// Temp file suffix for partial downloads (default: .kei-tmp).
-    /// Change if the default conflicts with your filesystem (e.g. Nextcloud rejects .part).
-    #[arg(long, env = "KEI_TEMP_SUFFIX")]
-    pub temp_suffix: Option<String>,
-
-    /// Send systemd `sd_notify` messages (READY, STOPPING, STATUS).
-    /// Auto-detected via `NOTIFY_SOCKET` under `Type=notify` units; pass
-    /// `--notify-systemd=false` to suppress even then.
-    #[arg(long, env = "KEI_NOTIFY_SYSTEMD", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub notify_systemd: Option<bool>,
-
-    /// Write PID to file (for service managers).
-    #[arg(long, env = "KEI_PID_FILE")]
-    pub pid_file: Option<std::path::PathBuf>,
-
-    /// Run a periodic local-vs-state reconciliation walk every Nth watch
-    /// cycle (1 = every cycle, 24 = daily on hourly cycles). Read-only:
-    /// reports missing files via `tracing::warn!` and never auto-marks
-    /// failed in the state DB. Only meaningful with `--watch-with-interval`;
-    /// ignored in single-shot mode. Also configurable via
-    /// `[watch] reconcile_every_n_cycles` in TOML (CLI takes precedence).
-    #[arg(long, env = "KEI_RECONCILE_EVERY_N_CYCLES", value_parser = clap::value_parser!(u64).range(1..))]
-    pub reconcile_every_n_cycles: Option<u64>,
-
-    /// Script to run on events: 2FA required, sync started/complete/failed, session expired.
-    /// Called with `KEI_EVENT`, `KEI_MESSAGE`, `KEI_ICLOUD_USERNAME` env vars.
-    /// Fire-and-forget: script failures are logged at warn! but never block
-    /// the sync or affect the exit code. Unix only: ignored with a warning on Windows.
-    #[arg(long, env = "KEI_NOTIFICATION_SCRIPT")]
-    pub notification_script: Option<String>,
-
-    /// Write a JSON run report to this path after each sync cycle.
-    /// Also configurable via `[report] json = "..."` in the TOML config.
-    /// In watch mode the file is overwritten every cycle - it reflects the
-    /// most recent cycle only, not a history log. Atomic write (temp + rename).
-    #[arg(long, env = "KEI_REPORT_JSON")]
-    pub report_json: Option<std::path::PathBuf>,
-
-    /// Port for the always-on HTTP server that serves `/healthz` and `/metrics` (default: 9090).
-    /// Set `KEI_HTTP_PORT` to override via environment.
-    #[arg(long, env = "KEI_HTTP_PORT", value_parser = clap::value_parser!(u16).range(1..))]
-    pub http_port: Option<u16>,
-
-    /// Bind address for the HTTP server (default: 0.0.0.0 - all interfaces).
-    /// Set to `127.0.0.1` to restrict to loopback only (desktop use). Also configurable
-    /// via `[server] bind` in TOML. Accepts any IPv4 or IPv6 address.
-    #[arg(long, env = "KEI_HTTP_BIND")]
-    pub http_bind: Option<std::net::IpAddr>,
 
     /// After successful auth, persist the password to the credential store
     /// (OS keyring or encrypted file).
@@ -445,11 +230,93 @@ pub struct SyncArgs {
     pub save_password: bool,
 
     /// Re-sync only previously failed assets
-    #[arg(long, conflicts_with_all = ["dry_run", "watch_with_interval"])]
+    #[arg(long, conflicts_with = "dry_run")]
     pub retry_failed: bool,
 
-    /// Maximum download attempts per asset before skipping (default: 10)
-    #[arg(long, env = "KEI_MAX_DOWNLOAD_ATTEMPTS")]
+    // Durable sync settings are TOML-only in v0.20. These skipped fields keep
+    // internal resolver tests and programmatic call sites able to construct
+    // non-default configs without re-exposing the old public CLI/env mirrors.
+    #[arg(skip)]
+    pub download_dir: Option<String>,
+    #[arg(skip)]
+    pub albums: Vec<String>,
+    #[arg(skip)]
+    pub smart_folders: Vec<String>,
+    #[arg(skip)]
+    pub unfiled: Option<bool>,
+    #[arg(skip)]
+    pub filename_exclude: Vec<String>,
+    #[arg(skip)]
+    pub libraries: Vec<String>,
+    #[arg(skip)]
+    pub size: Option<VersionSize>,
+    #[arg(skip)]
+    pub live_photo_size: Option<LivePhotoSize>,
+    #[arg(skip)]
+    pub threads: Option<u16>,
+    #[arg(skip)]
+    pub bandwidth_limit: Option<u64>,
+    #[arg(skip)]
+    pub skip_videos: Option<bool>,
+    #[arg(skip)]
+    pub skip_photos: Option<bool>,
+    #[arg(skip)]
+    pub live_photo_mode: Option<LivePhotoMode>,
+    #[arg(skip)]
+    pub force_size: Option<bool>,
+    #[arg(skip)]
+    pub folder_structure: Option<String>,
+    #[arg(skip)]
+    pub folder_structure_albums: Option<String>,
+    #[arg(skip)]
+    pub folder_structure_smart_folders: Option<String>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub set_exif_datetime: Option<bool>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub set_exif_rating: Option<bool>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub set_exif_gps: Option<bool>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub set_exif_description: Option<bool>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub embed_xmp: Option<bool>,
+    #[cfg(feature = "xmp")]
+    #[arg(skip)]
+    pub xmp_sidecar: Option<bool>,
+    #[arg(skip)]
+    pub watch_with_interval: Option<u64>,
+    #[arg(skip)]
+    pub keep_unicode_in_filenames: Option<bool>,
+    #[arg(skip)]
+    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
+    #[arg(skip)]
+    pub align_raw: Option<RawTreatmentPolicy>,
+    #[arg(skip)]
+    pub file_match_policy: Option<FileMatchPolicy>,
+    #[arg(skip)]
+    pub max_retries: Option<u32>,
+    #[arg(skip)]
+    pub temp_suffix: Option<String>,
+    #[arg(skip)]
+    pub notify_systemd: Option<bool>,
+    #[arg(skip)]
+    pub pid_file: Option<std::path::PathBuf>,
+    #[arg(skip)]
+    pub reconcile_every_n_cycles: Option<u64>,
+    #[arg(skip)]
+    pub notification_script: Option<String>,
+    #[arg(skip)]
+    pub report_json: Option<std::path::PathBuf>,
+    #[arg(skip)]
+    pub http_port: Option<u16>,
+    #[arg(skip)]
+    pub http_bind: Option<std::net::IpAddr>,
+    #[arg(skip)]
     pub max_download_attempts: Option<u32>,
 }
 
@@ -478,7 +345,7 @@ pub struct ImportArgs {
     pub password: PasswordArgs,
 
     /// Library/libraries to import. Repeatable; default `primary`. Same value
-    /// grammar as `kei sync --library`: a CloudKit zone name (full UUID or
+    /// grammar as `[filters].libraries`: a CloudKit zone name (full UUID or
     /// the truncated 8-char `SharedSync-` prefix that `{library}` renders
     /// into paths), the sentinels `primary` / `shared` / `all` / `none`, or
     /// `!name` to exclude.
@@ -747,7 +614,7 @@ pub enum Command {
 
         /// Library/libraries to list albums from. Repeatable; default
         /// `primary` (the PrimarySync zone). Same value grammar as
-        /// `kei sync --library`: a CloudKit zone name (full UUID or the
+        /// `[filters].libraries`: a CloudKit zone name (full UUID or the
         /// truncated 8-char `SharedSync-` prefix that `{library}` renders
         /// into paths), the sentinels `primary` / `shared` / `all` /
         /// `none`, or `!name` to exclude. Only consulted by
@@ -849,7 +716,7 @@ pub struct Cli {
         env = "KEI_FRIENDLY",
         long_help = "Use friendly progress UI (verb-cycling spinners, curated phase narration, summary card, sign-off). \
                      Default: on for plain TTYs, off in service/container/journal contexts and whenever a \
-                     machine-output flag (`--report-json`, `--only-print-filenames`) or an explicit \
+                     machine-output mode (`--only-print-filenames` or TOML report JSON) or an explicit \
                      `--log-level` / `RUST_LOG` is in play. `--friendly` overrides the TOML `[ui] friendly` \
                      setting and the auto-detected default; environmental hard-off contexts still win."
     )]
@@ -903,92 +770,12 @@ impl SyncArgs {
     /// Merge top-level (fallback) sync args into self.
     /// Subcommand values take precedence; top-level fills in gaps.
     fn merge_from(&mut self, fallback: &Self) {
-        if self.download_dir.is_none() {
-            self.download_dir.clone_from(&fallback.download_dir);
-        }
-        if self.albums.is_empty() {
-            self.albums.clone_from(&fallback.albums);
-        }
-        if self.libraries.is_empty() {
-            self.libraries.clone_from(&fallback.libraries);
-        }
-        if self.size.is_none() {
-            self.size = fallback.size;
-        }
-        if self.live_photo_size.is_none() {
-            self.live_photo_size = fallback.live_photo_size;
-        }
         if self.recent.is_none() {
             self.recent = fallback.recent;
         }
-        if self.threads.is_none() {
-            self.threads = fallback.threads;
-        }
-        if self.bandwidth_limit.is_none() {
-            self.bandwidth_limit = fallback.bandwidth_limit;
-        }
-        if self.unfiled.is_none() {
-            self.unfiled = fallback.unfiled;
-        }
-        if self.skip_videos.is_none() {
-            self.skip_videos = fallback.skip_videos;
-        }
-        if self.skip_photos.is_none() {
-            self.skip_photos = fallback.skip_photos;
-        }
-        if self.force_size.is_none() {
-            self.force_size = fallback.force_size;
-        }
-        if self.folder_structure.is_none() {
-            self.folder_structure.clone_from(&fallback.folder_structure);
-        }
-        if self.folder_structure_albums.is_none() {
-            self.folder_structure_albums
-                .clone_from(&fallback.folder_structure_albums);
-        }
-        if self.folder_structure_smart_folders.is_none() {
-            self.folder_structure_smart_folders
-                .clone_from(&fallback.folder_structure_smart_folders);
-        }
-        #[cfg(feature = "xmp")]
-        {
-            if self.set_exif_datetime.is_none() {
-                self.set_exif_datetime = fallback.set_exif_datetime;
-            }
-            if self.set_exif_rating.is_none() {
-                self.set_exif_rating = fallback.set_exif_rating;
-            }
-            if self.set_exif_gps.is_none() {
-                self.set_exif_gps = fallback.set_exif_gps;
-            }
-            if self.set_exif_description.is_none() {
-                self.set_exif_description = fallback.set_exif_description;
-            }
-            if self.embed_xmp.is_none() {
-                self.embed_xmp = fallback.embed_xmp;
-            }
-            if self.xmp_sidecar.is_none() {
-                self.xmp_sidecar = fallback.xmp_sidecar;
-            }
-        }
         self.dry_run = self.dry_run || fallback.dry_run;
-        if self.watch_with_interval.is_none() {
-            self.watch_with_interval = fallback.watch_with_interval;
-        }
         if self.no_progress_bar.is_none() {
             self.no_progress_bar = fallback.no_progress_bar;
-        }
-        if self.keep_unicode_in_filenames.is_none() {
-            self.keep_unicode_in_filenames = fallback.keep_unicode_in_filenames;
-        }
-        if self.live_photo_mov_filename_policy.is_none() {
-            self.live_photo_mov_filename_policy = fallback.live_photo_mov_filename_policy;
-        }
-        if self.align_raw.is_none() {
-            self.align_raw = fallback.align_raw;
-        }
-        if self.file_match_policy.is_none() {
-            self.file_match_policy = fallback.file_match_policy;
         }
         if self.skip_created_before.is_none() {
             self.skip_created_before
@@ -999,28 +786,6 @@ impl SyncArgs {
                 .clone_from(&fallback.skip_created_after);
         }
         self.only_print_filenames = self.only_print_filenames || fallback.only_print_filenames;
-        if self.max_retries.is_none() {
-            self.max_retries = fallback.max_retries;
-        }
-        if self.temp_suffix.is_none() {
-            self.temp_suffix.clone_from(&fallback.temp_suffix);
-        }
-        if self.notify_systemd.is_none() {
-            self.notify_systemd = fallback.notify_systemd;
-        }
-        if self.pid_file.is_none() {
-            self.pid_file.clone_from(&fallback.pid_file);
-        }
-        if self.reconcile_every_n_cycles.is_none() {
-            self.reconcile_every_n_cycles = fallback.reconcile_every_n_cycles;
-        }
-        if self.notification_script.is_none() {
-            self.notification_script
-                .clone_from(&fallback.notification_script);
-        }
-        if self.report_json.is_none() {
-            self.report_json.clone_from(&fallback.report_json);
-        }
         self.save_password = self.save_password || fallback.save_password;
         self.retry_failed = self.retry_failed || fallback.retry_failed;
     }
@@ -1167,101 +932,14 @@ fn subcommand_display_name(cmd: &Command) -> &'static str {
 fn explicit_top_level_sync_flags(matches: &clap::ArgMatches) -> Vec<&'static str> {
     use clap::parser::ValueSource;
     let mut out = Vec::new();
-    if matches.value_source("download_dir") == Some(ValueSource::CommandLine) {
-        out.push("--download-dir");
-    }
-    if matches.value_source("albums") == Some(ValueSource::CommandLine) {
-        out.push("--album");
-    }
-    if matches.value_source("smart_folders") == Some(ValueSource::CommandLine) {
-        out.push("--smart-folder");
-    }
-    if matches.value_source("unfiled") == Some(ValueSource::CommandLine) {
-        out.push("--unfiled");
-    }
-    if matches.value_source("filename_exclude") == Some(ValueSource::CommandLine) {
-        out.push("--filename-exclude");
-    }
-    if matches.value_source("libraries") == Some(ValueSource::CommandLine) {
-        out.push("--library");
-    }
-    if matches.value_source("size") == Some(ValueSource::CommandLine) {
-        out.push("--size");
-    }
-    if matches.value_source("live_photo_size") == Some(ValueSource::CommandLine) {
-        out.push("--live-photo-size");
-    }
     if matches.value_source("recent") == Some(ValueSource::CommandLine) {
         out.push("--recent");
-    }
-    if matches.value_source("threads") == Some(ValueSource::CommandLine) {
-        out.push("--threads");
-    }
-    if matches.value_source("bandwidth_limit") == Some(ValueSource::CommandLine) {
-        out.push("--bandwidth-limit");
-    }
-    if matches.value_source("skip_videos") == Some(ValueSource::CommandLine) {
-        out.push("--skip-videos");
-    }
-    if matches.value_source("skip_photos") == Some(ValueSource::CommandLine) {
-        out.push("--skip-photos");
-    }
-    if matches.value_source("live_photo_mode") == Some(ValueSource::CommandLine) {
-        out.push("--live-photo-mode");
-    }
-    if matches.value_source("force_size") == Some(ValueSource::CommandLine) {
-        out.push("--force-size");
-    }
-    if matches.value_source("folder_structure") == Some(ValueSource::CommandLine) {
-        out.push("--folder-structure");
-    }
-    if matches.value_source("folder_structure_albums") == Some(ValueSource::CommandLine) {
-        out.push("--folder-structure-albums");
-    }
-    if matches.value_source("folder_structure_smart_folders") == Some(ValueSource::CommandLine) {
-        out.push("--folder-structure-smart-folders");
-    }
-    #[cfg(feature = "xmp")]
-    {
-        if matches.value_source("set_exif_datetime") == Some(ValueSource::CommandLine) {
-            out.push("--set-exif-datetime");
-        }
-        if matches.value_source("set_exif_rating") == Some(ValueSource::CommandLine) {
-            out.push("--set-exif-rating");
-        }
-        if matches.value_source("set_exif_gps") == Some(ValueSource::CommandLine) {
-            out.push("--set-exif-gps");
-        }
-        if matches.value_source("set_exif_description") == Some(ValueSource::CommandLine) {
-            out.push("--set-exif-description");
-        }
-        if matches.value_source("embed_xmp") == Some(ValueSource::CommandLine) {
-            out.push("--embed-xmp");
-        }
-        if matches.value_source("xmp_sidecar") == Some(ValueSource::CommandLine) {
-            out.push("--xmp-sidecar");
-        }
     }
     if matches.value_source("dry_run") == Some(ValueSource::CommandLine) {
         out.push("--dry-run");
     }
-    if matches.value_source("watch_with_interval") == Some(ValueSource::CommandLine) {
-        out.push("--watch-with-interval");
-    }
     if matches.value_source("no_progress_bar") == Some(ValueSource::CommandLine) {
         out.push("--no-progress-bar");
-    }
-    if matches.value_source("keep_unicode_in_filenames") == Some(ValueSource::CommandLine) {
-        out.push("--keep-unicode-in-filenames");
-    }
-    if matches.value_source("live_photo_mov_filename_policy") == Some(ValueSource::CommandLine) {
-        out.push("--live-photo-mov-filename-policy");
-    }
-    if matches.value_source("align_raw") == Some(ValueSource::CommandLine) {
-        out.push("--align-raw");
-    }
-    if matches.value_source("file_match_policy") == Some(ValueSource::CommandLine) {
-        out.push("--file-match-policy");
     }
     if matches.value_source("skip_created_before") == Some(ValueSource::CommandLine) {
         out.push("--skip-created-before");
@@ -1272,41 +950,11 @@ fn explicit_top_level_sync_flags(matches: &clap::ArgMatches) -> Vec<&'static str
     if matches.value_source("only_print_filenames") == Some(ValueSource::CommandLine) {
         out.push("--only-print-filenames");
     }
-    if matches.value_source("max_retries") == Some(ValueSource::CommandLine) {
-        out.push("--max-retries");
-    }
-    if matches.value_source("temp_suffix") == Some(ValueSource::CommandLine) {
-        out.push("--temp-suffix");
-    }
-    if matches.value_source("notify_systemd") == Some(ValueSource::CommandLine) {
-        out.push("--notify-systemd");
-    }
-    if matches.value_source("pid_file") == Some(ValueSource::CommandLine) {
-        out.push("--pid-file");
-    }
-    if matches.value_source("reconcile_every_n_cycles") == Some(ValueSource::CommandLine) {
-        out.push("--reconcile-every-n-cycles");
-    }
-    if matches.value_source("notification_script") == Some(ValueSource::CommandLine) {
-        out.push("--notification-script");
-    }
-    if matches.value_source("report_json") == Some(ValueSource::CommandLine) {
-        out.push("--report-json");
-    }
-    if matches.value_source("http_port") == Some(ValueSource::CommandLine) {
-        out.push("--http-port");
-    }
-    if matches.value_source("http_bind") == Some(ValueSource::CommandLine) {
-        out.push("--http-bind");
-    }
     if matches.value_source("save_password") == Some(ValueSource::CommandLine) {
         out.push("--save-password");
     }
     if matches.value_source("retry_failed") == Some(ValueSource::CommandLine) {
         out.push("--retry-failed");
-    }
-    if matches.value_source("max_download_attempts") == Some(ValueSource::CommandLine) {
-        out.push("--max-download-attempts");
     }
     out
 }
@@ -1408,6 +1056,17 @@ mod tests {
 
     fn parse(args: &[&str]) -> Cli {
         Cli::try_parse_from(args).unwrap()
+    }
+
+    fn assert_removed_sync_flag(args: &[&str]) {
+        let err = Cli::try_parse_from(args).expect_err("removed sync flag must fail to parse");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    fn assert_removed_sync_option(tail: &[&str]) {
+        let mut args = vec!["kei", "--username", "test@example.com"];
+        args.extend_from_slice(tail);
+        assert_removed_sync_flag(&args);
     }
 
     /// Parse argv into a `Cli` and compute the explicit sync flags list.
@@ -1630,24 +1289,9 @@ mod tests {
         assert!(cli.username.is_none());
         assert!(cli.command.is_none());
     }
-
     #[test]
     fn test_backwards_compatibility_no_subcommand() {
-        let cli = Cli::try_parse_from([
-            "kei",
-            "--username",
-            "test@example.com",
-            "--download-dir",
-            "/photos",
-        ])
-        .unwrap();
-        assert!(cli.command.is_none());
-        match cli.effective_command() {
-            Command::Sync { sync, .. } => {
-                assert_eq!(sync.download_dir, Some("/photos".to_string()));
-            }
-            _ => panic!("Expected Sync command"),
-        }
+        assert_removed_sync_option(&["--download-dir", "/photos"]);
     }
 
     // ── New subcommands ───────────────────────────────────────────
@@ -1854,48 +1498,19 @@ mod tests {
             _ => panic!("Expected Config Setup"),
         }
     }
-
     #[test]
     fn test_sync_retry_failed_flag() {
-        let cli =
-            Cli::try_parse_from(["kei", "sync", "--retry-failed", "--download-dir", "/photos"])
-                .unwrap();
-        match cli.effective_command() {
-            Command::Sync { sync, .. } => assert!(sync.retry_failed),
-            _ => panic!("Expected Sync"),
-        }
+        assert_removed_sync_flag(&["kei", "sync", "--retry-failed", "--download-dir", "/photos"]);
     }
 
     // ── Legacy subcommand compat ──────────────────────────────────
-
     #[test]
     fn test_max_download_attempts_cli_parse() {
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--max-download-attempts",
-            "5",
-            "--download-dir",
-            "/photos",
-        ])
-        .unwrap();
-        match cli.effective_command() {
-            Command::Sync { sync, .. } => {
-                assert_eq!(sync.max_download_attempts, Some(5));
-            }
-            _ => panic!("Expected Sync"),
-        }
+        assert_removed_sync_flag(&["kei", "sync", "--max-download-attempts", "5"]);
     }
-
     #[test]
     fn test_max_download_attempts_defaults_to_none() {
-        let cli = Cli::try_parse_from(["kei", "sync", "--download-dir", "/photos"]).unwrap();
-        match cli.effective_command() {
-            Command::Sync { sync, .. } => {
-                assert_eq!(sync.max_download_attempts, None);
-            }
-            _ => panic!("Expected Sync"),
-        }
+        assert_removed_sync_flag(&["kei", "sync", "--max-download-attempts", "5"]);
     }
 
     #[test]
@@ -1975,59 +1590,26 @@ mod tests {
     }
 
     // ── Sync args ─────────────────────────────────────────────────
-
     #[test]
     fn test_library_accepts_custom_value() {
-        let mut args = base_args();
-        args.extend(["--library", "SharedSync-ABCD1234"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.libraries, vec!["SharedSync-ABCD1234".to_string()]);
+        assert_removed_sync_flag(&["kei", "--library", "SharedSync-ABCD1234"]);
     }
-
     #[test]
     fn test_library_repeatable_with_sentinels() {
-        let mut args = base_args();
-        args.extend([
-            "--library",
-            "primary",
-            "--library",
-            "shared",
-            "--library",
-            "!SharedSync-ABCD1234",
-        ]);
-        let cli = parse(&args);
-        assert_eq!(
-            cli.sync.libraries,
-            vec![
-                "primary".to_string(),
-                "shared".to_string(),
-                "!SharedSync-ABCD1234".to_string(),
-            ]
-        );
+        assert_removed_sync_flag(&["kei", "--library", "primary", "--library", "shared"]);
     }
-
     #[test]
     fn test_bandwidth_limit_bare_bytes() {
-        let mut args = base_args();
-        args.extend(["--bandwidth-limit", "1500000"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.bandwidth_limit, Some(1_500_000));
+        assert_removed_sync_option(&["--bandwidth-limit", "1024"]);
     }
-
     #[test]
     fn test_bandwidth_limit_decimal_suffixes() {
-        let mut args = base_args();
-        args.extend(["--bandwidth-limit", "10M"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.bandwidth_limit, Some(10_000_000));
+        assert_removed_sync_option(&["--bandwidth-limit", "1.5M"]);
     }
 
     #[test]
     fn test_bandwidth_limit_binary_suffix() {
-        let mut args = base_args();
-        args.extend(["--bandwidth-limit", "2Mi"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.bandwidth_limit, Some(2 * 1024 * 1024));
+        assert_removed_sync_option(&["--bandwidth-limit", "2Mi"]);
     }
 
     #[test]
@@ -2110,37 +1692,21 @@ mod tests {
         assert!(parse_bandwidth_limit("infM").is_err());
         assert!(parse_bandwidth_limit("inf").is_err());
     }
-
     #[test]
     fn test_max_retries_custom() {
-        let mut args = base_args();
-        args.extend(["--max-retries", "10"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.max_retries, Some(10));
+        assert_removed_sync_option(&["--max-retries", "10"]);
     }
-
     #[test]
     fn test_max_retries_zero_disables() {
-        let mut args = base_args();
-        args.extend(["--max-retries", "0"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.max_retries, Some(0));
+        assert_removed_sync_option(&["--max-retries", "0"]);
     }
-
     #[test]
     fn test_temp_suffix_custom() {
-        let mut args = base_args();
-        args.extend(["--temp-suffix", ".downloading"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.temp_suffix.as_deref(), Some(".downloading"));
+        assert_removed_sync_option(&["--temp-suffix", ".downloading"]);
     }
-
     #[test]
     fn test_skip_videos_flag() {
-        let mut args = base_args();
-        args.push("--skip-videos");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.skip_videos, Some(true));
+        assert_removed_sync_option(&["--skip-videos"]);
     }
 
     #[test]
@@ -2148,89 +1714,51 @@ mod tests {
         let cli = parse(&base_args());
         assert_eq!(cli.sync.unfiled, None);
     }
-
     #[test]
     fn test_unfiled_flag_bare_true() {
-        let mut args = base_args();
-        args.push("--unfiled");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.unfiled, Some(true));
+        assert_removed_sync_option(&["--unfiled"]);
     }
-
     #[test]
     fn test_unfiled_flag_explicit_false() {
-        let mut args = base_args();
-        args.extend(["--unfiled", "false"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.unfiled, Some(false));
+        assert_removed_sync_option(&["--unfiled", "false"]);
     }
 
     #[test]
     fn test_unfiled_flag_explicit_true() {
-        let mut args = base_args();
-        args.extend(["--unfiled", "true"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.unfiled, Some(true));
+        assert_removed_sync_option(&["--unfiled", "true"]);
     }
 
     #[test]
     fn test_skip_videos_explicit_false() {
-        let mut args = base_args();
-        args.extend(["--skip-videos", "false"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.skip_videos, Some(false));
+        assert_removed_sync_option(&["--skip-videos", "false"]);
     }
-
     #[test]
     fn test_skip_photos_flag() {
-        let mut args = base_args();
-        args.push("--skip-photos");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.skip_photos, Some(true));
+        assert_removed_sync_option(&["--skip-photos"]);
     }
-
     #[test]
     fn test_force_size_flag() {
-        let mut args = base_args();
-        args.push("--force-size");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.force_size, Some(true));
+        assert_removed_sync_option(&["--force-size"]);
     }
-
     #[cfg(feature = "xmp")]
     #[test]
     fn test_set_exif_datetime_flag() {
-        let mut args = base_args();
-        args.push("--set-exif-datetime");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.set_exif_datetime, Some(true));
+        assert_removed_sync_option(&["--set-exif-datetime"]);
     }
-
     #[cfg(feature = "xmp")]
     #[test]
     fn test_embed_xmp_flag() {
-        let mut args = base_args();
-        args.push("--embed-xmp");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.embed_xmp, Some(true));
+        assert_removed_sync_option(&["--embed-xmp"]);
     }
-
     #[cfg(feature = "xmp")]
     #[test]
     fn test_embed_xmp_flag_explicit_false() {
-        let mut args = base_args();
-        args.push("--embed-xmp=false");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.embed_xmp, Some(false));
+        assert_removed_sync_option(&["--embed-xmp=false"]);
     }
-
     #[cfg(feature = "xmp")]
     #[test]
     fn test_xmp_sidecar_flag() {
-        let mut args = base_args();
-        args.push("--xmp-sidecar");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.xmp_sidecar, Some(true));
+        assert_removed_sync_option(&["--xmp-sidecar"]);
     }
 
     #[test]
@@ -2240,40 +1768,21 @@ mod tests {
         let cli = parse(&args);
         assert_eq!(cli.sync.no_progress_bar, Some(true));
     }
-
     #[test]
     fn test_keep_unicode_in_filenames_flag() {
-        let mut args = base_args();
-        args.push("--keep-unicode-in-filenames");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.keep_unicode_in_filenames, Some(true));
+        assert_removed_sync_option(&["--keep-unicode-in-filenames"]);
     }
-
     #[test]
     fn test_notify_systemd_flag() {
-        let mut args = base_args();
-        args.push("--notify-systemd");
-        let cli = parse(&args);
-        assert_eq!(cli.sync.notify_systemd, Some(true));
+        assert_removed_sync_option(&["--notify-systemd"]);
     }
-
     #[test]
     fn test_pid_file_flag() {
-        let mut args = base_args();
-        args.extend(["--pid-file", "/tmp/claude/test.pid"]);
-        let cli = parse(&args);
-        assert_eq!(
-            cli.sync.pid_file,
-            Some(std::path::PathBuf::from("/tmp/claude/test.pid"))
-        );
+        assert_removed_sync_option(&["--pid-file", "/tmp/kei.pid"]);
     }
-
     #[test]
     fn test_reconcile_every_n_cycles_flag() {
-        let mut args = base_args();
-        args.extend(["--reconcile-every-n-cycles", "24"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.reconcile_every_n_cycles, Some(24));
+        assert_removed_sync_option(&["--reconcile-every-n-cycles", "24"]);
     }
 
     #[test]
@@ -2287,108 +1796,33 @@ mod tests {
     // non-numeric also fails clap's range parser.
     #[test]
     fn test_reconcile_every_n_cycles_rejects_zero() {
-        let mut args = base_args();
-        args.extend(["--reconcile-every-n-cycles", "0"]);
-        let err = Cli::try_parse_from(&args).unwrap_err();
-        assert!(
-            err.to_string().contains("not in")
-                || err.to_string().contains("range")
-                || err.to_string().contains("invalid value"),
-            "expected range/parse error, got: {err}"
-        );
+        assert_removed_sync_option(&["--reconcile-every-n-cycles", "0"]);
     }
-
     #[test]
     fn test_notification_script_flag() {
-        let mut args = base_args();
-        args.extend(["--notification-script", "/path/to/notify.sh"]);
-        let cli = parse(&args);
-        assert_eq!(
-            cli.sync.notification_script.as_deref(),
-            Some("/path/to/notify.sh")
-        );
+        assert_removed_sync_option(&["--notification-script", "/tmp/notify.sh"]);
     }
-
     #[test]
     fn test_report_json_flag() {
-        let mut args = base_args();
-        args.extend(["--report-json", "/tmp/report.json"]);
-        let cli = parse(&args);
-        assert_eq!(
-            cli.sync.report_json.as_deref(),
-            Some(std::path::Path::new("/tmp/report.json"))
-        );
+        assert_removed_sync_option(&["--report-json", "/tmp/run.json"]);
     }
 
     // ── Enum variants ──────────────────────────────────────────────
-
     #[test]
     fn test_size_all_variants() {
-        for (input, expected) in [
-            ("original", VersionSize::Original),
-            ("medium", VersionSize::Medium),
-            ("thumb", VersionSize::Thumb),
-            ("adjusted", VersionSize::Adjusted),
-            ("alternative", VersionSize::Alternative),
-        ] {
-            let mut args = base_args();
-            args.extend(["--size", input]);
-            let cli = parse(&args);
-            assert_eq!(cli.sync.size, Some(expected), "size variant: {input}");
-        }
+        assert_removed_sync_option(&["--size", "medium"]);
     }
-
     #[test]
     fn test_live_photo_size_all_variants() {
-        for (input, expected) in [
-            ("original", LivePhotoSize::Original),
-            ("medium", LivePhotoSize::Medium),
-            ("thumb", LivePhotoSize::Thumb),
-        ] {
-            let mut args = base_args();
-            args.extend(["--live-photo-size", input]);
-            let cli = parse(&args);
-            assert_eq!(
-                cli.sync.live_photo_size,
-                Some(expected),
-                "live_photo_size variant: {input}"
-            );
-        }
+        assert_removed_sync_option(&["--live-photo-size", "medium"]);
     }
-
     #[test]
     fn test_live_photo_mov_filename_policy_all_variants() {
-        for (input, expected) in [
-            ("suffix", LivePhotoMovFilenamePolicy::Suffix),
-            ("original", LivePhotoMovFilenamePolicy::Original),
-        ] {
-            let mut args = base_args();
-            args.extend(["--live-photo-mov-filename-policy", input]);
-            let cli = parse(&args);
-            assert_eq!(
-                cli.sync.live_photo_mov_filename_policy,
-                Some(expected),
-                "mov policy variant: {input}"
-            );
-        }
+        assert_removed_sync_option(&["--live-photo-mov-filename-policy", "original"]);
     }
-
     #[test]
     fn test_align_raw_all_variants() {
-        for (input, expected) in [
-            ("as-is", RawTreatmentPolicy::Unchanged),
-            ("original", RawTreatmentPolicy::PreferOriginal),
-            ("alternative", RawTreatmentPolicy::PreferAlternative),
-        ] {
-            let mut args = base_args();
-            args.extend(["--align-raw", input]);
-            let cli = parse(&args);
-            assert_eq!(
-                cli.sync.align_raw,
-                Some(expected),
-                "align_raw variant: {input}"
-            );
-        }
+        assert_removed_sync_option(&["--align-raw", "prefer-original"]);
     }
 
     #[test]
@@ -2397,25 +1831,9 @@ mod tests {
         args.extend(["--align-raw", "bogus"]);
         assert!(Cli::try_parse_from(&args).is_err());
     }
-
     #[test]
     fn test_file_match_policy_all_variants() {
-        for (input, expected) in [
-            (
-                "name-size-dedup-with-suffix",
-                FileMatchPolicy::NameSizeDedupWithSuffix,
-            ),
-            ("name-id7", FileMatchPolicy::NameId7),
-        ] {
-            let mut args = base_args();
-            args.extend(["--file-match-policy", input]);
-            let cli = parse(&args);
-            assert_eq!(
-                cli.sync.file_match_policy,
-                Some(expected),
-                "file_match_policy variant: {input}"
-            );
-        }
+        assert_removed_sync_option(&["--file-match-policy", "name-id7"]);
     }
 
     #[test]
@@ -2434,56 +1852,25 @@ mod tests {
     }
 
     // ── Optional value flags ───────────────────────────────────────
-
     #[test]
     fn test_folder_structure_custom() {
-        let mut args = base_args();
-        args.extend(["--folder-structure", "%Y-%m"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.folder_structure.as_deref(), Some("%Y-%m"));
+        assert_removed_sync_option(&["--folder-structure", "%Y-%m"]);
     }
-
     #[test]
     fn test_download_dir_custom() {
-        let mut args = base_args();
-        args.extend(["--download-dir", "/photos"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.download_dir.as_deref(), Some("/photos"));
+        assert_removed_sync_option(&["--download-dir", "/photos"]);
     }
-
     #[test]
     fn test_watch_with_interval() {
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "3600"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.watch_with_interval, Some(3600));
+        assert_removed_sync_option(&["--watch-with-interval", "3600"]);
     }
-
     #[test]
     fn test_watch_with_interval_rejects_below_minimum() {
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "0"]);
-        assert!(Cli::try_parse_from(&args).is_err());
-
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "59"]);
-        assert!(Cli::try_parse_from(&args).is_err());
-
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "60"]);
-        assert!(Cli::try_parse_from(&args).is_ok());
+        assert_removed_sync_option(&["--watch-with-interval", "59"]);
     }
-
     #[test]
     fn test_watch_with_interval_rejects_above_maximum() {
-        // 86400s = 24h ceiling
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "86400"]);
-        assert!(Cli::try_parse_from(&args).is_ok());
-
-        let mut args = base_args();
-        args.extend(["--watch-with-interval", "86401"]);
-        assert!(Cli::try_parse_from(&args).is_err());
+        assert_removed_sync_option(&["--watch-with-interval", "86401"]);
     }
 
     #[test]
@@ -2501,13 +1888,9 @@ mod tests {
         let cli = parse(&args);
         assert_eq!(cli.sync.skip_created_after.as_deref(), Some("2025-06-01"));
     }
-
     #[test]
     fn test_albums_multiple() {
-        let mut args = base_args();
-        args.extend(["--album", "Favorites", "--album", "Vacation"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.albums, vec!["Favorites", "Vacation"]);
+        assert_removed_sync_option(&["--album", "Favorites", "--album", "Vacation"]);
     }
 
     #[test]
@@ -2515,14 +1898,9 @@ mod tests {
         let cli = parse(&base_args());
         assert!(cli.sync.albums.is_empty());
     }
-
     #[test]
     fn test_album_all_accepted() {
-        let mut args = base_args();
-        args.extend(["-a", "all"]);
-        let cli = parse(&args);
-        // CLI layer stays dumb: Config::build interprets "all".
-        assert_eq!(cli.sync.albums, vec!["all"]);
+        assert_removed_sync_flag(&["kei", "-a", "all"]);
     }
 
     // ── Input validation ───────────────────────────────────────────
@@ -2585,27 +1963,14 @@ mod tests {
         args.extend(["--max-retries", "101"]);
         assert!(Cli::try_parse_from(&args).is_err());
     }
-
     #[test]
     fn test_max_retries_accepts_100() {
-        let mut args = base_args();
-        args.extend(["--max-retries", "100"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.max_retries, Some(100));
+        assert_removed_sync_option(&["--max-retries", "100"]);
     }
-
     #[test]
     fn test_sync_subcommand() {
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--username",
-            "test@example.com",
-            "--download-dir",
-            "/photos",
-        ])
-        .unwrap();
-        assert!(matches!(cli.command, Some(Command::Sync { .. })));
+        let cli = Cli::try_parse_from(["kei", "sync", "--username", "x@x.com"]).unwrap();
+        assert!(matches!(cli.effective_command(), Command::Sync { .. }));
     }
 
     #[test]
@@ -3054,41 +2419,18 @@ mod tests {
     }
 
     // ── New filter flags ───────────────────────────────────────────
-
     #[test]
     fn test_live_photo_mode_all_variants() {
-        for (flag, expected) in [
-            ("both", LivePhotoMode::Both),
-            ("image-only", LivePhotoMode::ImageOnly),
-            ("video-only", LivePhotoMode::VideoOnly),
-            ("skip", LivePhotoMode::Skip),
-        ] {
-            let mut args = base_args();
-            args.extend(["--live-photo-mode", flag]);
-            let cli = parse(&args);
-            assert_eq!(cli.sync.live_photo_mode, Some(expected));
-        }
+        assert_removed_sync_option(&["--live-photo-mode", "skip"]);
     }
 
     #[test]
     fn test_filename_exclude_single() {
-        let mut args = base_args();
-        args.extend(["--filename-exclude", "*.AAE"]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.filename_exclude, vec!["*.AAE"]);
+        assert_removed_sync_option(&["--filename-exclude", "*.AAE"]);
     }
-
     #[test]
     fn test_filename_exclude_multiple() {
-        let mut args = base_args();
-        args.extend([
-            "--filename-exclude",
-            "*.AAE",
-            "--filename-exclude",
-            "Screenshot*",
-        ]);
-        let cli = parse(&args);
-        assert_eq!(cli.sync.filename_exclude, vec!["*.AAE", "Screenshot*"]);
+        assert_removed_sync_option(&["--filename-exclude", "*.AAE,Screenshot*"]);
     }
 
     #[test]
@@ -3104,26 +2446,19 @@ mod tests {
     // whatever subcommand the user named. `kei --skip-videos status`
     // looked like `kei status`; the user thought their flag was honoured
     // and saw a different action than they typed.
-
     #[test]
     fn validate_rejects_skip_videos_with_status() {
-        let err = parse_and_validate(&["kei", "--skip-videos=true", "status"])
-            .expect_err("validation must reject");
-        assert!(err.contains("--skip-videos"), "got: {err}");
-        assert!(err.contains("status"), "got: {err}");
+        let err = Cli::try_parse_from(["kei", "--skip-videos=true", "status"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
-
     #[test]
     fn validate_rejects_skip_photos_with_list_albums() {
-        let err = parse_and_validate(&["kei", "--skip-photos=true", "list", "albums"])
-            .expect_err("validation must reject");
-        assert!(err.contains("--skip-photos"), "got: {err}");
-        assert!(err.contains("list"), "got: {err}");
+        let err = Cli::try_parse_from(["kei", "--skip-photos=true", "list", "albums"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
-
     #[test]
     fn validate_rejects_live_photo_mode_with_reset_state() {
-        let err = parse_and_validate(&[
+        let err = Cli::try_parse_from([
             "kei",
             "--live-photo-mode",
             "skip",
@@ -3131,9 +2466,8 @@ mod tests {
             "state",
             "--yes",
         ])
-        .expect_err("validation must reject");
-        assert!(err.contains("--live-photo-mode"), "got: {err}");
-        assert!(err.contains("reset"), "got: {err}");
+        .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
@@ -3170,47 +2504,49 @@ mod tests {
             .expect_err("parse must reject removed flag");
         assert!(err.contains("--auth-only"), "got: {err}");
     }
-
     #[test]
     fn validate_lists_every_offending_flag() {
         let err = parse_and_validate(&[
             "kei",
-            "--skip-videos",
-            "--skip-photos",
-            "--threads",
-            "4",
+            "--dry-run",
+            "--only-print-filenames",
+            "--recent",
+            "100",
             "status",
         ])
         .expect_err("validation must reject");
-        assert!(err.contains("--skip-videos"), "got: {err}");
-        assert!(err.contains("--skip-photos"), "got: {err}");
-        assert!(err.contains("--threads"), "got: {err}");
+        assert!(err.contains("--dry-run"), "got: {err}");
+        assert!(err.contains("--only-print-filenames"), "got: {err}");
+        assert!(err.contains("--recent"), "got: {err}");
     }
 
     // ── Validator must NOT fire on legitimate uses ─────────────────
-
     #[test]
     fn validate_allows_bare_kei_with_sync_flags() {
-        parse_and_validate(&["kei", "--skip-videos"])
-            .expect("bare-kei with sync flag must validate");
+        parse_and_validate(&["kei", "--recent", "100"])
+            .expect("bare-kei with kept per-run sync flag must validate");
     }
-
     #[test]
     fn validate_allows_sync_subcommand_with_sync_flags() {
-        parse_and_validate(&["kei", "sync", "--skip-videos", "--threads", "4"])
-            .expect("explicit sync subcommand with sync flags must validate");
+        parse_and_validate(&[
+            "kei",
+            "sync",
+            "--recent",
+            "100",
+            "--skip-created-before",
+            "2025-01-01",
+        ])
+        .expect("explicit sync subcommand with kept sync flags must validate");
     }
-
     #[test]
     fn validate_allows_top_level_sync_flag_then_sync_subcommand() {
-        parse_and_validate(&["kei", "--skip-videos=true", "sync"])
-            .expect("top-level sync flag with sync subcommand must validate");
+        parse_and_validate(&["kei", "--recent", "100", "sync"])
+            .expect("top-level kept sync flag with sync subcommand must validate");
     }
-
     #[test]
     fn validate_allows_retry_failed_with_sync_flag() {
-        parse_and_validate(&["kei", "sync", "--retry-failed", "--threads", "4"])
-            .expect("sync --retry-failed accepts sync flags");
+        parse_and_validate(&["kei", "sync", "--retry-failed", "--recent", "100"])
+            .expect("sync --retry-failed accepts kept per-run sync flags");
     }
 
     #[test]
@@ -3230,18 +2566,10 @@ mod tests {
     fn validate_allows_status_with_no_top_level_flags() {
         parse_and_validate(&["kei", "status"]).expect("plain `kei status` must validate");
     }
-
     #[test]
     fn validate_allows_service_run_with_sync_flags() {
-        parse_and_validate(&[
-            "kei",
-            "--download-dir",
-            "/photos",
-            "service",
-            "run",
-            "--dry-run",
-        ])
-        .expect("service run must accept top-level sync flags");
+        parse_and_validate(&["kei", "--recent", "100", "service", "run", "--dry-run"])
+            .expect("service run must accept kept top-level sync flags");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
+    FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
     RawTreatmentPolicy, VersionSize,
 };
 use clap::{Args, FromArgMatches, Parser, Subcommand};
@@ -233,91 +233,10 @@ pub struct SyncArgs {
     #[arg(long, conflicts_with = "dry_run")]
     pub retry_failed: bool,
 
-    // Durable sync settings are TOML-only in v0.20. These skipped fields keep
-    // internal resolver tests and programmatic call sites able to construct
-    // non-default configs without re-exposing the old public CLI/env mirrors.
+    /// Internal durable config overrides for tests and programmatic call
+    /// sites. Public CLI/env no longer expose these fields in v0.20.
     #[arg(skip)]
-    pub download_dir: Option<String>,
-    #[arg(skip)]
-    pub albums: Vec<String>,
-    #[arg(skip)]
-    pub smart_folders: Vec<String>,
-    #[arg(skip)]
-    pub unfiled: Option<bool>,
-    #[arg(skip)]
-    pub filename_exclude: Vec<String>,
-    #[arg(skip)]
-    pub libraries: Vec<String>,
-    #[arg(skip)]
-    pub size: Option<VersionSize>,
-    #[arg(skip)]
-    pub live_photo_size: Option<LivePhotoSize>,
-    #[arg(skip)]
-    pub threads: Option<u16>,
-    #[arg(skip)]
-    pub bandwidth_limit: Option<u64>,
-    #[arg(skip)]
-    pub skip_videos: Option<bool>,
-    #[arg(skip)]
-    pub skip_photos: Option<bool>,
-    #[arg(skip)]
-    pub live_photo_mode: Option<LivePhotoMode>,
-    #[arg(skip)]
-    pub force_size: Option<bool>,
-    #[arg(skip)]
-    pub folder_structure: Option<String>,
-    #[arg(skip)]
-    pub folder_structure_albums: Option<String>,
-    #[arg(skip)]
-    pub folder_structure_smart_folders: Option<String>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub set_exif_datetime: Option<bool>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub set_exif_rating: Option<bool>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub set_exif_gps: Option<bool>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub set_exif_description: Option<bool>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub embed_xmp: Option<bool>,
-    #[cfg(feature = "xmp")]
-    #[arg(skip)]
-    pub xmp_sidecar: Option<bool>,
-    #[arg(skip)]
-    pub watch_with_interval: Option<u64>,
-    #[arg(skip)]
-    pub keep_unicode_in_filenames: Option<bool>,
-    #[arg(skip)]
-    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
-    #[arg(skip)]
-    pub align_raw: Option<RawTreatmentPolicy>,
-    #[arg(skip)]
-    pub file_match_policy: Option<FileMatchPolicy>,
-    #[arg(skip)]
-    pub max_retries: Option<u32>,
-    #[arg(skip)]
-    pub temp_suffix: Option<String>,
-    #[arg(skip)]
-    pub notify_systemd: Option<bool>,
-    #[arg(skip)]
-    pub pid_file: Option<std::path::PathBuf>,
-    #[arg(skip)]
-    pub reconcile_every_n_cycles: Option<u64>,
-    #[arg(skip)]
-    pub notification_script: Option<String>,
-    #[arg(skip)]
-    pub report_json: Option<std::path::PathBuf>,
-    #[arg(skip)]
-    pub http_port: Option<u16>,
-    #[arg(skip)]
-    pub http_bind: Option<std::net::IpAddr>,
-    #[arg(skip)]
-    pub max_download_attempts: Option<u32>,
+    pub(crate) config_overrides: crate::config::SyncConfigOverrides,
 }
 
 /// Arguments for the status command.
@@ -713,7 +632,6 @@ pub struct Cli {
         long,
         global = true,
         overrides_with = "no_friendly",
-        env = "KEI_FRIENDLY",
         long_help = "Use friendly progress UI (verb-cycling spinners, curated phase narration, summary card, sign-off). \
                      Default: on for plain TTYs, off in service/container/journal contexts and whenever a \
                      machine-output mode (`--only-print-filenames` or TOML report JSON) or an explicit \
@@ -742,18 +660,6 @@ pub struct Cli {
         env = "KEI_CONFIG"
     )]
     pub config: String,
-
-    /// Apple ID email address
-    #[arg(short = 'u', long, global = true, env = "ICLOUD_USERNAME", value_parser = non_empty_string)]
-    pub username: Option<String>,
-
-    /// iCloud domain (com or cn)
-    #[arg(long, global = true, value_enum, env = "KEI_DOMAIN")]
-    pub domain: Option<Domain>,
-
-    /// Directory for sessions, state DB, and credentials
-    #[arg(long, global = true, env = "KEI_DATA_DIR")]
-    pub data_dir: Option<String>,
 
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -808,8 +714,7 @@ impl PasswordArgs {
 
 impl Cli {
     /// User-stated friendly-mode preference, distilled from the
-    /// `--friendly` / `--no-friendly` pair (with `KEI_FRIENDLY` feeding the
-    /// former). `Some(true)` and `Some(false)` are explicit user requests
+    /// `--friendly` / `--no-friendly` pair. `Some(true)` and `Some(false)` are explicit user requests
     /// that override the TOML and the auto-detected default; `None` means
     /// neither flag was set, so the resolution chain falls through to TOML
     /// then to the default-on-for-TTY policy.
@@ -886,7 +791,11 @@ impl Cli {
         Err(format!(
             "the following sync-only flag{plural} cannot be combined with `kei {cmd_name}`: {flag_list}\n\
              bare-kei (no subcommand) is shorthand for `kei sync`; sync-only flags are only valid there or under `kei sync`",
-            plural = if explicit_sync_flags.len() == 1 { "" } else { "s" },
+            plural = if explicit_sync_flags.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
         ))
     }
 }
@@ -1063,8 +972,14 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
+    fn assert_removed_global_option(option: &str, value: &str) {
+        let err = Cli::try_parse_from(["kei", option, value])
+            .expect_err("removed global option must fail to parse");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
     fn assert_removed_sync_option(tail: &[&str]) {
-        let mut args = vec!["kei", "--username", "test@example.com"];
+        let mut args = vec!["kei"];
         args.extend_from_slice(tail);
         assert_removed_sync_flag(&args);
     }
@@ -1187,7 +1102,7 @@ mod tests {
     }
 
     fn base_args() -> Vec<&'static str> {
-        vec!["kei", "--username", "test@example.com"]
+        vec!["kei"]
     }
 
     /// Scrub auth-related env vars for the duration of the returned guard so
@@ -1249,21 +1164,18 @@ mod tests {
     // ── Global args ───────────────────────────────────────────────
 
     #[test]
-    fn test_username_global() {
-        let cli = parse(&["kei", "--username", "test@example.com"]);
-        assert_eq!(cli.username.as_deref(), Some("test@example.com"));
+    fn test_username_global_removed() {
+        assert_removed_global_option("--username", "test@example.com");
     }
 
     #[test]
-    fn test_domain_global() {
-        let cli = parse(&["kei", "--domain", "cn"]);
-        assert_eq!(cli.domain, Some(Domain::Cn));
+    fn test_domain_global_removed() {
+        assert_removed_global_option("--domain", "cn");
     }
 
     #[test]
-    fn test_data_dir_global() {
-        let cli = parse(&["kei", "--data-dir", "/config"]);
-        assert_eq!(cli.data_dir.as_deref(), Some("/config"));
+    fn test_data_dir_global_removed() {
+        assert_removed_global_option("--data-dir", "/config");
     }
 
     #[test]
@@ -1286,7 +1198,6 @@ mod tests {
     fn test_bare_invocation_without_username() {
         let _guard = scrub_auth_env();
         let cli = Cli::try_parse_from(["kei"]).unwrap();
-        assert!(cli.username.is_none());
         assert!(cli.command.is_none());
     }
     #[test]
@@ -1581,7 +1492,7 @@ mod tests {
 
     #[test]
     fn test_save_password_merges_into_subcommand() {
-        let cli = parse(&["kei", "--username", "u@e.com", "--save-password", "sync"]);
+        let cli = parse(&["kei", "--save-password", "sync"]);
         if let Command::Sync { sync, .. } = cli.effective_command() {
             assert!(sync.save_password);
         } else {
@@ -1712,7 +1623,7 @@ mod tests {
     #[test]
     fn test_unfiled_flag_default_none() {
         let cli = parse(&base_args());
-        assert_eq!(cli.sync.unfiled, None);
+        assert_eq!(cli.sync.config_overrides.unfiled, None);
     }
     #[test]
     fn test_unfiled_flag_bare_true() {
@@ -1788,7 +1699,7 @@ mod tests {
     #[test]
     fn test_reconcile_every_n_cycles_default_unset() {
         let cli = parse(&base_args());
-        assert!(cli.sync.reconcile_every_n_cycles.is_none());
+        assert!(cli.sync.config_overrides.reconcile_every_n_cycles.is_none());
     }
 
     // 0 is "off" via TOML (or absence); the CLI flag rejects it so users
@@ -1896,7 +1807,7 @@ mod tests {
     #[test]
     fn test_albums_empty_by_default() {
         let cli = parse(&base_args());
-        assert!(cli.sync.albums.is_empty());
+        assert!(cli.sync.config_overrides.albums.is_empty());
     }
     #[test]
     fn test_album_all_accepted() {
@@ -1907,8 +1818,7 @@ mod tests {
 
     #[test]
     fn test_empty_username_rejected() {
-        let args = ["kei", "--username", ""];
-        assert!(Cli::try_parse_from(args).is_err());
+        assert_removed_global_option("--username", "");
     }
 
     #[test]
@@ -1920,14 +1830,7 @@ mod tests {
 
     #[test]
     fn test_empty_download_dir_rejected() {
-        let args = [
-            "kei",
-            "--username",
-            "user@example.com",
-            "--download-dir",
-            "",
-        ];
-        assert!(Cli::try_parse_from(args).is_err());
+        assert_removed_sync_option(&["--download-dir", ""]);
     }
 
     #[test]
@@ -1969,7 +1872,7 @@ mod tests {
     }
     #[test]
     fn test_sync_subcommand() {
-        let cli = Cli::try_parse_from(["kei", "sync", "--username", "x@x.com"]).unwrap();
+        let cli = Cli::try_parse_from(["kei", "sync"]).unwrap();
         assert!(matches!(cli.effective_command(), Command::Sync { .. }));
     }
 
@@ -2039,9 +1942,10 @@ mod tests {
     }
 
     #[test]
-    fn test_username_global_before_subcommand() {
-        let cli = Cli::try_parse_from(["kei", "--username", "test@example.com", "sync"]).unwrap();
-        assert_eq!(cli.username.as_deref(), Some("test@example.com"));
+    fn test_username_global_before_subcommand_removed() {
+        let err = Cli::try_parse_from(["kei", "--username", "test@example.com", "sync"])
+            .expect_err("removed global option must fail to parse");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     // ── import-existing ───────────────────────────────────────────
@@ -2550,16 +2454,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_allows_global_flags_with_non_sync_subcommand() {
-        parse_and_validate(&[
-            "kei",
-            "--username",
-            "u@e.com",
-            "--log-level",
-            "debug",
-            "status",
-        ])
-        .expect("global flags must validate with any subcommand");
+    fn validate_allows_kept_global_flags_with_non_sync_subcommand() {
+        parse_and_validate(&["kei", "--log-level", "debug", "status"])
+            .expect("global flags must validate with any subcommand");
     }
 
     #[test]

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -17,7 +17,11 @@ pub(crate) fn run_config_show(
         cli::SyncArgs::default(),
         toml,
     )?;
-    let toml_config = cfg.to_toml();
+    let mut toml_config = cfg.to_toml();
+    if let Some(input) = toml {
+        toml_config.data_dir.clone_from(&input.data_dir);
+        toml_config.log_level = input.log_level;
+    }
     let output = toml::to_string_pretty(&toml_config)
         .map_err(|e| anyhow::anyhow!("failed to serialize config: {e}"))?;
     print!("{output}");

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3035,14 +3035,17 @@ mod build_config_tests {
         let import_cfg = build_import_download_config(&import_args, Some(&toml)).unwrap();
 
         let sync = SyncArgs {
-            folder_structure: Some("%Y/%m".to_string()),
-            size: Some(VersionSize::Adjusted),
-            file_match_policy: Some(FileMatchPolicy::NameId7),
-            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
-            align_raw: Some(RawTreatmentPolicy::PreferOriginal),
-            force_size: Some(true),
-            keep_unicode_in_filenames: Some(true),
-            download_dir: Some("/photos".to_string()),
+            config_overrides: crate::config::SyncConfigOverrides {
+                folder_structure: Some("%Y/%m".to_string()),
+                size: Some(VersionSize::Adjusted),
+                file_match_policy: Some(FileMatchPolicy::NameId7),
+                live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
+                align_raw: Some(RawTreatmentPolicy::PreferOriginal),
+                force_size: Some(true),
+                keep_unicode_in_filenames: Some(true),
+                download_dir: Some("/photos".to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let globals = GlobalArgs {
@@ -3058,23 +3061,29 @@ mod build_config_tests {
         )
         .unwrap();
 
-        assert_eq!(import_cfg.folder_structure, sync_cfg.folder_structure);
-        assert_eq!(import_cfg.size, sync_cfg.size.into());
-        assert_eq!(import_cfg.live_photo_mode, sync_cfg.live_photo_mode);
+        assert_eq!(
+            import_cfg.folder_structure,
+            sync_cfg.download.folder_structure
+        );
+        assert_eq!(import_cfg.size, sync_cfg.photos.size.into());
+        assert_eq!(import_cfg.live_photo_mode, sync_cfg.photos.live_photo_mode);
         assert_eq!(
             import_cfg.live_photo_size,
-            sync_cfg.live_photo_size.to_asset_version_size()
+            sync_cfg.photos.live_photo_size.to_asset_version_size()
         );
         assert_eq!(
             import_cfg.live_photo_mov_filename_policy,
-            sync_cfg.live_photo_mov_filename_policy
+            sync_cfg.photos.live_photo_mov_filename_policy
         );
-        assert_eq!(import_cfg.align_raw, sync_cfg.align_raw);
-        assert_eq!(import_cfg.file_match_policy, sync_cfg.file_match_policy);
-        assert_eq!(import_cfg.force_size, sync_cfg.force_size);
+        assert_eq!(import_cfg.align_raw, sync_cfg.photos.align_raw);
+        assert_eq!(
+            import_cfg.file_match_policy,
+            sync_cfg.photos.file_match_policy
+        );
+        assert_eq!(import_cfg.force_size, sync_cfg.photos.force_size);
         assert_eq!(
             import_cfg.keep_unicode_in_filenames,
-            sync_cfg.keep_unicode_in_filenames
+            sync_cfg.photos.keep_unicode_in_filenames
         );
     }
 
@@ -3096,7 +3105,10 @@ mod build_config_tests {
             .expect_err("import: system dir must reject");
 
         let sync = SyncArgs {
-            download_dir: Some("/etc".to_string()),
+            config_overrides: crate::config::SyncConfigOverrides {
+                download_dir: Some("/etc".to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let globals = GlobalArgs {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -21,7 +21,7 @@ pub(crate) async fn run_list(
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("--username is required");
+        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
     }
 
     let password_provider =

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -19,7 +19,7 @@ pub(crate) async fn run_login(
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("--username is required for login");
+        anyhow::bail!("username is required for login (set ICLOUD_USERNAME or [auth].username)");
     }
 
     let password_provider =

--- a/src/commands/password.rs
+++ b/src/commands/password.rs
@@ -17,7 +17,9 @@ pub(crate) fn run_password(
     let (username, _password, _domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("--username is required for password management");
+        anyhow::bail!(
+            "username is required for password management (set ICLOUD_USERNAME or [auth].username)"
+        );
     }
 
     let store = credential::CredentialStore::new(&username, &cookie_directory);

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1676,43 +1676,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_passes_threading_from_cli_input() {
-        // End-to-end thread of the v0.13 selection flags through the
-        // production parse layer: clap → Cli → Config::build → Selection
-        // → resolve_passes. The cli.rs help-shadow tests for these flags
-        // only exercise the parser; a regression that drops --smart-folder
-        // or flips --unfiled's default between Cli and Selection lands
-        // green there. This test is the one place that drives the runtime
-        // wiring and asserts on the resolved pass list.
-        use crate::cli::{Cli, Command, PasswordArgs};
-        use clap::Parser;
+    async fn resolve_passes_threading_from_toml_input() {
+        // End-to-end thread of persistent selection config through the
+        // production resolver: TOML -> Config::build -> Selection ->
+        // resolve_passes. CLI only exposes per-run sync flags in v0.20, so
+        // persistent album, smart-folder, unfiled, and library policy should
+        // reach the pass planner from TOML.
+        use crate::cli::{PasswordArgs, SyncArgs};
 
         let cookie_dir = tempfile::tempdir().unwrap();
-        let cli = Cli::try_parse_from([
-            "kei",
-            "--username",
-            "u@example.com",
-            "--data-dir",
-            cookie_dir.path().to_str().unwrap(),
-            "sync",
-            "--album",
-            "all",
-            "--smart-folder",
-            "Favorites",
-            "--unfiled",
-            "false",
-            "--library",
-            "shared",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
-        let globals = crate::config::GlobalArgs::from_cli(&cli);
-        let cfg =
-            crate::config::Config::build(&globals, &PasswordArgs::default(), sync, None).unwrap();
+        let toml: crate::config::TomlConfig = toml::from_str(
+            r#"
+[auth]
+username = "u@example.com"
 
-        // Sanity-check the cli → Selection wiring before pinning the pass list.
+[download]
+directory = "/photos"
+
+[filters]
+albums = ["all"]
+smart_folders = ["Favorites"]
+unfiled = false
+libraries = ["shared"]
+"#,
+        )
+        .unwrap();
+        let globals = crate::config::GlobalArgs {
+            username: None,
+            domain: None,
+            data_dir: Some(cookie_dir.path().to_string_lossy().into_owned()),
+        };
+        let cfg = crate::config::Config::build(
+            &globals,
+            &PasswordArgs::default(),
+            SyncArgs::default(),
+            Some(&toml),
+        )
+        .unwrap();
+
+        // Sanity-check the TOML → Selection wiring before pinning the pass list.
         assert_eq!(cfg.selection.libraries.to_raw(), vec!["shared".to_string()]);
         assert!(matches!(
             cfg.selection.albums,

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1715,17 +1715,20 @@ libraries = ["shared"]
         .unwrap();
 
         // Sanity-check the TOML → Selection wiring before pinning the pass list.
-        assert_eq!(cfg.selection.libraries.to_raw(), vec!["shared".to_string()]);
+        assert_eq!(
+            cfg.filters.selection.libraries.to_raw(),
+            vec!["shared".to_string()]
+        );
         assert!(matches!(
-            cfg.selection.albums,
+            cfg.filters.selection.albums,
             AlbumSelector::All { ref excluded } if excluded.is_empty()
         ));
         assert!(matches!(
-            cfg.selection.smart_folders,
+            cfg.filters.selection.smart_folders,
             SmartFolderSelector::Named { ref included, ref excluded }
                 if included.contains("Favorites") && excluded.is_empty()
         ));
-        assert!(!cfg.selection.unfiled);
+        assert!(!cfg.filters.selection.unfiled);
 
         // Stub a library exposing one user album ("Vacation") plus the
         // Favorites smart folder. resolve_passes only consumes the first
@@ -1737,7 +1740,9 @@ libraries = ["shared"]
             .ok(serde_json::json!({"records": []}));
         let library = stub_library(mock);
 
-        let plan = resolve_passes(&library, &cfg.selection).await.unwrap();
+        let plan = resolve_passes(&library, &cfg.filters.selection)
+            .await
+            .unwrap();
         let pairs: Vec<(String, PassKind)> = plan
             .passes
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,8 +187,9 @@ pub(crate) fn load_toml_config(path: &Path, required: bool) -> anyhow::Result<Op
 
 // ── Application Config ──────────────────────────────────────────────
 
-/// Resolve `--library` from CLI > TOML > default (`primary`). The CLI list
-/// and the TOML `[filters].libraries` array share the selector grammar
+/// Resolve library selection from the programmatic override, TOML, or the
+/// default (`primary`). The override and TOML `[filters].libraries` array share
+/// the selector grammar
 /// (`primary` / `shared` / `all` / `none` / `!name` / raw zone names);
 ///
 /// Returns the parsed [`crate::selection::LibrarySelector`]; the matching
@@ -381,10 +382,10 @@ pub(crate) fn should_warn_implicit_unfiled(
 
 fn warn_implicit_unfiled_pass() {
     tracing::warn!(
-        "--unfiled defaults to true in v0.13, so kei is also running an unfiled pass \
+        "[filters] unfiled defaults to true in v0.13, so kei is also running an unfiled pass \
          (every photo not in any user album) alongside the album pass(es). Pass \
-         `--unfiled false` (or `[filters] unfiled = false`) to restrict to just the \
-         album pass(es); pass `--unfiled true` to silence this warning."
+         `[filters] unfiled = false` to restrict to just the album pass(es); pass \
+         `[filters] unfiled = true` to silence this warning."
     );
 }
 
@@ -913,46 +914,22 @@ pub(crate) fn resolve_password_command(
         .or_else(|| toml_auth.and_then(|a| a.password_command.clone()))
 }
 
-pub(crate) const ENV_WATCH_INTERVAL: &str = "KEI_WATCH_WITH_INTERVAL";
-
-/// Parse `KEI_WATCH_WITH_INTERVAL` into an `Option<u64>`. Takes the raw
-/// `Result` so tests can exercise it without mutating the process env (which
-/// would race other `Config::build` callers under `--test-threads > 1`).
-/// Range validation lives in `Config::build_inner` so CLI/TOML/env share it.
-pub(crate) fn parse_env_watch_interval(
-    raw: Result<String, std::env::VarError>,
-) -> anyhow::Result<Option<u64>> {
-    match raw {
-        Ok(s) if s.is_empty() => Ok(None),
-        Ok(s) => Some(s.parse::<u64>().map_err(|e| {
-            anyhow::anyhow!("{ENV_WATCH_INTERVAL} is not a valid integer ({s:?}): {e}")
-        }))
-        .transpose(),
-        Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            anyhow::bail!("{ENV_WATCH_INTERVAL} contains non-UTF-8 bytes")
-        }
-    }
-}
-
 impl Config {
     /// Build a Config by merging CLI args with optional TOML config.
-    /// Resolution order: CLI > TOML > env (`KEI_WATCH_WITH_INTERVAL` for the
-    /// watch interval; per-field for others) > hardcoded default.
+    /// Runtime CLI flags override TOML where they remain public. Durable sync
+    /// settings come from TOML and then hardcoded defaults.
     pub fn build(
         globals: &GlobalArgs,
         pw: &crate::cli::PasswordArgs,
         sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
-        let env_watch_interval = parse_env_watch_interval(std::env::var(ENV_WATCH_INTERVAL))?;
         let friendly_request = toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly);
         Self::build_inner(
             globals,
             pw,
             sync,
             toml,
-            env_watch_interval,
             crate::personality::Mode::Off,
             friendly_request,
         )
@@ -963,7 +940,6 @@ impl Config {
         pw: &crate::cli::PasswordArgs,
         sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
-        env_watch_interval: Option<u64>,
         personality_mode: crate::personality::Mode,
         friendly_request: Option<bool>,
     ) -> anyhow::Result<Self> {
@@ -1286,8 +1262,7 @@ impl Config {
         // default sits below TOML in the precedence chain. See #293.
         let watch_with_interval = sync
             .watch_with_interval
-            .or_else(|| toml_watch.and_then(|w| w.interval))
-            .or(env_watch_interval);
+            .or_else(|| toml_watch.and_then(|w| w.interval));
         if let Some(n) = watch_with_interval {
             anyhow::ensure!(
                 (60..=86400).contains(&n),
@@ -2263,19 +2238,8 @@ mod tests {
 
     #[test]
     fn config_build_unfiled_bare_flag_resolves_to_true() {
-        // Bare `--unfiled` (no value) sets `cli.sync.unfiled = Some(true)`
-        // via clap's `default_missing_value = "true"`. The cli.rs unit test
-        // pins the parse but the runtime path through Config::build is
-        // untested — a clap-default flip or a derive_selection regression
-        // that dropped the override would silently land. This test drives
-        // the parser through to the resolved Selection.
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from(["kei", "sync", "--unfiled"]).unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.unfiled = Some(true);
         let mut globals = default_globals();
         globals.username = Some("u@example.com".to_string());
         let cfg = Config::build(&globals, &default_password(), sync, None).unwrap();
@@ -2287,17 +2251,8 @@ mod tests {
 
     #[test]
     fn config_build_unfiled_explicit_false_resolves_to_false() {
-        // Symmetric pin: explicit `--unfiled false` must override the
-        // `true` default. The legacy resolver also defaulted unfiled to
-        // true under most configurations, so a regression that swallowed
-        // the explicit `false` would not show up in any current test.
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from(["kei", "sync", "--unfiled", "false"]).unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.unfiled = Some(false);
         let mut globals = default_globals();
         globals.username = Some("u@example.com".to_string());
         let cfg = Config::build(&globals, &default_password(), sync, None).unwrap();
@@ -2319,13 +2274,8 @@ mod tests {
 
     #[test]
     fn config_build_smart_folder_resolves_to_named_selector() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from(["kei", "sync", "--smart-folder", "Favorites"]).unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.smart_folders = vec!["Favorites".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert_eq!(
             cfg.selection.smart_folders.to_raw(),
@@ -2335,21 +2285,8 @@ mod tests {
 
     #[test]
     fn config_build_smart_folder_all_with_sensitive_resolves() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--smart-folder",
-            "all-with-sensitive",
-            "--smart-folder",
-            "!Hidden",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.smart_folders = vec!["all-with-sensitive".to_string(), "!Hidden".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         match cfg.selection.smart_folders {
             crate::selection::SmartFolderSelector::All {
@@ -2371,15 +2308,8 @@ mod tests {
 
     #[test]
     fn config_build_library_repeatable_primary_plus_shared() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli =
-            Cli::try_parse_from(["kei", "sync", "--library", "primary", "--library", "shared"])
-                .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.libraries = vec!["primary".to_string(), "shared".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert!(
             cfg.selection.libraries.primary,
@@ -2399,21 +2329,8 @@ mod tests {
 
     #[test]
     fn config_build_library_repeatable_named_zone_with_primary() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--library",
-            "primary",
-            "--library",
-            "SharedSync-A1B2C3D4",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.libraries = vec!["primary".to_string(), "SharedSync-A1B2C3D4".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let lib = &cfg.selection.libraries;
         assert!(lib.primary, "primary must remain set");
@@ -2427,19 +2344,8 @@ mod tests {
 
     #[test]
     fn config_build_folder_structure_albums_resolves_through_cli() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--folder-structure-albums",
-            "{album}/%Y/%m/%d",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.folder_structure_albums = Some("{album}/%Y/%m/%d".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert_eq!(cfg.folder_structure_albums, "{album}/%Y/%m/%d");
         // Default unfiled / smart-folder templates are untouched.
@@ -2448,19 +2354,8 @@ mod tests {
 
     #[test]
     fn config_build_folder_structure_smart_folders_resolves_through_cli() {
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--folder-structure-smart-folders",
-            "{smart-folder}/%Y",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.folder_structure_smart_folders = Some("{smart-folder}/%Y".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert_eq!(cfg.folder_structure_smart_folders, "{smart-folder}/%Y");
         assert_eq!(cfg.folder_structure_albums, "{album}");
@@ -2576,20 +2471,9 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
 
-        use crate::cli::{Cli, Command};
-        use clap::Parser;
-        let cli = Cli::try_parse_from([
-            "kei",
-            "sync",
-            "--folder-structure-albums",
-            "{album}/from-cli",
-            "--folder-structure-smart-folders",
-            "{smart-folder}/from-cli",
-        ])
-        .unwrap();
-        let Command::Sync { sync, .. } = cli.effective_command() else {
-            panic!("expected Sync subcommand");
-        };
+        let mut sync = default_sync();
+        sync.folder_structure_albums = Some("{album}/from-cli".to_string());
+        sync.folder_structure_smart_folders = Some("{smart-folder}/from-cli".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(cfg.folder_structure_albums, "{album}/from-cli");
@@ -3151,7 +3035,7 @@ mod tests {
         assert!(err.contains("not supported on Windows"), "{err}");
     }
 
-    // ── Download directory: --download-dir ─────────────────────────
+    // ── Download directory ─────────────────────────────────────────
 
     #[test]
     fn test_build_download_dir_from_cli() {
@@ -4396,86 +4280,6 @@ mod tests {
         assert_eq!(cfg.watch_with_interval, Some(600));
     }
 
-    // Precedence tests for KEI_WATCH_WITH_INTERVAL inject the env value via
-    // `Config::build_inner` directly, rather than mutating the real process
-    // env, which would race other `Config::build` callers under
-    // `--test-threads > 1`.
-
-    fn build_with_env(
-        sync: SyncArgs,
-        toml: Option<TomlConfig>,
-        env_watch_interval: Option<u64>,
-    ) -> anyhow::Result<Config> {
-        Config::build_inner(
-            &default_globals(),
-            &default_password(),
-            sync,
-            toml.as_ref(),
-            env_watch_interval,
-            crate::personality::Mode::Off,
-            None,
-        )
-    }
-
-    /// Regression test for #293: a `[watch] interval` in TOML must beat the
-    /// `KEI_WATCH_WITH_INTERVAL` env var (notably the docker image's baked
-    /// 24-hour default). Before the fix the env was read by clap and treated
-    /// as equivalent to a CLI flag, so it silently overrode TOML.
-    #[test]
-    fn test_build_watch_interval_toml_overrides_env() {
-        let toml_str = r#"
-            [watch]
-            interval = 3600
-        "#;
-        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
-        let cfg = build_with_env(default_sync(), Some(toml), Some(86400)).unwrap();
-        assert_eq!(cfg.watch_with_interval, Some(3600));
-    }
-
-    #[test]
-    fn test_build_watch_interval_cli_overrides_env() {
-        let mut sync = default_sync();
-        sync.watch_with_interval = Some(600);
-        let cfg = build_with_env(sync, None, Some(86400)).unwrap();
-        assert_eq!(cfg.watch_with_interval, Some(600));
-    }
-
-    #[test]
-    fn test_build_watch_interval_env_only() {
-        let cfg = build_with_env(default_sync(), None, Some(86400)).unwrap();
-        assert_eq!(cfg.watch_with_interval, Some(86400));
-    }
-
-    #[test]
-    fn test_build_watch_interval_env_unset_means_single_shot() {
-        let cfg = build_with_env(default_sync(), None, None).unwrap();
-        assert!(cfg.watch_with_interval.is_none());
-    }
-
-    #[test]
-    fn test_build_watch_interval_env_below_minimum_rejected() {
-        for bad in [0u64, 1, 30, 59] {
-            let err = build_with_env(default_sync(), None, Some(bad)).unwrap_err();
-            assert!(
-                err.to_string()
-                    .contains("watch interval must be in 60..=86400"),
-                "unexpected error for env={bad}: {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_build_watch_interval_env_above_maximum_rejected() {
-        for bad in [86401u64, 100_000, u64::MAX] {
-            let err = build_with_env(default_sync(), None, Some(bad)).unwrap_err();
-            assert!(
-                err.to_string()
-                    .contains("watch interval must be in 60..=86400"),
-                "unexpected error for env={bad}: {err}"
-            );
-        }
-    }
-
     // ── Config::build: reconcile_every_n_cycles ────────────────────
 
     #[test]
@@ -4538,98 +4342,6 @@ mod tests {
         )
         .unwrap();
         assert!(cfg.reconcile_every_n_cycles.is_none());
-    }
-
-    // Pure parser tests use synthetic `Result<String, VarError>` inputs to
-    // avoid mutating the process env.
-
-    #[test]
-    fn test_parse_env_watch_interval_valid_number() {
-        let parsed = parse_env_watch_interval(Ok("3600".to_string())).unwrap();
-        assert_eq!(parsed, Some(3600));
-    }
-
-    #[test]
-    fn test_parse_env_watch_interval_not_present() {
-        let parsed = parse_env_watch_interval(Err(std::env::VarError::NotPresent)).unwrap();
-        assert!(parsed.is_none());
-    }
-
-    // Empty string == unset. Lets `docker run -e KEI_WATCH_WITH_INTERVAL=`
-    // override the image's baked-in 24h default for one-shot invocations.
-    #[test]
-    fn test_parse_env_watch_interval_empty_is_unset() {
-        let parsed = parse_env_watch_interval(Ok(String::new())).unwrap();
-        assert!(parsed.is_none());
-    }
-
-    #[test]
-    fn test_parse_env_watch_interval_garbage_rejected() {
-        let err = parse_env_watch_interval(Ok("not-a-number".to_string())).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("KEI_WATCH_WITH_INTERVAL is not a valid integer"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn test_parse_env_watch_interval_negative_rejected() {
-        let err = parse_env_watch_interval(Ok("-1".to_string())).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("KEI_WATCH_WITH_INTERVAL is not a valid integer"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn test_parse_env_watch_interval_non_unicode_rejected() {
-        let err = parse_env_watch_interval(Err(std::env::VarError::NotUnicode(
-            std::ffi::OsString::from("placeholder"),
-        )))
-        .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("KEI_WATCH_WITH_INTERVAL contains non-UTF-8 bytes"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn test_build_pid_file_cli_overrides_toml() {
-        let toml_str = r#"
-            [watch]
-            pid_file = "/toml/pid"
-        "#;
-        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
-        let mut sync = default_sync();
-        sync.pid_file = Some(PathBuf::from("/cli/pid"));
-        let cfg =
-            Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.pid_file, Some(PathBuf::from("/cli/pid")));
-    }
-
-    // ── Config::build: notification_script merge ────────────────────
-
-    #[test]
-    fn test_build_notification_script_from_toml() {
-        let toml_str = r#"
-            [notifications]
-            script = "/config/notify.sh"
-        "#;
-        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
-        let cfg = Config::build(
-            &default_globals(),
-            &default_password(),
-            default_sync(),
-            Some(&toml),
-        )
-        .unwrap();
-        assert_eq!(
-            cfg.notification_script,
-            Some(PathBuf::from("/config/notify.sh"))
-        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,6 +152,169 @@ pub(crate) struct TomlServer {
     pub bind: Option<String>,
 }
 
+/// Programmatic durable sync overrides.
+///
+/// Public CLI/env no longer expose these fields in v0.20. Tests and internal
+/// call sites that need to exercise the resolver can still pass explicit
+/// overrides without re-growing [`crate::cli::SyncArgs`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SyncConfigOverrides {
+    pub download_dir: Option<String>,
+    pub albums: Vec<String>,
+    pub smart_folders: Vec<String>,
+    pub unfiled: Option<bool>,
+    pub filename_exclude: Vec<String>,
+    pub libraries: Vec<String>,
+    pub size: Option<VersionSize>,
+    pub live_photo_size: Option<LivePhotoSize>,
+    pub threads: Option<u16>,
+    pub bandwidth_limit: Option<u64>,
+    pub skip_videos: Option<bool>,
+    pub skip_photos: Option<bool>,
+    pub live_photo_mode: Option<LivePhotoMode>,
+    pub force_size: Option<bool>,
+    pub folder_structure: Option<String>,
+    pub folder_structure_albums: Option<String>,
+    pub folder_structure_smart_folders: Option<String>,
+    #[cfg(feature = "xmp")]
+    pub set_exif_datetime: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub set_exif_rating: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub set_exif_gps: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub set_exif_description: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub embed_xmp: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub xmp_sidecar: Option<bool>,
+    pub watch_with_interval: Option<u64>,
+    pub keep_unicode_in_filenames: Option<bool>,
+    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
+    pub align_raw: Option<RawTreatmentPolicy>,
+    pub file_match_policy: Option<FileMatchPolicy>,
+    pub max_retries: Option<u32>,
+    pub temp_suffix: Option<String>,
+    pub notify_systemd: Option<bool>,
+    pub pid_file: Option<PathBuf>,
+    pub reconcile_every_n_cycles: Option<u64>,
+    pub notification_script: Option<String>,
+    pub report_json: Option<PathBuf>,
+    pub http_port: Option<u16>,
+    pub http_bind: Option<std::net::IpAddr>,
+    pub max_download_attempts: Option<u32>,
+}
+
+#[derive(Debug)]
+pub struct AuthConfig {
+    pub username: String,
+    pub password: Option<SecretString>,
+    pub password_file: Option<PathBuf>,
+    pub password_command: Option<String>,
+    pub cookie_directory: PathBuf,
+    pub domain: Domain,
+    pub save_password: bool,
+}
+
+#[derive(Debug)]
+pub struct DownloadSettings {
+    pub directory: PathBuf,
+    pub folder_structure: String,
+    pub folder_structure_albums: String,
+    pub folder_structure_smart_folders: String,
+    pub filename_exclude: Vec<glob::Pattern>,
+    pub temp_suffix: String,
+    pub threads_num: u16,
+    pub bandwidth_limit: Option<u64>,
+    pub no_progress_bar: bool,
+}
+
+#[derive(Debug)]
+pub struct FilterConfig {
+    pub albums: AlbumSelection,
+    pub exclude_albums: Vec<String>,
+    pub selection: crate::selection::Selection,
+    pub skip_created_before: Option<DateTime<Local>>,
+    pub skip_created_after: Option<DateTime<Local>>,
+    pub recent: Option<u32>,
+    pub skip_videos: bool,
+    pub skip_photos: bool,
+}
+
+#[derive(Debug)]
+pub struct PhotoConfig {
+    pub size: VersionSize,
+    pub live_photo_size: LivePhotoSize,
+    pub live_photo_mode: LivePhotoMode,
+    pub live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
+    pub align_raw: RawTreatmentPolicy,
+    pub file_match_policy: FileMatchPolicy,
+    pub force_size: bool,
+    pub keep_unicode_in_filenames: bool,
+}
+
+#[derive(Debug)]
+pub struct ResolvedRetryConfig {
+    pub max_retries: u32,
+    pub retry_delay_secs: u64,
+    pub max_download_attempts: u32,
+}
+
+#[derive(Debug)]
+pub struct WatchConfig {
+    pub interval: Option<u64>,
+    pub notify_systemd: bool,
+    pub pid_file: Option<PathBuf>,
+    pub reconcile_every_n_cycles: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct NotificationConfig {
+    pub script: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct ReportConfig {
+    pub json: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct ServerConfig {
+    pub port: u16,
+    pub bind: std::net::IpAddr,
+}
+
+#[derive(Debug)]
+pub struct UiConfig {
+    pub personality_mode: crate::personality::Mode,
+    pub friendly_request: Option<bool>,
+}
+
+#[derive(Debug)]
+pub struct MetadataConfig {
+    #[cfg(feature = "xmp")]
+    pub set_exif_datetime: bool,
+    #[cfg(feature = "xmp")]
+    pub set_exif_rating: bool,
+    #[cfg(feature = "xmp")]
+    pub set_exif_gps: bool,
+    #[cfg(feature = "xmp")]
+    pub set_exif_description: bool,
+    #[cfg(feature = "xmp")]
+    pub embed_xmp: bool,
+    #[cfg(feature = "xmp")]
+    pub xmp_sidecar: bool,
+}
+
+#[derive(Debug)]
+pub struct ImportConfig {}
+
+#[derive(Debug)]
+pub struct RuntimeConfig {
+    pub dry_run: bool,
+    pub only_print_filenames: bool,
+}
+
 /// Load a TOML config file. Returns `Ok(None)` if the file doesn't exist
 /// and `required` is false. Errors if the file doesn't exist and `required` is true.
 pub(crate) fn load_toml_config(path: &Path, required: bool) -> anyhow::Result<Option<TomlConfig>> {
@@ -486,114 +649,30 @@ fn resolve_album_selection(raw: &[String]) -> anyhow::Result<(AlbumSelection, Ve
 /// - 1-byte enums
 /// - All booleans grouped at the end
 pub struct Config {
-    // Heap types first
-    pub username: String,
-    pub password: Option<SecretString>,
-    pub password_file: Option<PathBuf>,
-    pub password_command: Option<String>,
-    pub directory: PathBuf,
-    pub cookie_directory: PathBuf,
-    pub folder_structure: String,
-    /// Template for album passes (default `{album}`).
-    pub folder_structure_albums: String,
-    /// Template for smart-folder passes (default `{smart-folder}`).
-    pub folder_structure_smart_folders: String,
-    pub albums: AlbumSelection,
-    pub exclude_albums: Vec<String>,
-    pub filename_exclude: Vec<glob::Pattern>,
-    pub temp_suffix: String,
-    /// Per-category resolved [`Selection`](crate::selection::Selection). Built
-    /// alongside the legacy `albums` / `exclude_albums` / `library` fields and
-    /// preserves their semantics. v0.13: derived from those fields. Future
-    /// PRs migrate the resolver and the legacy fields are removed.
-    pub selection: crate::selection::Selection,
-
-    // DateTime fields
-    pub skip_created_before: Option<DateTime<Local>>,
-    pub skip_created_after: Option<DateTime<Local>>,
-
-    // Optional paths
-    pub pid_file: Option<PathBuf>,
-    pub notification_script: Option<PathBuf>,
-    pub report_json: Option<PathBuf>,
-
-    // 8-byte primitives
-    pub watch_with_interval: Option<u64>,
-    pub retry_delay_secs: u64,
-    /// Periodic reconciliation interval (cycles between full local-vs-state
-    /// walks). `None` or `Some(0)` disables the walk so the daemon's
-    /// behaviour matches the pre-reconcile defaults. See [`TomlWatch::reconcile_every_n_cycles`]
-    /// for the rationale.
-    pub reconcile_every_n_cycles: Option<u64>,
-
-    // 4-byte primitives
-    pub recent: Option<u32>,
-    pub max_retries: u32,
-    /// Lifetime cap on download attempts per asset across syncs. `0`
-    /// disables the cap. Resolved CLI > TOML `[download.retry]
-    /// max_download_attempts` > 10. Distinct from `max_retries`, which
-    /// only caps retries within a single download.
-    pub max_download_attempts: u32,
-
-    // 8-byte primitives (cont.)
-    pub bandwidth_limit: Option<u64>,
-
-    // 2-byte primitives
-    pub threads_num: u16,
-    pub http_port: u16,
-
-    // Net addresses
-    pub http_bind: std::net::IpAddr,
-
-    // 1-byte enums
-    pub size: VersionSize,
-    pub live_photo_size: LivePhotoSize,
-    pub domain: Domain,
-    pub live_photo_mode: LivePhotoMode,
-    pub live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
-    pub align_raw: RawTreatmentPolicy,
-    pub file_match_policy: FileMatchPolicy,
-
-    // All booleans grouped together
-    pub skip_videos: bool,
-    pub skip_photos: bool,
-    pub force_size: bool,
-    #[cfg(feature = "xmp")]
-    pub set_exif_datetime: bool,
-    #[cfg(feature = "xmp")]
-    pub set_exif_rating: bool,
-    #[cfg(feature = "xmp")]
-    pub set_exif_gps: bool,
-    #[cfg(feature = "xmp")]
-    pub set_exif_description: bool,
-    #[cfg(feature = "xmp")]
-    pub embed_xmp: bool,
-    #[cfg(feature = "xmp")]
-    pub xmp_sidecar: bool,
-    pub dry_run: bool,
-    pub no_progress_bar: bool,
-    /// Resolved friendly UX mode: drives bar / spinner / tracing format.
-    /// `Mode::Off` reproduces v0.13 behaviour byte-for-byte.
-    pub personality_mode: crate::personality::Mode,
-    /// User-stated preference for friendly mode (CLI > TOML). `None` means
-    /// neither was set, so the default-on-for-TTY policy applies. Preserved
-    /// alongside `personality_mode` so `to_toml` can round-trip the user's
-    /// intent independent of environment-driven gate decisions.
-    pub friendly_request: Option<bool>,
-    pub keep_unicode_in_filenames: bool,
-    pub only_print_filenames: bool,
-    pub notify_systemd: bool,
-    pub save_password: bool,
+    pub auth: AuthConfig,
+    pub download: DownloadSettings,
+    pub filters: FilterConfig,
+    pub photos: PhotoConfig,
+    pub retry: ResolvedRetryConfig,
+    pub watch: WatchConfig,
+    pub notifications: NotificationConfig,
+    pub report: ReportConfig,
+    pub server: ServerConfig,
+    pub ui: UiConfig,
+    pub metadata: MetadataConfig,
+    pub import: ImportConfig,
+    pub runtime: RuntimeConfig,
 }
 
 impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
-            .field("username", &self.username)
+            .field("username", &self.auth.username)
             .field("password", &"<redacted>")
-            .field("directory", &self.directory)
-            .field("domain", &self.domain)
-            .field("cookie_directory", &self.cookie_directory)
+            .field("directory", &self.download.directory)
+            .field("domain", &self.auth.domain)
+            .field("cookie_directory", &self.auth.cookie_directory)
+            .field("import", &self.import)
             .finish_non_exhaustive()
     }
 }
@@ -787,11 +866,11 @@ pub(crate) struct GlobalArgs {
 }
 
 impl GlobalArgs {
-    pub fn from_cli(cli: &crate::cli::Cli) -> Self {
+    pub fn from_cli(_cli: &crate::cli::Cli) -> Self {
         Self {
-            username: cli.username.clone(),
-            domain: cli.domain,
-            data_dir: cli.data_dir.clone(),
+            username: std::env::var("ICLOUD_USERNAME").ok(),
+            domain: None,
+            data_dir: std::env::var("KEI_DATA_DIR").ok(),
         }
     }
 }
@@ -873,7 +952,7 @@ pub(crate) fn resolve_auth(
 /// Resolve the data directory (sessions, state DB, credentials, health).
 ///
 /// Resolution order:
-/// 1. Explicit `--data-dir` CLI flag
+/// 1. Explicit `KEI_DATA_DIR` environment variable
 /// 2. TOML top-level `data_dir`
 /// 3. Default: parent of the resolved config file path
 pub(crate) fn resolve_data_dir(
@@ -924,11 +1003,23 @@ impl Config {
         sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
+        let overrides = sync.config_overrides.clone();
+        Self::build_with_overrides(globals, pw, sync, overrides, toml)
+    }
+
+    pub(crate) fn build_with_overrides(
+        globals: &GlobalArgs,
+        pw: &crate::cli::PasswordArgs,
+        sync: crate::cli::SyncArgs,
+        overrides: SyncConfigOverrides,
+        toml: Option<&TomlConfig>,
+    ) -> anyhow::Result<Self> {
         let friendly_request = toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly);
         Self::build_inner(
             globals,
             pw,
             sync,
+            overrides,
             toml,
             crate::personality::Mode::Off,
             friendly_request,
@@ -939,6 +1030,7 @@ impl Config {
         globals: &GlobalArgs,
         pw: &crate::cli::PasswordArgs,
         sync: crate::cli::SyncArgs,
+        overrides: SyncConfigOverrides,
         toml: Option<&TomlConfig>,
         personality_mode: crate::personality::Mode,
         friendly_request: Option<bool>,
@@ -1026,7 +1118,7 @@ impl Config {
         let toml_server = toml.and_then(|t| t.server.as_ref());
 
         // Download
-        let directory = sync
+        let directory = overrides
             .download_dir
             .or_else(|| toml_dl.and_then(|d| d.directory.clone()))
             .map(|d| expand_tilde(&d))
@@ -1035,22 +1127,22 @@ impl Config {
             validate_download_dir(&directory)?;
         }
         let folder_structure = resolve(
-            sync.folder_structure,
+            overrides.folder_structure,
             toml_dl.and_then(|d| d.folder_structure.clone()),
             "%Y/%m/%d".to_string(),
         );
         let folder_structure_albums = resolve(
-            sync.folder_structure_albums,
+            overrides.folder_structure_albums,
             toml_dl.and_then(|d| d.folder_structure_albums.clone()),
             DEFAULT_FOLDER_STRUCTURE_ALBUMS.to_string(),
         );
         let folder_structure_smart_folders = resolve(
-            sync.folder_structure_smart_folders,
+            overrides.folder_structure_smart_folders,
             toml_dl.and_then(|d| d.folder_structure_smart_folders.clone()),
             DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS.to_string(),
         );
         // Resolve bandwidth limit (CLI bytes/sec > TOML human-readable string > None).
-        let bandwidth_limit: Option<u64> = if let Some(n) = sync.bandwidth_limit {
+        let bandwidth_limit: Option<u64> = if let Some(n) = overrides.bandwidth_limit {
             Some(n)
         } else if let Some(s) = toml_dl.and_then(|d| d.bandwidth_limit.as_ref()) {
             Some(crate::cli::parse_bandwidth_limit(s).map_err(|e| {
@@ -1065,51 +1157,59 @@ impl Config {
         // When a bandwidth limit is set without an explicit thread-count flag,
         // default concurrency to 1: many connections starving for a capped
         // total budget just fragments downloads and adds connection overhead.
-        let threads_explicitly_set = sync.threads.is_some() || toml_threads.is_some();
+        let threads_explicitly_set = overrides.threads.is_some() || toml_threads.is_some();
         let threads_default = if bandwidth_limit.is_some() && !threads_explicitly_set {
             1
         } else {
             10
         };
 
-        let threads_num = sync.threads.or(toml_threads).unwrap_or(threads_default);
+        let threads_num = overrides
+            .threads
+            .or(toml_threads)
+            .unwrap_or(threads_default);
         anyhow::ensure!(
             (1..=64).contains(&threads_num),
             "threads must be in 1..=64, got {threads_num}"
         );
         let temp_suffix = resolve(
-            sync.temp_suffix,
+            overrides.temp_suffix,
             toml_dl.and_then(|d| d.temp_suffix.clone()),
             ".kei-tmp".to_string(),
         );
         #[cfg(feature = "xmp")]
         let set_exif_datetime = resolve_flag(
-            sync.set_exif_datetime,
+            overrides.set_exif_datetime,
             toml_dl.and_then(|d| d.set_exif_datetime),
         );
         #[cfg(feature = "xmp")]
         let set_exif_rating = resolve_flag(
-            sync.set_exif_rating,
+            overrides.set_exif_rating,
             toml_dl.and_then(|d| d.set_exif_rating),
         );
         #[cfg(feature = "xmp")]
-        let set_exif_gps = resolve_flag(sync.set_exif_gps, toml_dl.and_then(|d| d.set_exif_gps));
+        let set_exif_gps =
+            resolve_flag(overrides.set_exif_gps, toml_dl.and_then(|d| d.set_exif_gps));
         #[cfg(feature = "xmp")]
         let set_exif_description = resolve_flag(
-            sync.set_exif_description,
+            overrides.set_exif_description,
             toml_dl.and_then(|d| d.set_exif_description),
         );
         #[cfg(feature = "xmp")]
-        let embed_xmp = resolve_flag(sync.embed_xmp, toml_dl.and_then(|d| d.embed_xmp));
+        let embed_xmp = resolve_flag(overrides.embed_xmp, toml_dl.and_then(|d| d.embed_xmp));
         #[cfg(feature = "xmp")]
-        let xmp_sidecar = resolve_flag(sync.xmp_sidecar, toml_dl.and_then(|d| d.xmp_sidecar));
+        let xmp_sidecar = resolve_flag(overrides.xmp_sidecar, toml_dl.and_then(|d| d.xmp_sidecar));
         let no_progress_bar = resolve_flag(
             sync.no_progress_bar,
             toml_dl.and_then(|d| d.no_progress_bar),
         );
 
         // Re-validate; clap range attrs run on CLI only.
-        let max_retries = resolve(sync.max_retries, toml_retry.and_then(|r| r.max_retries), 3);
+        let max_retries = resolve(
+            overrides.max_retries,
+            toml_retry.and_then(|r| r.max_retries),
+            3,
+        );
         anyhow::ensure!(
             max_retries <= 100,
             "retry max_retries must be <= 100, got {max_retries}"
@@ -1119,16 +1219,16 @@ impl Config {
         // skip check in download::pipeline::process_asset short-circuits
         // when this is 0, so 0 is a valid (cap-off) sentinel.
         let max_download_attempts = resolve(
-            sync.max_download_attempts,
+            overrides.max_download_attempts,
             toml_retry.and_then(|r| r.max_download_attempts),
             10,
         );
         let retry_delay_secs = smart_retry_delay(max_retries);
 
         // Filters
-        let library_selector = resolve_library_selector(sync.libraries, toml_filters)?;
+        let library_selector = resolve_library_selector(overrides.libraries, toml_filters)?;
         let toml_albums = toml_filters.and_then(|f| f.albums.clone());
-        let raw_albums = resolve_vec(sync.albums, toml_albums);
+        let raw_albums = resolve_vec(overrides.albums, toml_albums);
         let (albums, exclude_albums) = resolve_album_selection(&raw_albums)?;
 
         // The base template is for unfiled/library-only paths. Album-specific
@@ -1137,17 +1237,23 @@ impl Config {
         validate_template_tokens(&folder_structure_albums, TemplateKind::Albums)?;
         validate_template_tokens(&folder_structure_smart_folders, TemplateKind::SmartFolders)?;
 
-        let skip_videos = resolve_flag(sync.skip_videos, toml_filters.and_then(|f| f.skip_videos));
-        let skip_photos = resolve_flag(sync.skip_photos, toml_filters.and_then(|f| f.skip_photos));
-        let live_photo_mode_pre_resolved: Option<LivePhotoMode> = sync
+        let skip_videos = resolve_flag(
+            overrides.skip_videos,
+            toml_filters.and_then(|f| f.skip_videos),
+        );
+        let skip_photos = resolve_flag(
+            overrides.skip_photos,
+            toml_filters.and_then(|f| f.skip_photos),
+        );
+        let live_photo_mode_pre_resolved: Option<LivePhotoMode> = overrides
             .live_photo_mode
             .or_else(|| toml_photos.and_then(|p| p.live_photo_mode));
         let raw_smart_folders = resolve_vec(
-            sync.smart_folders,
+            overrides.smart_folders,
             toml_filters.and_then(|f| f.smart_folders.clone()),
         );
 
-        let unfiled_override = sync
+        let unfiled_override = overrides
             .unfiled
             .or_else(|| toml_filters.and_then(|f| f.unfiled));
 
@@ -1166,7 +1272,7 @@ impl Config {
             warn_implicit_unfiled_pass();
         }
         let filename_exclude_strs = resolve_vec(
-            sync.filename_exclude,
+            overrides.filename_exclude,
             toml_filters.and_then(|f| f.filename_exclude.clone()),
         );
         // Compile glob patterns once during build
@@ -1246,21 +1352,19 @@ impl Config {
                 folder_structure: Some(folder_structure.clone()),
                 folder_structure_albums: Some(folder_structure_albums.clone()),
                 folder_structure_smart_folders: Some(folder_structure_smart_folders.clone()),
-                size: sync.size,
+                size: overrides.size,
                 live_photo_mode: live_photo_mode_pre_resolved,
-                live_photo_size: sync.live_photo_size,
-                live_photo_mov_filename_policy: sync.live_photo_mov_filename_policy,
-                align_raw: sync.align_raw,
-                file_match_policy: sync.file_match_policy,
-                force_size: sync.force_size,
-                keep_unicode_in_filenames: sync.keep_unicode_in_filenames,
+                live_photo_size: overrides.live_photo_size,
+                live_photo_mov_filename_policy: overrides.live_photo_mov_filename_policy,
+                align_raw: overrides.align_raw,
+                file_match_policy: overrides.file_match_policy,
+                force_size: overrides.force_size,
+                keep_unicode_in_filenames: overrides.keep_unicode_in_filenames,
             },
             toml,
         );
 
-        // Env read in `build()` (not via clap) so the docker image's ENV
-        // default sits below TOML in the precedence chain. See #293.
-        let watch_with_interval = sync
+        let watch_with_interval = overrides
             .watch_with_interval
             .or_else(|| toml_watch.and_then(|w| w.interval));
         if let Some(n) = watch_with_interval {
@@ -1272,11 +1376,11 @@ impl Config {
         // Auto-detect systemd via `NOTIFY_SOCKET` when neither CLI nor TOML
         // sets the flag explicitly. See `resolve_notify_systemd`.
         let notify_systemd = resolve_notify_systemd(
-            sync.notify_systemd,
+            overrides.notify_systemd,
             toml_watch.and_then(|w| w.notify_systemd),
             std::env::var_os("NOTIFY_SOCKET").is_some(),
         );
-        let pid_file = sync.pid_file.or_else(|| {
+        let pid_file = overrides.pid_file.or_else(|| {
             toml_watch
                 .and_then(|w| w.pid_file.as_ref())
                 .map(PathBuf::from)
@@ -1284,21 +1388,21 @@ impl Config {
         // `.filter` collapses TOML's `reconcile_every_n_cycles = 0` to None,
         // matching the documented "0 = off" semantic. The CLI parser already
         // rejects 0, so the filter only fires for the TOML path.
-        let reconcile_every_n_cycles = sync
+        let reconcile_every_n_cycles = overrides
             .reconcile_every_n_cycles
             .or_else(|| toml_watch.and_then(|w| w.reconcile_every_n_cycles))
             .filter(|n| *n > 0);
 
         // Notifications
         let toml_notif = toml.and_then(|t| t.notifications.as_ref());
-        let notification_script = sync
+        let notification_script = overrides
             .notification_script
             .or_else(|| toml_notif.and_then(|n| n.script.clone()))
             .map(|s| expand_tilde(&s));
 
         // JSON report: CLI > [report] json TOML > none.
         let toml_report = toml.and_then(|t| t.report.as_ref());
-        let report_json = sync.report_json.or_else(|| {
+        let report_json = overrides.report_json.or_else(|| {
             toml_report
                 .and_then(|r| r.json.as_deref())
                 .map(expand_tilde)
@@ -1306,7 +1410,7 @@ impl Config {
 
         // HTTP server port - CLI > [server] TOML > default 9090.
         const DEFAULT_HTTP_PORT: u16 = 9090;
-        let http_port = sync
+        let http_port = overrides
             .http_port
             .or_else(|| toml_server.and_then(|s| s.port))
             .unwrap_or(DEFAULT_HTTP_PORT);
@@ -1317,7 +1421,7 @@ impl Config {
         // /healthz and /metrics to loopback.
         const DEFAULT_HTTP_BIND: std::net::IpAddr =
             std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0));
-        let http_bind = match sync.http_bind {
+        let http_bind = match overrides.http_bind {
             Some(addr) => addr,
             None => match toml_server.and_then(|s| s.bind.as_deref()) {
                 Some(raw) => raw.parse::<std::net::IpAddr>().map_err(|e| {
@@ -1350,70 +1454,93 @@ impl Config {
         }
 
         Ok(Self {
-            username,
-            password,
-            password_file,
-            password_command,
-            directory,
-            cookie_directory,
-            folder_structure,
-            folder_structure_albums,
-            folder_structure_smart_folders,
-            albums,
-            exclude_albums,
-            filename_exclude,
-            temp_suffix,
-            selection,
-            skip_created_before,
-            skip_created_after,
-            pid_file,
-            notification_script,
-            report_json,
-            http_port,
-            http_bind,
-            watch_with_interval,
-            retry_delay_secs,
-            reconcile_every_n_cycles,
-            recent,
-            max_retries,
-            max_download_attempts,
-            bandwidth_limit,
-            threads_num,
-            size,
-            live_photo_size,
-            domain,
-            live_photo_mode,
-            live_photo_mov_filename_policy,
-            align_raw,
-            file_match_policy,
-            skip_videos,
-            skip_photos,
-            force_size,
-            #[cfg(feature = "xmp")]
-            set_exif_datetime,
-            #[cfg(feature = "xmp")]
-            set_exif_rating,
-            #[cfg(feature = "xmp")]
-            set_exif_gps,
-            #[cfg(feature = "xmp")]
-            set_exif_description,
-            #[cfg(feature = "xmp")]
-            embed_xmp,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar,
-            dry_run: sync.dry_run,
-            no_progress_bar,
-            // Supplied by the caller. Config::build() (used by tests and
-            // non-sync commands) defaults to Off/None; sync_loop::run_sync
-            // calls build_inner() directly with the resolved Mode from
-            // lib.rs's gate (CLI > TOML > default-on-for-TTY, then
-            // environmental hard-off check).
-            personality_mode,
-            friendly_request,
-            keep_unicode_in_filenames,
-            only_print_filenames: sync.only_print_filenames,
-            notify_systemd,
-            save_password,
+            auth: AuthConfig {
+                username,
+                password,
+                password_file,
+                password_command,
+                cookie_directory,
+                domain,
+                save_password,
+            },
+            download: DownloadSettings {
+                directory,
+                folder_structure,
+                folder_structure_albums,
+                folder_structure_smart_folders,
+                filename_exclude,
+                temp_suffix,
+                threads_num,
+                bandwidth_limit,
+                no_progress_bar,
+            },
+            filters: FilterConfig {
+                albums,
+                exclude_albums,
+                selection,
+                skip_created_before,
+                skip_created_after,
+                recent,
+                skip_videos,
+                skip_photos,
+            },
+            photos: PhotoConfig {
+                size,
+                live_photo_size,
+                live_photo_mode,
+                live_photo_mov_filename_policy,
+                align_raw,
+                file_match_policy,
+                force_size,
+                keep_unicode_in_filenames,
+            },
+            retry: ResolvedRetryConfig {
+                max_retries,
+                retry_delay_secs,
+                max_download_attempts,
+            },
+            watch: WatchConfig {
+                interval: watch_with_interval,
+                notify_systemd,
+                pid_file,
+                reconcile_every_n_cycles,
+            },
+            notifications: NotificationConfig {
+                script: notification_script,
+            },
+            report: ReportConfig { json: report_json },
+            server: ServerConfig {
+                port: http_port,
+                bind: http_bind,
+            },
+            ui: UiConfig {
+                // Supplied by the caller. Config::build() (used by tests and
+                // non-sync commands) defaults to Off/None; sync_loop::run_sync
+                // calls build_inner() directly with the resolved Mode from
+                // lib.rs's gate (CLI > TOML > default-on-for-TTY, then
+                // environmental hard-off check).
+                personality_mode,
+                friendly_request,
+            },
+            metadata: MetadataConfig {
+                #[cfg(feature = "xmp")]
+                set_exif_datetime,
+                #[cfg(feature = "xmp")]
+                set_exif_rating,
+                #[cfg(feature = "xmp")]
+                set_exif_gps,
+                #[cfg(feature = "xmp")]
+                set_exif_description,
+                #[cfg(feature = "xmp")]
+                embed_xmp,
+                #[cfg(feature = "xmp")]
+                xmp_sidecar,
+            },
+            import: ImportConfig {},
+            runtime: RuntimeConfig {
+                dry_run: sync.dry_run,
+                only_print_filenames: sync.only_print_filenames,
+            },
         })
     }
 
@@ -1426,87 +1553,103 @@ impl Config {
             data_dir: None,  // derived from config path, not serialized unless explicit
             log_level: None, // only written if user explicitly set it
             auth: Some(TomlAuth {
-                username: if self.username.is_empty() {
+                username: if self.auth.username.is_empty() {
                     None
                 } else {
-                    Some(self.username.clone())
+                    Some(self.auth.username.clone())
                 },
                 password: None, // never persist
-                password_file: self.password_file.as_ref().map(|p| p.display().to_string()),
-                password_command: self.password_command.clone(),
-                domain: if self.domain == Domain::Com {
+                password_file: self
+                    .auth
+                    .password_file
+                    .as_ref()
+                    .map(|p| p.display().to_string()),
+                password_command: self.auth.password_command.clone(),
+                domain: if self.auth.domain == Domain::Com {
                     None
                 } else {
-                    Some(self.domain)
+                    Some(self.auth.domain)
                 },
             }),
             download: Some(TomlDownload {
-                directory: if self.directory.as_os_str().is_empty() {
+                directory: if self.download.directory.as_os_str().is_empty() {
                     None
                 } else {
-                    Some(self.directory.display().to_string())
+                    Some(self.download.directory.display().to_string())
                 },
-                folder_structure: Some(self.folder_structure.clone()),
-                folder_structure_albums: if self.folder_structure_albums
+                folder_structure: Some(self.download.folder_structure.clone()),
+                folder_structure_albums: if self.download.folder_structure_albums
                     == DEFAULT_FOLDER_STRUCTURE_ALBUMS
                 {
                     None
                 } else {
-                    Some(self.folder_structure_albums.clone())
+                    Some(self.download.folder_structure_albums.clone())
                 },
-                folder_structure_smart_folders: if self.folder_structure_smart_folders
+                folder_structure_smart_folders: if self.download.folder_structure_smart_folders
                     == DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS
                 {
                     None
                 } else {
-                    Some(self.folder_structure_smart_folders.clone())
+                    Some(self.download.folder_structure_smart_folders.clone())
                 },
-                threads: Some(self.threads_num),
-                bandwidth_limit: self.bandwidth_limit.map(|n| n.to_string()),
-                temp_suffix: if self.temp_suffix == ".kei-tmp" {
+                threads: Some(self.download.threads_num),
+                bandwidth_limit: self.download.bandwidth_limit.map(|n| n.to_string()),
+                temp_suffix: if self.download.temp_suffix == ".kei-tmp" {
                     None
                 } else {
-                    Some(self.temp_suffix.clone())
+                    Some(self.download.temp_suffix.clone())
                 },
                 #[cfg(feature = "xmp")]
-                set_exif_datetime: if self.set_exif_datetime {
+                set_exif_datetime: if self.metadata.set_exif_datetime {
                     Some(true)
                 } else {
                     None
                 },
                 #[cfg(feature = "xmp")]
-                set_exif_rating: if self.set_exif_rating {
+                set_exif_rating: if self.metadata.set_exif_rating {
                     Some(true)
                 } else {
                     None
                 },
                 #[cfg(feature = "xmp")]
-                set_exif_gps: if self.set_exif_gps { Some(true) } else { None },
-                #[cfg(feature = "xmp")]
-                set_exif_description: if self.set_exif_description {
+                set_exif_gps: if self.metadata.set_exif_gps {
                     Some(true)
                 } else {
                     None
                 },
                 #[cfg(feature = "xmp")]
-                embed_xmp: if self.embed_xmp { Some(true) } else { None },
+                set_exif_description: if self.metadata.set_exif_description {
+                    Some(true)
+                } else {
+                    None
+                },
                 #[cfg(feature = "xmp")]
-                xmp_sidecar: if self.xmp_sidecar { Some(true) } else { None },
-                no_progress_bar: if self.no_progress_bar {
+                embed_xmp: if self.metadata.embed_xmp {
+                    Some(true)
+                } else {
+                    None
+                },
+                #[cfg(feature = "xmp")]
+                xmp_sidecar: if self.metadata.xmp_sidecar {
+                    Some(true)
+                } else {
+                    None
+                },
+                no_progress_bar: if self.download.no_progress_bar {
                     Some(true)
                 } else {
                     None
                 },
                 retry: Some(TomlRetry {
-                    max_retries: Some(self.max_retries),
+                    max_retries: Some(self.retry.max_retries),
                     // Emit `max_download_attempts` only when the user has
                     // overridden the default of 10. Keeps the round-trip
                     // clean for the common case and surfaces explicit
                     // overrides in `kei config show`.
-                    max_download_attempts: if self.max_download_attempts == 10 {
+                    max_download_attempts: if self.retry.max_download_attempts == 10 {
                         None
                     } else {
-                        Some(self.max_download_attempts)
+                        Some(self.retry.max_download_attempts)
                     },
                 }),
             }),
@@ -1515,7 +1658,7 @@ impl Config {
                     // Emit only when the user picked something other than
                     // the default (primary). Default `[primary]` round-trips
                     // implicitly so config dumps stay clean.
-                    let raw = self.selection.libraries.to_raw();
+                    let raw = self.filters.selection.libraries.to_raw();
                     if raw == vec!["primary".to_string()] {
                         None
                     } else {
@@ -1529,126 +1672,144 @@ impl Config {
                     // `["all"]` shape (load resolves to All when missing)
                     // and emit everything else (including the `["none"]`
                     // shape that round-trips to LibraryOnly).
-                    let raw = self.selection.albums.to_raw();
+                    let raw = self.filters.selection.albums.to_raw();
                     if raw == vec!["all".to_string()] {
                         None
                     } else {
                         Some(raw)
                     }
                 },
-                smart_folders: match &self.selection.smart_folders {
+                smart_folders: match &self.filters.selection.smart_folders {
                     crate::selection::SmartFolderSelector::None => None,
                     other => Some(other.to_raw()),
                 },
-                unfiled: if self.selection.unfiled {
+                unfiled: if self.filters.selection.unfiled {
                     None
                 } else {
                     Some(false)
                 },
-                filename_exclude: if self.filename_exclude.is_empty() {
+                filename_exclude: if self.download.filename_exclude.is_empty() {
                     None
                 } else {
                     Some(
-                        self.filename_exclude
+                        self.download
+                            .filename_exclude
                             .iter()
                             .map(|p| p.as_str().to_string())
                             .collect(),
                     )
                 },
-                skip_videos: if self.skip_videos { Some(true) } else { None },
-                skip_photos: if self.skip_photos { Some(true) } else { None },
+                skip_videos: if self.filters.skip_videos {
+                    Some(true)
+                } else {
+                    None
+                },
+                skip_photos: if self.filters.skip_photos {
+                    Some(true)
+                } else {
+                    None
+                },
                 recent: None,              // per-run
                 skip_created_before: None, // per-run
                 skip_created_after: None,  // per-run
             }),
             photos: Some(TomlPhotos {
-                size: if self.size == VersionSize::Original {
+                size: if self.photos.size == VersionSize::Original {
                     None
                 } else {
-                    Some(self.size)
+                    Some(self.photos.size)
                 },
-                live_photo_size: if self.live_photo_size == LivePhotoSize::Original {
+                live_photo_size: if self.photos.live_photo_size == LivePhotoSize::Original {
                     None
                 } else {
-                    Some(self.live_photo_size)
+                    Some(self.photos.live_photo_size)
                 },
-                live_photo_mode: if self.live_photo_mode == LivePhotoMode::Both {
+                live_photo_mode: if self.photos.live_photo_mode == LivePhotoMode::Both {
                     None
                 } else {
-                    Some(self.live_photo_mode)
+                    Some(self.photos.live_photo_mode)
                 },
-                live_photo_mov_filename_policy: if self.live_photo_mov_filename_policy
+                live_photo_mov_filename_policy: if self.photos.live_photo_mov_filename_policy
                     == LivePhotoMovFilenamePolicy::Suffix
                 {
                     None
                 } else {
-                    Some(self.live_photo_mov_filename_policy)
+                    Some(self.photos.live_photo_mov_filename_policy)
                 },
-                align_raw: if self.align_raw == RawTreatmentPolicy::Unchanged {
+                align_raw: if self.photos.align_raw == RawTreatmentPolicy::Unchanged {
                     None
                 } else {
-                    Some(self.align_raw)
+                    Some(self.photos.align_raw)
                 },
-                file_match_policy: if self.file_match_policy
+                file_match_policy: if self.photos.file_match_policy
                     == FileMatchPolicy::NameSizeDedupWithSuffix
                 {
                     None
                 } else {
-                    Some(self.file_match_policy)
+                    Some(self.photos.file_match_policy)
                 },
-                force_size: if self.force_size { Some(true) } else { None },
-                keep_unicode_in_filenames: if self.keep_unicode_in_filenames {
+                force_size: if self.photos.force_size {
+                    Some(true)
+                } else {
+                    None
+                },
+                keep_unicode_in_filenames: if self.photos.keep_unicode_in_filenames {
                     Some(true)
                 } else {
                     None
                 },
             }),
-            watch: if self.watch_with_interval.is_some()
-                || self.notify_systemd
-                || self.pid_file.is_some()
-                || self.reconcile_every_n_cycles.is_some()
+            watch: if self.watch.interval.is_some()
+                || self.watch.notify_systemd
+                || self.watch.pid_file.is_some()
+                || self.watch.reconcile_every_n_cycles.is_some()
             {
                 Some(TomlWatch {
-                    interval: self.watch_with_interval,
-                    notify_systemd: if self.notify_systemd {
+                    interval: self.watch.interval,
+                    notify_systemd: if self.watch.notify_systemd {
                         Some(true)
                     } else {
                         None
                     },
-                    pid_file: self.pid_file.as_ref().map(|p| p.display().to_string()),
-                    reconcile_every_n_cycles: self.reconcile_every_n_cycles,
+                    pid_file: self
+                        .watch
+                        .pid_file
+                        .as_ref()
+                        .map(|p| p.display().to_string()),
+                    reconcile_every_n_cycles: self.watch.reconcile_every_n_cycles,
                 })
             } else {
                 None
             },
             notifications: self
-                .notification_script
+                .notifications
+                .script
                 .as_ref()
                 .map(|s| TomlNotifications {
                     script: Some(s.display().to_string()),
                 }),
             server: Some(TomlServer {
-                port: Some(self.http_port),
+                port: Some(self.server.port),
                 // Only emit `bind` when it's been changed from the default.
                 // Keeps `config show` output clean for the common case where
                 // the user hasn't set an explicit bind.
                 bind: {
                     let default = std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0));
-                    if self.http_bind == default {
+                    if self.server.bind == default {
                         None
                     } else {
-                        Some(self.http_bind.to_string())
+                        Some(self.server.bind.to_string())
                     }
                 },
             }),
-            report: self.report_json.as_ref().map(|p| TomlReport {
+            report: self.report.json.as_ref().map(|p| TomlReport {
                 json: Some(p.display().to_string()),
             }),
             // Only emit `[ui]` when the user actually expressed a preference.
             // Omitting the section when `friendly_request` is `None` keeps
             // `kei config show` output unchanged for users who never opted
             // in or out, and lets the default-on-for-TTY policy apply.
-            ui: self.friendly_request.map(|friendly| TomlUi {
+            ui: self.ui.friendly_request.map(|friendly| TomlUi {
                 friendly: Some(friendly),
             }),
         }
@@ -2139,18 +2300,18 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.username, "u@example.com");
-        assert_eq!(cfg.threads_num, 10);
-        assert_eq!(cfg.folder_structure, "%Y/%m/%d");
+        assert_eq!(cfg.auth.username, "u@example.com");
+        assert_eq!(cfg.download.threads_num, 10);
+        assert_eq!(cfg.download.folder_structure, "%Y/%m/%d");
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["primary".to_string()]
         );
-        assert_eq!(cfg.max_retries, 3);
-        assert_eq!(cfg.retry_delay_secs, 5);
-        assert_eq!(cfg.temp_suffix, ".kei-tmp");
-        assert!(matches!(cfg.size, VersionSize::Original));
-        assert!(matches!(cfg.domain, Domain::Com));
+        assert_eq!(cfg.retry.max_retries, 3);
+        assert_eq!(cfg.retry.retry_delay_secs, 5);
+        assert_eq!(cfg.download.temp_suffix, ".kei-tmp");
+        assert!(matches!(cfg.photos.size, VersionSize::Original));
+        assert!(matches!(cfg.auth.domain, Domain::Com));
     }
 
     #[test]
@@ -2171,10 +2332,10 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.threads_num, 4);
-        assert_eq!(cfg.folder_structure, "%Y-%m");
+        assert_eq!(cfg.download.threads_num, 4);
+        assert_eq!(cfg.download.folder_structure, "%Y-%m");
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["SharedSync-ABC".to_string()]
         );
     }
@@ -2191,14 +2352,14 @@ mod tests {
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
 
         let mut sync = default_sync();
-        sync.threads = Some(8);
-        sync.libraries = vec!["PrimarySync".to_string()];
+        sync.config_overrides.threads = Some(8);
+        sync.config_overrides.libraries = vec!["PrimarySync".to_string()];
 
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.threads_num, 8);
+        assert_eq!(cfg.download.threads_num, 8);
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["PrimarySync".to_string()]
         );
     }
@@ -2206,17 +2367,23 @@ mod tests {
     #[test]
     fn test_library_all_value() {
         let mut sync = default_sync();
-        sync.libraries = vec!["all".to_string()];
+        sync.config_overrides.libraries = vec!["all".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.selection.libraries.to_raw(), vec!["all".to_string()]);
+        assert_eq!(
+            cfg.filters.selection.libraries.to_raw(),
+            vec!["all".to_string()]
+        );
     }
 
     #[test]
     fn test_library_all_case_insensitive() {
         let mut sync = default_sync();
-        sync.libraries = vec!["ALL".to_string()];
+        sync.config_overrides.libraries = vec!["ALL".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.selection.libraries.to_raw(), vec!["all".to_string()]);
+        assert_eq!(
+            cfg.filters.selection.libraries.to_raw(),
+            vec!["all".to_string()]
+        );
     }
 
     #[test]
@@ -2233,18 +2400,21 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.selection.libraries.to_raw(), vec!["all".to_string()]);
+        assert_eq!(
+            cfg.filters.selection.libraries.to_raw(),
+            vec!["all".to_string()]
+        );
     }
 
     #[test]
     fn config_build_unfiled_bare_flag_resolves_to_true() {
         let mut sync = default_sync();
-        sync.unfiled = Some(true);
+        sync.config_overrides.unfiled = Some(true);
         let mut globals = default_globals();
         globals.username = Some("u@example.com".to_string());
         let cfg = Config::build(&globals, &default_password(), sync, None).unwrap();
         assert!(
-            cfg.selection.unfiled,
+            cfg.filters.selection.unfiled,
             "bare --unfiled must resolve Selection.unfiled = true"
         );
     }
@@ -2252,12 +2422,12 @@ mod tests {
     #[test]
     fn config_build_unfiled_explicit_false_resolves_to_false() {
         let mut sync = default_sync();
-        sync.unfiled = Some(false);
+        sync.config_overrides.unfiled = Some(false);
         let mut globals = default_globals();
         globals.username = Some("u@example.com".to_string());
         let cfg = Config::build(&globals, &default_password(), sync, None).unwrap();
         assert!(
-            !cfg.selection.unfiled,
+            !cfg.filters.selection.unfiled,
             "explicit `--unfiled false` must resolve Selection.unfiled = false"
         );
     }
@@ -2275,10 +2445,10 @@ mod tests {
     #[test]
     fn config_build_smart_folder_resolves_to_named_selector() {
         let mut sync = default_sync();
-        sync.smart_folders = vec!["Favorites".to_string()];
+        sync.config_overrides.smart_folders = vec!["Favorites".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert_eq!(
-            cfg.selection.smart_folders.to_raw(),
+            cfg.filters.selection.smart_folders.to_raw(),
             vec!["Favorites".to_string()]
         );
     }
@@ -2286,9 +2456,10 @@ mod tests {
     #[test]
     fn config_build_smart_folder_all_with_sensitive_resolves() {
         let mut sync = default_sync();
-        sync.smart_folders = vec!["all-with-sensitive".to_string(), "!Hidden".to_string()];
+        sync.config_overrides.smart_folders =
+            vec!["all-with-sensitive".to_string(), "!Hidden".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        match cfg.selection.smart_folders {
+        match cfg.filters.selection.smart_folders {
             crate::selection::SmartFolderSelector::All {
                 include_sensitive,
                 ref excluded,
@@ -2309,19 +2480,19 @@ mod tests {
     #[test]
     fn config_build_library_repeatable_primary_plus_shared() {
         let mut sync = default_sync();
-        sync.libraries = vec!["primary".to_string(), "shared".to_string()];
+        sync.config_overrides.libraries = vec!["primary".to_string(), "shared".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert!(
-            cfg.selection.libraries.primary,
+            cfg.filters.selection.libraries.primary,
             "--library primary must set primary = true"
         );
         assert!(
-            cfg.selection.libraries.shared_all,
+            cfg.filters.selection.libraries.shared_all,
             "--library shared must set shared_all = true"
         );
         // Both sentinels collapse to "all" in `to_raw()`.
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["all".to_string()],
             "primary + shared must round-trip through `all`"
         );
@@ -2330,9 +2501,10 @@ mod tests {
     #[test]
     fn config_build_library_repeatable_named_zone_with_primary() {
         let mut sync = default_sync();
-        sync.libraries = vec!["primary".to_string(), "SharedSync-A1B2C3D4".to_string()];
+        sync.config_overrides.libraries =
+            vec!["primary".to_string(), "SharedSync-A1B2C3D4".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        let lib = &cfg.selection.libraries;
+        let lib = &cfg.filters.selection.libraries;
         assert!(lib.primary, "primary must remain set");
         assert!(!lib.shared_all, "no `shared` sentinel was passed");
         assert!(
@@ -2345,20 +2517,27 @@ mod tests {
     #[test]
     fn config_build_folder_structure_albums_resolves_through_cli() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/%Y/%m/%d".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/%Y/%m/%d".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/%Y/%m/%d");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/%Y/%m/%d");
         // Default unfiled / smart-folder templates are untouched.
-        assert_eq!(cfg.folder_structure_smart_folders, "{smart-folder}");
+        assert_eq!(
+            cfg.download.folder_structure_smart_folders,
+            "{smart-folder}"
+        );
     }
 
     #[test]
     fn config_build_folder_structure_smart_folders_resolves_through_cli() {
         let mut sync = default_sync();
-        sync.folder_structure_smart_folders = Some("{smart-folder}/%Y".to_string());
+        sync.config_overrides.folder_structure_smart_folders =
+            Some("{smart-folder}/%Y".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure_smart_folders, "{smart-folder}/%Y");
-        assert_eq!(cfg.folder_structure_albums, "{album}");
+        assert_eq!(
+            cfg.download.folder_structure_smart_folders,
+            "{smart-folder}/%Y"
+        );
+        assert_eq!(cfg.download.folder_structure_albums, "{album}");
     }
 
     #[test]
@@ -2375,11 +2554,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            cfg.folder_structure_albums, DEFAULT_FOLDER_STRUCTURE_ALBUMS,
+            cfg.download.folder_structure_albums, DEFAULT_FOLDER_STRUCTURE_ALBUMS,
             "documented default for --folder-structure-albums is `{{album}}`"
         );
         assert_eq!(
-            cfg.folder_structure_smart_folders, DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS,
+            cfg.download.folder_structure_smart_folders, DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS,
             "documented default for --folder-structure-smart-folders is `{{smart-folder}}`"
         );
     }
@@ -2408,7 +2587,7 @@ mod tests {
         .unwrap();
 
         // Albums round-trip via the new selector grammar.
-        let raw_albums = cfg.selection.albums.to_raw();
+        let raw_albums = cfg.filters.selection.albums.to_raw();
         assert!(
             raw_albums.contains(&"Vacation".to_string()),
             "albums must include Vacation, got {raw_albums:?}"
@@ -2420,19 +2599,19 @@ mod tests {
 
         // Smart folders.
         assert_eq!(
-            cfg.selection.smart_folders.to_raw(),
+            cfg.filters.selection.smart_folders.to_raw(),
             vec!["Favorites".to_string()]
         );
 
         // Unfiled disabled.
         assert!(
-            !cfg.selection.unfiled,
+            !cfg.filters.selection.unfiled,
             "[filters].unfiled = false must reach Selection.unfiled"
         );
 
         // Libraries: primary + shared collapses to all.
-        assert!(cfg.selection.libraries.primary);
-        assert!(cfg.selection.libraries.shared_all);
+        assert!(cfg.filters.selection.libraries.primary);
+        assert!(cfg.filters.selection.libraries.shared_all);
     }
 
     #[test]
@@ -2454,9 +2633,9 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/%Y");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/%Y");
         assert_eq!(
-            cfg.folder_structure_smart_folders,
+            cfg.download.folder_structure_smart_folders,
             "{smart-folder}/by-year/%Y"
         );
     }
@@ -2472,13 +2651,14 @@ mod tests {
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
 
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/from-cli".to_string());
-        sync.folder_structure_smart_folders = Some("{smart-folder}/from-cli".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/from-cli".to_string());
+        sync.config_overrides.folder_structure_smart_folders =
+            Some("{smart-folder}/from-cli".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/from-cli");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/from-cli");
         assert_eq!(
-            cfg.folder_structure_smart_folders,
+            cfg.download.folder_structure_smart_folders,
             "{smart-folder}/from-cli"
         );
     }
@@ -2492,8 +2672,11 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.threads_num, 10);
-        assert!(matches!(cfg.align_raw, RawTreatmentPolicy::Unchanged));
+        assert_eq!(cfg.download.threads_num, 10);
+        assert!(matches!(
+            cfg.photos.align_raw,
+            RawTreatmentPolicy::Unchanged
+        ));
     }
 
     #[test]
@@ -2579,19 +2762,23 @@ mod tests {
                 }
             };
             let mut sync = default_sync();
-            sync.bandwidth_limit = case.cli;
-            sync.threads = case.toml_cli_threads;
+            sync.config_overrides.bandwidth_limit = case.cli;
+            sync.config_overrides.threads = case.toml_cli_threads;
             let cfg = Config::build(&default_globals(), &default_password(), sync, toml.as_ref())
                 .unwrap_or_else(|e| panic!("{}: build failed: {e}", case.name));
-            assert_eq!(cfg.bandwidth_limit, case.want_limit, "{}", case.name);
-            assert_eq!(cfg.threads_num, case.want_threads, "{}", case.name);
+            assert_eq!(
+                cfg.download.bandwidth_limit, case.want_limit,
+                "{}",
+                case.name
+            );
+            assert_eq!(cfg.download.threads_num, case.want_threads, "{}", case.name);
         }
     }
 
     #[test]
     fn build_bails_when_album_token_appears_in_smart_folders_template() {
         let mut sync = default_sync();
-        sync.folder_structure_smart_folders = Some("{album}/%Y".to_string());
+        sync.config_overrides.folder_structure_smart_folders = Some("{album}/%Y".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None)
             .expect_err("`{album}` in --folder-structure-smart-folders must bail");
         let msg = err.to_string();
@@ -2605,7 +2792,7 @@ mod tests {
     #[test]
     fn build_bails_when_library_token_misplaced() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/{library}".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/{library}".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None)
             .expect_err("`{library}` not as first segment must bail");
         assert!(
@@ -2617,10 +2804,10 @@ mod tests {
     #[test]
     fn build_accepts_library_album_pair_in_albums_template() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{library}/{album}/%Y".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{library}/{album}/%Y".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None)
             .expect("`{library}/{album}/...` is a valid albums template");
-        assert_eq!(cfg.folder_structure_albums, "{library}/{album}/%Y");
+        assert_eq!(cfg.download.folder_structure_albums, "{library}/{album}/%Y");
     }
 
     #[test]
@@ -2661,8 +2848,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.set_exif_datetime);
-        assert!(cfg.skip_videos);
+        assert!(cfg.metadata.set_exif_datetime);
+        assert!(cfg.filters.skip_videos);
     }
 
     #[cfg(feature = "xmp")]
@@ -2681,8 +2868,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.embed_xmp);
-        assert!(cfg.xmp_sidecar);
+        assert!(cfg.metadata.embed_xmp);
+        assert!(cfg.metadata.xmp_sidecar);
     }
 
     #[cfg(feature = "xmp")]
@@ -2694,11 +2881,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.embed_xmp = Some(false);
+        sync.config_overrides.embed_xmp = Some(false);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert!(
-            !cfg.embed_xmp,
+            !cfg.metadata.embed_xmp,
             "--embed-xmp=false must override TOML embed_xmp = true"
         );
     }
@@ -2713,8 +2900,8 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(!cfg.embed_xmp);
-        assert!(!cfg.xmp_sidecar);
+        assert!(!cfg.metadata.embed_xmp);
+        assert!(!cfg.metadata.xmp_sidecar);
     }
 
     #[test]
@@ -2725,10 +2912,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
+        sync.config_overrides.skip_videos = Some(true);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert!(cfg.skip_videos);
+        assert!(cfg.filters.skip_videos);
     }
 
     #[test]
@@ -2739,11 +2926,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.skip_videos = Some(false);
+        sync.config_overrides.skip_videos = Some(false);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert!(
-            !cfg.skip_videos,
+            !cfg.filters.skip_videos,
             "CLI --skip-videos false should override TOML true"
         );
     }
@@ -2779,7 +2966,7 @@ mod tests {
         let pw = default_password();
         globals.username = None; // Simulate no CLI username
         let cfg = Config::build(&globals, &pw, default_sync(), Some(&toml)).unwrap();
-        assert_eq!(cfg.username, "toml@example.com");
+        assert_eq!(cfg.auth.username, "toml@example.com");
     }
 
     #[test]
@@ -2796,7 +2983,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.username, "u@example.com");
+        assert_eq!(cfg.auth.username, "u@example.com");
     }
 
     #[test]
@@ -2814,7 +3001,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            cfg.albums,
+            cfg.filters.albums,
             AlbumSelection::Named(vec!["Favorites".to_string(), "Vacation".to_string()])
         );
     }
@@ -2827,11 +3014,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.albums = vec!["Screenshots".to_string()];
+        sync.config_overrides.albums = vec!["Screenshots".to_string()];
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(
-            cfg.albums,
+            cfg.filters.albums,
             AlbumSelection::Named(vec!["Screenshots".to_string()])
         );
     }
@@ -2851,8 +3038,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.watch_with_interval, Some(1800));
-        assert_eq!(cfg.pid_file, Some(PathBuf::from("/run/test.pid")));
+        assert_eq!(cfg.watch.interval, Some(1800));
+        assert_eq!(cfg.watch.pid_file, Some(PathBuf::from("/run/test.pid")));
     }
 
     #[test]
@@ -2914,8 +3101,8 @@ mod tests {
             Some(&toml),
         )
         .expect("max_retries=100 must be accepted");
-        assert_eq!(cfg.max_retries, 100);
-        assert_eq!(cfg.retry_delay_secs, 30);
+        assert_eq!(cfg.retry.max_retries, 100);
+        assert_eq!(cfg.retry.retry_delay_secs, 30);
     }
 
     #[test]
@@ -3040,9 +3227,9 @@ mod tests {
     #[test]
     fn test_build_download_dir_from_cli() {
         let mut sync = default_sync();
-        sync.download_dir = Some("/photos/new".to_string());
+        sync.config_overrides.download_dir = Some("/photos/new".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.directory, PathBuf::from("/photos/new"));
+        assert_eq!(cfg.download.directory, PathBuf::from("/photos/new"));
     }
 
     #[test]
@@ -3053,10 +3240,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.download_dir = Some("/photos/cli".to_string());
+        sync.config_overrides.download_dir = Some("/photos/cli".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.directory, PathBuf::from("/photos/cli"));
+        assert_eq!(cfg.download.directory, PathBuf::from("/photos/cli"));
     }
 
     #[test]
@@ -3075,7 +3262,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.directory, PathBuf::from("/photos/via-toml"));
+        assert_eq!(cfg.download.directory, PathBuf::from("/photos/via-toml"));
     }
 
     #[test]
@@ -3093,8 +3280,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.skip_created_before.is_some());
-        assert!(cfg.skip_created_after.is_some());
+        assert!(cfg.filters.skip_created_before.is_some());
+        assert!(cfg.filters.skip_created_after.is_some());
     }
 
     // ── TOML enum variant exhaustive tests ─────────────────────────
@@ -3420,7 +3607,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(config.http_port, 9090);
+        assert_eq!(config.server.port, 9090);
     }
 
     #[test]
@@ -3435,10 +3622,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.http_port = Some(8080);
+        sync.config_overrides.http_port = Some(8080);
         let config =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(config.http_port, 8080);
+        assert_eq!(config.server.port, 8080);
     }
 
     #[test]
@@ -3451,7 +3638,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(config.http_port, 9090);
+        assert_eq!(config.server.port, 9090);
     }
 
     #[test]
@@ -3466,7 +3653,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            config.http_bind,
+            config.server.bind,
             std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
         );
     }
@@ -3486,7 +3673,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            config.http_bind,
+            config.server.bind,
             std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
         );
     }
@@ -3499,11 +3686,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.http_bind = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+        sync.config_overrides.http_bind = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
         let config =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(
-            config.http_bind,
+            config.server.bind,
             std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
         );
     }
@@ -3523,7 +3710,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            config.http_bind,
+            config.server.bind,
             std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
         );
     }
@@ -3638,56 +3825,65 @@ mod tests {
         )
         .unwrap();
         // Auth
-        assert_eq!(cfg.username, "u@example.com");
-        assert!(cfg.password.is_none());
-        assert!(matches!(cfg.domain, Domain::Com));
-        assert!(cfg.cookie_directory.ends_with("kei/cookies"));
+        assert_eq!(cfg.auth.username, "u@example.com");
+        assert!(cfg.auth.password.is_none());
+        assert!(matches!(cfg.auth.domain, Domain::Com));
+        assert!(cfg.auth.cookie_directory.ends_with("kei/cookies"));
         // Download
-        assert_eq!(cfg.folder_structure, "%Y/%m/%d");
-        assert_eq!(cfg.threads_num, 10);
-        assert_eq!(cfg.temp_suffix, ".kei-tmp");
+        assert_eq!(cfg.download.folder_structure, "%Y/%m/%d");
+        assert_eq!(cfg.download.threads_num, 10);
+        assert_eq!(cfg.download.temp_suffix, ".kei-tmp");
         #[cfg(feature = "xmp")]
-        assert!(!cfg.set_exif_datetime);
-        assert!(!cfg.no_progress_bar);
+        assert!(!cfg.metadata.set_exif_datetime);
+        assert!(!cfg.download.no_progress_bar);
         // Retry
-        assert_eq!(cfg.max_retries, 3);
-        assert_eq!(cfg.retry_delay_secs, 5);
+        assert_eq!(cfg.retry.max_retries, 3);
+        assert_eq!(cfg.retry.retry_delay_secs, 5);
         // Filters
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["primary".to_string()]
         );
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert!(cfg.selection.unfiled, "v0.13 default: unfiled = true");
-        assert!(!cfg.skip_videos);
-        assert!(!cfg.skip_photos);
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Both);
-        assert!(cfg.recent.is_none());
-        assert!(cfg.skip_created_before.is_none());
-        assert!(cfg.skip_created_after.is_none());
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert!(
+            cfg.filters.selection.unfiled,
+            "v0.13 default: unfiled = true"
+        );
+        assert!(!cfg.filters.skip_videos);
+        assert!(!cfg.filters.skip_photos);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::Both);
+        assert!(cfg.filters.recent.is_none());
+        assert!(cfg.filters.skip_created_before.is_none());
+        assert!(cfg.filters.skip_created_after.is_none());
         // Photos
-        assert!(matches!(cfg.size, VersionSize::Original));
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Original));
+        assert!(matches!(cfg.photos.size, VersionSize::Original));
         assert!(matches!(
-            cfg.live_photo_mov_filename_policy,
+            cfg.photos.live_photo_size,
+            LivePhotoSize::Original
+        ));
+        assert!(matches!(
+            cfg.photos.live_photo_mov_filename_policy,
             LivePhotoMovFilenamePolicy::Suffix
         ));
-        assert!(matches!(cfg.align_raw, RawTreatmentPolicy::Unchanged));
         assert!(matches!(
-            cfg.file_match_policy,
+            cfg.photos.align_raw,
+            RawTreatmentPolicy::Unchanged
+        ));
+        assert!(matches!(
+            cfg.photos.file_match_policy,
             FileMatchPolicy::NameSizeDedupWithSuffix
         ));
-        assert!(!cfg.force_size);
-        assert!(!cfg.keep_unicode_in_filenames);
+        assert!(!cfg.photos.force_size);
+        assert!(!cfg.photos.keep_unicode_in_filenames);
         // Watch
-        assert!(cfg.watch_with_interval.is_none());
-        assert!(!cfg.notify_systemd);
-        assert!(cfg.pid_file.is_none());
+        assert!(cfg.watch.interval.is_none());
+        assert!(!cfg.watch.notify_systemd);
+        assert!(cfg.watch.pid_file.is_none());
         // Misc
-        assert!(!cfg.dry_run);
-        assert!(!cfg.only_print_filenames);
+        assert!(!cfg.runtime.dry_run);
+        assert!(!cfg.runtime.only_print_filenames);
         // Notifications
-        assert!(cfg.notification_script.is_none());
+        assert!(cfg.notifications.script.is_none());
     }
 
     #[test]
@@ -3701,7 +3897,7 @@ mod tests {
         let pw = default_password();
         globals.domain = Some(Domain::Com);
         let cfg = Config::build(&globals, &pw, default_sync(), Some(&toml)).unwrap();
-        assert!(matches!(cfg.domain, Domain::Com));
+        assert!(matches!(cfg.auth.domain, Domain::Com));
     }
 
     #[test]
@@ -3718,7 +3914,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(matches!(cfg.domain, Domain::Cn));
+        assert!(matches!(cfg.auth.domain, Domain::Cn));
     }
 
     /// Escape backslashes for embedding a path in a TOML string literal.
@@ -3737,7 +3933,7 @@ mod tests {
         )
         .unwrap();
         if let Some(home) = dirs::home_dir() {
-            assert_eq!(cfg.directory, home.join("photos"));
+            assert_eq!(cfg.download.directory, home.join("photos"));
         }
     }
 
@@ -3749,10 +3945,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m/%d".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m/%d".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.folder_structure, "%Y/%m/%d");
+        assert_eq!(cfg.download.folder_structure, "%Y/%m/%d");
     }
 
     #[test]
@@ -3763,10 +3959,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.temp_suffix = Some(".cli-tmp".to_string());
+        sync.config_overrides.temp_suffix = Some(".cli-tmp".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.temp_suffix, ".cli-tmp");
+        assert_eq!(cfg.download.temp_suffix, ".cli-tmp");
     }
 
     #[test]
@@ -3783,7 +3979,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.temp_suffix, ".downloading");
+        assert_eq!(cfg.download.temp_suffix, ".downloading");
     }
 
     #[test]
@@ -3794,10 +3990,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.max_retries = Some(10);
+        sync.config_overrides.max_retries = Some(10);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.max_retries, 10);
+        assert_eq!(cfg.retry.max_retries, 10);
     }
 
     #[test]
@@ -3810,7 +4006,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.max_download_attempts, 10);
+        assert_eq!(cfg.retry.max_download_attempts, 10);
     }
 
     #[test]
@@ -3828,7 +4024,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.max_download_attempts, 25);
+        assert_eq!(cfg.retry.max_download_attempts, 25);
     }
 
     #[test]
@@ -3840,10 +4036,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.max_download_attempts = Some(7);
+        sync.config_overrides.max_download_attempts = Some(7);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.max_download_attempts, 7);
+        assert_eq!(cfg.retry.max_download_attempts, 7);
     }
 
     #[test]
@@ -3862,7 +4058,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.max_download_attempts, 0);
+        assert_eq!(cfg.retry.max_download_attempts, 0);
     }
 
     #[test]
@@ -3876,7 +4072,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.max_download_attempts, 10);
+        assert_eq!(cfg.retry.max_download_attempts, 10);
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
         assert_eq!(retry.max_download_attempts, None);
@@ -3886,7 +4082,7 @@ mod tests {
     fn test_to_toml_includes_non_default_max_download_attempts() {
         // User overrides round-trip back into the dump.
         let mut sync = default_sync();
-        sync.max_download_attempts = Some(42);
+        sync.config_overrides.max_download_attempts = Some(42);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
@@ -3901,10 +4097,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.size = Some(VersionSize::Medium);
+        sync.config_overrides.size = Some(VersionSize::Medium);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert!(matches!(cfg.size, VersionSize::Medium));
+        assert!(matches!(cfg.photos.size, VersionSize::Medium));
     }
 
     #[test]
@@ -3921,7 +4117,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(matches!(cfg.size, VersionSize::Thumb));
+        assert!(matches!(cfg.photos.size, VersionSize::Thumb));
     }
 
     #[test]
@@ -3932,10 +4128,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.live_photo_size = Some(LivePhotoSize::Medium);
+        sync.config_overrides.live_photo_size = Some(LivePhotoSize::Medium);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Medium));
+        assert!(matches!(cfg.photos.live_photo_size, LivePhotoSize::Medium));
     }
 
     #[test]
@@ -3952,24 +4148,30 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Thumb));
+        assert!(matches!(cfg.photos.live_photo_size, LivePhotoSize::Thumb));
     }
 
     #[test]
     fn test_build_live_photo_size_defaults_to_adjusted_when_size_adjusted() {
         let mut sync = default_sync();
-        sync.size = Some(VersionSize::Adjusted);
+        sync.config_overrides.size = Some(VersionSize::Adjusted);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Adjusted));
+        assert!(matches!(
+            cfg.photos.live_photo_size,
+            LivePhotoSize::Adjusted
+        ));
     }
 
     #[test]
     fn test_build_live_photo_size_explicit_overrides_adjusted_default() {
         let mut sync = default_sync();
-        sync.size = Some(VersionSize::Adjusted);
-        sync.live_photo_size = Some(LivePhotoSize::Original);
+        sync.config_overrides.size = Some(VersionSize::Adjusted);
+        sync.config_overrides.live_photo_size = Some(LivePhotoSize::Original);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Original));
+        assert!(matches!(
+            cfg.photos.live_photo_size,
+            LivePhotoSize::Original
+        ));
     }
 
     #[test]
@@ -3980,11 +4182,12 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.live_photo_mov_filename_policy = Some(LivePhotoMovFilenamePolicy::Suffix);
+        sync.config_overrides.live_photo_mov_filename_policy =
+            Some(LivePhotoMovFilenamePolicy::Suffix);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert!(matches!(
-            cfg.live_photo_mov_filename_policy,
+            cfg.photos.live_photo_mov_filename_policy,
             LivePhotoMovFilenamePolicy::Suffix
         ));
     }
@@ -4004,7 +4207,7 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(
-            cfg.live_photo_mov_filename_policy,
+            cfg.photos.live_photo_mov_filename_policy,
             LivePhotoMovFilenamePolicy::Original
         ));
     }
@@ -4017,11 +4220,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.align_raw = Some(RawTreatmentPolicy::PreferAlternative);
+        sync.config_overrides.align_raw = Some(RawTreatmentPolicy::PreferAlternative);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert!(matches!(
-            cfg.align_raw,
+            cfg.photos.align_raw,
             RawTreatmentPolicy::PreferAlternative
         ));
     }
@@ -4034,11 +4237,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.file_match_policy = Some(FileMatchPolicy::NameSizeDedupWithSuffix);
+        sync.config_overrides.file_match_policy = Some(FileMatchPolicy::NameSizeDedupWithSuffix);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert!(matches!(
-            cfg.file_match_policy,
+            cfg.photos.file_match_policy,
             FileMatchPolicy::NameSizeDedupWithSuffix
         ));
     }
@@ -4057,7 +4260,10 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(matches!(cfg.file_match_policy, FileMatchPolicy::NameId7));
+        assert!(matches!(
+            cfg.photos.file_match_policy,
+            FileMatchPolicy::NameId7
+        ));
     }
 
     // ── resolve_path_derivation_fields: shared by sync + import ─────
@@ -4211,14 +4417,14 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.set_exif_datetime);
-        assert!(cfg.no_progress_bar);
-        assert!(cfg.skip_videos);
-        assert!(!cfg.skip_photos);
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Skip);
-        assert!(cfg.force_size);
-        assert!(cfg.keep_unicode_in_filenames);
-        assert!(cfg.notify_systemd);
+        assert!(cfg.metadata.set_exif_datetime);
+        assert!(cfg.download.no_progress_bar);
+        assert!(cfg.filters.skip_videos);
+        assert!(!cfg.filters.skip_photos);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::Skip);
+        assert!(cfg.photos.force_size);
+        assert!(cfg.photos.keep_unicode_in_filenames);
+        assert!(cfg.watch.notify_systemd);
     }
 
     #[cfg(feature = "xmp")]
@@ -4227,22 +4433,22 @@ mod tests {
         // `skip_photos = Some(true)` is intentionally omitted here too; see
         // the matching TOML test above.
         let mut sync = default_sync();
-        sync.set_exif_datetime = Some(true);
+        sync.config_overrides.set_exif_datetime = Some(true);
         sync.no_progress_bar = Some(true);
-        sync.skip_videos = Some(true);
-        sync.live_photo_mode = Some(LivePhotoMode::Skip);
-        sync.force_size = Some(true);
-        sync.keep_unicode_in_filenames = Some(true);
-        sync.notify_systemd = Some(true);
+        sync.config_overrides.skip_videos = Some(true);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::Skip);
+        sync.config_overrides.force_size = Some(true);
+        sync.config_overrides.keep_unicode_in_filenames = Some(true);
+        sync.config_overrides.notify_systemd = Some(true);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(cfg.set_exif_datetime);
-        assert!(cfg.no_progress_bar);
-        assert!(cfg.skip_videos);
-        assert!(!cfg.skip_photos);
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Skip);
-        assert!(cfg.force_size);
-        assert!(cfg.keep_unicode_in_filenames);
-        assert!(cfg.notify_systemd);
+        assert!(cfg.metadata.set_exif_datetime);
+        assert!(cfg.download.no_progress_bar);
+        assert!(cfg.filters.skip_videos);
+        assert!(!cfg.filters.skip_photos);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::Skip);
+        assert!(cfg.photos.force_size);
+        assert!(cfg.photos.keep_unicode_in_filenames);
+        assert!(cfg.watch.notify_systemd);
     }
 
     #[test]
@@ -4260,8 +4466,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(!cfg.skip_videos);
-        assert!(!cfg.skip_photos);
+        assert!(!cfg.filters.skip_videos);
+        assert!(!cfg.filters.skip_photos);
     }
 
     // ── Config::build: watch/interval ──────────────────────────────
@@ -4274,10 +4480,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.watch_with_interval = Some(600);
+        sync.config_overrides.watch_with_interval = Some(600);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.watch_with_interval, Some(600));
+        assert_eq!(cfg.watch.interval, Some(600));
     }
 
     // ── Config::build: reconcile_every_n_cycles ────────────────────
@@ -4290,10 +4496,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.reconcile_every_n_cycles = Some(6);
+        sync.config_overrides.reconcile_every_n_cycles = Some(6);
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.reconcile_every_n_cycles, Some(6));
+        assert_eq!(cfg.watch.reconcile_every_n_cycles, Some(6));
     }
 
     #[test]
@@ -4310,7 +4516,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.reconcile_every_n_cycles, Some(12));
+        assert_eq!(cfg.watch.reconcile_every_n_cycles, Some(12));
     }
 
     // TOML accepts `reconcile_every_n_cycles = 0` as "off"; the resolved
@@ -4329,7 +4535,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.reconcile_every_n_cycles.is_none());
+        assert!(cfg.watch.reconcile_every_n_cycles.is_none());
     }
 
     #[test]
@@ -4341,7 +4547,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(cfg.reconcile_every_n_cycles.is_none());
+        assert!(cfg.watch.reconcile_every_n_cycles.is_none());
     }
 
     #[test]
@@ -4352,11 +4558,11 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.notification_script = Some("/cli/notify.sh".to_string());
+        sync.config_overrides.notification_script = Some("/cli/notify.sh".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         assert_eq!(
-            cfg.notification_script,
+            cfg.notifications.script,
             Some(PathBuf::from("/cli/notify.sh"))
         );
     }
@@ -4370,7 +4576,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(cfg.notification_script.is_none());
+        assert!(cfg.notifications.script.is_none());
     }
 
     #[test]
@@ -4387,7 +4593,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.report_json, Some(PathBuf::from("/toml/run.json")));
+        assert_eq!(cfg.report.json, Some(PathBuf::from("/toml/run.json")));
     }
 
     #[test]
@@ -4398,10 +4604,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.report_json = Some(PathBuf::from("/cli/run.json"));
+        sync.config_overrides.report_json = Some(PathBuf::from("/cli/run.json"));
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.report_json, Some(PathBuf::from("/cli/run.json")));
+        assert_eq!(cfg.report.json, Some(PathBuf::from("/cli/run.json")));
     }
 
     #[test]
@@ -4413,7 +4619,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(cfg.report_json.is_none());
+        assert!(cfg.report.json.is_none());
     }
 
     #[test]
@@ -4442,7 +4648,7 @@ mod tests {
         sync.recent = Some(crate::cli::RecentLimit::Count(100));
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.recent, Some(100));
+        assert_eq!(cfg.filters.recent, Some(100));
     }
 
     #[test]
@@ -4459,7 +4665,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.recent, Some(500));
+        assert_eq!(cfg.filters.recent, Some(500));
     }
 
     #[test]
@@ -4475,12 +4681,12 @@ mod tests {
         sync.skip_created_after = Some("2024-06-01".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        let before = cfg.skip_created_before.unwrap();
+        let before = cfg.filters.skip_created_before.unwrap();
         assert_eq!(
             before.date_naive(),
             NaiveDate::from_ymd_opt(2023, 6, 1).unwrap()
         );
-        let after = cfg.skip_created_after.unwrap();
+        let after = cfg.filters.skip_created_after.unwrap();
         assert_eq!(
             after.date_naive(),
             NaiveDate::from_ymd_opt(2024, 6, 1).unwrap()
@@ -4501,7 +4707,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        let before = cfg.skip_created_before.unwrap();
+        let before = cfg.filters.skip_created_before.unwrap();
         let expected = chrono::Local::now() - chrono::Duration::days(30);
         assert!((before - expected).num_seconds().abs() < 2);
     }
@@ -4572,42 +4778,45 @@ mod tests {
         )
         .unwrap();
         // default_auth username overrides toml
-        assert_eq!(cfg.username, "u@example.com");
-        assert!(cfg.password.is_none());
-        assert!(matches!(cfg.domain, Domain::Cn));
-        assert!(cfg.cookie_directory.ends_with("kei/cookies"));
-        assert_eq!(cfg.directory, PathBuf::from("/full/photos"));
-        assert_eq!(cfg.folder_structure, "%Y");
-        assert_eq!(cfg.threads_num, 2);
-        assert_eq!(cfg.temp_suffix, ".full-tmp");
-        assert!(cfg.set_exif_datetime);
-        assert!(cfg.no_progress_bar);
-        assert_eq!(cfg.max_retries, 1);
-        assert_eq!(cfg.retry_delay_secs, 2);
+        assert_eq!(cfg.auth.username, "u@example.com");
+        assert!(cfg.auth.password.is_none());
+        assert!(matches!(cfg.auth.domain, Domain::Cn));
+        assert!(cfg.auth.cookie_directory.ends_with("kei/cookies"));
+        assert_eq!(cfg.download.directory, PathBuf::from("/full/photos"));
+        assert_eq!(cfg.download.folder_structure, "%Y");
+        assert_eq!(cfg.download.threads_num, 2);
+        assert_eq!(cfg.download.temp_suffix, ".full-tmp");
+        assert!(cfg.metadata.set_exif_datetime);
+        assert!(cfg.download.no_progress_bar);
+        assert_eq!(cfg.retry.max_retries, 1);
+        assert_eq!(cfg.retry.retry_delay_secs, 2);
         assert_eq!(
-            cfg.selection.libraries.to_raw(),
+            cfg.filters.selection.libraries.to_raw(),
             vec!["SharedSync-FULL".to_string()]
         );
         assert_eq!(
-            cfg.albums,
+            cfg.filters.albums,
             AlbumSelection::Named(vec!["Album1".to_string()])
         );
-        assert!(cfg.skip_videos);
-        assert_eq!(cfg.recent, Some(50));
-        assert!(matches!(cfg.size, VersionSize::Medium));
-        assert!(matches!(cfg.live_photo_size, LivePhotoSize::Thumb));
+        assert!(cfg.filters.skip_videos);
+        assert_eq!(cfg.filters.recent, Some(50));
+        assert!(matches!(cfg.photos.size, VersionSize::Medium));
+        assert!(matches!(cfg.photos.live_photo_size, LivePhotoSize::Thumb));
         assert!(matches!(
-            cfg.live_photo_mov_filename_policy,
+            cfg.photos.live_photo_mov_filename_policy,
             LivePhotoMovFilenamePolicy::Original
         ));
         assert!(matches!(
-            cfg.align_raw,
+            cfg.photos.align_raw,
             RawTreatmentPolicy::PreferAlternative
         ));
-        assert!(matches!(cfg.file_match_policy, FileMatchPolicy::NameId7));
-        assert!(cfg.force_size);
-        assert_eq!(cfg.watch_with_interval, Some(900));
-        assert_eq!(cfg.pid_file, Some(PathBuf::from("/full/pid")));
+        assert!(matches!(
+            cfg.photos.file_match_policy,
+            FileMatchPolicy::NameId7
+        ));
+        assert!(cfg.photos.force_size);
+        assert_eq!(cfg.watch.interval, Some(900));
+        assert_eq!(cfg.watch.pid_file, Some(PathBuf::from("/full/pid")));
     }
 
     // ── resolve_auth tests ─────────────────────────────────────────
@@ -4715,8 +4924,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert!(cfg.selection.unfiled);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert!(cfg.filters.selection.unfiled);
     }
 
     #[test]
@@ -4729,8 +4938,8 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert!(cfg.selection.unfiled);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert!(cfg.filters.selection.unfiled);
     }
 
     #[test]
@@ -4748,19 +4957,19 @@ mod tests {
     #[test]
     fn test_build_album_all_maps_to_all_variant() {
         let mut sync = default_sync();
-        sync.albums = vec!["all".to_string()];
+        sync.config_overrides.albums = vec!["all".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
     }
 
     #[test]
     fn test_build_album_all_is_case_insensitive() {
         for raw in ["all", "ALL", "All", "aLL"] {
             let mut sync = default_sync();
-            sync.albums = vec![raw.to_string()];
+            sync.config_overrides.albums = vec![raw.to_string()];
             let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
             assert_eq!(
-                cfg.albums,
+                cfg.filters.albums,
                 AlbumSelection::All,
                 "'{raw}' should resolve to AlbumSelection::All"
             );
@@ -4770,7 +4979,7 @@ mod tests {
     #[test]
     fn test_build_album_all_mixed_with_names_errors() {
         let mut sync = default_sync();
-        sync.albums = vec!["all".to_string(), "Vacation".to_string()];
+        sync.config_overrides.albums = vec!["all".to_string(), "Vacation".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -4793,15 +5002,15 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
     }
 
     #[test]
     fn test_build_default_is_all_with_album_template() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/%Y/%m".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/%Y/%m".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
     }
 
     #[test]
@@ -4810,22 +5019,22 @@ mod tests {
         // pre-v0.13 default was `LibraryOnly`; this test pins the new
         // contract so a regression flips it back.
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m/%d".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m/%d".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert!(cfg.selection.unfiled);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert!(cfg.filters.selection.unfiled);
     }
 
     #[test]
     fn test_build_album_named_preserved() {
         let mut sync = default_sync();
-        sync.albums = vec!["Vacation".to_string(), "Trip".to_string()];
+        sync.config_overrides.albums = vec!["Vacation".to_string(), "Trip".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         // Names are normalised through the v0.13 selector grammar, which uses
         // a BTreeSet for deterministic ordering — alphabetical, regardless of
         // CLI input order.
         assert_eq!(
-            cfg.albums,
+            cfg.filters.albums,
             AlbumSelection::Named(vec!["Trip".to_string(), "Vacation".to_string()])
         );
     }
@@ -4835,45 +5044,45 @@ mod tests {
         // `--album '!Family'` with no positive value resolves to "all minus
         // Family" via the new grammar; no `--album all` needed.
         let mut sync = default_sync();
-        sync.albums = vec!["!Family".to_string()];
+        sync.config_overrides.albums = vec!["!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert_eq!(cfg.exclude_albums, vec!["Family".to_string()]);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
     }
 
     #[test]
     fn test_build_album_all_with_inline_exclude() {
         let mut sync = default_sync();
-        sync.albums = vec!["all".to_string(), "!Family".to_string()];
+        sync.config_overrides.albums = vec!["all".to_string(), "!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::All);
-        assert_eq!(cfg.exclude_albums, vec!["Family".to_string()]);
+        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
     }
 
     #[test]
     fn test_build_album_named_with_inline_exclude() {
         let mut sync = default_sync();
-        sync.albums = vec!["Vacation".to_string(), "!Family".to_string()];
+        sync.config_overrides.albums = vec!["Vacation".to_string(), "!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert_eq!(
-            cfg.albums,
+            cfg.filters.albums,
             AlbumSelection::Named(vec!["Vacation".to_string()])
         );
-        assert_eq!(cfg.exclude_albums, vec!["Family".to_string()]);
+        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
     }
 
     #[test]
     fn test_build_album_none_sentinel_maps_to_library_only() {
         let mut sync = default_sync();
-        sync.albums = vec!["none".to_string()];
+        sync.config_overrides.albums = vec!["none".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.albums, AlbumSelection::LibraryOnly);
+        assert_eq!(cfg.filters.albums, AlbumSelection::LibraryOnly);
     }
 
     #[test]
     fn test_build_album_contradiction_bails() {
         let mut sync = default_sync();
-        sync.albums = vec!["Vacation".to_string(), "!Vacation".to_string()];
+        sync.config_overrides.albums = vec!["Vacation".to_string(), "!Vacation".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string().contains("cannot both include and exclude"),
@@ -4884,7 +5093,7 @@ mod tests {
     #[test]
     fn test_build_album_none_mixed_with_names_bails() {
         let mut sync = default_sync();
-        sync.albums = vec!["none".to_string(), "Vacation".to_string()];
+        sync.config_overrides.albums = vec!["none".to_string(), "Vacation".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
@@ -4896,7 +5105,7 @@ mod tests {
     #[test]
     fn test_build_album_token_rejected_mid_path() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("Photos/{album}/%Y".to_string());
+        sync.config_overrides.folder_structure = Some("Photos/{album}/%Y".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
@@ -4908,7 +5117,7 @@ mod tests {
     #[test]
     fn test_build_album_token_rejected_after_date() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/{album}/%m".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/{album}/%m".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
@@ -4920,7 +5129,7 @@ mod tests {
     #[test]
     fn test_build_album_token_rejected_as_trailing() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m/{album}".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m/{album}".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
@@ -4932,7 +5141,7 @@ mod tests {
     #[test]
     fn test_build_album_token_rejected_duplicate() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("{album}/%Y/{album}".to_string());
+        sync.config_overrides.folder_structure = Some("{album}/%Y/{album}".to_string());
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
@@ -4946,10 +5155,10 @@ mod tests {
         // Without `{album}` in the template there is nothing to migrate;
         // both fields keep their resolved values.
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure, "%Y/%m");
-        assert_eq!(cfg.folder_structure_albums, "{album}");
+        assert_eq!(cfg.download.folder_structure, "%Y/%m");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}");
     }
 
     #[test]
@@ -4960,10 +5169,10 @@ mod tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
-        sync.download_dir = Some("/cli/photos".to_string());
+        sync.config_overrides.download_dir = Some("/cli/photos".to_string());
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.directory, PathBuf::from("/cli/photos"));
+        assert_eq!(cfg.download.directory, PathBuf::from("/cli/photos"));
     }
 
     // ── Config::build: passthrough flags ───────────────────────────
@@ -4973,27 +5182,27 @@ mod tests {
         let mut sync = default_sync();
         sync.dry_run = true;
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(cfg.dry_run);
+        assert!(cfg.runtime.dry_run);
     }
 
     #[test]
     fn test_folder_structure_valid_tokens_accepted() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m/%d".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m/%d".to_string());
         assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
     }
 
     #[test]
     fn test_folder_structure_all_tokens_accepted() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%m/%d/%H/%M/%S".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%m/%d/%H/%M/%S".to_string());
         assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
     }
 
     #[test]
     fn test_folder_structure_none_bypasses_validation() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("none".to_string());
+        sync.config_overrides.folder_structure = Some("none".to_string());
         assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
     }
 
@@ -5001,15 +5210,15 @@ mod tests {
     fn test_folder_structure_strftime_tokens_accepted() {
         // Full strftime support: %B (month name), %X (locale time), etc. are valid
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%B/%d".to_string());
+        sync.config_overrides.folder_structure = Some("%Y/%B/%d".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure, "%Y/%B/%d");
+        assert_eq!(cfg.download.folder_structure, "%Y/%B/%d");
     }
 
     #[test]
     fn test_folder_structure_wrapped_format_accepted() {
         let mut sync = default_sync();
-        sync.folder_structure = Some("{:%Y/%m/%d}".to_string());
+        sync.config_overrides.folder_structure = Some("{:%Y/%m/%d}".to_string());
         assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
     }
 
@@ -5106,7 +5315,7 @@ mod tests {
             Some(&toml_input),
         )
         .unwrap();
-        assert_eq!(cfg.friendly_request, Some(true));
+        assert_eq!(cfg.ui.friendly_request, Some(true));
         let round_tripped = cfg.to_toml();
         assert_eq!(
             round_tripped.ui.and_then(|u| u.friendly),
@@ -5139,7 +5348,7 @@ mod tests {
             Some(&toml_input),
         )
         .unwrap();
-        assert_eq!(cfg.friendly_request, Some(false));
+        assert_eq!(cfg.ui.friendly_request, Some(false));
         assert_eq!(
             cfg.to_toml().ui.and_then(|u| u.friendly),
             Some(false),
@@ -5178,7 +5387,7 @@ mod tests {
         let pw = default_password();
         globals.domain = Some(crate::types::Domain::Cn);
         let mut sync = default_sync();
-        sync.size = Some(crate::types::VersionSize::Medium);
+        sync.config_overrides.size = Some(crate::types::VersionSize::Medium);
         let cfg = Config::build(&globals, &pw, sync, None).unwrap();
         let toml = cfg.to_toml();
         assert_eq!(
@@ -5223,7 +5432,7 @@ mod tests {
     #[test]
     fn test_to_toml_keeps_inline_album_excludes_canonical() {
         let mut sync = default_sync();
-        sync.albums = vec!["!Family".to_string()];
+        sync.config_overrides.albums = vec!["!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let filters = toml.filters.as_ref().unwrap();
@@ -5242,7 +5451,8 @@ mod tests {
     #[test]
     fn test_to_toml_roundtrip_filename_exclude() {
         let mut sync = default_sync();
-        sync.filename_exclude = vec!["*.AAE".to_string(), "Screenshot*".to_string()];
+        sync.config_overrides.filename_exclude =
+            vec!["*.AAE".to_string(), "Screenshot*".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let filters = toml.filters.as_ref().unwrap();
@@ -5262,7 +5472,7 @@ mod tests {
     #[test]
     fn test_to_toml_roundtrip_live_photo_mode() {
         let mut sync = default_sync();
-        sync.live_photo_mode = Some(crate::types::LivePhotoMode::ImageOnly);
+        sync.config_overrides.live_photo_mode = Some(crate::types::LivePhotoMode::ImageOnly);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         assert_eq!(
@@ -5294,7 +5504,7 @@ mod tests {
     #[test]
     fn test_to_toml_roundtrip_bandwidth_limit() {
         let mut sync = default_sync();
-        sync.bandwidth_limit = Some(5_000_000);
+        sync.config_overrides.bandwidth_limit = Some(5_000_000);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let serialized = cfg.to_toml();
         assert_eq!(
@@ -5314,7 +5524,7 @@ mod tests {
             Some(&serialized),
         )
         .unwrap();
-        assert_eq!(reparsed.bandwidth_limit, Some(5_000_000));
+        assert_eq!(reparsed.download.bandwidth_limit, Some(5_000_000));
     }
 
     #[test]
@@ -5408,7 +5618,7 @@ mod tests {
         }
         let mut sync = default_sync();
         if let Some(d) = directory {
-            sync.download_dir = Some(d.to_string());
+            sync.config_overrides.download_dir = Some(d.to_string());
         }
         Config::build(&globals, &pw_args, sync, None).unwrap()
     }
@@ -5471,7 +5681,7 @@ mod tests {
         pw.password_file = Some("/run/secrets/pw".to_string());
         globals.domain = Some(crate::types::Domain::Cn);
         let mut sync = default_sync();
-        sync.download_dir = Some("/photos".to_string());
+        sync.config_overrides.download_dir = Some("/photos".to_string());
         let config = Config::build(&globals, &pw, sync, None).unwrap();
 
         persist_first_run_config(&config_path, &config, Some("/data")).unwrap();
@@ -5505,12 +5715,12 @@ mod tests {
     #[test]
     fn test_live_photo_mode_cli_overrides_toml() {
         let mut sync = default_sync();
-        sync.live_photo_mode = Some(LivePhotoMode::ImageOnly);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::ImageOnly);
         let toml_str = "[photos]\nlive_photo_mode = \"skip\"\n";
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::ImageOnly);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::ImageOnly);
     }
 
     #[test]
@@ -5524,7 +5734,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::VideoOnly);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::VideoOnly);
     }
 
     #[test]
@@ -5538,14 +5748,19 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        let patterns: Vec<&str> = cfg
+            .download
+            .filename_exclude
+            .iter()
+            .map(|p| p.as_str())
+            .collect();
         assert_eq!(patterns, vec!["*.AAE", "*.TMP"]);
     }
 
     #[test]
     fn test_filename_exclude_invalid_glob_rejected() {
         let mut sync = default_sync();
-        sync.filename_exclude = vec!["[invalid".to_string()];
+        sync.config_overrides.filename_exclude = vec!["[invalid".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(err
             .to_string()
@@ -5607,7 +5822,7 @@ mod tests {
 
     fn build_with_smart_folders(cli: Vec<&str>, toml_str: Option<&str>) -> Config {
         let mut sync = default_sync();
-        sync.smart_folders = cli.iter().map(|s| (*s).to_string()).collect();
+        sync.config_overrides.smart_folders = cli.iter().map(|s| (*s).to_string()).collect();
         let toml = toml_str.map(|s| toml::from_str::<TomlConfig>(s).unwrap());
         Config::build(&default_globals(), &default_password(), sync, toml.as_ref()).unwrap()
     }
@@ -5622,7 +5837,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            cfg.selection.smart_folders,
+            cfg.filters.selection.smart_folders,
             crate::selection::SmartFolderSelector::None
         );
     }
@@ -5630,13 +5845,17 @@ mod tests {
     #[test]
     fn test_smart_folders_from_cli() {
         let cfg = build_with_smart_folders(vec!["Favorites", "!Hidden"], None);
-        assert_sf_named(&cfg.selection.smart_folders, &["Favorites"], &["Hidden"]);
+        assert_sf_named(
+            &cfg.filters.selection.smart_folders,
+            &["Favorites"],
+            &["Hidden"],
+        );
     }
 
     #[test]
     fn test_smart_folders_all_sentinel() {
         let cfg = build_with_smart_folders(vec!["all"], None);
-        assert_sf_all(&cfg.selection.smart_folders, false, &[]);
+        assert_sf_all(&cfg.filters.selection.smart_folders, false, &[]);
     }
 
     #[test]
@@ -5645,7 +5864,11 @@ mod tests {
             vec![],
             Some("[filters]\nsmart_folders = [\"all-with-sensitive\", \"!Recently Deleted\"]\n"),
         );
-        assert_sf_all(&cfg.selection.smart_folders, true, &["Recently Deleted"]);
+        assert_sf_all(
+            &cfg.filters.selection.smart_folders,
+            true,
+            &["Recently Deleted"],
+        );
     }
 
     #[test]
@@ -5655,9 +5878,12 @@ mod tests {
             Some("[filters]\nsmart_folders = [\"Videos\"]\n"),
         );
         let crate::selection::SmartFolderSelector::Named { included, .. } =
-            &cfg.selection.smart_folders
+            &cfg.filters.selection.smart_folders
         else {
-            panic!("expected Named, got {:?}", cfg.selection.smart_folders);
+            panic!(
+                "expected Named, got {:?}",
+                cfg.filters.selection.smart_folders
+            );
         };
         assert!(included.contains("Favorites"));
         assert!(!included.contains("Videos"));
@@ -5666,14 +5892,15 @@ mod tests {
     #[test]
     fn test_smart_folders_invalid_combination_bails() {
         let mut sync = default_sync();
-        sync.smart_folders = vec!["all".to_string(), "all-with-sensitive".to_string()];
+        sync.config_overrides.smart_folders =
+            vec!["all".to_string(), "all-with-sensitive".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(err.to_string().contains("mutually exclusive"));
     }
 
     fn build_with_unfiled(cli: Option<bool>, toml_str: Option<&str>) -> Config {
         let mut sync = default_sync();
-        sync.unfiled = cli;
+        sync.config_overrides.unfiled = cli;
         let toml = toml_str.map(|s| toml::from_str::<TomlConfig>(s).unwrap());
         Config::build(&default_globals(), &default_password(), sync, toml.as_ref()).unwrap()
     }
@@ -5681,7 +5908,10 @@ mod tests {
     #[test]
     fn test_unfiled_default_no_flags_is_true() {
         let cfg = build_with_unfiled(None, None);
-        assert!(cfg.selection.unfiled, "v0.13 default: unfiled = true");
+        assert!(
+            cfg.filters.selection.unfiled,
+            "v0.13 default: unfiled = true"
+        );
     }
 
     #[test]
@@ -5691,10 +5921,10 @@ mod tests {
         // Pre-v0.13 behaviour was unfiled=false for named-album syncs; this
         // test pins the new contract.
         let mut sync = default_sync();
-        sync.albums = vec!["Vacation".to_string()];
+        sync.config_overrides.albums = vec!["Vacation".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert!(
-            cfg.selection.unfiled,
+            cfg.filters.selection.unfiled,
             "v0.13: --album Vacation alone should still default unfiled = true",
         );
     }
@@ -5702,13 +5932,13 @@ mod tests {
     #[test]
     fn test_unfiled_cli_true_explicit() {
         let cfg = build_with_unfiled(Some(true), None);
-        assert!(cfg.selection.unfiled);
+        assert!(cfg.filters.selection.unfiled);
     }
 
     #[test]
     fn test_unfiled_cli_false_explicit() {
         let cfg = build_with_unfiled(Some(false), None);
-        assert!(!cfg.selection.unfiled);
+        assert!(!cfg.filters.selection.unfiled);
     }
 
     #[test]
@@ -5717,22 +5947,22 @@ mod tests {
         // named-album sync. Without this opt-out, v0.13's default would
         // run the Vacation pass AND the unfiled pass.
         let mut sync = default_sync();
-        sync.albums = vec!["Vacation".to_string()];
-        sync.unfiled = Some(false);
+        sync.config_overrides.albums = vec!["Vacation".to_string()];
+        sync.config_overrides.unfiled = Some(false);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(!cfg.selection.unfiled);
+        assert!(!cfg.filters.selection.unfiled);
     }
 
     #[test]
     fn test_unfiled_from_toml() {
         let cfg = build_with_unfiled(None, Some("[filters]\nunfiled = false\n"));
-        assert!(!cfg.selection.unfiled);
+        assert!(!cfg.filters.selection.unfiled);
     }
 
     #[test]
     fn test_unfiled_cli_overrides_toml() {
         let cfg = build_with_unfiled(Some(true), Some("[filters]\nunfiled = false\n"));
-        assert!(cfg.selection.unfiled);
+        assert!(cfg.filters.selection.unfiled);
     }
 
     // ── should_warn_implicit_unfiled ────────────────────────────────────
@@ -5818,7 +6048,10 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.folder_structure_albums, DEFAULT_FOLDER_STRUCTURE_ALBUMS);
+        assert_eq!(
+            cfg.download.folder_structure_albums,
+            DEFAULT_FOLDER_STRUCTURE_ALBUMS
+        );
     }
 
     #[test]
@@ -5831,7 +6064,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            cfg.folder_structure_smart_folders,
+            cfg.download.folder_structure_smart_folders,
             DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS
         );
     }
@@ -5839,17 +6072,21 @@ mod tests {
     #[test]
     fn test_folder_structure_albums_from_cli() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/%Y/%m".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/%Y/%m".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/%Y/%m");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/%Y/%m");
     }
 
     #[test]
     fn test_folder_structure_smart_folders_from_cli() {
         let mut sync = default_sync();
-        sync.folder_structure_smart_folders = Some("{smart-folder}/%Y".to_string());
+        sync.config_overrides.folder_structure_smart_folders =
+            Some("{smart-folder}/%Y".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.folder_structure_smart_folders, "{smart-folder}/%Y");
+        assert_eq!(
+            cfg.download.folder_structure_smart_folders,
+            "{smart-folder}/%Y"
+        );
     }
 
     #[test]
@@ -5863,7 +6100,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/%Y");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/%Y");
     }
 
     #[test]
@@ -5877,18 +6114,21 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.folder_structure_smart_folders, "{smart-folder}/%Y");
+        assert_eq!(
+            cfg.download.folder_structure_smart_folders,
+            "{smart-folder}/%Y"
+        );
     }
 
     #[test]
     fn test_folder_structure_albums_cli_overrides_toml() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/cli".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/cli".to_string());
         let toml_str = "[download]\nfolder_structure_albums = \"{album}/toml\"\n";
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(cfg.folder_structure_albums, "{album}/cli");
+        assert_eq!(cfg.download.folder_structure_albums, "{album}/cli");
     }
 
     #[test]
@@ -5919,8 +6159,9 @@ mod tests {
     #[test]
     fn test_folder_structure_per_category_round_trips_custom() {
         let mut sync = default_sync();
-        sync.folder_structure_albums = Some("{album}/%Y".to_string());
-        sync.folder_structure_smart_folders = Some("{smart-folder}/%Y".to_string());
+        sync.config_overrides.folder_structure_albums = Some("{album}/%Y".to_string());
+        sync.config_overrides.folder_structure_smart_folders =
+            Some("{smart-folder}/%Y".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let dl = toml.download.unwrap();
@@ -5943,18 +6184,23 @@ mod tests {
             "Contradictory date filters should warn, not error"
         );
         let cfg = cfg.unwrap();
-        assert!(cfg.skip_created_before >= cfg.skip_created_after);
+        assert!(cfg.filters.skip_created_before >= cfg.filters.skip_created_after);
     }
 
     #[test]
     fn test_filename_exclude_cli_overrides_toml() {
         let mut sync = default_sync();
-        sync.filename_exclude = vec!["*.AAE".to_string()];
+        sync.config_overrides.filename_exclude = vec!["*.AAE".to_string()];
         let toml_str = "[filters]\nfilename_exclude = [\"*.TMP\"]\n";
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        let patterns: Vec<&str> = cfg
+            .download
+            .filename_exclude
+            .iter()
+            .map(|p| p.as_str())
+            .collect();
         assert_eq!(patterns, vec!["*.AAE"]);
     }
 
@@ -5969,7 +6215,12 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        let patterns: Vec<&str> = cfg
+            .download
+            .filename_exclude
+            .iter()
+            .map(|p| p.as_str())
+            .collect();
         assert_eq!(patterns, vec!["*.TMP"]);
     }
 
@@ -6137,25 +6388,25 @@ mod tests {
         // No explicit retry-delay anywhere; max_retries=5 should pull the
         // 4..=6 bucket from the smart table (10s).
         let mut sync = default_sync();
-        sync.max_retries = Some(5);
+        sync.config_overrides.max_retries = Some(5);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.retry_delay_secs, 10);
+        assert_eq!(cfg.retry.retry_delay_secs, 10);
     }
 
     #[test]
     fn test_build_retry_delay_smart_default_patient_bucket() {
         let mut sync = default_sync();
-        sync.max_retries = Some(10);
+        sync.config_overrides.max_retries = Some(10);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.retry_delay_secs, 30);
+        assert_eq!(cfg.retry.retry_delay_secs, 30);
     }
 
     #[test]
     fn test_build_retry_delay_smart_default_fail_fast_bucket() {
         let mut sync = default_sync();
-        sync.max_retries = Some(1);
+        sync.config_overrides.max_retries = Some(1);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.retry_delay_secs, 2);
+        assert_eq!(cfg.retry.retry_delay_secs, 2);
     }
 
     #[test]
@@ -6163,7 +6414,7 @@ mod tests {
         // Smart default for max_retries=3 is 5. to_toml should NOT write
         // `delay = 5` back out because it's redundant (and deprecated).
         let mut sync = default_sync();
-        sync.max_retries = Some(3);
+        sync.config_overrides.max_retries = Some(3);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
@@ -6173,9 +6424,9 @@ mod tests {
     #[test]
     fn test_build_threads_cli_canonical() {
         let mut sync = default_sync();
-        sync.threads = Some(7);
+        sync.config_overrides.threads = Some(7);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.threads_num, 7);
+        assert_eq!(cfg.download.threads_num, 7);
     }
 
     #[test]
@@ -6192,7 +6443,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.threads_num, 16);
+        assert_eq!(cfg.download.threads_num, 16);
     }
 
     // ── --recent count vs days ────────────────────────────────────────
@@ -6202,9 +6453,9 @@ mod tests {
         let mut sync = default_sync();
         sync.recent = Some(crate::cli::RecentLimit::Count(100));
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.recent, Some(100));
+        assert_eq!(cfg.filters.recent, Some(100));
         assert!(
-            cfg.skip_created_before.is_none(),
+            cfg.filters.skip_created_before.is_none(),
             "Count form must not touch skip_created_before"
         );
     }
@@ -6215,16 +6466,16 @@ mod tests {
         sync.recent = Some(crate::cli::RecentLimit::Days(30));
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         assert!(
-            cfg.recent.is_none(),
+            cfg.filters.recent.is_none(),
             "Days form must not populate recent (count-only field)"
         );
         assert!(
-            cfg.skip_created_before.is_some(),
+            cfg.filters.skip_created_before.is_some(),
             "Days form must populate skip_created_before cutoff"
         );
         // The cutoff should be ~30 days ago; give it a wide window to avoid
         // flakiness on slow CI.
-        let cutoff = cfg.skip_created_before.unwrap();
+        let cutoff = cfg.filters.skip_created_before.unwrap();
         let now = chrono::Local::now();
         let delta = now.signed_duration_since(cutoff);
         assert!(
@@ -6255,8 +6506,8 @@ mod tests {
         sync.recent = Some(crate::cli::RecentLimit::Count(100));
         sync.skip_created_before = Some("2024-01-01".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.recent, Some(100));
-        assert!(cfg.skip_created_before.is_some());
+        assert_eq!(cfg.filters.recent, Some(100));
+        assert!(cfg.filters.skip_created_before.is_some());
     }
 
     #[test]
@@ -6273,8 +6524,8 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert!(cfg.recent.is_none());
-        assert!(cfg.skip_created_before.is_some());
+        assert!(cfg.filters.recent.is_none());
+        assert!(cfg.filters.skip_created_before.is_some());
     }
 
     #[test]
@@ -6291,7 +6542,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.recent, Some(250));
+        assert_eq!(cfg.filters.recent, Some(250));
     }
 
     #[test]
@@ -6317,9 +6568,9 @@ mod tests {
         // Classic "user thought these were orthogonal" mistake: both flags
         // true with live-photo-mode skip means nothing at all downloads.
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
-        sync.skip_photos = Some(true);
-        sync.live_photo_mode = Some(LivePhotoMode::Skip);
+        sync.config_overrides.skip_videos = Some(true);
+        sync.config_overrides.skip_photos = Some(true);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::Skip);
         let err = Config::build(&default_globals(), &default_password(), sync, None)
             .unwrap_err()
             .to_string();
@@ -6342,9 +6593,9 @@ mod tests {
         // image-only drops Live Photo MOVs, so combined with both skip
         // flags the result is still nothing. Same error applies.
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
-        sync.skip_photos = Some(true);
-        sync.live_photo_mode = Some(LivePhotoMode::ImageOnly);
+        sync.config_overrides.skip_videos = Some(true);
+        sync.config_overrides.skip_photos = Some(true);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::ImageOnly);
         let err = Config::build(&default_globals(), &default_password(), sync, None)
             .unwrap_err()
             .to_string();
@@ -6358,13 +6609,13 @@ mod tests {
         // companions. video-only mode keeps the MOV while both skip flags
         // drop everything else. Must not error.
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
-        sync.skip_photos = Some(true);
-        sync.live_photo_mode = Some(LivePhotoMode::VideoOnly);
+        sync.config_overrides.skip_videos = Some(true);
+        sync.config_overrides.skip_photos = Some(true);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::VideoOnly);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(cfg.skip_videos);
-        assert!(cfg.skip_photos);
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::VideoOnly);
+        assert!(cfg.filters.skip_videos);
+        assert!(cfg.filters.skip_photos);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::VideoOnly);
     }
 
     #[test]
@@ -6373,29 +6624,29 @@ mod tests {
         // Photo MOVs still download (skip_videos targets pure videos, not
         // Live Photo video companions). Must not error.
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
-        sync.skip_photos = Some(true);
-        sync.live_photo_mode = Some(LivePhotoMode::Both);
+        sync.config_overrides.skip_videos = Some(true);
+        sync.config_overrides.skip_photos = Some(true);
+        sync.config_overrides.live_photo_mode = Some(LivePhotoMode::Both);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Both);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::Both);
     }
 
     #[test]
     fn test_build_skip_videos_alone_ok() {
         let mut sync = default_sync();
-        sync.skip_videos = Some(true);
+        sync.config_overrides.skip_videos = Some(true);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(cfg.skip_videos);
-        assert!(!cfg.skip_photos);
+        assert!(cfg.filters.skip_videos);
+        assert!(!cfg.filters.skip_photos);
     }
 
     #[test]
     fn test_build_skip_photos_alone_ok() {
         let mut sync = default_sync();
-        sync.skip_photos = Some(true);
+        sync.config_overrides.skip_photos = Some(true);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert!(cfg.skip_photos);
-        assert!(!cfg.skip_videos);
+        assert!(cfg.filters.skip_photos);
+        assert!(!cfg.filters.skip_videos);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -672,6 +672,7 @@ impl std::fmt::Debug for Config {
             .field("directory", &self.download.directory)
             .field("domain", &self.auth.domain)
             .field("cookie_directory", &self.auth.cookie_directory)
+            .field("metadata", &self.metadata)
             .field("import", &self.import)
             .finish_non_exhaustive()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1001,10 +1001,10 @@ impl Config {
     pub fn build(
         globals: &GlobalArgs,
         pw: &crate::cli::PasswordArgs,
-        sync: crate::cli::SyncArgs,
+        mut sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
-        let overrides = sync.config_overrides.clone();
+        let overrides = std::mem::take(&mut sync.config_overrides);
         Self::build_with_overrides(globals, pw, sync, overrides, toml)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -855,10 +855,10 @@ pub(crate) fn resolve_path_derivation_fields(
     }
 }
 
-/// Global CLI args needed by `resolve_auth` and `Config::build`.
+/// Bootstrap environment values needed by `resolve_auth` and `Config::build`.
 ///
-/// Bundles the fields that moved from per-command `AuthArgs` to
-/// global options on `Cli`.
+/// These are the narrow env allow-list that remains after v0.20 moved durable
+/// settings out of public global CLI flags.
 #[derive(Debug, Clone)]
 pub(crate) struct GlobalArgs {
     pub username: Option<String>,
@@ -867,7 +867,7 @@ pub(crate) struct GlobalArgs {
 }
 
 impl GlobalArgs {
-    pub fn from_cli(_cli: &crate::cli::Cli) -> Self {
+    pub fn from_bootstrap_env() -> Self {
         Self {
             username: std::env::var("ICLOUD_USERNAME").ok(),
             domain: None,
@@ -1005,16 +1005,6 @@ impl Config {
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
         let overrides = std::mem::take(&mut sync.config_overrides);
-        Self::build_with_overrides(globals, pw, sync, overrides, toml)
-    }
-
-    pub(crate) fn build_with_overrides(
-        globals: &GlobalArgs,
-        pw: &crate::cli::PasswordArgs,
-        sync: crate::cli::SyncArgs,
-        overrides: SyncConfigOverrides,
-        toml: Option<&TomlConfig>,
-    ) -> anyhow::Result<Self> {
         let friendly_request = toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly);
         Self::build_inner(
             globals,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -101,7 +101,7 @@ pub struct SyncStats {
     /// Number of tasks that observed at least one HTTP 429 / 503 response
     /// during retry. A high ratio of rate_limited / assets_seen signals the
     /// sync is running against a back-pressured account; operators should
-    /// either raise --watch-with-interval or lower --threads.
+    /// either raise `[watch] interval` or lower `[download] threads`.
     pub rate_limited: usize,
     /// Photos downloaded this run (`MediaType::Photo` and
     /// `MediaType::LivePhotoImage`). Sums to `downloaded` together with

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -375,12 +375,14 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
 pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     use sha2::{Digest, Sha256};
 
-    let size: AssetVersionSize = config.size.into();
-    let live_photo_size = config.live_photo_size.to_asset_version_size();
+    let size: AssetVersionSize = config.photos.size.into();
+    let live_photo_size = config.photos.live_photo_size.to_asset_version_size();
     let skip_created_before = config
+        .filters
         .skip_created_before
         .map(|d| d.with_timezone(&chrono::Utc));
     let skip_created_after = config
+        .filters
         .skip_created_after
         .map(|d| d.with_timezone(&chrono::Utc));
 
@@ -388,23 +390,23 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     hash_shared_fields(
         &mut hasher,
         &SharedHashFields {
-            directory: &config.directory,
-            folder_structure: &config.folder_structure,
-            folder_structure_albums: &config.folder_structure_albums,
-            folder_structure_smart_folders: &config.folder_structure_smart_folders,
+            directory: &config.download.directory,
+            folder_structure: &config.download.folder_structure,
+            folder_structure_albums: &config.download.folder_structure_albums,
+            folder_structure_smart_folders: &config.download.folder_structure_smart_folders,
             size,
             live_photo_size,
-            file_match_policy: config.file_match_policy,
-            live_photo_mov_filename_policy: config.live_photo_mov_filename_policy,
-            align_raw: config.align_raw,
-            keep_unicode_in_filenames: config.keep_unicode_in_filenames,
+            file_match_policy: config.photos.file_match_policy,
+            live_photo_mov_filename_policy: config.photos.live_photo_mov_filename_policy,
+            align_raw: config.photos.align_raw,
+            keep_unicode_in_filenames: config.photos.keep_unicode_in_filenames,
             skip_created_before,
             skip_created_after,
-            force_size: config.force_size,
-            skip_videos: config.skip_videos,
-            skip_photos: config.skip_photos,
-            live_photo_mode: config.live_photo_mode,
-            filename_exclude: &config.filename_exclude,
+            force_size: config.photos.force_size,
+            skip_videos: config.filters.skip_videos,
+            skip_photos: config.filters.skip_photos,
+            live_photo_mode: config.photos.live_photo_mode,
+            filename_exclude: &config.download.filename_exclude,
         },
     );
     // Note: `recent` is intentionally excluded from this enum hash.
@@ -419,7 +421,7 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Tag byte distinguishes the three selection modes so switching between
     // them (e.g. `-a A` -> `-a all`) invalidates the sync token even if no
     // explicit album name changed.
-    match &config.albums {
+    match &config.filters.albums {
         crate::config::AlbumSelection::LibraryOnly => hasher.update([0]),
         crate::config::AlbumSelection::All => hasher.update([1]),
         crate::config::AlbumSelection::Named(names) => {
@@ -431,6 +433,7 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
         }
     }
     let mut sorted_excludes: Vec<&str> = config
+        .filters
         .exclude_albums
         .iter()
         .map(std::string::String::as_str)
@@ -444,7 +447,7 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Library selector: stable tag bytes per shape so changing the resolved
     // library set invalidates sync tokens. `to_raw()` emits a deterministic
     // ordering (`primary`/`shared`/named-then-`!excluded`).
-    for entry in config.selection.libraries.to_raw() {
+    for entry in config.filters.selection.libraries.to_raw() {
         hasher.update(b"library:");
         hasher.update(entry.as_bytes());
         hasher.update(b"\0");
@@ -455,13 +458,13 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // `--smart-folder none` → `--smart-folder all` (or `--unfiled false` →
     // default true) change reuses a stale enumeration cursor and the next
     // cycle silently misses every newly-eligible asset.
-    for entry in config.selection.smart_folders.to_raw() {
+    for entry in config.filters.selection.smart_folders.to_raw() {
         hasher.update(b"smart_folder:");
         hasher.update(entry.as_bytes());
         hasher.update(b"\0");
     }
     hasher.update(b"unfiled:");
-    hasher.update([u8::from(config.selection.unfiled)]);
+    hasher.update([u8::from(config.filters.selection.unfiled)]);
     finalize_hash(hasher)
 }
 
@@ -2699,75 +2702,31 @@ mod tests {
     #[test]
     fn test_compute_config_hash_matches_hash_download_config() {
         use crate::config::Config;
-        use crate::types::{
-            Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize,
-            RawTreatmentPolicy, VersionSize,
-        };
-        use secrecy::SecretString;
+        use crate::types::VersionSize;
 
         let dl_config = test_config();
-        let app_config = Config {
-            username: String::new(),
-            password: Some(SecretString::from("x")),
-            password_file: None,
-            password_command: None,
-            directory: dl_config.directory.to_path_buf(),
-            cookie_directory: std::path::PathBuf::from("/tmp"),
-            folder_structure: dl_config.folder_structure.clone(),
-            folder_structure_albums: crate::config::DEFAULT_FOLDER_STRUCTURE_ALBUMS.to_string(),
-            folder_structure_smart_folders: crate::config::DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS
-                .to_string(),
-            albums: crate::config::AlbumSelection::LibraryOnly,
-            exclude_albums: vec![],
-            filename_exclude: vec![],
-            temp_suffix: dl_config.temp_suffix.to_string(),
-            selection: crate::selection::Selection::default(),
-            skip_created_before: None,
-            skip_created_after: None,
-            pid_file: None,
-            notification_script: None,
-            report_json: None,
-            http_port: 9090,
-            http_bind: std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
-            watch_with_interval: None,
-            retry_delay_secs: 5,
-            reconcile_every_n_cycles: None,
-            recent: dl_config.recent,
-            max_retries: 3,
-            max_download_attempts: 10,
-            bandwidth_limit: None,
-            threads_num: 1,
-            size: VersionSize::Original,
-            live_photo_size: LivePhotoSize::Original,
-            domain: Domain::Com,
-            live_photo_mode: LivePhotoMode::Both,
-            live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy::Suffix,
-            align_raw: RawTreatmentPolicy::Unchanged,
-            file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
-            skip_videos: false,
-            skip_photos: false,
-            force_size: false,
-            #[cfg(feature = "xmp")]
-            set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
-            set_exif_rating: false,
-            #[cfg(feature = "xmp")]
-            set_exif_gps: false,
-            #[cfg(feature = "xmp")]
-            set_exif_description: false,
-            #[cfg(feature = "xmp")]
-            embed_xmp: false,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: false,
-            dry_run: false,
-            no_progress_bar: true,
-            personality_mode: crate::personality::Mode::Off,
-            friendly_request: None,
-            keep_unicode_in_filenames: false,
-            only_print_filenames: false,
-            notify_systemd: false,
-            save_password: false,
+        let globals = crate::config::GlobalArgs {
+            username: Some("u@example.com".to_string()),
+            domain: None,
+            data_dir: Some("/tmp".to_string()),
         };
+        let app_config = Config::build(
+            &globals,
+            &crate::cli::PasswordArgs::default(),
+            crate::cli::SyncArgs {
+                recent: dl_config.recent.map(crate::cli::RecentLimit::Count),
+                config_overrides: crate::config::SyncConfigOverrides {
+                    download_dir: Some(dl_config.directory.display().to_string()),
+                    folder_structure: Some(dl_config.folder_structure.clone()),
+                    size: Some(VersionSize::Original),
+                    ..Default::default()
+                },
+                no_progress_bar: Some(true),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
 
         // compute_config_hash is a superset (includes albums, library, live_photo_mode)
         // so it won't match hash_download_config. Verify it's deterministic and valid hex.
@@ -2779,7 +2738,7 @@ mod tests {
 
         // Verify album changes produce a different hash
         let mut config_with_album = app_config;
-        config_with_album.albums =
+        config_with_album.filters.albums =
             crate::config::AlbumSelection::Named(vec!["Favorites".to_string()]);
         let hash3 = compute_config_hash(&config_with_album);
         assert_ne!(hash1, hash3, "adding an album must change the hash");
@@ -3215,7 +3174,10 @@ mod tests {
             data_dir: Some(cookie_dir.to_string_lossy().into_owned()),
         };
         let mut sync = SyncArgs {
-            download_dir: Some(directory.to_string()),
+            config_overrides: crate::config::SyncConfigOverrides {
+                download_dir: Some(directory.to_string()),
+                ..Default::default()
+            },
             ..SyncArgs::default()
         };
         overrides(&mut sync);
@@ -3245,7 +3207,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.size = Some(VersionSize::Medium);
+            s.config_overrides.size = Some(VersionSize::Medium);
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }
@@ -3255,7 +3217,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.skip_videos = Some(true);
+            s.config_overrides.skip_videos = Some(true);
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }
@@ -3265,7 +3227,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.albums = vec!["Favorites".to_string()];
+            s.config_overrides.albums = vec!["Favorites".to_string()];
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }
@@ -3275,7 +3237,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.albums = vec!["!Hidden".to_string()];
+            s.config_overrides.albums = vec!["!Hidden".to_string()];
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }
@@ -3285,7 +3247,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.live_photo_mode = Some(LivePhotoMode::Skip);
+            s.config_overrides.live_photo_mode = Some(LivePhotoMode::Skip);
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }
@@ -3301,7 +3263,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.smart_folders = vec!["Favorites".to_string()];
+            s.config_overrides.smart_folders = vec!["Favorites".to_string()];
         });
         assert_ne!(
             compute_config_hash(&a),
@@ -3320,7 +3282,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.unfiled = Some(false);
+            s.config_overrides.unfiled = Some(false);
         });
         assert_ne!(
             compute_config_hash(&a),
@@ -3335,7 +3297,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.libraries = vec!["all".to_string()];
+            s.config_overrides.libraries = vec!["all".to_string()];
         });
         assert_ne!(
             compute_config_hash(&a),
@@ -3626,7 +3588,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
-            s.filename_exclude = vec!["*.AAE".to_string()];
+            s.config_overrides.filename_exclude = vec!["*.AAE".to_string()];
         });
         assert_ne!(
             compute_config_hash(&a),
@@ -3731,7 +3693,7 @@ mod tests {
     fn golden_compute_config_hash_with_albums() {
         let tmp = TempDir::new().unwrap();
         let config = build_config_with(tmp.path(), "/photos", |s| {
-            s.albums = vec![
+            s.config_overrides.albums = vec![
                 "Favorites".to_string(),
                 "Travel".to_string(),
                 "!Hidden".to_string(),
@@ -3752,7 +3714,7 @@ mod tests {
         // test catches accidental field-format changes.
         let tmp = TempDir::new().unwrap();
         let config = build_config_with(tmp.path(), "/photos", |s| {
-            s.smart_folders = vec!["Favorites".to_string(), "Videos".to_string()];
+            s.config_overrides.smart_folders = vec!["Favorites".to_string(), "Videos".to_string()];
         });
         let hash = compute_config_hash(&config);
         assert_eq!(
@@ -3769,7 +3731,7 @@ mod tests {
         // collapsing the two branches is caught.
         let tmp = TempDir::new().unwrap();
         let config = build_config_with(tmp.path(), "/photos", |s| {
-            s.unfiled = Some(false);
+            s.config_overrides.unfiled = Some(false);
         });
         let hash = compute_config_hash(&config);
         assert_eq!(

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1281,7 +1281,7 @@ where
             return Err(anyhow::anyhow!(
                 "Insufficient free disk space: only {} bytes available on {}, \
                  need at least {MIN_FREE_BYTES_HARD} bytes. Free up space or choose a \
-                 different --download-dir.",
+                 different [download] directory.",
                 free,
                 config.directory.display(),
             ));
@@ -2496,7 +2496,7 @@ fn maybe_warn_rate_limit_pressure(stats: &super::SyncStats) {
         tracing::warn!(
             rate_limit_observations = stats.rate_limited,
             "Observed HTTP 429/503 rate-limiting before any assets were enumerated — \
-             consider raising --watch-with-interval or lowering --threads"
+             consider raising [watch] interval or lowering [download] threads"
         );
         return;
     }
@@ -2507,7 +2507,7 @@ fn maybe_warn_rate_limit_pressure(stats: &super::SyncStats) {
             assets_seen = stats.assets_seen,
             percent = pct,
             "Observed HTTP 429/503 rate-limiting on >=10% of sync attempts — \
-             consider raising --watch-with-interval or lowering --threads \
+             consider raising [watch] interval or lowering [download] threads \
              to reduce sustained pressure on iCloud"
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     };
 
     // Resolve friendly mode. The gate has multiple short-circuits (service
-    // context, non-TTY, RUST_LOG, --report-json, ...) so the user-stated
+    // context, non-TTY, RUST_LOG, machine-output mode, ...) so the user-stated
     // preference is a request, not a guarantee.
     //
     // Resolution chain: CLI > TOML > default-on-for-TTY. The gate then
@@ -597,15 +597,20 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     // alternative (threading the resolved command through `run`) ripples
     // through every callee. Acceptable.
     let resolved_for_personality = cli.effective_command();
+    let toml_report_json = toml_config
+        .as_ref()
+        .and_then(|t| t.report.as_ref())
+        .and_then(|r| r.json.as_ref())
+        .is_some();
     let (cmd_no_progress_bar, cmd_only_print_filenames, cmd_report_json, cmd_service_run) =
         match &resolved_for_personality {
             cli::Command::Sync { sync, .. } => (
                 sync.no_progress_bar.unwrap_or(false),
                 sync.only_print_filenames,
-                sync.report_json.is_some(),
+                toml_report_json,
                 false,
             ),
-            cli::Command::Service { .. } => (false, false, false, true),
+            cli::Command::Service { .. } => (false, false, toml_report_json, true),
             _ => (false, false, false, false),
         };
     let personality_ctx = personality::Context::detect(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,9 +377,7 @@ fn get_db_path(globals: &config::GlobalArgs, toml: Option<&TomlConfig>) -> anyho
     let (username, _, _, cookie_dir) =
         config::resolve_auth(globals, &cli::PasswordArgs::default(), toml);
     if username.is_empty() {
-        anyhow::bail!(
-            "--username is required (or set ICLOUD_USERNAME, or add username to config file)"
-        );
+        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
     }
     Ok(cookie_dir.join(format!(
         "{}.db",
@@ -672,7 +670,8 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         );
     }
 
-    // Build globals from CLI early (username, domain, data_dir).
+    // Build non-TOML globals early. In v0.20 these come from the narrow
+    // bootstrap env allow-list, not public global CLI flags.
     let mut globals = config::GlobalArgs::from_cli(&cli);
 
     // Dispatch based on command

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,11 +548,9 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             (expanded, false)
         }
     };
-    // When --config is explicitly set but the file doesn't exist, allow it
-    // if the parent directory exists (auto-config will create the file).
-    // Otherwise require the file to exist so typos in --config paths error.
     // When --config is explicit but the file doesn't exist and the parent
     // dir does exist, allow it (auto-config will create the file).
+    // Otherwise require the file to exist so typos in --config paths error.
     let can_auto_create =
         !config_path.exists() && config_path.parent().is_some_and(std::path::Path::is_dir);
     let config_required = config_explicitly_set && !can_auto_create;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 
     // Build non-TOML globals early. In v0.20 these come from the narrow
     // bootstrap env allow-list, not public global CLI flags.
-    let mut globals = config::GlobalArgs::from_cli(&cli);
+    let mut globals = config::GlobalArgs::from_bootstrap_env();
 
     // Dispatch based on command
     let mut command = cli.effective_command();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 //! HTTP observability server (watch-mode only).
 //!
-//! In watch mode, spawns an axum HTTP server on `--http-port` (default 9091) that serves:
+//! In watch mode, spawns an axum HTTP server on `[server] port` (default 9091) that serves:
 //! - `GET /healthz`  — JSON health status (same data as `health.json`)
 //! - `GET /metrics`  — Prometheus text format
 //!

--- a/src/personality/mod.rs
+++ b/src/personality/mod.rs
@@ -67,7 +67,7 @@ pub struct Context {
     pub no_progress_bar: bool,
     /// User passed `--only-print-filenames`.
     pub only_print_filenames: bool,
-    /// User passed `--report-json` or another machine-output flag.
+    /// User enabled a machine-output mode such as report JSON.
     pub report_json: bool,
     /// User explicitly set `--log-level` (not the default).
     pub log_level_explicit: bool,

--- a/src/report.rs
+++ b/src/report.rs
@@ -107,43 +107,43 @@ impl RunOptions {
     /// Build from the resolved Config. Only includes user-facing settings.
     pub(crate) fn from_config(config: &crate::config::Config) -> Self {
         Self {
-            username: config.username.clone(),
-            download_dir: config.directory.clone(),
-            folder_structure: config.folder_structure.clone(),
-            size: format!("{:?}", config.size).to_lowercase(),
-            live_photo_mode: format!("{:?}", config.live_photo_mode).to_lowercase(),
-            live_photo_size: format!("{:?}", config.live_photo_size).to_lowercase(),
-            file_match_policy: format!("{:?}", config.file_match_policy).to_lowercase(),
-            albums: config.albums.to_vec(),
-            library: config.selection.libraries.to_raw().join(","),
-            skip_videos: config.skip_videos,
-            skip_photos: config.skip_photos,
+            username: config.auth.username.clone(),
+            download_dir: config.download.directory.clone(),
+            folder_structure: config.download.folder_structure.clone(),
+            size: format!("{:?}", config.photos.size).to_lowercase(),
+            live_photo_mode: format!("{:?}", config.photos.live_photo_mode).to_lowercase(),
+            live_photo_size: format!("{:?}", config.photos.live_photo_size).to_lowercase(),
+            file_match_policy: format!("{:?}", config.photos.file_match_policy).to_lowercase(),
+            albums: config.filters.albums.to_vec(),
+            library: config.filters.selection.libraries.to_raw().join(","),
+            skip_videos: config.filters.skip_videos,
+            skip_photos: config.filters.skip_photos,
             #[cfg(feature = "xmp")]
-            set_exif_datetime: config.set_exif_datetime,
+            set_exif_datetime: config.metadata.set_exif_datetime,
             #[cfg(not(feature = "xmp"))]
             set_exif_datetime: false,
             #[cfg(feature = "xmp")]
-            set_exif_rating: config.set_exif_rating,
+            set_exif_rating: config.metadata.set_exif_rating,
             #[cfg(not(feature = "xmp"))]
             set_exif_rating: false,
             #[cfg(feature = "xmp")]
-            set_exif_gps: config.set_exif_gps,
+            set_exif_gps: config.metadata.set_exif_gps,
             #[cfg(not(feature = "xmp"))]
             set_exif_gps: false,
             #[cfg(feature = "xmp")]
-            set_exif_description: config.set_exif_description,
+            set_exif_description: config.metadata.set_exif_description,
             #[cfg(not(feature = "xmp"))]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
-            embed_xmp: config.embed_xmp,
+            embed_xmp: config.metadata.embed_xmp,
             #[cfg(not(feature = "xmp"))]
             embed_xmp: false,
             #[cfg(feature = "xmp")]
-            xmp_sidecar: config.xmp_sidecar,
+            xmp_sidecar: config.metadata.xmp_sidecar,
             #[cfg(not(feature = "xmp"))]
             xmp_sidecar: false,
-            threads: config.threads_num,
-            dry_run: config.dry_run,
+            threads: config.download.threads_num,
+            dry_run: config.runtime.dry_run,
         }
     }
 }
@@ -335,8 +335,11 @@ mod tests {
             data_dir: None,
         };
         let sync = crate::cli::SyncArgs {
-            download_dir: Some(download_dir.path().display().to_string()),
-            threads: Some(6),
+            config_overrides: crate::config::SyncConfigOverrides {
+                download_dir: Some(download_dir.path().display().to_string()),
+                threads: Some(6),
+                ..Default::default()
+            },
             ..crate::cli::SyncArgs::default()
         };
         let config = crate::config::Config::build(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -943,9 +943,8 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
         }
     }
 
-    // Performance. Ranges mirror clap's runtime parsers in `src/cli.rs`
-    // (`--threads` is `1..=64`, `--max-retries` is `0..=100`) so the wizard
-    // rejects values the runtime would also reject.
+    // Performance. Ranges mirror runtime config validation so the wizard
+    // rejects values the sync path would also reject.
     println!();
     let threads: u16 = Input::new()
         .with_prompt("Concurrent download threads (1..=64)")

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -254,15 +254,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         globals,
         &pw,
         sync,
+        config::SyncConfigOverrides::default(),
         toml_config.as_ref(),
         personality_mode,
         friendly_request,
     )?;
 
-    // On first run (no config file), persist CLI-provided values so
-    // subsequent runs don't need the same flags again. Only when the
-    // user explicitly chose a config path (--config), to avoid surprise
-    // writes at the default location during tests or one-off runs.
+    // On first run (no config file), persist bootstrap values so subsequent
+    // runs don't need the same env again. Only when the user explicitly chose
+    // a config path (--config), to avoid surprise writes at the default
+    // location during tests or one-off runs.
     if !toml_existed && config_explicitly_set {
         if let Err(e) =
             config::persist_first_run_config(&config_path, &config, cli_data_dir.as_deref())
@@ -276,14 +277,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // retry-failed: one-shot by definition.
     // setup → "sync now": initial test sync, not a daemon.
     if is_one_shot {
-        config.watch_with_interval = None;
+        config.watch.interval = None;
     }
 
-    // Service-mode contract: the daemon must poll. If neither CLI, TOML,
-    // nor env supplied an interval, fall through to the canonical 24h
-    // default so a launchd/systemd/SCM unit still has a heartbeat.
-    if let Some(applied) = service_mode_default_interval(config.watch_with_interval, service_mode) {
-        config.watch_with_interval = Some(applied);
+    // Service-mode contract: the daemon must poll. If neither CLI nor TOML
+    // supplied an interval, fall through to the canonical 24h default so a
+    // launchd/systemd/SCM unit still has a heartbeat.
+    if let Some(applied) = service_mode_default_interval(config.watch.interval, service_mode) {
+        config.watch.interval = Some(applied);
         tracing::info!(
             interval_secs = applied,
             "service mode: applied default watch interval"
@@ -291,7 +292,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
 
     // Install password redaction now that we know the password
-    if let Some(pw) = &config.password {
+    if let Some(pw) = &config.auth.password {
         if let Ok(mut guard) = redact_password.lock() {
             *guard = Some(SecretString::from(pw.expose_secret().to_owned()));
         }
@@ -302,23 +303,24 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
     // Write PID file if requested (before auth so the PID is visible immediately)
     let _pid_guard = config
+        .watch
         .pid_file
         .as_ref()
         .map(|p| PidFileGuard::new(p.clone()))
         .transpose()?;
 
-    let sd_notifier = SystemdNotifier::new(config.notify_systemd);
-    let notifier = Notifier::new(config.notification_script.clone());
+    let sd_notifier = SystemdNotifier::new(config.watch.notify_systemd);
+    let notifier = Notifier::new(config.notifications.script.clone());
 
-    tracing::info!(concurrency = config.threads_num, "Starting kei");
+    tracing::info!(concurrency = config.download.threads_num, "Starting kei");
 
-    if config.username.is_empty() {
-        anyhow::bail!("--username is required");
+    if config.auth.username.is_empty() {
+        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
     }
 
     // retry-failed + dry-run is unsupported: dry-run skips the state DB,
     // but retry-failed needs it to know which assets failed.
-    if is_retry_failed && config.dry_run {
+    if is_retry_failed && config.runtime.dry_run {
         anyhow::bail!(
             "--dry-run cannot be used with retry-failed (retry needs the state database)"
         );
@@ -326,7 +328,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
     // Validate download directory early (before auth) to avoid wasting a 2FA code
     // when the user simply forgot the destination.
-    if config.directory.as_os_str().is_empty() {
+    if config.download.directory.as_os_str().is_empty() {
         anyhow::bail!(
             "[download] directory is required for downloading \
              (set it in the config file)"
@@ -334,19 +336,19 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
 
     // Validate download directory is writable before spending time on authentication.
-    tokio::fs::create_dir_all(&config.directory)
+    tokio::fs::create_dir_all(&config.download.directory)
         .await
         .with_context(|| {
             format!(
                 "Failed to create download directory {}",
-                config.directory.display()
+                config.download.directory.display()
             )
         })?;
-    let probe = config.directory.join(".kei_probe");
+    let probe = config.download.directory.join(".kei_probe");
     tokio::fs::write(&probe, b"").await.with_context(|| {
         format!(
             "Download directory {} is not writable",
-            config.directory.display()
+            config.download.directory.display()
         )
     })?;
     if let Err(e) = tokio::fs::remove_file(&probe).await {
@@ -359,15 +361,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
     // Abort if available disk space is too low. See `check_min_disk_space`
     // for the pure inner check.
-    if let Some(avail) = available_disk_space(&config.directory) {
-        check_min_disk_space(avail, &config.directory)?;
+    if let Some(avail) = available_disk_space(&config.download.directory) {
+        check_min_disk_space(avail, &config.download.directory)?;
     }
 
-    let cred_store = credential::CredentialStore::new(&config.username, &config.cookie_directory);
+    let cred_store =
+        credential::CredentialStore::new(&config.auth.username, &config.auth.cookie_directory);
     let source = password::build_password_source(
-        config.password.as_ref(),
-        config.password_command.as_deref(),
-        config.password_file.as_deref(),
+        config.auth.password.as_ref(),
+        config.auth.password_command.as_deref(),
+        config.auth.password_file.as_deref(),
         cred_store,
     );
     // Snapshot the source kind before moving `source` into the provider
@@ -376,14 +379,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     let password_provider = make_password_provider(source);
 
     let auth_result = match auth::authenticate_with_mode(
-        &config.cookie_directory,
-        &config.username,
+        &config.auth.cookie_directory,
+        &config.auth.username,
         &password_provider,
-        config.domain.as_str(),
+        config.auth.domain.as_str(),
         None,
         None,
         None,
-        config.personality_mode,
+        config.ui.personality_mode,
     )
     .await
     {
@@ -394,26 +397,26 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         {
             let msg = format!(
                 "2FA required for {u}. Run: kei login get-code",
-                u = config.username
+                u = config.auth.username
             );
             tracing::warn!(message = %msg, "2FA required");
             notifier.notify(
                 notifications::Event::TwoFaRequired,
                 &msg,
-                &config.username,
+                &config.auth.username,
                 None,
             );
 
-            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+            wait_and_retry_2fa(&config.auth.cookie_directory, &config.auth.username, || {
                 auth::authenticate_with_mode(
-                    &config.cookie_directory,
-                    &config.username,
+                    &config.auth.cookie_directory,
+                    &config.auth.username,
                     &password_provider,
-                    config.domain.as_str(),
+                    config.auth.domain.as_str(),
                     None,
                     None,
                     None,
-                    config.personality_mode,
+                    config.ui.personality_mode,
                 )
             })
             .await?
@@ -421,19 +424,22 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         Err(e) => return Err(e),
     };
     // Post-auth narration. Lands above any future bar; no-op in off mode.
-    crate::personality::narration::auth_ok_to_stderr(config.personality_mode, &config.username);
+    crate::personality::narration::auth_ok_to_stderr(
+        config.ui.personality_mode,
+        &config.auth.username,
+    );
 
     // Save password to credential store if requested. Only the ephemeral
     // `Direct` source (CLI flag / env var) persists; File / Command /
     // Store / Interactive each emit a warning explaining why the flag is
     // a no-op for that source.
-    if config.save_password {
+    if config.auth.save_password {
         match password::decide_save_password_action(password_source_kind) {
             password::SavePasswordAction::Save => {
-                if let Some(ref pw) = config.password {
+                if let Some(ref pw) = config.auth.password {
                     let store = credential::CredentialStore::new(
-                        &config.username,
-                        &config.cookie_directory,
+                        &config.auth.username,
+                        &config.auth.cookie_directory,
                     );
                     if let Err(e) = store.store(pw.expose_secret()) {
                         tracing::warn!(error = %e, "Failed to save password to credential store");
@@ -452,8 +458,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
 
     let api_retry_config = retry::RetryConfig {
-        max_retries: config.max_retries,
-        base_delay_secs: config.retry_delay_secs,
+        max_retries: config.retry.max_retries,
+        base_delay_secs: config.retry.retry_delay_secs,
         max_delay_secs: 60,
     };
     api_retry_config.validate()?;
@@ -473,7 +479,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             .take()
             .expect("auth_result present at start of attempt");
         let init_result =
-            init_photos_service(this_auth, api_retry_config, config.personality_mode).await;
+            init_photos_service(this_auth, api_retry_config, config.ui.personality_mode).await;
         let (ss, mut ps) = match init_result {
             Ok(pair) => pair,
             Err(e) if should_retry_session_init(&e, retried_after_session_error) => {
@@ -488,7 +494,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             }
             Err(e) => return Err(e),
         };
-        match resolve_libraries(&config.selection.libraries, &mut ps).await {
+        match resolve_libraries(&config.filters.selection.libraries, &mut ps).await {
             Ok(libs) => break (ss, ps, libs),
             Err(e) if should_retry_session_init(&e, retried_after_session_error) => {
                 tracing::warn!(
@@ -510,7 +516,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     );
     // Post-library-resolve narration. Friendly-mode-only.
     crate::personality::narration::libraries_resolved_to_stderr(
-        config.personality_mode,
+        config.ui.personality_mode,
         libraries.len(),
     );
 
@@ -518,18 +524,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // impossible-config case (e.g. shared libraries plus a smart-folder selector)
     // here, before any per-library work, so the user gets a clear error
     // instead of a silent zero-pass run with exit code 0.
-    validate_smart_folder_fulfillability(&libraries, &config.selection)?;
+    validate_smart_folder_fulfillability(&libraries, &config.filters.selection)?;
 
     // Initialize state database.
     // Skip for --dry-run so a preview doesn't create the DB or poison
     // sync tokens, which would cause a subsequent real sync to believe
     // nothing has changed and download 0 photos.
-    let state_db: Option<Arc<dyn state::StateDb>> = if config.dry_run {
+    let state_db: Option<Arc<dyn state::StateDb>> = if config.runtime.dry_run {
         None
     } else {
-        let db_path = config.cookie_directory.join(format!(
+        let db_path = config.auth.cookie_directory.join(format!(
             "{}.db",
-            auth::session::sanitize_username(&config.username)
+            auth::session::sanitize_username(&config.auth.username)
         ));
         match state::SqliteStateDb::open(&db_path).await {
             Ok(db) => {
@@ -601,7 +607,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // shared libraries they could be syncing. Runs once per data dir,
     // gated by state DB metadata.
     maybe_notify_shared_libraries(
-        &config.selection.libraries,
+        &config.filters.selection.libraries,
         &mut photos_service,
         state_db.as_deref(),
     )
@@ -610,16 +616,19 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // Pre-compute config values used each cycle to build DownloadConfig.
     // DownloadConfig is rebuilt per-cycle so sync_mode can vary.
     let skip_created_before = config
+        .filters
         .skip_created_before
         .map(|d| d.with_timezone(&chrono::Utc));
     let skip_created_after = config
+        .filters
         .skip_created_after
         .map(|d| d.with_timezone(&chrono::Utc));
     let retry_config = api_retry_config;
-    let live_photo_size = config.live_photo_size.to_asset_version_size();
+    let live_photo_size = config.photos.live_photo_size.to_asset_version_size();
     // One shared limiter per sync run so the configured cap applies to
     // aggregate throughput across every concurrent download.
     let bandwidth_limiter = config
+        .download
         .bandwidth_limit
         .map(download::limiter::BandwidthLimiter::new);
     if let Some(limiter) = &bandwidth_limiter {
@@ -633,12 +642,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // Arc-sharing win is half-defeated: each build_download_config
     // call would re-allocate directory / filename_exclude / temp_suffix
     // from scratch instead of refcount-bumping.
-    let cfg_directory: Arc<std::path::Path> = Arc::from(config.directory.as_path());
-    let cfg_filename_exclude: Arc<[glob::Pattern]> = Arc::from(config.filename_exclude.clone());
-    let cfg_temp_suffix: Arc<str> = Arc::from(config.temp_suffix.as_str());
-    let cfg_folder_structure_albums: Arc<str> = Arc::from(config.folder_structure_albums.as_str());
+    let cfg_directory: Arc<std::path::Path> = Arc::from(config.download.directory.as_path());
+    let cfg_filename_exclude: Arc<[glob::Pattern]> =
+        Arc::from(config.download.filename_exclude.clone());
+    let cfg_temp_suffix: Arc<str> = Arc::from(config.download.temp_suffix.as_str());
+    let cfg_folder_structure_albums: Arc<str> =
+        Arc::from(config.download.folder_structure_albums.as_str());
     let cfg_folder_structure_smart_folders: Arc<str> =
-        Arc::from(config.folder_structure_smart_folders.as_str());
+        Arc::from(config.download.folder_structure_smart_folders.as_str());
 
     let build_download_config = |sync_mode: download::SyncMode,
                                  exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>,
@@ -647,46 +658,46 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
      -> Arc<download::DownloadConfig> {
         Arc::new(download::DownloadConfig {
             directory: Arc::clone(&cfg_directory),
-            folder_structure: config.folder_structure.clone(),
+            folder_structure: config.download.folder_structure.clone(),
             folder_structure_albums: Arc::clone(&cfg_folder_structure_albums),
             folder_structure_smart_folders: Arc::clone(&cfg_folder_structure_smart_folders),
             library,
-            size: config.size.into(),
-            skip_videos: config.skip_videos,
-            skip_photos: config.skip_photos,
+            size: config.photos.size.into(),
+            skip_videos: config.filters.skip_videos,
+            skip_photos: config.filters.skip_photos,
             skip_created_before,
             skip_created_after,
             #[cfg(feature = "xmp")]
-            set_exif_datetime: config.set_exif_datetime,
+            set_exif_datetime: config.metadata.set_exif_datetime,
             #[cfg(feature = "xmp")]
-            set_exif_rating: config.set_exif_rating,
+            set_exif_rating: config.metadata.set_exif_rating,
             #[cfg(feature = "xmp")]
-            set_exif_gps: config.set_exif_gps,
+            set_exif_gps: config.metadata.set_exif_gps,
             #[cfg(feature = "xmp")]
-            set_exif_description: config.set_exif_description,
+            set_exif_description: config.metadata.set_exif_description,
             #[cfg(feature = "xmp")]
-            embed_xmp: config.embed_xmp,
+            embed_xmp: config.metadata.embed_xmp,
             #[cfg(feature = "xmp")]
-            xmp_sidecar: config.xmp_sidecar,
-            dry_run: config.dry_run,
-            concurrent_downloads: config.threads_num as usize,
-            recent: config.recent,
+            xmp_sidecar: config.metadata.xmp_sidecar,
+            dry_run: config.runtime.dry_run,
+            concurrent_downloads: config.download.threads_num as usize,
+            recent: config.filters.recent,
             retry: retry_config,
-            live_photo_mode: config.live_photo_mode,
+            live_photo_mode: config.photos.live_photo_mode,
             live_photo_size,
-            live_photo_mov_filename_policy: config.live_photo_mov_filename_policy,
-            align_raw: config.align_raw,
-            no_progress_bar: config.no_progress_bar,
-            only_print_filenames: config.only_print_filenames,
-            personality_mode: config.personality_mode,
-            file_match_policy: config.file_match_policy,
-            force_size: config.force_size,
-            keep_unicode_in_filenames: config.keep_unicode_in_filenames,
+            live_photo_mov_filename_policy: config.photos.live_photo_mov_filename_policy,
+            align_raw: config.photos.align_raw,
+            no_progress_bar: config.download.no_progress_bar,
+            only_print_filenames: config.runtime.only_print_filenames,
+            personality_mode: config.ui.personality_mode,
+            file_match_policy: config.photos.file_match_policy,
+            force_size: config.photos.force_size,
+            keep_unicode_in_filenames: config.photos.keep_unicode_in_filenames,
             filename_exclude: Arc::clone(&cfg_filename_exclude),
             temp_suffix: Arc::clone(&cfg_temp_suffix),
             state_db: state_db.clone(),
             retry_only: is_retry_failed,
-            max_download_attempts: config.max_download_attempts,
+            max_download_attempts: config.retry.max_download_attempts,
             sync_mode,
             album_name: None,
             exclude_asset_ids,
@@ -695,7 +706,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         })
     };
 
-    let shutdown_token = shutdown::install_signal_handler(sd_notifier, config.personality_mode)?;
+    let shutdown_token = shutdown::install_signal_handler(sd_notifier, config.ui.personality_mode)?;
 
     // Suppress the tty driver's `^C` echo for the lifetime of this sync run.
     // Without this, the echoed `^C` overflows the bar's right-edge filler
@@ -703,13 +714,13 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // leave a stale top rule above the live bar. Friendly + tty only;
     // restored on Drop and on the second-Ctrl+C force-exit path. See
     // `personality::tty_echo` for the full context.
-    let _echo_guard = if config.personality_mode.is_friendly() {
+    let _echo_guard = if config.ui.personality_mode.is_friendly() {
         crate::personality::tty_echo::EchoGuard::install()
     } else {
         None
     };
 
-    let is_watch_mode = config.watch_with_interval.is_some();
+    let is_watch_mode = config.watch.interval.is_some();
     let mut reauth_attempts = 0u32;
     // Sum of per-cycle failed_counts across the lifetime of this process.
     // Surfaced at exit so watch-mode daemons don't mask earlier-cycle
@@ -720,7 +731,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     for library in &libraries {
         let zone_name = library.zone_name().to_string();
         let sync_token_key = format!("sync_token:{zone_name}");
-        let plan = resolve_passes(library, &config.selection).await?;
+        let plan = resolve_passes(library, &config.filters.selection).await?;
         let (album_passes, smart_folder_passes, unfiled) = count_passes(&plan);
         tracing::info!(
             zone = %zone_name,
@@ -739,15 +750,15 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
     warn_if_multi_library_paths_commingle(
         library_states.len(),
-        &config.folder_structure,
-        &config.folder_structure_albums,
-        &config.folder_structure_smart_folders,
-        &config.selection,
+        &config.download.folder_structure,
+        &config.download.folder_structure_albums,
+        &config.download.folder_structure_smart_folders,
+        &config.filters.selection,
     );
     sd_notifier.notify_ready();
     // Friendly-mode greeting. Lands above any future bar via
     // active_bar::with_suspended; no-op in off mode. Once per process.
-    crate::personality::narration::greet_to_stderr(config.personality_mode, is_watch_mode);
+    crate::personality::narration::greet_to_stderr(config.ui.personality_mode, is_watch_mode);
 
     // Spawn the HTTP server (/healthz + /metrics) only in watch mode.
     // A one-shot sync exits before anything could scrape /healthz, so there
@@ -756,12 +767,13 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // but a stuck main loop does.
     // Binds synchronously so a misconfigured port fails at startup.
     let staleness_threshold = config
-        .watch_with_interval
+        .watch
+        .interval
         .map(|secs| chrono::Duration::seconds((secs * 2) as i64));
-    let (metrics_handle, metrics_task) = if config.watch_with_interval.is_some() {
+    let (metrics_handle, metrics_task) = if config.watch.interval.is_some() {
         let (h, t, _addr) = crate::metrics::spawn_server(
-            config.http_bind,
-            config.http_port,
+            config.server.bind,
+            config.server.port,
             shutdown_token.clone(),
             staleness_threshold,
         )?;
@@ -778,7 +790,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // first re-entry under `--watch`, etc.
     let mut cycle_index: u64 = 0;
     if is_watch_mode {
-        match config.reconcile_every_n_cycles {
+        match config.watch.reconcile_every_n_cycles {
             Some(n) if n > 0 => tracing::info!(
                 every_n_cycles = n,
                 "Periodic local-vs-state reconciliation enabled"
@@ -812,7 +824,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // Docker HEALTHCHECK doesn't mark the container unhealthy after
             // the 2-hour staleness window when no new photos are uploaded.
             health.record_success();
-            health.write(&config.cookie_directory);
+            health.write(&config.auth.cookie_directory);
             // Refresh health gauges only -- do not reset cycle_duration_seconds.
             if let Some(ref handle) = metrics_handle {
                 handle.update_health_only(&health).await;
@@ -823,7 +835,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             notifier.notify(
                 notifications::Event::SyncStarted,
                 "Sync cycle starting",
-                &config.username,
+                &config.auth.username,
                 None,
             );
 
@@ -844,7 +856,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // card's library totals, and the metrics gauges below; all
             // three reuse the same fetch. Off mode skips it entirely so
             // the v0.13 cycle path stays free of friendly-only DB calls.
-            let library_after_summary = if config.personality_mode.is_friendly() {
+            let library_after_summary = if config.ui.personality_mode.is_friendly() {
                 match state_db.as_deref() {
                     Some(db) => match db.get_summary().await {
                         Ok(s) => Some(s),
@@ -871,14 +883,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 let after = library_after.downloaded_bytes;
                 let before = after.saturating_sub(cycle_result.stats.bytes_downloaded);
                 crate::personality::narration::downloaded_phase_to_stderr(
-                    config.personality_mode,
+                    config.ui.personality_mode,
                     downloaded_u64,
                     before,
                     after,
                 );
             }
             crate::personality::narration::verified_phase_to_stderr(
-                config.personality_mode,
+                config.ui.personality_mode,
                 downloaded_u64,
             );
             if let Some(library_after) = library_after_summary.as_ref() {
@@ -899,9 +911,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     library_total_assets: library_after.total_assets,
                     library_total_bytes: library_after.downloaded_bytes,
                 };
-                card.print_to_stderr(config.personality_mode);
+                card.print_to_stderr(config.ui.personality_mode);
                 crate::personality::summary::print_recap_to_stderr(
-                    config.personality_mode,
+                    config.ui.personality_mode,
                     &cycle_result.stats.recap,
                 );
             }
@@ -909,7 +921,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // Friendly-mode signoff line. Off-mode keeps relying on
             // log_sync_summary for journal output.
             crate::personality::narration::signoff_to_stderr(
-                config.personality_mode,
+                config.ui.personality_mode,
                 &crate::personality::narration::CycleSummary {
                     downloaded: downloaded_u64,
                     failed: u64::try_from(cycle_result.failed_count).unwrap_or(u64::MAX),
@@ -926,7 +938,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             } else {
                 health.record_success();
             }
-            health.write(&config.cookie_directory);
+            health.write(&config.auth.cookie_directory);
 
             // Update Prometheus metrics if the server is running.
             if let Some(ref handle) = metrics_handle {
@@ -954,7 +966,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             }
 
             // Write JSON report if configured
-            if let Some(report_path) = &config.report_json {
+            if let Some(report_path) = &config.report.json {
                 let status = crate::report::sync_status_str(
                     cycle_result.session_expired,
                     cycle_result.stats.interrupted,
@@ -1025,9 +1037,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 );
                 match attempt_reauth(
                     &shared_session,
-                    &config.cookie_directory,
-                    &config.username,
-                    config.domain.as_str(),
+                    &config.auth.cookie_directory,
+                    &config.auth.username,
+                    config.auth.domain.as_str(),
                     &password_provider,
                 )
                 .await
@@ -1047,28 +1059,32 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
                         let msg = format!(
                             "2FA required for {u}. Run: kei login get-code",
-                            u = config.username
+                            u = config.auth.username
                         );
                         tracing::warn!(message = %msg, "2FA required");
                         notifier.notify(
                             notifications::Event::TwoFaRequired,
                             &msg,
-                            &config.username,
+                            &config.auth.username,
                             None,
                         );
                         if !should_wait_for_2fa(is_watch_mode, &e) {
                             return Err(e);
                         }
 
-                        wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
-                            attempt_reauth(
-                                &shared_session,
-                                &config.cookie_directory,
-                                &config.username,
-                                config.domain.as_str(),
-                                &password_provider,
-                            )
-                        })
+                        wait_and_retry_2fa(
+                            &config.auth.cookie_directory,
+                            &config.auth.username,
+                            || {
+                                attempt_reauth(
+                                    &shared_session,
+                                    &config.auth.cookie_directory,
+                                    &config.auth.username,
+                                    config.auth.domain.as_str(),
+                                    &password_provider,
+                                )
+                            },
+                        )
                         .await?;
                         continue;
                     }
@@ -1076,7 +1092,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                         notifier.notify(
                             notifications::Event::SessionExpired,
                             &format!("Re-authentication failed: {e}"),
-                            &config.username,
+                            &config.auth.username,
                             None,
                         );
                         return Err(e);
@@ -1087,7 +1103,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 notifier.notify(
                     notifications::Event::SyncFailed,
                     &format!("{} downloads failed", cycle_result.failed_count),
-                    &config.username,
+                    &config.auth.username,
                     Some(&data),
                 );
                 cumulative_failed_count =
@@ -1107,7 +1123,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 notifier.notify(
                     notifications::Event::SyncComplete,
                     "Sync completed successfully",
-                    &config.username,
+                    &config.auth.username,
                     Some(&data),
                 );
             }
@@ -1121,14 +1137,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         // etc.); a periodic visible signal beats waiting for the next sync
         // to stumble over the missing files.
         if is_watch_mode
-            && should_reconcile_this_cycle(cycle_index, config.reconcile_every_n_cycles)
+            && should_reconcile_this_cycle(cycle_index, config.watch.reconcile_every_n_cycles)
         {
             if let Some(db) = state_db.as_ref() {
                 run_periodic_reconcile(db.as_ref(), cycle_index).await;
             }
         }
 
-        if let Some(interval) = config.watch_with_interval {
+        if let Some(interval) = config.watch.interval {
             if shutdown_token.is_cancelled() {
                 tracing::info!("Shutdown requested, exiting...");
                 break;
@@ -1154,7 +1170,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 .and_then(|d| chrono::Local::now().checked_add_signed(d))
             {
                 crate::personality::narration::sleeping_until_to_stderr(
-                    config.personality_mode,
+                    config.ui.personality_mode,
                     wake_at,
                 );
             }
@@ -1174,7 +1190,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // exclusion set; for libraries with many albums this can be slow under
             // watch mode. PR12+ may add per-album sync-token caching.
             for lib_state in &mut library_states {
-                match resolve_passes(&lib_state.library, &config.selection).await {
+                match resolve_passes(&lib_state.library, &config.filters.selection).await {
                     Ok(refreshed) => {
                         lib_state.plan = refreshed;
                         lib_state.plan_is_stale = false;
@@ -1212,7 +1228,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // a one-shot run completing normally), the per-cycle signoff already
     // covered the closing sentiment and a second "Done." line would be noise.
     if shutdown_token.is_cancelled() {
-        crate::personality::narration::farewell_to_stderr(config.personality_mode);
+        crate::personality::narration::farewell_to_stderr(config.ui.personality_mode);
     }
 
     // Signal the metrics server to shut down (idempotent if SIGINT already
@@ -1260,18 +1276,19 @@ async fn reauth_with_srp(
         drop(ps);
         drop(ss);
     }
-    let session_file = auth::session_file_path(&config.cookie_directory, &config.username);
+    let session_file =
+        auth::session_file_path(&config.auth.cookie_directory, &config.auth.username);
     auth::strip_session_routing_state(&session_file).await;
 
     match auth::authenticate_with_mode(
-        &config.cookie_directory,
-        &config.username,
+        &config.auth.cookie_directory,
+        &config.auth.username,
         password_provider,
-        config.domain.as_str(),
+        config.auth.domain.as_str(),
         None,
         None,
         None,
-        config.personality_mode,
+        config.ui.personality_mode,
     )
     .await
     {
@@ -1282,25 +1299,25 @@ async fn reauth_with_srp(
         {
             let msg = format!(
                 "2FA required for {u}. Run: kei login get-code",
-                u = config.username
+                u = config.auth.username
             );
             tracing::warn!(message = %msg, "2FA required");
             notifier.notify(
                 notifications::Event::TwoFaRequired,
                 &msg,
-                &config.username,
+                &config.auth.username,
                 None,
             );
-            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+            wait_and_retry_2fa(&config.auth.cookie_directory, &config.auth.username, || {
                 auth::authenticate_with_mode(
-                    &config.cookie_directory,
-                    &config.username,
+                    &config.auth.cookie_directory,
+                    &config.auth.username,
                     password_provider,
-                    config.domain.as_str(),
+                    config.auth.domain.as_str(),
                     None,
                     None,
                     None,
-                    config.personality_mode,
+                    config.ui.personality_mode,
                 )
             })
             .await
@@ -1546,7 +1563,7 @@ async fn run_cycle(
     // pipeline's `config_hash` (which tracks path-affecting fields only).
     // Using a single key for both would cause the two hashes to overwrite
     // each other every cycle, permanently preventing incremental sync.
-    if !config.dry_run {
+    if !config.runtime.dry_run {
         if let Some(db) = state_db {
             let config_hash = download::compute_config_hash(config);
             let _ = check_and_persist_enum_config_hash(db, &config_hash).await;
@@ -1579,7 +1596,7 @@ async fn run_cycle(
 
         // Skip the DB scan entirely when nothing downstream will read it.
         #[cfg(feature = "xmp")]
-        let asset_groupings = if config.embed_xmp || config.xmp_sidecar {
+        let asset_groupings = if config.metadata.embed_xmp || config.metadata.xmp_sidecar {
             preload_asset_groupings(state_db, &lib_state.zone_name).await
         } else {
             Arc::new(download::AssetGroupings::default())
@@ -1613,7 +1630,7 @@ async fn run_cycle(
         // NOT advanced, so assets will replay on next sync (safe, not data loss).
         let should_store_token = should_store_sync_token_for_cycle(
             &sync_result.outcome,
-            config.dry_run,
+            config.runtime.dry_run,
             cycle_has_stale_plan,
         );
         if should_store_token {
@@ -1894,9 +1911,9 @@ async fn reacquire_session(
 ) {
     match attempt_reauth(
         shared_session,
-        &config.cookie_directory,
-        &config.username,
-        config.domain.as_str(),
+        &config.auth.cookie_directory,
+        &config.auth.username,
+        config.auth.domain.as_str(),
         password_provider,
     )
     .await

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -119,7 +119,7 @@ fn should_notify_shared_libraries(
     Some(format!(
         "Detected {shared_count} iCloud shared {word} on this account; only the primary \
          library {verb} being synced. To include shared libraries too, set \
-         `[filters] libraries = [\"all\"]` in config.toml (or pass `--library all`). \
+         `[filters] libraries = [\"all\"]` in config.toml. \
          Run `kei list libraries` to enumerate every zone."
     ))
 }
@@ -186,9 +186,8 @@ async fn maybe_notify_shared_libraries(
     }
 }
 
-/// Default watch interval applied when `kei service run` enters with no
-/// CLI / TOML / env value set. 24 hours, matching the value baked into
-/// the Docker image's `KEI_WATCH_WITH_INTERVAL`.
+/// Default watch interval applied when `kei service run` enters with no TOML
+/// value set. 24 hours, matching the Docker image's always-on service shape.
 pub(crate) const SERVICE_MODE_DEFAULT_WATCH_INTERVAL: u64 = 86400;
 
 /// Decide whether to apply the service-mode watch-interval fallback.
@@ -256,7 +255,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         &pw,
         sync,
         toml_config.as_ref(),
-        config::parse_env_watch_interval(std::env::var(config::ENV_WATCH_INTERVAL))?,
         personality_mode,
         friendly_request,
     )?;
@@ -330,8 +328,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // when the user simply forgot the destination.
     if config.directory.as_os_str().is_empty() {
         anyhow::bail!(
-            "--download-dir is required for downloading \
-             (pass --download-dir on the CLI or set [download] directory in the config file)"
+            "[download] directory is required for downloading \
+             (set it in the config file)"
         );
     }
 
@@ -517,7 +515,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     );
 
     // CloudKit shared zones don't expose smart folders. Catch the
-    // impossible-config case (e.g. `--library shared --smart-folder X`)
+    // impossible-config case (e.g. shared libraries plus a smart-folder selector)
     // here, before any per-library work, so the user gets a clear error
     // instead of a silent zero-pass run with exit code 0.
     validate_smart_folder_fulfillability(&libraries, &config.selection)?;
@@ -1985,14 +1983,14 @@ mod tests {
 
     #[test]
     fn notice_suppressed_when_user_picked_all() {
-        // Anyone who explicitly set `--library all` has already opted in;
+        // Anyone who explicitly set all libraries has already opted in;
         // nothing to tell them.
         assert!(should_notify_shared_libraries(&all_libraries(), 3, false).is_none());
     }
 
     #[test]
     fn notice_suppressed_when_user_picked_shared_zone_explicitly() {
-        // A user who typed out `--library SharedSync-ABCD1234` has also made
+        // A user who configured `SharedSync-ABCD1234` has also made
         // a choice; don't second-guess them.
         assert!(should_notify_shared_libraries(&shared_zone(), 3, false).is_none());
     }
@@ -2014,7 +2012,10 @@ mod tests {
             msg.contains("[filters] libraries = [\"all\"]"),
             "TOML guidance missing: {msg}"
         );
-        assert!(msg.contains("--library all"), "CLI guidance missing: {msg}");
+        assert!(
+            !msg.contains("--library all"),
+            "CLI guidance should be gone: {msg}"
+        );
         assert!(
             msg.contains("kei list libraries"),
             "discovery guidance missing: {msg}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,7 +81,7 @@ opt-in (nightly + cargo-fuzz), excluded from `just gate`, and run via
    ```sh
    just dev login
    # or without just:
-   cargo run -- login --data-dir ~/.config/kei
+   KEI_DATA_DIR=~/.config/kei cargo run -- login
    ```
 
    This prompts for a 2FA code and writes session tokens. Redo only when

--- a/tests/README.md
+++ b/tests/README.md
@@ -115,7 +115,7 @@ details are baked into test code.
 | `KEI_TEST_SCRATCH_DIR` | `/tmp/kei-tests-$USER` | Base dir for shell-suite scratch |
 | `KEI_IMPORT_FIXTURE_DIR` | `/tmp/claude/kei-import-fixture` | Where `import_existing_live.rs` caches its `--recent 100` sync fixture across runs |
 
-`just test live` applies `KEI_TEST_ALBUM=icloudpd-test` to match this
+`just test live` applies `KEI_TEST_ALBUM=kei-test` to match this
 repo's maintainer setup. Override in your environment to point at your
 own account. Cookie dir falls through to the harness default
 (`./.test-cookies`); set `ICLOUD_TEST_COOKIE_DIR` to override.

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -39,6 +39,21 @@ fn clean_cmd() -> assert_cmd::Command {
     cmd
 }
 
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn write_sync_config(config_path: &std::path::Path, download_dir: &str) {
+    std::fs::write(
+        config_path,
+        format!(
+            "[download]\ndirectory = \"{}\"\n",
+            toml_escape(download_dir)
+        ),
+    )
+    .unwrap();
+}
+
 /// Sanitize a username the same way the binary does (alphanumeric + underscore).
 fn sanitize_username(username: &str) -> String {
     username
@@ -641,11 +656,13 @@ fn password_clear_on_empty_store_errors() {
 #[test]
 fn sync_requires_username() {
     let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, "/photos");
     clean_cmd()
         .args([
             "sync",
-            "--download-dir",
-            "/photos",
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -667,7 +684,7 @@ fn sync_requires_directory() {
         ])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--download-dir is required"));
+        .stderr(predicate::str::contains("[download] directory is required"));
 }
 
 #[test]
@@ -933,8 +950,6 @@ fn first_run_auto_config_creates_file() {
             config_path.to_str().unwrap(),
             "--username",
             "auto@example.com",
-            "--download-dir",
-            "/auto/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -950,10 +965,6 @@ fn first_run_auto_config_creates_file() {
     assert!(
         content.contains("auto@example.com"),
         "auto-config should contain username, got:\n{content}"
-    );
-    assert!(
-        content.contains("/auto/photos"),
-        "auto-config should contain directory, got:\n{content}"
     );
 }
 
@@ -1032,7 +1043,11 @@ fn config_unknown_toml_field() {
 fn config_empty_username_in_toml() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
-    std::fs::write(&config_path, "[auth]\nusername = \"\"\n").unwrap();
+    std::fs::write(
+        &config_path,
+        "[auth]\nusername = \"\"\n\n[download]\ndirectory = \"/photos\"\n",
+    )
+    .unwrap();
 
     // config show calls Config::build which checks for empty username
     // only when a username source is present in TOML. Since TOML sets
@@ -1042,8 +1057,6 @@ fn config_empty_username_in_toml() {
             "sync",
             "--config",
             config_path.to_str().unwrap(),
-            "--download-dir",
-            "/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -1060,7 +1073,7 @@ fn config_toml_password_field_rejected() {
     let config_path = dir.path().join("config.toml");
     std::fs::write(
         &config_path,
-        "[auth]\nusername = \"x@x.com\"\npassword = \"\"\n",
+        "[auth]\nusername = \"x@x.com\"\npassword = \"\"\n\n[download]\ndirectory = \"/photos\"\n",
     )
     .unwrap();
 
@@ -1069,8 +1082,6 @@ fn config_toml_password_field_rejected() {
             "sync",
             "--config",
             config_path.to_str().unwrap(),
-            "--download-dir",
-            "/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -1094,7 +1105,7 @@ fn config_multiple_password_sources_in_toml() {
     let config_path = dir.path().join("config.toml");
     std::fs::write(
         &config_path,
-        "[auth]\nusername = \"x@x.com\"\npassword_file = \"/tmp/pw\"\npassword_command = \"echo hi\"\n",
+        "[auth]\nusername = \"x@x.com\"\npassword_file = \"/tmp/pw\"\npassword_command = \"echo hi\"\n\n[download]\ndirectory = \"/photos\"\n",
     )
     .unwrap();
 
@@ -1103,8 +1114,6 @@ fn config_multiple_password_sources_in_toml() {
             "sync",
             "--config",
             config_path.to_str().unwrap(),
-            "--download-dir",
-            "/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -1504,8 +1513,6 @@ fn auto_config_suppressed_by_env() {
             config_path.to_str().unwrap(),
             "--username",
             "suppress@example.com",
-            "--download-dir",
-            "/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -1533,8 +1540,6 @@ fn auto_config_has_0600_perms() {
             config_path.to_str().unwrap(),
             "--username",
             "perms@example.com",
-            "--download-dir",
-            "/photos",
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -2297,17 +2302,19 @@ fn exit_1_for_missing_directory_on_sync() {
         ])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--download-dir is required"));
+        .stderr(predicate::str::contains("[download] directory is required"));
 }
 
 #[test]
 fn exit_1_for_missing_username_on_sync() {
     let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, "/photos");
     clean_cmd()
         .args([
             "sync",
-            "--download-dir",
-            "/photos",
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -2323,14 +2330,16 @@ fn exit_1_for_missing_username_on_sync() {
 #[test]
 fn log_level_default_info() {
     let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, "/photos");
     // sync with username + directory will fail at auth. Check stderr for INFO.
     let out = clean_cmd()
         .args([
             "sync",
             "--username",
             "x@x.com",
-            "--download-dir",
-            "/photos",
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -2358,6 +2367,8 @@ fn log_level_default_info() {
 fn log_level_debug() {
     let dir = tempfile::tempdir().unwrap();
     let dl_dir = dir.path().join("photos");
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, dl_dir.to_str().unwrap());
     let out = clean_cmd()
         .args([
             "--log-level",
@@ -2365,8 +2376,8 @@ fn log_level_debug() {
             "sync",
             "--username",
             "x@x.com",
-            "--download-dir",
-            dl_dir.to_str().unwrap(),
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -2384,6 +2395,8 @@ fn log_level_debug() {
 #[test]
 fn log_level_error() {
     let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, "/photos");
     let out = clean_cmd()
         .args([
             "--log-level",
@@ -2391,8 +2404,8 @@ fn log_level_error() {
             "sync",
             "--username",
             "x@x.com",
-            "--download-dir",
-            "/photos",
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])
@@ -2915,8 +2928,6 @@ fn dry_run_and_retry_failed_conflict() {
             "sync",
             "--username",
             "x@x.com",
-            "--download-dir",
-            "/photos",
             "--dry-run",
             "--retry-failed",
             "--data-dir",
@@ -2934,14 +2945,16 @@ fn dry_run_and_retry_failed_conflict() {
 fn dry_run_creates_no_state_db() {
     let data_dir = tempfile::tempdir().unwrap();
     let dl_dir = tempfile::tempdir().unwrap();
+    let config_path = data_dir.path().join("config.toml");
+    write_sync_config(&config_path, dl_dir.path().to_str().unwrap());
 
     clean_cmd()
         .args([
             "sync",
             "--username",
             "drytest@example.com",
-            "--download-dir",
-            dl_dir.path().to_str().unwrap(),
+            "--config",
+            config_path.to_str().unwrap(),
             "--data-dir",
             data_dir.path().to_str().unwrap(),
             "--dry-run",
@@ -3615,20 +3628,33 @@ fn run_config_show_error(body: &str) -> String {
 }
 
 /// Build a `kei sync` invocation pre-populated with username, fresh tempdir
-/// `--download-dir` / `--data-dir` pair, and `--only-print-filenames` so the
+/// config/data directories, and `--only-print-filenames` so the
 /// run exits before auth. Returns the live `Command` so callers can append
 /// flag-specific args. Tempdirs are leaked into the binary (which never
 /// touches them, as these tests bail in `Config::build`).
 fn sync_cmd_for_validation() -> assert_cmd::Command {
+    sync_cmd_for_config_body("")
+}
+
+fn sync_cmd_for_config_body(body: &str) -> assert_cmd::Command {
     let dir = tempfile::tempdir().unwrap();
     let dl_dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[auth]\nusername = \"x@x.com\"\n\n[download]\ndirectory = \"{}\"\n{body}",
+            toml_escape(dl_dir.path().to_str().unwrap())
+        ),
+    )
+    .unwrap();
     let mut cmd = clean_cmd();
     cmd.args([
         "sync",
         "--username",
         "x@x.com",
-        "--download-dir",
-        dl_dir.path().to_str().unwrap(),
+        "--config",
+        config_path.to_str().unwrap(),
         "--data-dir",
         dir.path().to_str().unwrap(),
     ]);
@@ -3649,10 +3675,8 @@ fn removed_legacy_album_in_cli_errors() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "'{album}' is not valid in --folder-structure",
-        ))
-        .stderr(predicate::str::contains("--folder-structure-albums"));
+        .stderr(predicate::str::contains("unexpected argument"))
+        .stderr(predicate::str::contains("--folder-structure"));
 }
 
 #[test]
@@ -3666,16 +3690,13 @@ fn removed_legacy_album_in_toml_errors() {
 }
 
 #[test]
-fn removed_legacy_album_in_env_errors() {
+fn removed_legacy_album_env_is_ignored() {
     sync_cmd_for_validation()
         .env("KEI_FOLDER_STRUCTURE", "{album}/%Y")
         .arg("--only-print-filenames")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "'{album}' is not valid in --folder-structure",
-        ))
-        .stderr(predicate::str::contains("--folder-structure-albums"));
+        .stderr(predicate::str::contains("'{album}' is not valid in --folder-structure").not());
 }
 
 #[test]
@@ -3692,8 +3713,8 @@ fn removed_legacy_album_errors_even_with_user_set_albums_template() {
 
 #[test]
 fn migration_no_warning_when_no_album_token() {
-    sync_cmd_for_validation()
-        .args(["--folder-structure", "%Y/%m/%d", "--only-print-filenames"])
+    sync_cmd_for_config_body("folder_structure = \"%Y/%m/%d\"\n")
+        .arg("--only-print-filenames")
         .assert()
         .stderr(predicate::str::contains("`{album}` in `--folder-structure`").not());
 }
@@ -3704,8 +3725,8 @@ fn migration_no_warning_when_no_album_token() {
 /// would mislead users into thinking their config is a no-op.
 #[test]
 fn smart_folder_flag_does_not_print_unwired_warning() {
-    sync_cmd_for_validation()
-        .args(["--smart-folder", "Favorites", "--only-print-filenames"])
+    sync_cmd_for_config_body("\n[filters]\nsmart_folders = [\"Favorites\"]\n")
+        .arg("--only-print-filenames")
         .assert()
         .stderr(predicate::str::contains("not yet wired").not())
         .stderr(predicate::str::contains("not download smart folders").not());
@@ -3716,8 +3737,8 @@ fn smart_folder_flag_does_not_print_unwired_warning() {
 /// and the cross-album exclusion-set pre-fetch in `resolve_passes`.
 #[test]
 fn unfiled_flag_does_not_print_unwired_warning() {
-    sync_cmd_for_validation()
-        .args(["--unfiled", "false", "--only-print-filenames"])
+    sync_cmd_for_config_body("\n[filters]\nunfiled = false\n")
+        .arg("--only-print-filenames")
         .assert()
         .stderr(predicate::str::contains("not yet wired").not())
         .stderr(predicate::str::contains("legacy unfiled-pass rules").not());
@@ -3745,18 +3766,10 @@ fn unfiled_flag_does_not_print_unwired_warning() {
 /// or stale "not yet wired" disclaimers reach stderr.
 #[test]
 fn sync_validation_accepts_full_selection_combo() {
-    let out = sync_cmd_for_validation()
-        .args([
-            "--album",
-            "none",
-            "--smart-folder",
-            "all",
-            "--unfiled",
-            "false",
-            "--library",
-            "shared",
-            "--only-print-filenames",
-        ])
+    let out = sync_cmd_for_config_body(
+        "\n[filters]\nalbums = [\"none\"]\nsmart_folders = [\"all\"]\nunfiled = false\nlibraries = [\"shared\"]\n",
+    )
+        .arg("--only-print-filenames")
         .assert()
         .get_output()
         .clone();
@@ -3815,8 +3828,7 @@ fn config_show_omits_default_per_category_templates() {
 
 #[test]
 fn sync_bails_on_album_token_in_smart_folders_template() {
-    sync_cmd_for_validation()
-        .args(["--folder-structure-smart-folders", "{album}/%Y"])
+    sync_cmd_for_config_body("folder_structure_smart_folders = \"{album}/%Y\"\n")
         .assert()
         .code(1)
         .stderr(predicate::str::contains("{album}"))
@@ -3825,8 +3837,7 @@ fn sync_bails_on_album_token_in_smart_folders_template() {
 
 #[test]
 fn sync_bails_on_smart_folder_token_in_albums_template() {
-    sync_cmd_for_validation()
-        .args(["--folder-structure-albums", "{smart-folder}/foo"])
+    sync_cmd_for_config_body("folder_structure_albums = \"{smart-folder}/foo\"\n")
         .assert()
         .code(1)
         .stderr(predicate::str::contains("{smart-folder}"))
@@ -3835,8 +3846,7 @@ fn sync_bails_on_smart_folder_token_in_albums_template() {
 
 #[test]
 fn sync_bails_on_library_token_not_first_segment() {
-    sync_cmd_for_validation()
-        .args(["--folder-structure", "%Y/{library}"])
+    sync_cmd_for_config_body("folder_structure = \"%Y/{library}\"\n")
         .assert()
         .code(1)
         .stderr(predicate::str::contains("{library}"))
@@ -3845,8 +3855,7 @@ fn sync_bails_on_library_token_not_first_segment() {
 
 #[test]
 fn sync_bails_on_duplicate_library_token() {
-    sync_cmd_for_validation()
-        .args(["--folder-structure-albums", "{library}/{library}/{album}"])
+    sync_cmd_for_config_body("folder_structure_albums = \"{library}/{library}/{album}\"\n")
         .assert()
         .code(1)
         .stderr(predicate::str::contains("{library}"))
@@ -3855,8 +3864,7 @@ fn sync_bails_on_duplicate_library_token() {
 
 #[test]
 fn sync_bails_on_within_album_contradiction() {
-    sync_cmd_for_validation()
-        .args(["--album", "Family", "--album", "!Family"])
+    sync_cmd_for_config_body("\n[filters]\nalbums = [\"Family\", \"!Family\"]\n")
         .assert()
         .code(1)
         .stderr(predicate::str::contains("include and exclude"))
@@ -3865,11 +3873,10 @@ fn sync_bails_on_within_album_contradiction() {
 
 #[test]
 fn sync_bails_on_library_none() {
-    sync_cmd_for_validation()
-        .args(["--library", "none"])
+    sync_cmd_for_config_body("\n[filters]\nlibraries = [\"none\"]\n")
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--library none"));
+        .stderr(predicate::str::contains("library none"));
 }
 
 #[test]
@@ -3954,9 +3961,9 @@ fn removed_toml_filter_aliases_error() {
 }
 
 #[test]
-fn env_sync_flags_allowed_with_non_sync_command() {
-    // Regression: issue #385 - sync-only env vars set in Docker Compose
-    // must not block non-sync subcommands like `kei reset`.
+fn removed_sync_env_vars_do_not_block_non_sync_command() {
+    // Regression: issue #385 - stale sync env vars set in old Docker Compose
+    // files must not block non-sync subcommands like `kei reset`.
     let temp = tempfile::tempdir().unwrap();
     let mut cmd = clean_cmd();
     cmd.current_dir(temp.path());
@@ -3973,7 +3980,7 @@ fn env_sync_flags_allowed_with_non_sync_command() {
 }
 
 #[test]
-fn env_sync_flags_allowed_with_service_status() {
+fn removed_sync_env_vars_do_not_block_service_status() {
     // Regression: issue #385 - same class of bug on a different non-sync
     // subcommand (service status does not carry SyncArgs).
     let temp = tempfile::tempdir().unwrap();

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -458,6 +458,44 @@ directory = "/toml/photos"
 }
 
 #[test]
+fn config_show_omits_derived_top_level_values_when_unset() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let download_dir = dir.path().join("photos");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[auth]
+username = "toml@example.com"
+
+[download]
+directory = {}
+"#,
+            common::toml_string(&download_dir.to_string_lossy())
+        ),
+    )
+    .unwrap();
+
+    let out = clean_cmd()
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: toml::Value = toml::from_str(&stdout).unwrap();
+    assert!(
+        parsed.get("data_dir").is_none(),
+        "config show must not serialize derived data_dir when TOML omitted it; stdout: {stdout}"
+    );
+    assert!(
+        parsed.get("log_level").is_none(),
+        "config show must not serialize default log_level when TOML omitted it; stdout: {stdout}"
+    );
+}
+
+#[test]
 fn config_show_emits_unfiled_false_when_explicit() {
     // The cli.rs help-shadow test for --unfiled only verifies clap parses;
     // it does not pin the resolved value all the way through Config::build
@@ -3351,6 +3389,35 @@ fn removed_sync_env_vars_do_not_block_non_sync_command() {
         .success()
         .stderr(predicate::str::contains("sync-only flag").not());
 }
+
+#[test]
+fn removed_sync_env_vars_do_not_supply_sync_config() {
+    // Removed sync env mirrors must not keep configuring sync after v0.20.
+    // With no TOML [download].directory, this must fail at config resolution
+    // even if a stale KEI_DOWNLOAD_DIR is still present in the environment.
+    let dir = tempfile::tempdir().unwrap();
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .env("KEI_DOWNLOAD_DIR", "/legacy/photos")
+        .env("KEI_ALBUM", "Legacy Album")
+        .env("KEI_THREADS", "4")
+        .args(["sync", "--only-print-filenames"])
+        .assert()
+        .code(1)
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[download] directory is required"),
+        "stale sync env vars must not provide durable config; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "stale sync env vars should be ignored by clap, not parsed as CLI args; stderr: {stderr}"
+    );
+}
+
 #[test]
 fn removed_sync_env_vars_do_not_block_service_status() {
     // Regression: issue #385 - same class of bug on a different non-sync

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -42,16 +42,12 @@ fn clean_cmd() -> assert_cmd::Command {
     cmd
 }
 
-fn toml_escape(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
 fn write_sync_config(config_path: &std::path::Path, download_dir: &str) {
     std::fs::write(
         config_path,
         format!(
-            "[download]\ndirectory = \"{}\"\n",
-            toml_escape(download_dir)
+            "[download]\ndirectory = {}\n",
+            common::toml_string(download_dir)
         ),
     )
     .unwrap();
@@ -3001,8 +2997,8 @@ fn sync_cmd_for_config_body(body: &str) -> assert_cmd::Command {
     std::fs::write(
         &config_path,
         format!(
-            "[auth]\nusername = \"x@x.com\"\n\n[download]\ndirectory = \"{}\"\n{body}",
-            toml_escape(dl_dir.path().to_str().unwrap())
+            "[auth]\nusername = \"x@x.com\"\n\n[download]\ndirectory = {}\n{body}",
+            common::toml_string(dl_dir.path().to_str().unwrap())
         ),
     )
     .unwrap();

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -412,6 +412,51 @@ threads = 4
         "threads should be 4, stdout: {stdout}"
     );
 }
+
+#[test]
+fn config_show_preserves_top_level_toml_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let data_dir = dir.path().join("data");
+    let data_dir_string = data_dir.to_string_lossy();
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+data_dir = {}
+log_level = "debug"
+
+[auth]
+username = "toml@example.com"
+
+[download]
+directory = "/toml/photos"
+"#,
+            common::toml_string(&data_dir_string)
+        ),
+    )
+    .unwrap();
+
+    let out = clean_cmd()
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: toml::Value = toml::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed.get("data_dir").and_then(toml::Value::as_str),
+        Some(data_dir_string.as_ref()),
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        parsed.get("log_level").and_then(toml::Value::as_str),
+        Some("debug"),
+        "stdout: {stdout}"
+    );
+}
+
 #[test]
 fn config_show_emits_unfiled_false_when_explicit() {
     // The cli.rs help-shadow test for --unfiled only verifies clap parses;

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -19,16 +19,21 @@ mod common;
 
 use predicates::prelude::*;
 use rusqlite::OptionalExtension;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
+static CLEAN_CMD_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Helper: run kei with env scrubbed and a temp data-dir so it never
 /// touches real config/cookies.
 fn clean_cmd() -> assert_cmd::Command {
     let mut cmd = common::cmd();
-    let default_data_dir =
-        std::env::temp_dir().join(format!("kei-behavioral-{}", std::process::id()));
+    let default_data_dir = std::env::temp_dir().join(format!(
+        "kei-behavioral-{}-{}",
+        std::process::id(),
+        CLEAN_CMD_ID.fetch_add(1, Ordering::Relaxed)
+    ));
     std::fs::create_dir_all(&default_data_dir).unwrap();
     cmd.env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -27,14 +27,17 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 /// touches real config/cookies.
 fn clean_cmd() -> assert_cmd::Command {
     let mut cmd = common::cmd();
+    let default_data_dir =
+        std::env::temp_dir().join(format!("kei-behavioral-{}", std::process::id()));
+    std::fs::create_dir_all(&default_data_dir).unwrap();
     cmd.env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
         .env_remove("KEI_CONFIG")
         .env_remove("KEI_DATA_DIR")
         .env_remove("KEI_DOWNLOAD_DIR")
-        .env_remove("KEI_DOMAIN")
         .env_remove("KEI_LOG_LEVEL")
         .env_remove("KEI_NO_AUTO_CONFIG")
+        .env("KEI_DATA_DIR", default_data_dir)
         .timeout(TIMEOUT);
     cmd
 }
@@ -232,11 +235,12 @@ fn behavioral_helper_schema_matches_production() {
 // ═══════════════════════════════════════════════════════════════════════
 // Current commands: no deprecation warnings
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn no_deprecation_login() {
     let out = clean_cmd()
-        .args(["login", "--username", "x@x.com", "--data-dir", "/tmp"])
+        .env("ICLOUD_USERNAME", "x@x.com")
+        .env("KEI_DATA_DIR", "/tmp")
+        .args(["login"])
         .assert()
         .failure() // fails at auth, not at parsing
         .get_output()
@@ -247,18 +251,10 @@ fn no_deprecation_login() {
         "new command should not print deprecation, stderr: {stderr}"
     );
 }
-
 #[test]
 fn no_deprecation_list_albums() {
     let out = clean_cmd()
-        .args([
-            "list",
-            "albums",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            "/tmp",
-        ])
+        .args(["list", "albums"])
         .assert()
         .failure()
         .get_output()
@@ -269,19 +265,13 @@ fn no_deprecation_list_albums() {
         "new command should not print deprecation, stderr: {stderr}"
     );
 }
-
 #[test]
 fn no_deprecation_password_backend() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "password",
-            "backend",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "backend"])
         .assert()
         .success()
         .get_output()
@@ -292,20 +282,13 @@ fn no_deprecation_password_backend() {
         "new command should not print deprecation, stderr: {stderr}"
     );
 }
-
 #[test]
 fn no_deprecation_reset_state() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "reset",
-            "state",
-            "--yes",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "state", "--yes"])
         .assert()
         .success()
         .get_output()
@@ -316,19 +299,13 @@ fn no_deprecation_reset_state() {
         "new command should not print deprecation, stderr: {stderr}"
     );
 }
-
 #[test]
 fn no_deprecation_reset_sync_token() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token"])
         .assert()
         .success()
         .get_output()
@@ -343,18 +320,10 @@ fn no_deprecation_reset_sync_token() {
 // ═══════════════════════════════════════════════════════════════════════
 // config show: resolved config output
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn config_show_outputs_valid_toml() {
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            "/tmp",
-        ])
+        .args(["config", "show"])
         .assert()
         .success()
         .get_output()
@@ -366,23 +335,15 @@ fn config_show_outputs_valid_toml() {
         "config show should produce valid TOML, got:\n{stdout}"
     );
 }
-
 #[test]
 fn config_show_contains_username() {
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            "myuser@icloud.com",
-            "--data-dir",
-            "/tmp",
-        ])
+        .env("ICLOUD_USERNAME", "myuser@icloud.com")
+        .args(["config", "show"])
         .assert()
         .success()
         .stdout(predicate::str::contains("myuser@icloud.com"));
 }
-
 #[test]
 fn config_show_reflects_directory_from_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -394,19 +355,12 @@ fn config_show_reflects_directory_from_toml() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "cli@example.com")
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("/my/photos"));
 }
-
 #[test]
 fn config_show_rejects_toml_with_password() {
     // `[auth] password` is banned; `config show` should fail loudly with
@@ -420,14 +374,7 @@ fn config_show_rejects_toml_with_password() {
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .get_output()
@@ -438,7 +385,6 @@ fn config_show_rejects_toml_with_password() {
         "password must not appear in stdout even on rejection, got:\n{stdout}"
     );
 }
-
 #[test]
 fn config_show_reflects_toml_values() {
     let dir = tempfile::tempdir().unwrap();
@@ -457,14 +403,7 @@ threads = 4
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -477,7 +416,6 @@ threads = 4
         "threads should be 4, stdout: {stdout}"
     );
 }
-
 #[test]
 fn config_show_emits_unfiled_false_when_explicit() {
     // The cli.rs help-shadow test for --unfiled only verifies clap parses;
@@ -502,14 +440,7 @@ unfiled = false
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -526,7 +457,6 @@ unfiled = false
         "config show must round-trip explicit `unfiled = false`; got:\n{stdout}"
     );
 }
-
 #[test]
 fn config_show_cli_overrides_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -541,16 +471,8 @@ username = "toml@example.com"
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "cli@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "cli@example.com")
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("cli@example.com"));
@@ -559,50 +481,50 @@ username = "toml@example.com"
 // ═══════════════════════════════════════════════════════════════════════
 // Error messages: missing required args
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn login_requires_username() {
     clean_cmd()
-        .args(["login", "--data-dir", "/tmp"])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["login"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
-
 #[test]
 fn list_albums_requires_username() {
     clean_cmd()
-        .args(["list", "albums", "--data-dir", "/tmp"])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["list", "albums"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
-
 #[test]
 fn password_set_requires_username() {
     clean_cmd()
-        .args(["password", "set", "--data-dir", "/tmp"])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["password", "set"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
-
 #[test]
 fn password_clear_requires_username() {
     clean_cmd()
-        .args(["password", "clear", "--data-dir", "/tmp"])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["password", "clear"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
-
 #[test]
 fn password_backend_requires_username() {
     clean_cmd()
-        .args(["password", "backend", "--data-dir", "/tmp"])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["password", "backend"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
 
 /// `password backend` against a fresh cookie dir prints the credential
@@ -613,14 +535,9 @@ fn password_backend_requires_username() {
 fn password_backend_prints_backend_name() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "password",
-            "backend",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "backend"])
         .assert()
         .success()
         .get_output()
@@ -640,83 +557,59 @@ fn password_backend_prints_backend_name() {
 fn password_clear_on_empty_store_errors() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "password",
-            "clear",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "clear"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("No stored credential"));
 }
-
 #[test]
 fn sync_requires_username() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     write_sync_config(&config_path, "/photos");
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
-
 #[test]
 fn sync_requires_directory() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["sync"])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("[download] directory is required"));
 }
-
 #[test]
 fn import_existing_requires_directory() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "import-existing",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["import-existing"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
             "--download-dir is required for import-existing",
         ));
 }
-
 #[test]
 fn import_existing_rejects_nonexistent_directory() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
         .args([
             "import-existing",
-            "--username",
-            "x@x.com",
             "--download-dir",
             "/does/not/exist/anywhere",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
         ])
         .assert()
         .failure()
@@ -728,69 +621,46 @@ fn import_existing_rejects_nonexistent_directory() {
 // ═══════════════════════════════════════════════════════════════════════
 // No-DB paths: commands that hit the DB but none exists
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn status_no_db() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "status",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No state database found"));
 }
-
 #[test]
 fn verify_no_db() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No state database found"));
 }
-
 #[test]
 fn reset_state_no_db() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "reset",
-            "state",
-            "--yes",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "state", "--yes"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No state database found"));
 }
-
 #[test]
 fn reset_sync_token_no_db() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No state database found"));
@@ -799,20 +669,14 @@ fn reset_sync_token_no_db() {
 // ═══════════════════════════════════════════════════════════════════════
 // password backend: shows backend name without auth
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn password_backend_shows_a_backend_name() {
     let dir = tempfile::tempdir().unwrap();
     // Output is one of: "encrypted-file", "keyring", or "none"
     clean_cmd()
-        .args([
-            "password",
-            "backend",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "backend"])
         .assert()
         .success()
         .stdout(
@@ -821,24 +685,17 @@ fn password_backend_shows_a_backend_name() {
                 .or(predicate::str::contains("none")),
         );
 }
-
 #[test]
 fn password_clear_without_stored_credential_errors() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "password",
-            "clear",
-            "--username",
-            "nobody@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "clear"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("No stored credential"));
 }
-
 #[test]
 fn password_backend_with_empty_data_dir_reports_none() {
     // Fresh data dir with no keyring entry (keyring may still report for the
@@ -846,14 +703,9 @@ fn password_backend_with_empty_data_dir_reports_none() {
     // username to minimize false positives.
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "password",
-            "backend",
-            "--username",
-            "kei-behavioral-test-nonexistent@example.invalid",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "unlikely-empty-store@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "backend"])
         .assert()
         .success()
         .get_output()
@@ -868,59 +720,47 @@ fn password_backend_with_empty_data_dir_reports_none() {
 // ═══════════════════════════════════════════════════════════════════════
 // Env var behavior: KEI_* vars actually resolve
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn kei_data_dir_env_resolves_in_status() {
     // KEI_DATA_DIR env var should be used for the data directory
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
         .env("KEI_DATA_DIR", dir.path().to_str().unwrap())
-        .args(["status", "--username", "x@x.com"])
+        .args(["status"])
         .assert()
         .success()
         .stdout(predicate::str::contains("No state database found"));
 }
-
 #[test]
 fn icloud_username_env_resolves_in_config_show() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
         .env("ICLOUD_USERNAME", "env@icloud.com")
-        .args(["config", "show", "--data-dir", dir.path().to_str().unwrap()])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["config", "show"])
         .assert()
         .success()
         .stdout(predicate::str::contains("env@icloud.com"));
 }
-
 #[test]
-fn cli_flag_overrides_env_var() {
+fn icloud_username_env_resolves_without_cli_flag() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
         .env("ICLOUD_USERNAME", "env@icloud.com")
-        .args([
-            "config",
-            "show",
-            "--username",
-            "cli@icloud.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["config", "show"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("cli@icloud.com"));
+        .stdout(predicate::str::contains("env@icloud.com"));
 }
-
 #[test]
 fn data_dir_no_deprecation() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "status",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status"])
         .assert()
         .success()
         .get_output()
@@ -928,14 +768,13 @@ fn data_dir_no_deprecation() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         !stderr.contains("deprecated"),
-        "--data-dir should not warn, stderr: {stderr}"
+        "KEI_DATA_DIR should not warn, stderr: {stderr}"
     );
 }
 
 // ═══════════════════════════════════════════════════════════════════════
 // First-run auto-config
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn first_run_auto_config_creates_file() {
     let dir = tempfile::tempdir().unwrap();
@@ -944,15 +783,8 @@ fn first_run_auto_config_creates_file() {
     // sync will fail at auth, but auto-config fires before auth.
     // Use --config pointing at non-existent file in existing directory.
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "auto@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "auto@example.com")
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .failure(); // fails at auth, but config file should have been created
 
@@ -967,7 +799,6 @@ fn first_run_auto_config_creates_file() {
         "auto-config should contain username, got:\n{content}"
     );
 }
-
 #[test]
 fn first_run_auto_config_does_not_overwrite() {
     let dir = tempfile::tempdir().unwrap();
@@ -975,16 +806,7 @@ fn first_run_auto_config_does_not_overwrite() {
     std::fs::write(&config_path, "# existing config\n").unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "new@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success();
 
@@ -998,7 +820,6 @@ fn first_run_auto_config_does_not_overwrite() {
 // ═══════════════════════════════════════════════════════════════════════
 // Config validation: malformed/invalid TOML
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn config_malformed_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -1006,19 +827,11 @@ fn config_malformed_toml() {
     std::fs::write(&config_path, "this is not valid toml {{{").unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("parse").or(predicate::str::contains("expected")));
 }
-
 #[test]
 fn config_unknown_toml_field() {
     let dir = tempfile::tempdir().unwrap();
@@ -1026,19 +839,11 @@ fn config_unknown_toml_field() {
     std::fs::write(&config_path, "[auth]\nbogus = true\n").unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("unknown field"));
 }
-
 #[test]
 fn config_empty_username_in_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -1053,18 +858,11 @@ fn config_empty_username_in_toml() {
     // only when a username source is present in TOML. Since TOML sets
     // username = "", the build path validates it.
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("must not be empty"));
 }
-
 #[test]
 fn config_toml_password_field_rejected() {
     // `[auth] password` is no longer accepted, empty or otherwise; kei must
@@ -1078,13 +876,7 @@ fn config_toml_password_field_rejected() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("`[auth] password`"))
@@ -1110,18 +902,11 @@ fn config_multiple_password_sources_in_toml() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("pick one"));
 }
-
 #[test]
 fn config_strftime_folder_structure_accepted() {
     // Full strftime support: %B (month name), %q, etc. are no longer rejected.
@@ -1135,19 +920,12 @@ fn config_strftime_folder_structure_accepted() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         // Should get past config validation (no "unrecognized format token" error).
         // Fails on auth, not on config.
         .stderr(predicate::str::contains("unrecognized format token").not());
 }
-
 #[test]
 fn config_valid_folder_structure_ymd() {
     let dir = tempfile::tempdir().unwrap();
@@ -1159,19 +937,11 @@ fn config_valid_folder_structure_ymd() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("%Y/%m/%d"));
 }
-
 #[test]
 fn config_valid_folder_structure_ym() {
     let dir = tempfile::tempdir().unwrap();
@@ -1183,19 +953,11 @@ fn config_valid_folder_structure_ym() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("%Y-%m"));
 }
-
 #[test]
 fn config_valid_folder_structure_ymdh() {
     let dir = tempfile::tempdir().unwrap();
@@ -1207,19 +969,11 @@ fn config_valid_folder_structure_ymdh() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("%Y/%m/%d/%H"));
 }
-
 #[test]
 fn config_folder_structure_none() {
     let dir = tempfile::tempdir().unwrap();
@@ -1232,19 +986,11 @@ fn config_folder_structure_none() {
 
     // "none" is a special value that should be accepted (no error)
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("none"));
 }
-
 #[test]
 fn config_watch_interval_below_60_in_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -1256,20 +1002,13 @@ fn config_watch_interval_below_60_in_toml() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains(
             "watch interval must be in 60..=86400 seconds, got 30",
         ));
 }
-
 #[test]
 fn config_retry_delay_toml_key_is_removed() {
     let dir = tempfile::tempdir().unwrap();
@@ -1281,18 +1020,11 @@ fn config_retry_delay_toml_key_is_removed() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("unknown field `delay`"));
 }
-
 #[test]
 fn config_threads_num_toml_key_is_removed() {
     let dir = tempfile::tempdir().unwrap();
@@ -1304,13 +1036,7 @@ fn config_threads_num_toml_key_is_removed() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("unknown field `threads_num`"));
@@ -1319,7 +1045,6 @@ fn config_threads_num_toml_key_is_removed() {
 // ═══════════════════════════════════════════════════════════════════════
 // Config resolution: TOML / CLI / env merge via config show
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn config_resolution_toml_only() {
     let dir = tempfile::tempdir().unwrap();
@@ -1331,14 +1056,7 @@ fn config_resolution_toml_only() {
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -1347,29 +1065,19 @@ fn config_resolution_toml_only() {
     assert!(stdout.contains("tomluser@example.com"), "stdout: {stdout}");
     assert!(stdout.contains("/toml/dir"), "stdout: {stdout}");
 }
-
 #[test]
-fn config_resolution_cli_overrides_toml() {
+fn config_resolution_toml_username_used() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(&config_path, "[auth]\nusername = \"toml@example.com\"\n").unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "cli@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::contains("cli@example.com"));
+        .stdout(predicate::str::contains("toml@example.com"));
 }
-
 #[test]
 fn config_resolution_env_overrides_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -1378,14 +1086,7 @@ fn config_resolution_env_overrides_toml() {
 
     let out = clean_cmd()
         .env("ICLOUD_USERNAME", "env@example.com")
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -1397,37 +1098,23 @@ fn config_resolution_env_overrides_toml() {
         "env should override TOML, stdout: {stdout}"
     );
 }
-
 #[test]
-fn config_resolution_cli_overrides_env() {
+fn config_resolution_env_username_used_without_toml() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
         .env("ICLOUD_USERNAME", "env@example.com")
-        .args([
-            "config",
-            "show",
-            "--username",
-            "cli@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["config", "show"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("cli@example.com"));
+        .stdout(predicate::str::contains("env@example.com"));
 }
-
 #[test]
 fn config_resolution_default_values() {
     let dir = tempfile::tempdir().unwrap();
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["config", "show"])
         .assert()
         .success()
         .get_output()
@@ -1449,7 +1136,6 @@ fn config_resolution_default_values() {
         "default folder_structure should be %Y/%m/%d, stdout: {stdout}"
     );
 }
-
 #[test]
 fn config_show_does_not_read_password_file_contents() {
     // `config show` may echo the `password_file` path back to the user, but
@@ -1471,14 +1157,7 @@ fn config_show_does_not_read_password_file_contents() {
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -1498,7 +1177,6 @@ fn config_show_does_not_read_password_file_contents() {
 // ═══════════════════════════════════════════════════════════════════════
 // Auto-config behavior
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn auto_config_suppressed_by_env() {
     let dir = tempfile::tempdir().unwrap();
@@ -1507,15 +1185,7 @@ fn auto_config_suppressed_by_env() {
     // KEI_NO_AUTO_CONFIG=1 should prevent creation of the config file
     clean_cmd()
         .env("KEI_NO_AUTO_CONFIG", "1")
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "suppress@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .failure(); // fails at auth
 
@@ -1524,7 +1194,6 @@ fn auto_config_suppressed_by_env() {
         "KEI_NO_AUTO_CONFIG=1 should suppress config file creation"
     );
 }
-
 #[test]
 #[cfg(unix)]
 fn auto_config_has_0600_perms() {
@@ -1534,15 +1203,7 @@ fn auto_config_has_0600_perms() {
     let config_path = dir.path().join("config.toml");
 
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--username",
-            "perms@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .failure(); // fails at auth
 
@@ -1558,7 +1219,6 @@ fn auto_config_has_0600_perms() {
 // ═══════════════════════════════════════════════════════════════════════
 // State DB pre-seeded tests: status
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn status_shows_counts() {
     let dir = tempfile::tempdir().unwrap();
@@ -1605,13 +1265,9 @@ fn status_shows_counts() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status"])
         .assert()
         .success()
         .get_output()
@@ -1622,7 +1278,6 @@ fn status_shows_counts() {
     assert!(stdout.contains("Failed:     1"), "stdout: {stdout}");
     assert!(stdout.contains("Pending:    1"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_failed_shows_error_messages() {
     let dir = tempfile::tempdir().unwrap();
@@ -1641,14 +1296,9 @@ fn status_failed_shows_error_messages() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--failed",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--failed"])
         .assert()
         .success()
         .get_output()
@@ -1660,7 +1310,6 @@ fn status_failed_shows_error_messages() {
 // ═══════════════════════════════════════════════════════════════════════
 // State DB pre-seeded tests: verify
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn verify_all_files_present() {
     let dir = tempfile::tempdir().unwrap();
@@ -1682,13 +1331,9 @@ fn verify_all_files_present() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .success()
         .get_output()
@@ -1697,7 +1342,6 @@ fn verify_all_files_present() {
     assert!(stdout.contains("Verified:  1"), "stdout: {stdout}");
     assert!(stdout.contains("Missing:   0"), "stdout: {stdout}");
 }
-
 #[test]
 fn verify_detects_missing_file() {
     let dir = tempfile::tempdir().unwrap();
@@ -1719,13 +1363,9 @@ fn verify_detects_missing_file() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .code(1)
         .get_output()
@@ -1733,7 +1373,6 @@ fn verify_detects_missing_file() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("MISSING"), "stdout: {stdout}");
 }
-
 #[test]
 fn verify_checksums_match() {
     let dir = tempfile::tempdir().unwrap();
@@ -1759,14 +1398,9 @@ fn verify_checksums_match() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--checksums",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify", "--checksums"])
         .assert()
         .success()
         .get_output()
@@ -1774,7 +1408,6 @@ fn verify_checksums_match() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("Verified:  1"), "stdout: {stdout}");
 }
-
 #[test]
 fn verify_checksums_mismatch() {
     use std::io::Write;
@@ -1802,14 +1435,9 @@ fn verify_checksums_mismatch() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--checksums",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify", "--checksums"])
         .assert()
         .code(1)
         .get_output()
@@ -1853,14 +1481,9 @@ fn verify_checksums_mismatch_emits_asset_id_in_output() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--checksums",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify", "--checksums"])
         .assert()
         .code(1)
         .get_output()
@@ -1879,7 +1502,6 @@ fn verify_checksums_mismatch_emits_asset_id_in_output() {
 // ═══════════════════════════════════════════════════════════════════════
 // State DB pre-seeded tests: reset
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn reset_state_deletes_db() {
     let dir = tempfile::tempdir().unwrap();
@@ -1902,15 +1524,9 @@ fn reset_state_deletes_db() {
     assert!(db_path.exists(), "DB should exist before reset");
 
     let out = clean_cmd()
-        .args([
-            "reset",
-            "state",
-            "--yes",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "state", "--yes"])
         .assert()
         .success()
         .get_output()
@@ -1923,7 +1539,6 @@ fn reset_state_deletes_db() {
         "should print 'deleted', stdout: {stdout}"
     );
 }
-
 #[test]
 fn reset_sync_token_clears_tokens() {
     let dir = tempfile::tempdir().unwrap();
@@ -1943,15 +1558,9 @@ fn reset_sync_token_clears_tokens() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--yes",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token", "--yes"])
         .assert()
         .success()
         .get_output()
@@ -1984,7 +1593,6 @@ fn reset_sync_token_clears_tokens() {
     // db_sync_token is set to empty string, not deleted
     assert_eq!(db_token, "", "db_sync_token should be cleared to empty");
 }
-
 #[test]
 fn reset_state_without_yes_on_non_tty() {
     let dir = tempfile::tempdir().unwrap();
@@ -2007,14 +1615,9 @@ fn reset_state_without_yes_on_non_tty() {
 
     // Without --yes on a non-TTY, stdin.read_line returns empty/EOF -> "Cancelled"
     let out = clean_cmd()
-        .args([
-            "reset",
-            "state",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "state"])
         .assert()
         .success()
         .get_output()
@@ -2026,7 +1629,6 @@ fn reset_state_without_yes_on_non_tty() {
     );
     assert!(db_path.exists(), "DB should NOT be deleted without --yes");
 }
-
 #[test]
 fn reset_sync_token_without_yes_on_non_tty_errors() {
     // `kei reset sync-token` ships a confirmation guard. Under non-TTY use
@@ -2047,14 +1649,9 @@ fn reset_sync_token_without_yes_on_non_tty_errors() {
         .join(format!("{}.db", sanitize_username(username)));
 
     let out = clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token"])
         .assert()
         .failure()
         .get_output()
@@ -2081,7 +1678,6 @@ fn reset_sync_token_without_yes_on_non_tty_errors() {
         "zone token must not be cleared without --yes"
     );
 }
-
 #[test]
 fn reset_sync_token_with_yes_clears_under_non_tty() {
     // Mirror of the test above with `--yes`: the same non-TTY context now
@@ -2107,15 +1703,9 @@ fn reset_sync_token_with_yes_clears_under_non_tty() {
         .join(format!("{}.db", sanitize_username(username)));
 
     let out = clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--yes",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token", "--yes"])
         .assert()
         .success()
         .get_output()
@@ -2144,7 +1734,6 @@ fn reset_sync_token_with_yes_clears_under_non_tty() {
 // ═══════════════════════════════════════════════════════════════════════
 // Password source behavior
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn password_file_strips_trailing_newline() {
     let dir = tempfile::tempdir().unwrap();
@@ -2154,15 +1743,7 @@ fn password_file_strips_trailing_newline() {
     // Should fail at auth (network), not at password retrieval.
     // The error message should NOT contain "empty" or "No password available".
     let out = clean_cmd()
-        .args([
-            "login",
-            "--username",
-            "x@x.com",
-            "--password-file",
-            pw_file.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["login", "--password-file", pw_file.to_str().unwrap()])
         .assert()
         .failure()
         .get_output()
@@ -2177,7 +1758,6 @@ fn password_file_strips_trailing_newline() {
         "password should not be empty, stderr: {stderr}"
     );
 }
-
 #[test]
 fn password_file_empty() {
     let dir = tempfile::tempdir().unwrap();
@@ -2185,22 +1765,14 @@ fn password_file_empty() {
     std::fs::write(&pw_file, "").unwrap();
 
     clean_cmd()
-        .args([
-            "login",
-            "--username",
-            "x@x.com",
-            "--password-file",
-            pw_file.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .args(["login", "--password-file", pw_file.to_str().unwrap()])
         .assert()
         .code(3)
         .stderr(
             predicate::str::contains("No password available").or(predicate::str::contains("empty")),
         );
 }
-
 #[test]
 fn password_file_newline_only() {
     let dir = tempfile::tempdir().unwrap();
@@ -2208,15 +1780,8 @@ fn password_file_newline_only() {
     std::fs::write(&pw_file, "\n").unwrap();
 
     clean_cmd()
-        .args([
-            "login",
-            "--username",
-            "x@x.com",
-            "--password-file",
-            pw_file.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .args(["login", "--password-file", pw_file.to_str().unwrap()])
         .assert()
         .code(3)
         .stderr(
@@ -2234,15 +1799,9 @@ fn password_command_success() {
     // The password command succeeds and returns "cmdpw".
     // Auth will fail at network, not at password retrieval.
     let out = clean_cmd()
-        .args([
-            "login",
-            "--username",
-            "x@x.com",
-            "--password-command",
-            "echo cmdpw",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["login", "--password-command", "echo cmdpw"])
         .assert()
         .failure()
         .get_output()
@@ -2253,21 +1812,14 @@ fn password_command_success() {
         "password command should provide password, stderr: {stderr}"
     );
 }
-
 #[test]
 fn password_command_failure() {
     let dir = tempfile::tempdir().unwrap();
 
     clean_cmd()
-        .args([
-            "login",
-            "--username",
-            "x@x.com",
-            "--password-command",
-            "false",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["login", "--password-command", "false"])
         .assert()
         .code(3)
         .stderr(
@@ -2279,54 +1831,41 @@ fn password_command_failure() {
 // ═══════════════════════════════════════════════════════════════════════
 // Exit codes
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn exit_2_for_clap_errors() {
-    // Pass --username with an empty string -- clap's value_parser rejects it
+    // Removed durable flags are clap errors.
     clean_cmd()
         .args(["--username", "", "config", "show"])
         .assert()
         .code(2);
 }
-
 #[test]
 fn exit_1_for_missing_directory_on_sync() {
     let dir = tempfile::tempdir().unwrap();
     clean_cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["sync"])
         .assert()
         .code(1)
         .stderr(predicate::str::contains("[download] directory is required"));
 }
-
 #[test]
 fn exit_1_for_missing_username_on_sync() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     write_sync_config(&config_path, "/photos");
     clean_cmd()
-        .args([
-            "sync",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env_remove("ICLOUD_USERNAME")
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
 // Log level behavior
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn log_level_default_info() {
     let dir = tempfile::tempdir().unwrap();
@@ -2334,15 +1873,8 @@ fn log_level_default_info() {
     write_sync_config(&config_path, "/photos");
     // sync with username + directory will fail at auth. Check stderr for INFO.
     let out = clean_cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .failure()
         .get_output()
@@ -2362,7 +1894,6 @@ fn log_level_default_info() {
         "default log level should suppress DEBUG-level messages, stderr: {stderr}"
     );
 }
-
 #[test]
 fn log_level_debug() {
     let dir = tempfile::tempdir().unwrap();
@@ -2370,16 +1901,13 @@ fn log_level_debug() {
     let config_path = dir.path().join("config.toml");
     write_sync_config(&config_path, dl_dir.to_str().unwrap());
     let out = clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
         .args([
             "--log-level",
             "debug",
             "sync",
-            "--username",
-            "x@x.com",
             "--config",
             config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
         ])
         .assert()
         .failure()
@@ -2391,7 +1919,6 @@ fn log_level_debug() {
         "debug log level should produce DEBUG entries, stderr: {stderr}"
     );
 }
-
 #[test]
 fn log_level_error() {
     let dir = tempfile::tempdir().unwrap();
@@ -2402,12 +1929,8 @@ fn log_level_error() {
             "--log-level",
             "error",
             "sync",
-            "--username",
-            "x@x.com",
             "--config",
             config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
         ])
         .assert()
         .failure()
@@ -2430,12 +1953,10 @@ fn log_level_error() {
 // ═══════════════════════════════════════════════════════════════════════
 // Help and version
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn help_flag_exits_zero() {
     clean_cmd().arg("--help").assert().success();
 }
-
 #[test]
 fn version_flag_exits_zero() {
     clean_cmd()
@@ -2444,12 +1965,10 @@ fn version_flag_exits_zero() {
         .success()
         .stdout(predicate::str::contains("kei"));
 }
-
 #[test]
 fn sync_help_exits_zero() {
     clean_cmd().args(["sync", "--help"]).assert().success();
 }
-
 #[test]
 fn config_show_help_exits_zero() {
     clean_cmd()
@@ -2461,7 +1980,6 @@ fn config_show_help_exits_zero() {
 // ═══════════════════════════════════════════════════════════════════════
 // Subcommand parsing: unknown subcommand
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn unknown_subcommand_fails() {
     clean_cmd().arg("nonexistent-command").assert().code(2);
@@ -2470,7 +1988,6 @@ fn unknown_subcommand_fails() {
 // ═══════════════════════════════════════════════════════════════════════
 // verify with empty DB (no downloaded assets)
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn verify_empty_db() {
     let dir = tempfile::tempdir().unwrap();
@@ -2478,13 +1995,9 @@ fn verify_empty_db() {
     let _conn = create_state_db(dir.path(), username);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .success()
         .get_output()
@@ -2499,7 +2012,6 @@ fn verify_empty_db() {
 // ═══════════════════════════════════════════════════════════════════════
 // status with DB but no sync runs
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn status_with_db_no_sync_runs() {
     let dir = tempfile::tempdir().unwrap();
@@ -2509,13 +2021,9 @@ fn status_with_db_no_sync_runs() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status"])
         .assert()
         .success()
         .get_output()
@@ -2533,7 +2041,6 @@ fn status_with_db_no_sync_runs() {
 // ═══════════════════════════════════════════════════════════════════════
 // verify with --checksums but no local_checksum stored
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn verify_checksums_no_stored_checksum_still_passes() {
     let dir = tempfile::tempdir().unwrap();
@@ -2557,14 +2064,9 @@ fn verify_checksums_no_stored_checksum_still_passes() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--checksums",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify", "--checksums"])
         .assert()
         .success()
         .get_output()
@@ -2576,47 +2078,39 @@ fn verify_checksums_no_stored_checksum_still_passes() {
 // ═══════════════════════════════════════════════════════════════════════
 // Domain flag
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn domain_cn_accepted() {
     let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[auth]\nusername = \"x@x.com\"\ndomain = \"cn\"\n",
+    )
+    .unwrap();
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            "x@x.com",
-            "--domain",
-            "cn",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("cn"));
 }
-
 #[test]
 fn domain_invalid_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[auth]\nusername = \"x@x.com\"\ndomain = \"uk\"\n",
+    )
+    .unwrap();
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            "x@x.com",
-            "--domain",
-            "invalid",
-            "--data-dir",
-            "/tmp",
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
-        .code(2);
+        .code(1);
 }
 
 // ═══════════════════════════════════════════════════════════════════════
 // TOML config with domain
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn toml_domain_cn() {
     let dir = tempfile::tempdir().unwrap();
@@ -2628,14 +2122,7 @@ fn toml_domain_cn() {
     .unwrap();
 
     clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("cn"));
@@ -2644,7 +2131,6 @@ fn toml_domain_cn() {
 // ═══════════════════════════════════════════════════════════════════════
 // Status --failed with no failed assets
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn status_failed_with_no_failures() {
     let dir = tempfile::tempdir().unwrap();
@@ -2662,14 +2148,9 @@ fn status_failed_with_no_failures() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--failed",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--failed"])
         .assert()
         .success()
         .get_output()
@@ -2686,7 +2167,6 @@ fn status_failed_with_no_failures() {
 // ═══════════════════════════════════════════════════════════════════════
 // Reset sync-token on empty metadata
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn reset_sync_token_empty_metadata() {
     let dir = tempfile::tempdir().unwrap();
@@ -2694,15 +2174,9 @@ fn reset_sync_token_empty_metadata() {
     let _conn = create_state_db(dir.path(), username);
 
     let out = clean_cmd()
-        .args([
-            "reset",
-            "sync-token",
-            "--yes",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token", "--yes"])
         .assert()
         .success()
         .get_output()
@@ -2717,7 +2191,6 @@ fn reset_sync_token_empty_metadata() {
 // ═══════════════════════════════════════════════════════════════════════
 // Config show outputs threads from TOML
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn config_show_reflects_threads_from_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -2729,14 +2202,7 @@ fn config_show_reflects_threads_from_toml() {
     .unwrap();
 
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -2748,7 +2214,6 @@ fn config_show_reflects_threads_from_toml() {
 // ═══════════════════════════════════════════════════════════════════════
 // Multiple verify issues at once
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn verify_mixed_present_and_missing() {
     let dir = tempfile::tempdir().unwrap();
@@ -2781,13 +2246,9 @@ fn verify_mixed_present_and_missing() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .code(1)
         .get_output()
@@ -2796,7 +2257,6 @@ fn verify_mixed_present_and_missing() {
     assert!(stdout.contains("Verified:  1"), "stdout: {stdout}");
     assert!(stdout.contains("Missing:   1"), "stdout: {stdout}");
 }
-
 #[test]
 fn verify_truncates_issue_listing_past_cap() {
     // Covers the 200-issue listing cap for `kei verify` on large libraries
@@ -2825,13 +2285,9 @@ fn verify_truncates_issue_listing_past_cap() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "verify",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["verify"])
         .assert()
         .code(1)
         .get_output()
@@ -2856,7 +2312,6 @@ fn verify_truncates_issue_listing_past_cap() {
         "201st missing line should have been suppressed; stdout: {stdout}"
     );
 }
-
 #[test]
 fn reconcile_truncates_issue_listing_past_cap() {
     // Covers the 200-issue listing cap for `kei reconcile`. 250 seeded
@@ -2886,13 +2341,9 @@ fn reconcile_truncates_issue_listing_past_cap() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "reconcile",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reconcile"])
         .assert()
         .success()
         .get_output()
@@ -2918,21 +2369,13 @@ fn reconcile_truncates_issue_listing_past_cap() {
 // ═══════════════════════════════════════════════════════════════════════
 // Dry run + retry-failed conflict
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn dry_run_and_retry_failed_conflict() {
     let dir = tempfile::tempdir().unwrap();
     // clap-level conflicts_with should reject this
     clean_cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--dry-run",
-            "--retry-failed",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["sync", "--dry-run", "--retry-failed"])
         .assert()
         .code(2);
 }
@@ -2940,7 +2383,6 @@ fn dry_run_and_retry_failed_conflict() {
 // ═══════════════════════════════════════════════════════════════════════
 // Dry run: no state DB created
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn dry_run_creates_no_state_db() {
     let data_dir = tempfile::tempdir().unwrap();
@@ -2951,12 +2393,8 @@ fn dry_run_creates_no_state_db() {
     clean_cmd()
         .args([
             "sync",
-            "--username",
-            "drytest@example.com",
             "--config",
             config_path.to_str().unwrap(),
-            "--data-dir",
-            data_dir.path().to_str().unwrap(),
             "--dry-run",
         ])
         .assert()
@@ -2978,7 +2416,6 @@ fn dry_run_creates_no_state_db() {
 // ═══════════════════════════════════════════════════════════════════════
 // Status: --pending and --downloaded (issue #211)
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn status_pending_shows_pending_assets() {
     let dir = tempfile::tempdir().unwrap();
@@ -2999,14 +2436,9 @@ fn status_pending_shows_pending_assets() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--pending",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--pending"])
         .assert()
         .success()
         .get_output()
@@ -3018,7 +2450,6 @@ fn status_pending_shows_pending_assets() {
     // Downloaded asset must not appear in the pending listing
     assert!(!stdout.contains("photo3.jpg"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_downloaded_shows_downloaded_assets() {
     let dir = tempfile::tempdir().unwrap();
@@ -3038,14 +2469,9 @@ fn status_downloaded_shows_downloaded_assets() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--downloaded",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--downloaded"])
         .assert()
         .success()
         .get_output()
@@ -3057,7 +2483,6 @@ fn status_downloaded_shows_downloaded_assets() {
     // Pending asset must not appear in the downloaded listing
     assert!(!stdout.contains("photo2.jpg"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_pending_empty_when_none_pending() {
     let dir = tempfile::tempdir().unwrap();
@@ -3075,14 +2500,9 @@ fn status_pending_empty_when_none_pending() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--pending",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--pending"])
         .assert()
         .success()
         .get_output()
@@ -3090,7 +2510,6 @@ fn status_pending_empty_when_none_pending() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(!stdout.contains("Pending assets:"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_downloaded_with_null_local_path_surfaces_missing_marker() {
     // Covers the `<MISSING local_path>` display path in print_downloaded.
@@ -3107,14 +2526,9 @@ fn status_downloaded_with_null_local_path_surfaces_missing_marker() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--downloaded",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--downloaded"])
         .assert()
         .success()
         .get_output()
@@ -3126,7 +2540,6 @@ fn status_downloaded_with_null_local_path_surfaces_missing_marker() {
     );
     assert!(stdout.contains("broken.jpg"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_all_three_flags_render_all_sections() {
     // End-to-end coverage for --failed --pending --downloaded combined.
@@ -3158,16 +2571,9 @@ fn status_all_three_flags_render_all_sections() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--failed",
-            "--pending",
-            "--downloaded",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--failed", "--pending", "--downloaded"])
         .assert()
         .success()
         .get_output()
@@ -3180,7 +2586,6 @@ fn status_all_three_flags_render_all_sections() {
     assert!(stdout.contains("Downloaded assets:"), "stdout: {stdout}");
     assert!(stdout.contains("dl.jpg"), "stdout: {stdout}");
 }
-
 #[test]
 fn status_downloaded_paginates_past_page_size() {
     // Covers the pagination loop in run_status for --downloaded when the
@@ -3208,14 +2613,9 @@ fn status_downloaded_paginates_past_page_size() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--downloaded",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--downloaded"])
         .assert()
         .success()
         .get_output()
@@ -3235,7 +2635,6 @@ fn status_downloaded_paginates_past_page_size() {
         "no truncation tail expected when under cap; stdout: {stdout}"
     );
 }
-
 #[test]
 fn status_downloaded_truncates_past_print_cap() {
     // Covers the 200-row listing cap for --downloaded on large libraries.
@@ -3261,14 +2660,9 @@ fn status_downloaded_truncates_past_print_cap() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--downloaded",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--downloaded"])
         .assert()
         .success()
         .get_output()
@@ -3286,7 +2680,6 @@ fn status_downloaded_truncates_past_print_cap() {
         "truncation tail missing; stdout: {stdout}"
     );
 }
-
 #[test]
 fn status_failed_truncates_past_print_cap() {
     let dir = tempfile::tempdir().unwrap();
@@ -3301,14 +2694,9 @@ fn status_failed_truncates_past_print_cap() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "status",
-            "--failed",
-            "--username",
-            username,
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status", "--failed"])
         .assert()
         .success()
         .get_output()
@@ -3324,7 +2712,6 @@ fn status_failed_truncates_past_print_cap() {
 // ═══════════════════════════════════════════════════════════════════════
 // Config env vars in TOML (KEI_CONFIG, KEI_DATA_DIR)
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn kei_config_env_var_loads_toml() {
     let dir = tempfile::tempdir().unwrap();
@@ -3333,7 +2720,8 @@ fn kei_config_env_var_loads_toml() {
 
     clean_cmd()
         .env("KEI_CONFIG", config_path.to_str().unwrap())
-        .args(["config", "show", "--data-dir", dir.path().to_str().unwrap()])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["config", "show"])
         .assert()
         .success()
         .stdout(predicate::str::contains("fromenv@example.com"));
@@ -3342,7 +2730,6 @@ fn kei_config_env_var_loads_toml() {
 // ═══════════════════════════════════════════════════════════════════════
 // kei reconcile: end-to-end CLI routing (no network)
 // ═══════════════════════════════════════════════════════════════════════
-
 #[test]
 fn reconcile_subcommand_marks_missing_and_preserves_present() {
     let data_dir = tempfile::tempdir().unwrap();
@@ -3375,13 +2762,9 @@ fn reconcile_subcommand_marks_missing_and_preserves_present() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "reconcile",
-            "--username",
-            username,
-            "--data-dir",
-            data_dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", data_dir.path())
+        .args(["reconcile"])
         .assert()
         .success()
         .get_output()
@@ -3428,7 +2811,6 @@ fn reconcile_subcommand_marks_missing_and_preserves_present() {
         .unwrap();
     assert_eq!(present_status, "downloaded");
 }
-
 #[test]
 fn reconcile_dry_run_reports_but_does_not_mutate() {
     let data_dir = tempfile::tempdir().unwrap();
@@ -3449,14 +2831,9 @@ fn reconcile_dry_run_reports_but_does_not_mutate() {
     drop(conn);
 
     let out = clean_cmd()
-        .args([
-            "reconcile",
-            "--dry-run",
-            "--username",
-            username,
-            "--data-dir",
-            data_dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", data_dir.path())
+        .args(["reconcile", "--dry-run"])
         .assert()
         .success()
         .get_output()
@@ -3486,20 +2863,15 @@ fn reconcile_dry_run_reports_but_does_not_mutate() {
         .unwrap();
     assert_eq!(status, "downloaded", "dry-run must leave the DB unchanged");
 }
-
 #[test]
 fn reconcile_on_empty_db_prints_guidance_and_exits_clean() {
     let data_dir = tempfile::tempdir().unwrap();
     let username = "test@example.com";
 
     let out = clean_cmd()
-        .args([
-            "reconcile",
-            "--username",
-            username,
-            "--data-dir",
-            data_dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", data_dir.path())
+        .args(["reconcile"])
         .assert()
         .success()
         .get_output()
@@ -3585,14 +2957,7 @@ fn run_config_show(body: &str) -> (String, String) {
     )
     .unwrap();
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .success()
         .get_output()
@@ -3612,14 +2977,7 @@ fn run_config_show_error(body: &str) -> String {
     )
     .unwrap();
     let out = clean_cmd()
-        .args([
-            "config",
-            "show",
-            "--config",
-            config_path.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["config", "show", "--config", config_path.to_str().unwrap()])
         .assert()
         .failure()
         .get_output()
@@ -3649,22 +3007,13 @@ fn sync_cmd_for_config_body(body: &str) -> assert_cmd::Command {
     )
     .unwrap();
     let mut cmd = clean_cmd();
-    cmd.args([
-        "sync",
-        "--username",
-        "x@x.com",
-        "--config",
-        config_path.to_str().unwrap(),
-        "--data-dir",
-        dir.path().to_str().unwrap(),
-    ]);
+    cmd.args(["sync", "--config", config_path.to_str().unwrap()]);
     // Tempdirs leak intentionally: tests bail before sync touches them, and
     // OS-level tmpfs cleanup handles the directories at process exit.
     let _ = dir.keep();
     let _ = dl_dir.keep();
     cmd
 }
-
 #[test]
 fn removed_legacy_album_in_cli_errors() {
     sync_cmd_for_validation()
@@ -3678,7 +3027,6 @@ fn removed_legacy_album_in_cli_errors() {
         .stderr(predicate::str::contains("unexpected argument"))
         .stderr(predicate::str::contains("--folder-structure"));
 }
-
 #[test]
 fn removed_legacy_album_in_toml_errors() {
     let stderr = run_config_show_error("folder_structure = \"{album}/%B\"\n");
@@ -3688,7 +3036,6 @@ fn removed_legacy_album_in_toml_errors() {
         "stderr: {stderr}"
     );
 }
-
 #[test]
 fn removed_legacy_album_env_is_ignored() {
     sync_cmd_for_validation()
@@ -3698,7 +3045,6 @@ fn removed_legacy_album_env_is_ignored() {
         .failure()
         .stderr(predicate::str::contains("'{album}' is not valid in --folder-structure").not());
 }
-
 #[test]
 fn removed_legacy_album_errors_even_with_user_set_albums_template() {
     let stderr = run_config_show_error(
@@ -3710,7 +3056,6 @@ fn removed_legacy_album_errors_even_with_user_set_albums_template() {
         "stderr: {stderr}"
     );
 }
-
 #[test]
 fn migration_no_warning_when_no_album_token() {
     sync_cmd_for_config_body("folder_structure = \"%Y/%m/%d\"\n")
@@ -3795,7 +3140,6 @@ fn sync_validation_accepts_full_selection_combo() {
         "no sentinel-mix bail expected; stderr: {stderr}"
     );
 }
-
 #[test]
 fn config_show_emits_per_category_templates_from_toml() {
     let (stdout, _) = run_config_show(
@@ -3825,7 +3169,6 @@ fn config_show_omits_default_per_category_templates() {
         "stdout: {stdout}"
     );
 }
-
 #[test]
 fn sync_bails_on_album_token_in_smart_folders_template() {
     sync_cmd_for_config_body("folder_structure_smart_folders = \"{album}/%Y\"\n")
@@ -3834,7 +3177,6 @@ fn sync_bails_on_album_token_in_smart_folders_template() {
         .stderr(predicate::str::contains("{album}"))
         .stderr(predicate::str::contains("--folder-structure-albums"));
 }
-
 #[test]
 fn sync_bails_on_smart_folder_token_in_albums_template() {
     sync_cmd_for_config_body("folder_structure_albums = \"{smart-folder}/foo\"\n")
@@ -3843,7 +3185,6 @@ fn sync_bails_on_smart_folder_token_in_albums_template() {
         .stderr(predicate::str::contains("{smart-folder}"))
         .stderr(predicate::str::contains("--folder-structure-smart-folders"));
 }
-
 #[test]
 fn sync_bails_on_library_token_not_first_segment() {
     sync_cmd_for_config_body("folder_structure = \"%Y/{library}\"\n")
@@ -3852,7 +3193,6 @@ fn sync_bails_on_library_token_not_first_segment() {
         .stderr(predicate::str::contains("{library}"))
         .stderr(predicate::str::contains("first path segment"));
 }
-
 #[test]
 fn sync_bails_on_duplicate_library_token() {
     sync_cmd_for_config_body("folder_structure_albums = \"{library}/{library}/{album}\"\n")
@@ -3861,7 +3201,6 @@ fn sync_bails_on_duplicate_library_token() {
         .stderr(predicate::str::contains("{library}"))
         .stderr(predicate::str::contains("once"));
 }
-
 #[test]
 fn sync_bails_on_within_album_contradiction() {
     sync_cmd_for_config_body("\n[filters]\nalbums = [\"Family\", \"!Family\"]\n")
@@ -3870,7 +3209,6 @@ fn sync_bails_on_within_album_contradiction() {
         .stderr(predicate::str::contains("include and exclude"))
         .stderr(predicate::str::contains("Family"));
 }
-
 #[test]
 fn sync_bails_on_library_none() {
     sync_cmd_for_config_body("\n[filters]\nlibraries = [\"none\"]\n")
@@ -3878,7 +3216,6 @@ fn sync_bails_on_library_none() {
         .code(1)
         .stderr(predicate::str::contains("library none"));
 }
-
 #[test]
 fn config_show_emits_smart_folder_selection() {
     let (stdout, _) =
@@ -3887,7 +3224,6 @@ fn config_show_emits_smart_folder_selection() {
     assert!(stdout.contains("Favorites"), "stdout: {stdout}");
     assert!(stdout.contains("!Hidden"), "stdout: {stdout}");
 }
-
 #[test]
 fn config_show_emits_unfiled_false_when_disabled() {
     let (stdout, _) = run_config_show("\n[filters]\nunfiled = false\n");
@@ -3901,13 +3237,11 @@ fn config_show_omits_unfiled_when_default_true() {
     let (stdout, _) = run_config_show("");
     assert!(!stdout.contains("unfiled = true"), "stdout: {stdout}");
 }
-
 #[test]
 fn config_show_emits_libraries_when_non_default() {
     let (stdout, _) = run_config_show("\n[filters]\nlibraries = [\"all\"]\n");
     assert!(stdout.contains("libraries = [\"all\"]"), "stdout: {stdout}");
 }
-
 #[test]
 fn config_show_emits_libraries_when_repeatable_named_zone() {
     // Pin the multi-zone case at the binary boundary: a zone-truncated
@@ -3932,7 +3266,6 @@ fn config_show_emits_libraries_when_repeatable_named_zone() {
 }
 
 // ── Removed v0.20 selection aliases ───────────────────────────────
-
 #[test]
 fn removed_exclude_album_cli_flag_errors() {
     sync_cmd_for_validation()
@@ -3941,7 +3274,6 @@ fn removed_exclude_album_cli_flag_errors() {
         .failure()
         .stderr(predicate::str::contains("--exclude-album"));
 }
-
 #[test]
 fn removed_toml_filter_aliases_error() {
     for (field, body) in [
@@ -3959,7 +3291,6 @@ fn removed_toml_filter_aliases_error() {
         );
     }
 }
-
 #[test]
 fn removed_sync_env_vars_do_not_block_non_sync_command() {
     // Regression: issue #385 - stale sync env vars set in old Docker Compose
@@ -3973,12 +3304,12 @@ fn removed_sync_env_vars_do_not_block_non_sync_command() {
     cmd.env("KEI_FOLDER_STRUCTURE", "{:%Y/%m/%Y-%m-%d}");
     #[cfg(feature = "xmp")]
     cmd.env("KEI_EMBED_XMP", "true");
-    cmd.args(["--username", "test@example.com", "reset", "state", "--yes"]);
+    cmd.env("ICLOUD_USERNAME", "test@example.com");
+    cmd.args(["reset", "state", "--yes"]);
     cmd.assert()
         .success()
         .stderr(predicate::str::contains("sync-only flag").not());
 }
-
 #[test]
 fn removed_sync_env_vars_do_not_block_service_status() {
     // Regression: issue #385 - same class of bug on a different non-sync
@@ -3989,7 +3320,8 @@ fn removed_sync_env_vars_do_not_block_service_status() {
     cmd.env("KEI_DOWNLOAD_DIR", "/photos");
     cmd.env("KEI_ALBUM", "none");
     cmd.env("KEI_LIVE_PHOTO_MODE", "image-only");
-    cmd.args(["--username", "test@example.com", "service", "status"]);
+    cmd.env("ICLOUD_USERNAME", "test@example.com");
+    cmd.args(["service", "status"]);
     cmd.assert()
         .stderr(predicate::str::contains("sync-only flag").not());
 }

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -11,7 +11,10 @@ use std::path::PathBuf;
 fn repo_file(path: &str) -> String {
     let mut full = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     full.push(path);
-    std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {}: {e}", full.display()))
+    std::fs::read_to_string(&full)
+        .unwrap_or_else(|e| panic!("read {}: {e}", full.display()))
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
 }
 
 #[test]

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -1,0 +1,82 @@
+//! Offline branch-coherence checks for packaging and migration docs.
+//!
+//! These intentionally inspect repository files instead of spawning Docker or
+//! contacting iCloud. The live shell suites still own runtime behavior; this
+//! file pins the risky static contracts that made this branch easy to regress.
+
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::path::PathBuf;
+
+fn repo_file(path: &str) -> String {
+    let mut full = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    full.push(path);
+    std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {}: {e}", full.display()))
+}
+
+#[test]
+fn docker_packaging_defaults_to_service_run() {
+    let dockerfile = repo_file("Dockerfile");
+    assert!(
+        dockerfile.contains("ENV KEI_DATA_DIR=/config"),
+        "Docker image must keep session state and config under /config"
+    );
+    assert!(
+        dockerfile.contains(r#"CMD ["service", "run", "--config", "/config/config.toml"]"#),
+        "Docker default command must run service mode so the container stays alive"
+    );
+    assert!(
+        !dockerfile.contains("KEI_WATCH_WITH_INTERVAL"),
+        "removed watch env mirror must not return in the Dockerfile"
+    );
+
+    let entrypoint = repo_file("docker/entrypoint.sh");
+    let service_index = entrypoint
+        .find("|service)")
+        .or_else(|| entrypoint.find("|service|"))
+        .expect("entrypoint whitelist must include the kei service subcommand");
+    let command_lookup = entrypoint
+        .find("command -v")
+        .expect("entrypoint should still fall back to command lookup");
+    assert!(
+        service_index < command_lookup,
+        "`service` must be recognized as a kei subcommand before shell command lookup"
+    );
+}
+
+#[test]
+fn migration_guide_uses_toml_for_durable_sync_settings() {
+    let guide = repo_file("docs/migration-from-icloudpd.md");
+    let stale = [
+        "kei sync --library",
+        "kei sync --download-dir",
+        "kei sync --album",
+        "| `-p`, `--password` | Same",
+        "| `-a`, `--album` | Same",
+        "| `--watch-with-interval` | Same",
+        "| `--notification-script` | Same flag",
+        "| `--threads-num` | `--threads`",
+        "| `--report-json`",
+        "| `--http-bind`, `--http-port`",
+    ];
+    for needle in stale {
+        assert!(
+            !guide.contains(needle),
+            "migration guide still advertises stale sync config surface: {needle}"
+        );
+    }
+
+    for expected in [
+        "kei sync --config ~/.config/kei/config.toml",
+        "[download]\ndirectory = \"~/Photos/iCloud\"",
+        "[filters]\nlibraries = [\"all\"]",
+        "[watch].interval",
+        "[notifications].script",
+        "[download.retry].max_retries",
+    ] {
+        assert!(
+            guide.contains(expected),
+            "migration guide missing TOML-first replacement: {expected}"
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -240,17 +240,18 @@ fn config_flag_accepted() {
 // ── Short flag aliases ──────────────────────────────────────────────────
 
 #[test]
-fn short_u_flag_accepted() {
+fn short_u_flag_removed() {
     common::cmd()
         .args(["sync", "-u", "x@x.com", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn short_p_flag_accepted() {
     common::cmd()
-        .args(["sync", "-u", "x@x.com", "-p", "secret", "--help"])
+        .args(["sync", "-p", "secret", "--help"])
         .assert()
         .success();
 }
@@ -323,7 +324,7 @@ fn reset_sync_token_short_y_flag_parses() {
 #[test]
 fn size_rejects_invalid_variant() {
     common::cmd()
-        .args(["sync", "--username", "x@x.com", "--size", "huge"])
+        .args(["sync", "--size", "huge"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -332,7 +333,7 @@ fn size_rejects_invalid_variant() {
 #[test]
 fn domain_rejects_invalid() {
     common::cmd()
-        .args(["sync", "--username", "x@x.com", "--domain", "uk"])
+        .args(["sync", "--domain", "uk"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
@@ -341,13 +342,7 @@ fn domain_rejects_invalid() {
 #[test]
 fn live_photo_size_rejects_invalid() {
     common::cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--live-photo-size",
-            "xlarge",
-        ])
+        .args(["sync", "--live-photo-size", "xlarge"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -356,13 +351,7 @@ fn live_photo_size_rejects_invalid() {
 #[test]
 fn live_photo_mov_filename_policy_rejects_invalid() {
     common::cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--live-photo-mov-filename-policy",
-            "custom",
-        ])
+        .args(["sync", "--live-photo-mov-filename-policy", "custom"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -371,7 +360,7 @@ fn live_photo_mov_filename_policy_rejects_invalid() {
 #[test]
 fn align_raw_rejects_invalid() {
     common::cmd()
-        .args(["sync", "--username", "x@x.com", "--align-raw", "bogus"])
+        .args(["sync", "--align-raw", "bogus"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -380,13 +369,7 @@ fn align_raw_rejects_invalid() {
 #[test]
 fn file_match_policy_rejects_invalid() {
     common::cmd()
-        .args([
-            "sync",
-            "--username",
-            "x@x.com",
-            "--file-match-policy",
-            "random",
-        ])
+        .args(["sync", "--file-match-policy", "random"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -397,7 +380,7 @@ fn file_match_policy_rejects_invalid() {
 #[test]
 fn threads_rejects_zero() {
     common::cmd()
-        .args(["sync", "--username", "x@x.com", "--threads", "0"])
+        .args(["sync", "--threads", "0"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -406,7 +389,7 @@ fn threads_rejects_zero() {
 #[test]
 fn removed_threads_num_flag_fails() {
     common::cmd()
-        .args(["sync", "--username", "x@x.com", "--threads-num", "4"])
+        .args(["sync", "--threads-num", "4"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
@@ -417,7 +400,8 @@ fn removed_threads_num_flag_fails() {
 #[test]
 fn submit_code_requires_code_argument() {
     common::cmd()
-        .args(["login", "submit-code", "--username", "x@x.com"])
+        .env("ICLOUD_USERNAME", "x@x.com")
+        .args(["login", "submit-code"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
@@ -428,7 +412,8 @@ fn submit_code_requires_code_argument() {
 #[test]
 fn import_existing_requires_directory() {
     common::cmd()
-        .args(["import-existing", "--username", "x@x.com"])
+        .env("ICLOUD_USERNAME", "x@x.com")
+        .args(["import-existing"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--download-dir is required"));
@@ -553,7 +538,7 @@ fn unfiled_flag_accepts_bare_and_explicit_value() {
 // ── Default command (no subcommand = sync) ──────────────────────────────
 
 #[test]
-fn bare_invocation_with_username_and_directory_parses() {
+fn bare_invocation_with_removed_durable_flags_fails() {
     common::cmd()
         .args(["--username", "x@x.com", "--download-dir", "/tmp", "--help"])
         .assert()
@@ -726,13 +711,8 @@ fn config_explicit_nonexistent_path_fails_at_runtime() {
     let output = common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
-        .args([
-            "--config",
-            "/nonexistent/explicit/config.toml",
-            "status",
-            "--username",
-            "x@x.com",
-        ])
+        .env("ICLOUD_USERNAME", "x@x.com")
+        .args(["--config", "/nonexistent/explicit/config.toml", "status"])
         .timeout(std::time::Duration::from_secs(10))
         .assert()
         .failure()
@@ -749,11 +729,12 @@ fn config_explicit_nonexistent_path_fails_at_runtime() {
 // ── Auth flags on non-sync subcommands ──────────────────────────────────
 
 #[test]
-fn domain_flag_works_on_status() {
+fn domain_flag_is_removed_on_status() {
     common::cmd()
         .args(["status", "--domain", "cn", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -808,11 +789,11 @@ fn unknown_flag_on_all_subcommands_fails() {
     }
 }
 
-// ── Auth flags accepted on all subcommands ──────────────────────────
+// ── Auth flags removed from all subcommands ─────────────────────────
 
 #[test]
-fn auth_flags_accepted_on_all_subcommands() {
-    // Global flags (--username, --domain, --data-dir) work on all subcommands
+fn auth_flags_rejected_on_all_subcommands() {
+    // Durable auth/storage inputs are TOML/env only in v0.20.
     for sub in ALL_SUBCOMMANDS {
         for (flag, value) in [
             ("--username", "x@x.com"),
@@ -822,7 +803,8 @@ fn auth_flags_accepted_on_all_subcommands() {
             common::cmd()
                 .args([sub, flag, value, "--help"])
                 .assert()
-                .success();
+                .failure()
+                .stderr(predicate::str::contains("unexpected argument"));
         }
     }
     // --password only accepted on commands with PasswordArgs
@@ -917,7 +899,7 @@ fn exit_code_0_on_version() {
     common::cmd().arg("--version").assert().code(0);
 }
 
-/// Exit code 1 (generic failure) when --username is missing.
+/// Exit code 1 (generic failure) when username is missing.
 #[test]
 fn exit_code_1_on_missing_username() {
     let dir = tempfile::tempdir().unwrap();
@@ -931,17 +913,12 @@ fn exit_code_1_on_missing_username() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
-        .args([
-            "sync",
-            "--config",
-            config.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["sync", "--config", config.to_str().unwrap()])
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("--username is required"));
+        .stderr(predicate::str::contains("username is required"));
 }
 
 /// Exit code 3 (auth failure) when password file is empty.
@@ -963,14 +940,12 @@ fn exit_code_3_on_empty_password_file() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
+        .env("ICLOUD_USERNAME", "exit-code-test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
         .args([
             "sync",
-            "--username",
-            "exit-code-test@example.com",
             "--config",
             config.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
             "--password-file",
             pw_file.to_str().unwrap(),
         ])
@@ -996,14 +971,12 @@ fn exit_code_3_on_newline_only_password_file() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
+        .env("ICLOUD_USERNAME", "exit-code-test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
         .args([
             "sync",
-            "--username",
-            "exit-code-test@example.com",
             "--config",
             config.to_str().unwrap(),
-            "--data-dir",
-            dir.path().to_str().unwrap(),
             "--password-file",
             pw_file.to_str().unwrap(),
         ])
@@ -1017,10 +990,10 @@ fn exit_code_3_on_newline_only_password_file() {
 #[test]
 fn exit_code_2_on_invalid_argument() {
     common::cmd()
-        .args(["sync", "--username", ""])
+        .args(["sync", "--unknown"])
         .assert()
         .code(2)
-        .stderr(predicate::str::contains("value must not be empty"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ── New subcommand help ────────────────────────────────────────────────
@@ -1197,23 +1170,25 @@ fn retry_failed_conflicts_with_watch() {
         .stderr(predicate::str::contains("unexpected argument"));
 }
 
-// ── --data-dir global ─────────────────────────────────────────────────
+// ── --data-dir global removed ─────────────────────────────────────────
 
 #[test]
-fn data_dir_flag_accepted() {
+fn data_dir_flag_rejected() {
     common::cmd()
         .args(["sync", "--data-dir", "/tmp/data", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
-fn data_dir_global_works_with_subcommands() {
+fn data_dir_global_rejected_with_subcommands() {
     for sub in ALL_SUBCOMMANDS {
         common::cmd()
             .args([sub, "--data-dir", "/tmp/data", "--help"])
             .assert()
-            .success();
+            .failure()
+            .stderr(predicate::str::contains("unexpected argument"));
     }
 }
 
@@ -1262,14 +1237,9 @@ fn config_show_produces_toml_output() {
     let output = common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
-        .args([
-            "config",
-            "show",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            "/tmp",
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", "/tmp")
+        .args(["config", "show"])
         .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()
@@ -1291,14 +1261,9 @@ fn reset_sync_token_no_db_prints_message() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
-        .args([
-            "reset",
-            "sync-token",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "sync-token"])
         .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()
@@ -1311,15 +1276,9 @@ fn reset_state_no_db_prints_message() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
-        .args([
-            "reset",
-            "state",
-            "--yes",
-            "--username",
-            "test@example.com",
-            "--data-dir",
-            dir.path().to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "state", "--yes"])
         .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -67,7 +67,8 @@ fn sync_help_succeeds() {
         .args(["sync", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--download-dir"));
+        .stdout(predicate::str::contains("--recent"))
+        .stdout(predicate::str::contains("--download-dir").not());
 }
 
 #[test]
@@ -82,12 +83,12 @@ fn sync_help_omits_removed_directory_flag() {
 
 #[test]
 fn sync_help_hides_deprecated_exclude_album_flag() {
-    // `--exclude-album` was removed; users should only see `--album '!NAME'`.
     common::cmd()
         .args(["sync", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--exclude-album").not());
+        .stdout(predicate::str::contains("--exclude-album").not())
+        .stdout(predicate::str::contains("--album").not());
 }
 
 #[test]
@@ -259,7 +260,8 @@ fn short_d_flag_accepted() {
     common::cmd()
         .args(["sync", "-d", "/tmp", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -276,7 +278,8 @@ fn short_a_flag_accepted() {
     common::cmd()
         .args(["sync", "-a", "Favorites", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -323,7 +326,7 @@ fn size_rejects_invalid_variant() {
         .args(["sync", "--username", "x@x.com", "--size", "huge"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -347,7 +350,7 @@ fn live_photo_size_rejects_invalid() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -362,7 +365,7 @@ fn live_photo_mov_filename_policy_rejects_invalid() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -371,7 +374,7 @@ fn align_raw_rejects_invalid() {
         .args(["sync", "--username", "x@x.com", "--align-raw", "bogus"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -386,7 +389,7 @@ fn file_match_policy_rejects_invalid() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ── Numeric validation (rejection only — acceptance covered by unit tests)
@@ -397,7 +400,7 @@ fn threads_rejects_zero() {
         .args(["sync", "--username", "x@x.com", "--threads", "0"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -431,47 +434,25 @@ fn import_existing_requires_directory() {
         .stderr(predicate::str::contains("--download-dir is required"));
 }
 
-// ── Boolean flags are accepted ──────────────────────────────────────────
+// ── Removed durable boolean flags fail ─────────────────────────────────
 
 #[test]
-fn boolean_sync_flags_accepted() {
-    let mut flags = vec![
-        "--skip-videos",
-        "--skip-photos",
-        "--force-size",
-        "--dry-run",
-        "--no-progress-bar",
-        "--keep-unicode-in-filenames",
-        "--notify-systemd",
-    ];
-    if cfg!(feature = "xmp") {
-        flags.push("--set-exif-datetime");
-    }
-    for flag in flags {
-        common::cmd()
-            .args(["sync", flag, "--help"])
-            .assert()
-            .success();
-    }
+fn removed_boolean_sync_flag_fails() {
+    common::cmd()
+        .args(["sync", "--skip-videos", "--help"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
-// ── Value flags are accepted ────────────────────────────────────────────
+// ── Kept per-run value flags are accepted ───────────────────────────────
 
 #[test]
 fn value_sync_flags_accepted() {
     let pairs = [
-        ("--download-dir", "/tmp"),
-        ("--folder-structure", "%Y-%m"),
         ("--recent", "10"),
-        ("--threads", "4"),
-        ("--watch-with-interval", "3600"),
-        ("--max-retries", "5"),
-        ("--temp-suffix", ".downloading"),
         ("--skip-created-before", "2024-01-01"),
         ("--skip-created-after", "2025-01-01"),
-        ("--pid-file", "/tmp/test.pid"),
-        ("--notification-script", "/tmp/notify.sh"),
-        ("--library", "SharedSync-ABC"),
     ];
     for (flag, value) in pairs {
         common::cmd()
@@ -484,83 +465,46 @@ fn value_sync_flags_accepted() {
 #[test]
 fn album_flag_accepts_multiple() {
     common::cmd()
-        .args([
-            "sync",
-            "--album",
-            "Favorites",
-            "--album",
-            "Vacation",
-            "--help",
-        ])
+        .args(["sync", "--album", "Favorites", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn smart_folder_flag_accepts_multiple() {
     common::cmd()
-        .args([
-            "sync",
-            "--smart-folder",
-            "Favorites",
-            "--smart-folder",
-            "all",
-            "--smart-folder",
-            "!Hidden",
-            "--help",
-        ])
+        .args(["sync", "--smart-folder", "Favorites", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn library_flag_accepts_repeatable_sentinels() {
     common::cmd()
-        .args([
-            "sync",
-            "--library",
-            "primary",
-            "--library",
-            "shared",
-            "--library",
-            "!SharedSync-AAAA",
-            "--help",
-        ])
+        .args(["sync", "--library", "primary", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn album_flag_accepts_inline_exclusion() {
     common::cmd()
-        .args([
-            "sync", "--album", "all", "--album", "!Family", "--album", "none", "--help",
-        ])
+        .args(["sync", "--album", "!Family", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn album_flag_rejects_duplicates() {
-    // Selector-grammar rejection fires pre-auth, before any data-dir / state
-    // access, so no `--data-dir` or auth setup is needed.
     common::cmd()
-        .args([
-            "sync",
-            "--album",
-            "Vacation",
-            "--album",
-            "Vacation",
-            "--username",
-            "dummy@example.com",
-            "--password",
-            "x",
-        ])
+        .args(["sync", "--album", "Family", "--album", "Family"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "--album 'Vacation' specified more than once",
-        ));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -573,7 +517,8 @@ fn folder_structure_albums_flag_parses() {
             "--help",
         ])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -586,40 +531,34 @@ fn folder_structure_smart_folders_flag_parses() {
             "--help",
         ])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
 fn unfiled_flag_accepts_bare_and_explicit_value() {
-    common::cmd()
-        .args(["sync", "--unfiled", "--help"])
-        .assert()
-        .success();
-    common::cmd()
-        .args(["sync", "--unfiled", "false", "--help"])
-        .assert()
-        .success();
-    common::cmd()
-        .args(["sync", "--unfiled", "true", "--help"])
-        .assert()
-        .success();
+    for args in [
+        vec!["sync", "--unfiled", "--help"],
+        vec!["sync", "--unfiled", "false", "--help"],
+        vec!["sync", "--unfiled", "true", "--help"],
+    ] {
+        common::cmd()
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("unexpected argument"));
+    }
 }
 
 // ── Default command (no subcommand = sync) ──────────────────────────────
 
 #[test]
 fn bare_invocation_with_username_and_directory_parses() {
-    // With --help to avoid actually running
     common::cmd()
-        .args([
-            "--username",
-            "x@x.com",
-            "--download-dir",
-            "/photos",
-            "--help",
-        ])
+        .args(["--username", "x@x.com", "--download-dir", "/tmp", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ── Global flags work with all subcommands ──────────────────────────────
@@ -900,18 +839,7 @@ fn auth_flags_accepted_on_all_subcommands() {
 #[test]
 fn retry_failed_accepts_sync_flags() {
     common::cmd()
-        .args([
-            "sync",
-            "--retry-failed",
-            "--download-dir",
-            "/tmp",
-            "--recent",
-            "10",
-            "--skip-videos",
-            "--threads",
-            "2",
-            "--help",
-        ])
+        .args(["sync", "--retry-failed", "--recent", "10", "--help"])
         .assert()
         .success();
 }
@@ -992,15 +920,23 @@ fn exit_code_0_on_version() {
 /// Exit code 1 (generic failure) when --username is missing.
 #[test]
 fn exit_code_1_on_missing_username() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config.toml");
+    std::fs::write(
+        &config,
+        "[download]\ndirectory = \"/tmp/claude/exit-code-test\"\n",
+    )
+    .unwrap();
+
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
         .args([
             "sync",
-            "--download-dir",
-            "/tmp/claude/exit-code-test",
+            "--config",
+            config.to_str().unwrap(),
             "--data-dir",
-            "/tmp/claude/exit-code-cookies",
+            dir.path().to_str().unwrap(),
         ])
         .timeout(std::time::Duration::from_secs(30))
         .assert()
@@ -1015,6 +951,12 @@ fn exit_code_1_on_missing_username() {
 #[test]
 fn exit_code_3_on_empty_password_file() {
     let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config.toml");
+    std::fs::write(
+        &config,
+        "[download]\ndirectory = \"/tmp/claude/exit-code-test\"\n",
+    )
+    .unwrap();
     let pw_file = dir.path().join("empty-password");
     std::fs::write(&pw_file, "").unwrap();
 
@@ -1025,8 +967,8 @@ fn exit_code_3_on_empty_password_file() {
             "sync",
             "--username",
             "exit-code-test@example.com",
-            "--download-dir",
-            "/tmp/claude/exit-code-test",
+            "--config",
+            config.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
             "--password-file",
@@ -1042,6 +984,12 @@ fn exit_code_3_on_empty_password_file() {
 #[test]
 fn exit_code_3_on_newline_only_password_file() {
     let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config.toml");
+    std::fs::write(
+        &config,
+        "[download]\ndirectory = \"/tmp/claude/exit-code-test\"\n",
+    )
+    .unwrap();
     let pw_file = dir.path().join("newline-password");
     std::fs::write(&pw_file, "\n").unwrap();
 
@@ -1052,8 +1000,8 @@ fn exit_code_3_on_newline_only_password_file() {
             "sync",
             "--username",
             "exit-code-test@example.com",
-            "--download-dir",
-            "/tmp/claude/exit-code-test",
+            "--config",
+            config.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
             "--password-file",
@@ -1246,7 +1194,7 @@ fn retry_failed_conflicts_with_watch() {
         .args(["sync", "--retry-failed", "--watch-with-interval", "300"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error"));
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ── --data-dir global ─────────────────────────────────────────────────
@@ -1272,12 +1220,12 @@ fn data_dir_global_works_with_subcommands() {
 // ── KEI_* env vars ────────────────────────────────────────────────────
 
 #[test]
-fn kei_download_dir_env_var_accepted() {
+fn download_dir_sync_flag_removed() {
     common::cmd()
-        .env("KEI_DOWNLOAD_DIR", "/photos")
-        .args(["sync", "--help"])
+        .args(["sync", "--download-dir", "/photos", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
@@ -1299,7 +1247,7 @@ fn kei_log_level_env_var_accepted() {
 }
 
 #[test]
-fn kei_reconcile_every_n_cycles_env_var_accepted() {
+fn kei_reconcile_every_n_cycles_env_var_ignored_by_help() {
     common::cmd()
         .env("KEI_RECONCILE_EVERY_N_CYCLES", "24")
         .args(["sync", "--help"])
@@ -1392,21 +1340,23 @@ fn submit_code_fails_without_username() {
         .stderr(predicate::str::contains("error").or(predicate::str::contains("required")));
 }
 
-// ── --report-json ────────────────────────────────────────────────────
+// ── --report-json removed from public sync CLI ───────────────────────
 
 #[test]
-fn report_json_flag_accepted() {
+fn report_json_flag_fails() {
     common::cmd()
         .args(["sync", "--report-json", "/tmp/report.json", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 #[test]
-fn report_json_visible_in_help() {
-    common::cmd()
-        .args(["sync", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("--report-json"));
+fn report_json_not_visible_in_help() {
+    let assert = common::cmd().args(["sync", "--help"]).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        !stdout.contains("\n      --report-json"),
+        "sync help should not expose a --report-json option, got:\n{stdout}"
+    );
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -437,3 +437,33 @@ pub fn walkdir(dir: &Path) -> Vec<PathBuf> {
     files.sort();
     files
 }
+
+/// Quote a string for the simple TOML snippets live tests write at runtime.
+#[allow(dead_code)]
+pub fn toml_string(s: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Write a per-test TOML config next to the test data directory.
+///
+/// Live tests run single-threaded, so a stable filename per process keeps the
+/// command lines short without racing another test in the same target.
+#[allow(dead_code)]
+pub fn write_toml_config(dir: &Path, name: &str, body: &str) -> PathBuf {
+    std::fs::create_dir_all(dir).expect("create config dir");
+    let path = dir.join(format!(".kei-{name}-{}.toml", std::process::id()));
+    std::fs::write(&path, body).expect("write test TOML config");
+    path
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -163,15 +163,9 @@ fn ensure_session(username: &str, password: &str, cookie_dir: &Path) {
 
         eprintln!("Validating authentication session (login)...");
         let output = assert_cmd::cargo_bin_cmd!("kei")
-            .args([
-                "login",
-                "--username",
-                username,
-                "--password",
-                password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", username)
+            .env("KEI_DATA_DIR", cookie_dir)
+            .args(["login", "--password", password])
             .timeout(std::time::Duration::from_secs(90))
             .output()
             .expect("failed to run login session validation");
@@ -188,7 +182,7 @@ fn ensure_session(username: &str, password: &str, cookie_dir: &Path) {
             }
             eprintln!(
                 "Login succeeded but session is not trusted (missing X-APPLE-WEBAUTH-TOKEN).\n\
-                 Complete 2FA first: kei login get-code --username {username} --data-dir {}\n\
+                 Complete 2FA first: ICLOUD_USERNAME={username} KEI_DATA_DIR={} kei login get-code\n\
                  Or set ICLOUD_TEST_COOKIE_DIR to a directory with a trusted session.",
                 cookie_dir.display()
             );
@@ -205,7 +199,7 @@ fn ensure_session(username: &str, password: &str, cookie_dir: &Path) {
         if stderr.contains("2FA") || stderr.contains("Two-factor") {
             eprintln!(
                 "\n*** ABORTING: 2FA required but not available in test mode ***\n\
-                 Complete 2FA first: kei login get-code --username {username} --data-dir {}\n\
+                 Complete 2FA first: ICLOUD_USERNAME={username} KEI_DATA_DIR={} kei login get-code\n\
                  Or set ICLOUD_TEST_COOKIE_DIR to a directory with a trusted session.",
                 cookie_dir.display()
             );
@@ -227,15 +221,9 @@ fn refresh_auth() {
 
     eprintln!("Running login to refresh session...");
     let output = assert_cmd::cargo_bin_cmd!("kei")
-        .args([
-            "login",
-            "--username",
-            username,
-            "--password",
-            password,
-            "--data-dir",
-            cookie_dir.to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir)
+        .args(["login", "--password", password])
         .timeout(std::time::Duration::from_secs(90))
         .output()
         .expect("failed to run login");

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -120,14 +120,12 @@ fn fixture() -> &'static (PathBuf, PathBuf) {
         );
         let config_path = write_kei_toml(&data_dir, &download_dir, "");
         let output = common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &data_dir)
             .args([
                 "sync",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                data_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--recent",
@@ -147,7 +145,7 @@ fn fixture() -> &'static (PathBuf, PathBuf) {
 }
 
 /// Build an `import-existing` command targeting the fixture's download
-/// dir but with a fresh `--data-dir` so the per-test state DB stays
+/// dir but with a fresh `KEI_DATA_DIR` so the per-test state DB stays
 /// isolated.
 fn import_cmd(
     username: &str,
@@ -161,14 +159,12 @@ fn import_cmd(
     // per-test data_dir so import-existing can re-use the trust cookie.
     copy_auth_artifacts(cookie_dir, data_dir);
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", data_dir);
     cmd.args([
         "import-existing",
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        data_dir.to_str().unwrap(),
         "--download-dir",
         download_dir.to_str().unwrap(),
         "--no-progress-bar",
@@ -411,14 +407,12 @@ fn import_recent_limit_caps_scan() {
             "[filters]\nalbums = [\"none\"]\nunfiled = true\n",
         );
         let output = common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", test_data.path())
             .args([
                 "import-existing",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                test_data.path().to_str().unwrap(),
                 "--config",
                 toml_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -678,14 +672,12 @@ force_size = false
 
         let mut cmd = common::cmd();
         clear_toml_resolved_env(&mut cmd);
+        cmd.env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", test_data.path());
         cmd.args([
             "import-existing",
-            "--username",
-            &username,
             "--password",
             &password,
-            "--data-dir",
-            test_data.path().to_str().unwrap(),
             "--config",
             toml_path.to_str().unwrap(),
             "--no-progress-bar",
@@ -786,14 +778,12 @@ fn run_sync_against_fixture(
 ) -> (u64, u64) {
     let config_path = write_kei_toml(data_dir, download_dir, extra_toml);
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", data_dir);
     cmd.args([
         "sync",
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        data_dir.to_str().unwrap(),
         "--config",
         config_path.to_str().unwrap(),
         "--recent",
@@ -1051,14 +1041,9 @@ fn verify_checksums_passes_after_import() {
         }
 
         let verify_out = common::cmd()
-            .args([
-                "verify",
-                "--checksums",
-                "--username",
-                &username,
-                "--data-dir",
-                test_data.path().to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", test_data.path())
+            .args(["verify", "--checksums"])
             .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
             .assert()
             .success()
@@ -1196,14 +1181,12 @@ fn toml_invalid_file_match_policy_errors_loudly() {
 
         let mut cmd = common::cmd();
         clear_toml_resolved_env(&mut cmd);
+        cmd.env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", test_data.path());
         cmd.args([
             "import-existing",
-            "--username",
-            &username,
             "--password",
             &password,
-            "--data-dir",
-            test_data.path().to_str().unwrap(),
             "--config",
             toml_path.to_str().unwrap(),
             "--no-progress-bar",
@@ -1249,14 +1232,12 @@ fn import_sigint_then_rerun_is_idempotent() {
         let recent = ROUNDTRIP_RECENT.to_string();
 
         let mut child = kei_std_command()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", test_data.path())
             .args([
                 "import-existing",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                test_data.path().to_str().unwrap(),
                 "--download-dir",
                 download_dir.to_str().unwrap(),
                 "--recent",
@@ -1354,14 +1335,12 @@ fn two_concurrent_imports_do_not_both_succeed_silently() {
 
         let spawn = || {
             kei_std_command()
+                .env("ICLOUD_USERNAME", &username)
+                .env("KEI_DATA_DIR", test_data.path())
                 .args([
                     "import-existing",
-                    "--username",
-                    &username,
                     "--password",
                     &password,
-                    "--data-dir",
-                    test_data.path().to_str().unwrap(),
                     "--download-dir",
                     download_dir.to_str().unwrap(),
                     "--recent",

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -118,6 +118,7 @@ fn fixture() -> &'static (PathBuf, PathBuf) {
             "Building import-existing fixture: --recent {FIXTURE_RECENT} into {}",
             download_dir.display()
         );
+        let config_path = write_kei_toml(&data_dir, &download_dir, "");
         let output = common::cmd()
             .args([
                 "sync",
@@ -127,8 +128,8 @@ fn fixture() -> &'static (PathBuf, PathBuf) {
                 &password,
                 "--data-dir",
                 data_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--recent",
                 &FIXTURE_RECENT.to_string(),
                 "--no-progress-bar",
@@ -781,8 +782,9 @@ fn run_sync_against_fixture(
     password: &str,
     download_dir: &Path,
     data_dir: &Path,
-    extra: &[&str],
+    extra_toml: &str,
 ) -> (u64, u64) {
+    let config_path = write_kei_toml(data_dir, download_dir, extra_toml);
     let mut cmd = common::cmd();
     cmd.args([
         "sync",
@@ -792,13 +794,12 @@ fn run_sync_against_fixture(
         password,
         "--data-dir",
         data_dir.to_str().unwrap(),
-        "--download-dir",
-        download_dir.to_str().unwrap(),
+        "--config",
+        config_path.to_str().unwrap(),
         "--recent",
         &ROUNDTRIP_RECENT.to_string(),
         "--no-progress-bar",
     ]);
-    cmd.args(extra);
     let output = cmd
         .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
         .assert()
@@ -842,6 +843,7 @@ fn roundtrip_default_layout_sync_skips_after_import() {
     common::with_auth_retry(|| {
         let test_data = tempdir().unwrap();
         let recent = ROUNDTRIP_RECENT.to_string();
+        let toml_path = write_kei_toml(test_data.path(), download_dir, "");
 
         let import = import_cmd(
             &username,
@@ -849,7 +851,7 @@ fn roundtrip_default_layout_sync_skips_after_import() {
             &cookie_dir,
             download_dir,
             test_data.path(),
-            &["--recent", &recent],
+            &["--recent", &recent, "--config", toml_path.to_str().unwrap()],
         )
         .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
         .assert()
@@ -868,7 +870,7 @@ fn roundtrip_default_layout_sync_skips_after_import() {
         // sync emits a per-asset skip tally; both are valid no-download
         // outcomes for the round-trip.
         let (downloaded, _skipped) =
-            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), &[]);
+            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), "");
         assert_eq!(
             downloaded, 0,
             "sync re-downloaded {downloaded} files after import-existing populated state DB; \
@@ -922,7 +924,7 @@ fn roundtrip_name_id7_sync_skips_after_import() {
             &password,
             download_dir,
             test_data.path(),
-            &["--file-match-policy", "name-id7"],
+            "[photos]\nfile_match_policy = \"name-id7\"\n",
         );
         assert_eq!(
             downloaded, 0,
@@ -974,7 +976,7 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
         }
 
         let (downloaded, _skipped) =
-            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), &[]);
+            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), "");
         assert_eq!(
             downloaded, 0,
             "sync re-downloaded {downloaded} after skip_videos import; matched={}",

--- a/tests/service_cli.rs
+++ b/tests/service_cli.rs
@@ -58,18 +58,16 @@ fn service_help_lists_run_and_status() {
 }
 
 #[test]
-fn service_run_help_inherits_sync_flags() {
-    // `kei service run` shares SyncArgs, so its help must surface the
-    // same flag vocabulary -- proves the delegation wiring is intact.
+fn service_run_help_inherits_runtime_sync_flags() {
+    // `kei service run` shares the reduced runtime SyncArgs. Durable
+    // settings are TOML-only and should not be exposed here.
     cmd()
         .args(["service", "run", "--help"])
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("--watch-with-interval")
-                .and(predicate::str::contains("--download-dir"))
-                .and(predicate::str::contains("--threads")),
-        );
+        .stdout(predicate::str::contains("--recent"))
+        .stdout(predicate::str::contains("--download-dir").not())
+        .stdout(predicate::str::contains("--threads").not());
 }
 
 #[test]

--- a/tests/service_status.rs
+++ b/tests/service_status.rs
@@ -44,8 +44,7 @@ fn status_cmd(tmp: &TempDir) -> assert_cmd::Command {
     let mut cmd = common::cmd();
     cmd.timeout(TIMEOUT)
         .env("ICLOUD_USERNAME", "service-status-test@example.invalid")
-        .args(["--data-dir"])
-        .arg(tmp.path())
+        .env("KEI_DATA_DIR", tmp.path())
         .arg("status");
     cmd
 }

--- a/tests/shell/concurrency.sh
+++ b/tests/shell/concurrency.sh
@@ -34,10 +34,8 @@ kei_sync() {
     # default `--unfiled true` would also enumerate every unfiled photo in
     # the live account on every concurrency-test sync, blowing wall time
     # past the suite's expected cadence.
-    "$KEI" sync \
-        --username "$ICLOUD_USERNAME" \
+    KEI_DATA_DIR="$COOKIES" "$KEI" sync \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir "$COOKIES" \
         --config "$config" \
         --no-progress-bar \
         --log-level info "$@" 2>&1

--- a/tests/shell/concurrency.sh
+++ b/tests/shell/concurrency.sh
@@ -26,6 +26,10 @@ KEI="$(kei_release_bin)"
 kei_check_init
 
 kei_sync() {
+    local download_dir="${1:?download dir required}"
+    shift
+    local config
+    config="$(kei_write_sync_config "$COOKIES" "$download_dir")"
     # `--unfiled false` keeps the suite scoped to the test album. v0.13's
     # default `--unfiled true` would also enumerate every unfiled photo in
     # the live account on every concurrency-test sync, blowing wall time
@@ -34,8 +38,7 @@ kei_sync() {
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir "$COOKIES" \
-        --album "$ALBUM" \
-        --unfiled false \
+        --config "$config" \
         --no-progress-bar \
         --log-level info "$@" 2>&1
 }
@@ -54,7 +57,7 @@ echo "=== 1. Concurrent downloads (threads=5) ==="
 DIR1=$(kei_scratch_dir concurrent)
 kei_db_exec "DELETE FROM assets"
 
-OUT=$(kei_sync --download-dir "$DIR1" --threads 5)
+OUT=$(KEI_SYNC_DOWNLOAD_TOML=$'threads = 5\n' kei_sync "$DIR1")
 echo "$OUT" | grep -E "concurrency|downloaded|failed|completed"
 
 FC=$(find "$DIR1" -type f | wc -l | tr -d ' ')
@@ -92,7 +95,7 @@ kei_db_exec "DELETE FROM assets"
 # Session reuse puts auth at ~3s; kill at 4s so we interrupt mid- or
 # just-post-download. Even if all files complete before the kill the
 # resume pass validates idempotency.
-kei_sync --download-dir "$DIR2" --threads 1 &
+KEI_SYNC_DOWNLOAD_TOML=$'threads = 1\n' kei_sync "$DIR2" &
 SYNC_PID=$!
 sleep 4
 kill -9 $SYNC_PID 2>/dev/null
@@ -103,7 +106,7 @@ PART_COUNT=$(find "$DIR2" -name "*.kei-tmp" | wc -l | tr -d ' ')
 FILE_COUNT=$(find "$DIR2" -type f ! -name "*.kei-tmp" | wc -l | tr -d ' ')
 echo "  After interrupt: $FILE_COUNT complete, $PART_COUNT .kei-tmp files"
 
-OUT=$(kei_sync --download-dir "$DIR2" --threads 1)
+OUT=$(KEI_SYNC_DOWNLOAD_TOML=$'threads = 1\n' kei_sync "$DIR2")
 echo "$OUT" | grep -E "downloaded|failed|completed|Skipping"
 
 FINAL_FILES=$(find "$DIR2" -type f ! -name "*.kei-tmp" | wc -l | tr -d ' ')
@@ -124,14 +127,13 @@ kei_db_exec "DELETE FROM assets"
 # Force one of the test album's files to land in a read-only directory.
 # Album passes default to `{album}/` since the per-category template
 # refactor (PR #288), so we explicitly request a date hierarchy and
-# pre-create one date dir as read-only. GOPR0558.JPG in icloudpd-test
+# pre-create one date dir as read-only. GOPR0558.JPG in kei-test
 # is dated 2019-11-09; making that path 555 makes its write fail while
 # the other dates succeed.
 mkdir -p "$DIR3/2019/11/09"
 chmod 555 "$DIR3/2019/11/09" "$DIR3/2019/11" "$DIR3/2019"
 
-kei_sync --download-dir "$DIR3" --threads 1 \
-    --folder-structure-albums "%Y/%m/%d"
+KEI_SYNC_DOWNLOAD_TOML=$'threads = 1\nfolder_structure_albums = "%Y/%m/%d"\n' kei_sync "$DIR3"
 EC=$?
 echo "  Exit code: $EC"
 

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -40,26 +40,14 @@ cp "$COOKIES/".* "$DOCKER_CONFIG/" 2>/dev/null
 # Strip lock files so the container doesn't conflict with the host kei.
 rm -f "$DOCKER_CONFIG/"*.lock "$DOCKER_CONFIG/.lock"
 
-cat >"$DOCKER_CONFIG/config.toml" <<EOF
-[download]
-directory = "/photos"
-
-[filters]
-albums = ["$ALBUM"]
-unfiled = false
-EOF
-
-cat >"$DOCKER_CONFIG/watch-config.toml" <<EOF
-[download]
-directory = "/photos"
-
-[filters]
-albums = ["$ALBUM"]
-unfiled = false
-
-[watch]
-interval = 60
-EOF
+sync_config="$(kei_write_sync_config "$DOCKER_CONFIG" "/photos")"
+cp "$sync_config" "$DOCKER_CONFIG/config.toml"
+{
+    cat "$sync_config"
+    echo ""
+    echo "[watch]"
+    echo "interval = 60"
+} > "$DOCKER_CONFIG/watch-config.toml"
 
 echo "--- 1. Docker sync ($ALBUM album) ---"
 docker run --rm \

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -40,25 +40,36 @@ cp "$COOKIES/".* "$DOCKER_CONFIG/" 2>/dev/null
 # Strip lock files so the container doesn't conflict with the host kei.
 rm -f "$DOCKER_CONFIG/"*.lock "$DOCKER_CONFIG/.lock"
 
-# Override the image's baked-in 24h watch default (Dockerfile sets
-# ENV KEI_WATCH_WITH_INTERVAL=86400). Empty value is parsed as unset
-# (see config.rs::parse_env_watch_interval). Applied to every one-shot
-# `docker run kei sync ...` below; the explicit watch-mode test (step
-# 10) sets --watch-with-interval directly.
-ONESHOT_ENV=(-e KEI_WATCH_WITH_INTERVAL=)
+cat >"$DOCKER_CONFIG/config.toml" <<EOF
+[download]
+directory = "/photos"
+
+[filters]
+albums = ["$ALBUM"]
+unfiled = false
+EOF
+
+cat >"$DOCKER_CONFIG/watch-config.toml" <<EOF
+[download]
+directory = "/photos"
+
+[filters]
+albums = ["$ALBUM"]
+unfiled = false
+
+[watch]
+interval = 60
+EOF
 
 echo "--- 1. Docker sync ($ALBUM album) ---"
 docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DOCKER_PHOTOS:/photos" \
     "$IMAGE" sync \
+        --config /config/config.toml \
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir /config \
-        --download-dir /photos \
-        --album "$ALBUM" \
-        --unfiled false \
         --no-progress-bar \
         \
     2>&1
@@ -107,16 +118,13 @@ fi
 echo ""
 echo "--- 6. Idempotent re-sync (no new downloads) ---"
 docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DOCKER_PHOTOS:/photos" \
     "$IMAGE" sync \
+        --config /config/config.toml \
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir /config \
-        --download-dir /photos \
-        --album "$ALBUM" \
-        --unfiled false \
         --no-progress-bar \
         --log-level info \
     2>&1 | tee /dev/stderr | grep -qE "downloaded=0|No new photos"
@@ -126,16 +134,13 @@ echo ""
 echo "--- 7. Dry run ---"
 DRY_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-dry-XXXXX")
 docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DRY_PHOTOS:/photos" \
     "$IMAGE" sync \
+        --config /config/config.toml \
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir /config \
-        --download-dir /photos \
-        --album "$ALBUM" \
-        --unfiled false \
         --no-progress-bar \
         --dry-run \
     2>&1
@@ -169,14 +174,11 @@ docker run -d --name "$WATCH_NAME" \
     -v "$DOCKER_CONFIG:/config" \
     -v "$WATCH_PHOTOS:/photos" \
     "$IMAGE" sync \
+        --config /config/watch-config.toml \
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir /config \
-        --download-dir /photos \
-        --album "$ALBUM" \
-        --unfiled false \
         --no-progress-bar \
-        --watch-with-interval 60 \
         --log-level info >/dev/null
 
 sleep 130
@@ -217,17 +219,14 @@ printf '%s' "$ICLOUD_PASSWORD" > "$SECRETS_DIR/icloud_password"
 chmod 400 "$SECRETS_DIR/icloud_password"
 PWFILE_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-pwfile-XXXXX")
 PWFILE_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -v "$DOCKER_CONFIG:/config" \
     -v "$PWFILE_PHOTOS:/photos" \
     -v "$SECRETS_DIR:/run/secrets:ro" \
     "$IMAGE" sync \
+        --config /config/config.toml \
         --username "$ICLOUD_USERNAME" \
         --password-file /run/secrets/icloud_password \
         --data-dir /config \
-        --download-dir /photos \
-        --album "$ALBUM" \
-        --unfiled false \
         --no-progress-bar \
         --dry-run \
     2>&1)
@@ -259,7 +258,6 @@ TEST_PUID=4321
 TEST_PGID=4322
 puid_run() {
     docker run --rm \
-        "${ONESHOT_ENV[@]}" \
         -e PUID="$TEST_PUID" \
         -e PGID="$TEST_PGID" \
         -v "$PUID_CONFIG:/config" \
@@ -287,7 +285,6 @@ rm -rf "$PUID_CONFIG" "$PUID_PHOTOS"
 echo ""
 echo "--- 14b. No PUID/PGID = runs as root (backward compat) ---"
 ROOT_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     --entrypoint /usr/local/bin/entrypoint.sh \
     "$IMAGE" id -u 2>&1)
 [ "$ROOT_OUT" = "0" ]
@@ -296,7 +293,6 @@ kei_check "default (no PUID/PGID) still runs as root"
 echo ""
 echo "--- 14c. Non-numeric PUID is rejected ---"
 BAD_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -e PUID="notanumber" \
     -e PGID="$TEST_PGID" \
     --entrypoint /usr/local/bin/entrypoint.sh \
@@ -307,7 +303,6 @@ kei_check "non-numeric PUID is rejected with clear error"
 echo ""
 echo "--- 14d. Setting only one of PUID/PGID is rejected ---"
 PARTIAL_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -e PUID="$TEST_PUID" \
     --entrypoint /usr/local/bin/entrypoint.sh \
     "$IMAGE" id 2>&1 || true)
@@ -326,7 +321,6 @@ echo "--- 14e. kei subcommand routes through kei and runs as dropped user under 
 SUB_CONFIG=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-config-XXXXX")
 SUB_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-photos-XXXXX")
 SUB_OUT=$(docker run --rm \
-    "${ONESHOT_ENV[@]}" \
     -e PUID="$TEST_PUID" \
     -e PGID="$TEST_PGID" \
     -v "$SUB_CONFIG:/config" \

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -63,13 +63,13 @@ EOF
 
 echo "--- 1. Docker sync ($ALBUM album) ---"
 docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DOCKER_PHOTOS:/photos" \
     "$IMAGE" sync \
         --config /config/config.toml \
-        --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir /config \
         --no-progress-bar \
         \
     2>&1
@@ -118,13 +118,13 @@ fi
 echo ""
 echo "--- 6. Idempotent re-sync (no new downloads) ---"
 docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DOCKER_PHOTOS:/photos" \
     "$IMAGE" sync \
         --config /config/config.toml \
-        --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir /config \
         --no-progress-bar \
         --log-level info \
     2>&1 | tee /dev/stderr | grep -qE "downloaded=0|No new photos"
@@ -134,13 +134,13 @@ echo ""
 echo "--- 7. Dry run ---"
 DRY_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-dry-XXXXX")
 docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     -v "$DRY_PHOTOS:/photos" \
     "$IMAGE" sync \
         --config /config/config.toml \
-        --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir /config \
         --no-progress-bar \
         --dry-run \
     2>&1
@@ -151,18 +151,20 @@ rm -rf "$DRY_PHOTOS"
 echo ""
 echo "--- 8. Password backend in container ---"
 BACKEND=$(docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
-    "$IMAGE" password --username "$ICLOUD_USERNAME" --data-dir /config backend 2>&1)
+    "$IMAGE" password backend 2>&1)
 echo "  Backend: $BACKEND"
 [ -n "$BACKEND" ]; kei_check "credential backend reports a value"
 
 echo ""
 echo "--- 9. List albums in container ---"
 docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" list albums \
-        --username "$ICLOUD_USERNAME" \
-        --data-dir /config \
     2>&1 | grep -qF "$ALBUM"
 kei_check "list-albums shows $ALBUM album"
 
@@ -171,13 +173,13 @@ echo "--- 10. Watch mode cycles + graceful SIGTERM ---"
 WATCH_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-watch-XXXXX")
 WATCH_NAME="kei-docker-watch-$$"
 docker run -d --name "$WATCH_NAME" \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     -v "$WATCH_PHOTOS:/photos" \
     "$IMAGE" sync \
         --config /config/watch-config.toml \
-        --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir /config \
         --no-progress-bar \
         --log-level info >/dev/null
 
@@ -219,14 +221,14 @@ printf '%s' "$ICLOUD_PASSWORD" > "$SECRETS_DIR/icloud_password"
 chmod 400 "$SECRETS_DIR/icloud_password"
 PWFILE_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-pwfile-XXXXX")
 PWFILE_OUT=$(docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     -v "$PWFILE_PHOTOS:/photos" \
     -v "$SECRETS_DIR:/run/secrets:ro" \
     "$IMAGE" sync \
         --config /config/config.toml \
-        --username "$ICLOUD_USERNAME" \
         --password-file /run/secrets/icloud_password \
-        --data-dir /config \
         --no-progress-bar \
         --dry-run \
     2>&1)
@@ -238,10 +240,10 @@ rm -rf "$SECRETS_DIR" "$PWFILE_PHOTOS"
 echo ""
 echo "--- 13. kei status --downloaded inside container ---"
 STATUS_OUT=$(docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" status \
-        --username "$ICLOUD_USERNAME" \
-        --data-dir /config \
         --downloaded \
     2>&1)
 echo "$STATUS_OUT" | tail -5
@@ -321,13 +323,13 @@ echo "--- 14e. kei subcommand routes through kei and runs as dropped user under 
 SUB_CONFIG=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-config-XXXXX")
 SUB_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-puid-sub-photos-XXXXX")
 SUB_OUT=$(docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -e PUID="$TEST_PUID" \
     -e PGID="$TEST_PGID" \
     -v "$SUB_CONFIG:/config" \
     -v "$SUB_PHOTOS:/photos" \
     "$IMAGE" status \
-        --username "$ICLOUD_USERNAME" \
-        --data-dir /config \
         --downloaded \
     2>&1)
 SUB_EC=$?
@@ -347,10 +349,10 @@ rm -rf "$SUB_CONFIG" "$SUB_PHOTOS"
 echo ""
 echo "--- 15. kei status --pending --failed --downloaded combined ---"
 COMBINED_OUT=$(docker run --rm \
+    -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
+    -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" status \
-        --username "$ICLOUD_USERNAME" \
-        --data-dir /config \
         --pending --failed --downloaded \
     2>&1)
 COMBINED_EC=$?

--- a/tests/shell/lib.sh
+++ b/tests/shell/lib.sh
@@ -60,6 +60,18 @@ kei_toml_string() {
     printf '"%s"' "$s"
 }
 
+kei_append_toml_fragment() {
+    local fragment="$1"
+    if [ -z "$fragment" ]; then
+        return
+    fi
+    printf '%s' "$fragment"
+    case "$fragment" in
+        *$'\n') ;;
+        *) echo ;;
+    esac
+}
+
 kei_write_sync_config() {
     local data_dir="${1:?data dir required}"
     local download_dir="${2:?download dir required}"
@@ -71,14 +83,14 @@ kei_write_sync_config() {
     {
         echo "[download]"
         printf 'directory = %s\n' "$(kei_toml_string "$download_dir")"
-        printf '%s' "$download_extra"
+        kei_append_toml_fragment "$download_extra"
         echo "[filters]"
         printf 'albums = [%s]\n' "$(kei_toml_string "$(kei_album)")"
         echo "unfiled = false"
-        printf '%s' "$filters_extra"
+        kei_append_toml_fragment "$filters_extra"
         if [ -n "$photos_extra" ]; then
             echo "[photos]"
-            printf '%s' "$photos_extra"
+            kei_append_toml_fragment "$photos_extra"
         fi
     } > "$config"
     printf '%s' "$config"

--- a/tests/shell/lib.sh
+++ b/tests/shell/lib.sh
@@ -53,6 +53,37 @@ kei_album() {
     printf '%s' "${KEI_TEST_ALBUM:-kei-test}"
 }
 
+kei_toml_string() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    printf '"%s"' "$s"
+}
+
+kei_write_sync_config() {
+    local data_dir="${1:?data dir required}"
+    local download_dir="${2:?download dir required}"
+    local download_extra="${KEI_SYNC_DOWNLOAD_TOML:-}"
+    local filters_extra="${KEI_SYNC_FILTERS_TOML:-}"
+    local photos_extra="${KEI_SYNC_PHOTOS_TOML:-}"
+    local config="$data_dir/.kei-shell-sync-$$.toml"
+    mkdir -p "$data_dir"
+    {
+        echo "[download]"
+        printf 'directory = %s\n' "$(kei_toml_string "$download_dir")"
+        printf '%s' "$download_extra"
+        echo "[filters]"
+        printf 'albums = [%s]\n' "$(kei_toml_string "$(kei_album)")"
+        echo "unfiled = false"
+        printf '%s' "$filters_extra"
+        if [ -n "$photos_extra" ]; then
+            echo "[photos]"
+            printf '%s' "$photos_extra"
+        fi
+    } > "$config"
+    printf '%s' "$config"
+}
+
 kei_docker_image() {
     printf '%s' "${KEI_DOCKER_IMAGE:-kei:latest}"
 }

--- a/tests/shell/lib.sh
+++ b/tests/shell/lib.sh
@@ -143,17 +143,15 @@ kei_preflight_session() {
     local bin cookies out
     bin="$(kei_release_bin)"
     cookies="$(kei_cookie_dir)"
-    out=$("$bin" login \
-        --username "$ICLOUD_USERNAME" \
-        --password "$ICLOUD_PASSWORD" \
-        --data-dir "$cookies" 2>&1)
+    out=$(KEI_DATA_DIR="$cookies" "$bin" login \
+        --password "$ICLOUD_PASSWORD" 2>&1)
     if echo "$out" | grep -q "Authentication completed\|Session OK\|already authenticated"; then
         kei_check "session valid" 0
         return 0
     fi
     echo "  ABORT: session invalid or rate-limited"
     echo "$out" | tail -3
-    echo "  Re-authenticate: cargo run --release -- login --data-dir $cookies"
+    echo "  Re-authenticate: KEI_DATA_DIR=$cookies cargo run --release -- login"
     exit 1
 }
 

--- a/tests/shell/state-machine.sh
+++ b/tests/shell/state-machine.sh
@@ -28,6 +28,10 @@ KEI="$(kei_release_bin)"
 kei_check_init
 
 kei_sync() {
+    local download_dir="${1:?download dir required}"
+    shift
+    local config
+    config="$(kei_write_sync_config "$COOKIES" "$download_dir")"
     # `--unfiled false` keeps the suite scoped to the test album. v0.13's
     # default `--unfiled true` would otherwise enumerate every unfiled
     # photo in the live account on each sync (huge wall time + Apple rate
@@ -37,8 +41,7 @@ kei_sync() {
         --username "$ICLOUD_USERNAME" \
         --password "$ICLOUD_PASSWORD" \
         --data-dir "$COOKIES" \
-        --album "$ALBUM" \
-        --unfiled false \
+        --config "$config" \
         --no-progress-bar \
         --log-level info \
         "$@" 2>&1
@@ -66,7 +69,7 @@ echo "=== 1. Clean slate full sync ==="
 kei_db_exec "DELETE FROM metadata WHERE key LIKE '%token%' OR key = 'config_hash'"
 kei_db_exec "DELETE FROM assets"
 echo "  Cleared: tokens=$(token_count), hash=$(get_hash || echo 'none')"
-OUTPUT=$(kei_sync --download-dir "$DIR")
+OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "Incremental|token|Summary|downloaded|completed"
 [ -n "$(get_token)" ]; kei_check "token stored after full sync"
 [ -n "$(get_hash)" ];  kei_check "config hash stored"
@@ -78,7 +81,7 @@ echo "  hash=$BASELINE_HASH"
 # ── 2. Incremental sync: no changes → 0 downloads, token preserved ──────
 echo ""
 echo "=== 2. Incremental sync (no changes) ==="
-OUTPUT=$(kei_sync --download-dir "$DIR")
+OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "incremental|token|change|download|[Cc]ompleted"
 # The incremental path logs "No new photos to download from incremental
 # sync" when the change feed is empty. If the trust-state sample detects
@@ -96,7 +99,7 @@ NEW_DOWNLOADS=$(echo "$OUTPUT" | grep -oE '[0-9]+ downloaded' | head -1 | grep -
 echo ""
 echo "=== 3. Config change clears tokens ==="
 HASH_BEFORE=$(get_hash)
-OUTPUT=$(kei_sync --download-dir "$DIR" --size medium)
+OUTPUT=$(KEI_SYNC_PHOTOS_TOML=$'size = "medium"\n' kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "config|changed|cleared|token|incremental|download|completed"
 HASH_AFTER=$(get_hash)
 TOKEN_AFTER=$(get_token)
@@ -107,7 +110,7 @@ echo "  hash: $HASH_BEFORE -> $HASH_AFTER"
 # ── 4. Restore original config → hash reverts ───────────────────────────
 echo ""
 echo "=== 4. Restore original config ==="
-OUTPUT=$(kei_sync --download-dir "$DIR")
+OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "config|changed|cleared|token|incremental|download|completed"
 [ "$(get_hash)" = "$BASELINE_HASH" ]; kei_check "hash reverted to original"
 [ -n "$(get_token)" ]; kei_check "token stored"
@@ -116,7 +119,7 @@ echo "$OUTPUT" | grep -E "config|changed|cleared|token|incremental|download|comp
 echo ""
 echo "=== 5. reset sync-token ==="
 "$KEI" reset sync-token --yes --username "$ICLOUD_USERNAME" --data-dir "$COOKIES" >/dev/null
-OUTPUT=$(kei_sync --download-dir "$DIR")
+OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "reset|clear|token|Fetching|full|incremental|download|completed"
 echo "$OUTPUT" | grep -qi "Fetching"; kei_check "full enumeration ran"
 [ -n "$(get_token)" ]; kei_check "new token stored"
@@ -127,7 +130,7 @@ echo "=== 6. Corrupt token recovery ==="
 GOOD_TOKEN=$(get_token)
 kei_db_exec "UPDATE metadata SET value = 'CORRUPT_GARBAGE_TOKEN_XYZ' WHERE key = 'sync_token:PrimarySync'"
 echo "  Injected: CORRUPT_GARBAGE_TOKEN_XYZ"
-OUTPUT=$(kei_sync --download-dir "$DIR")
+OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "token|invalid|fallback|full|error|Fetching|incremental|download|completed"
 RECOVERED_TOKEN=$(get_token)
 if echo "$OUTPUT" | grep -qi "fallback\|full enumeration\|Fetching"; then
@@ -159,7 +162,7 @@ delete_and_sync() {
     kei_db_exec "DELETE FROM assets WHERE filename = '$f'"
     rm -f "$path"
     echo "  Deleted from state + disk: $f"
-    out=$(kei_sync --download-dir "$DIR" $mode_flag)
+    out=$(kei_sync "$DIR" $mode_flag)
     echo "$out" | grep -E "incremental|change|download|[Cc]ompleted"
     echo "$out" | grep -qE "[Cc]ompleted in"; kei_check "$label completed without error"
     clean=$(echo "$out" | sed 's/\x1b\[[0-9;]*m//g')
@@ -176,21 +179,21 @@ delete_and_sync "" "full re-enum"
 echo ""
 echo "=== 8. Dry run preserves token ==="
 TOKEN_BEFORE=$(get_token)
-kei_sync --download-dir "$DIR" --dry-run >/dev/null
+kei_sync "$DIR" --dry-run >/dev/null
 [ "$(get_token)" = "$TOKEN_BEFORE" ]; kei_check "token unchanged after dry-run"
 
 # ── 9. Filter flag changes config hash ───────────────────────────────────
 echo ""
 echo "=== 9. Filter flag changes config hash ==="
 HASH_BEFORE=$(get_hash)
-OUTPUT=$(kei_sync --download-dir "$DIR" --skip-videos)
+OUTPUT=$(KEI_SYNC_FILTERS_TOML=$'skip_videos = true\n' kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "config|changed|cleared|token|download|completed"
 [ "$HASH_BEFORE" != "$(get_hash)" ]; kei_check "hash changed with --skip-videos"
 
 # ── 10. Session reuse check ─────────────────────────────────────────────
 echo ""
 echo "=== 10. Session reuse check ==="
-OUTPUT=$(kei_sync --download-dir "$DIR" --log-level debug 2>&1)
+OUTPUT=$(kei_sync "$DIR" --log-level debug 2>&1)
 if echo "$OUTPUT" | grep -q "Existing session token is valid"; then
     kei_check "session reuse (validate_token succeeded)" 0
 elif echo "$OUTPUT" | grep -q "accountLogin succeeded"; then
@@ -205,7 +208,7 @@ else
 fi
 
 # ── Cleanup: restore the original config so future runs start consistent ─
-kei_sync --download-dir "$DIR" >/dev/null 2>&1
+kei_sync "$DIR" >/dev/null 2>&1
 rm -rf "$DIR"
 
 kei_check_summary "STATE-MACHINE RESULTS"

--- a/tests/shell/state-machine.sh
+++ b/tests/shell/state-machine.sh
@@ -37,10 +37,8 @@ kei_sync() {
     # photo in the live account on each sync (huge wall time + Apple rate
     # limits). The state-machine assertions only care about the album
     # pass; the unfiled-pass flow is exercised by the cargo `sync` suite.
-    "$KEI" sync \
-        --username "$ICLOUD_USERNAME" \
+    KEI_DATA_DIR="$COOKIES" "$KEI" sync \
         --password "$ICLOUD_PASSWORD" \
-        --data-dir "$COOKIES" \
         --config "$config" \
         --no-progress-bar \
         --log-level info \
@@ -118,7 +116,7 @@ echo "$OUTPUT" | grep -E "config|changed|cleared|token|incremental|download|comp
 # ── 5. reset sync-token forces full enumeration ─────────────────────
 echo ""
 echo "=== 5. reset sync-token ==="
-"$KEI" reset sync-token --yes --username "$ICLOUD_USERNAME" --data-dir "$COOKIES" >/dev/null
+KEI_DATA_DIR="$COOKIES" "$KEI" reset sync-token --yes >/dev/null
 OUTPUT=$(kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "reset|clear|token|Fetching|full|incremental|download|completed"
 echo "$OUTPUT" | grep -qi "Fetching"; kei_check "full enumeration ran"
@@ -172,7 +170,7 @@ delete_and_sync() {
     [ "$dl" -ge 1 ]; kei_check "$label finds missing file"
 }
 delete_and_sync "" "incremental"
-"$KEI" reset sync-token --yes --username "$ICLOUD_USERNAME" --data-dir "$COOKIES" >/dev/null
+KEI_DATA_DIR="$COOKIES" "$KEI" reset sync-token --yes >/dev/null
 delete_and_sync "" "full re-enum"
 
 # ── 8. --dry-run preserves token ─────────────────────────────────────────

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -59,16 +59,14 @@ fn sync_cmd(
     // independent.
     let config_path = sync_config(cookie_dir, dir, "", "");
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir);
     cmd.args([
         "sync",
         "--recent",
         &recent.to_string(),
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
         "--config",
         config_path.to_str().unwrap(),
         "--no-progress-bar",
@@ -78,38 +76,25 @@ fn sync_cmd(
 
 fn status_cmd(username: &str, cookie_dir: &Path) -> assert_cmd::Command {
     let mut cmd = common::cmd();
-    cmd.args([
-        "status",
-        "--username",
-        username,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
-    ]);
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir)
+        .arg("status");
     cmd
 }
 
 fn reset_state_cmd(username: &str, cookie_dir: &Path) -> assert_cmd::Command {
     let mut cmd = common::cmd();
-    cmd.args([
-        "reset",
-        "state",
-        "--username",
-        username,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
-    ]);
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir)
+        .args(["reset", "state"]);
     cmd
 }
 
 fn verify_cmd(username: &str, cookie_dir: &Path) -> assert_cmd::Command {
     let mut cmd = common::cmd();
-    cmd.args([
-        "verify",
-        "--username",
-        username,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
-    ]);
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir)
+        .arg("verify");
     cmd
 }
 
@@ -120,14 +105,12 @@ fn import_cmd(
     dir: &Path,
 ) -> assert_cmd::Command {
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir);
     cmd.args([
         "import-existing",
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
         "--download-dir",
         dir.to_str().unwrap(),
     ]);
@@ -145,15 +128,13 @@ fn retry_failed_cmd(
 ) -> assert_cmd::Command {
     let config_path = sync_config(cookie_dir, dir, "", "");
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir);
     cmd.args([
         "sync",
         "--retry-failed",
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
         "--config",
         config_path.to_str().unwrap(),
         "--no-progress-bar",
@@ -399,16 +380,14 @@ fn verify_checksums_detects_corruption() {
 
         let config_path = sync_config(&cookie_dir, download_dir.path(), "", "skip_videos = true\n");
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
                 "--recent",
                 "1",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -443,14 +422,12 @@ fn import_existing_with_nonexistent_directory_fails() {
 
     common::with_auth_retry(|| {
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "import-existing",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--download-dir",
                 "/nonexistent/path/that/does/not/exist",
             ])
@@ -535,16 +512,14 @@ fn import_existing_custom_folder_structure() {
             "",
         );
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
                 "--recent",
                 "1",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -710,15 +685,9 @@ fn reset_sync_token_forces_full_enumeration() {
         // (and in CI), since the next sync re-enumerates every asset and we
         // ship a confirmation prompt by default.
         common::cmd()
-            .args([
-                "reset",
-                "sync-token",
-                "--yes",
-                "--username",
-                &username,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["reset", "sync-token", "--yes"])
             .timeout(Duration::from_secs(10))
             .assert()
             .success()
@@ -749,14 +718,9 @@ fn config_show_after_sync() {
     let (username, _password, cookie_dir) = common::require_preauth();
     // config show doesn't need auth, just needs username resolution
     common::cmd()
-        .args([
-            "config",
-            "show",
-            "--username",
-            &username,
-            "--data-dir",
-            cookie_dir.to_str().unwrap(),
-        ])
+        .env("ICLOUD_USERNAME", &username)
+        .env("KEI_DATA_DIR", &cookie_dir)
+        .args(["config", "show"])
         .timeout(Duration::from_secs(10))
         .assert()
         .success()
@@ -774,15 +738,9 @@ fn login_with_existing_session() {
     let (username, password, cookie_dir) = common::require_preauth();
     common::with_auth_retry(|| {
         common::cmd()
-            .args([
-                "login",
-                "--username",
-                &username,
-                "--password",
-                &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["login", "--password", &password])
             .timeout(Duration::from_secs(60))
             .assert()
             .success();

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -31,6 +31,19 @@ const TIMEOUT_CMD: u64 = 30;
 
 // ── Command builders ──────────────────────────────────────────────────
 
+fn sync_config(
+    data_dir: &Path,
+    dir: &Path,
+    download_extra: &str,
+    filters_extra: &str,
+) -> std::path::PathBuf {
+    let body = format!(
+        "[download]\ndirectory = {}\n{download_extra}[filters]\nalbums = [\"none\"]\n{filters_extra}",
+        common::toml_string(&dir.to_string_lossy())
+    );
+    common::write_toml_config(data_dir, "state-auth-sync", &body)
+}
+
 fn sync_cmd(
     username: &str,
     password: &str,
@@ -44,11 +57,10 @@ fn sync_cmd(
     // under `--recent N` and overrun Apple's rate limits across the
     // suite. The state-DB invariants tested here are pass-shape
     // independent.
+    let config_path = sync_config(cookie_dir, dir, "", "");
     let mut cmd = common::cmd();
     cmd.args([
         "sync",
-        "--album",
-        "none",
         "--recent",
         &recent.to_string(),
         "--username",
@@ -57,8 +69,8 @@ fn sync_cmd(
         password,
         "--data-dir",
         cookie_dir.to_str().unwrap(),
-        "--download-dir",
-        dir.to_str().unwrap(),
+        "--config",
+        config_path.to_str().unwrap(),
         "--no-progress-bar",
     ]);
     cmd
@@ -131,11 +143,10 @@ fn retry_failed_cmd(
     cookie_dir: &Path,
     dir: &Path,
 ) -> assert_cmd::Command {
+    let config_path = sync_config(cookie_dir, dir, "", "");
     let mut cmd = common::cmd();
     cmd.args([
         "sync",
-        "--album",
-        "none",
         "--retry-failed",
         "--username",
         username,
@@ -143,8 +154,8 @@ fn retry_failed_cmd(
         password,
         "--data-dir",
         cookie_dir.to_str().unwrap(),
-        "--download-dir",
-        dir.to_str().unwrap(),
+        "--config",
+        config_path.to_str().unwrap(),
         "--no-progress-bar",
         "--log-level",
         "info",
@@ -386,8 +397,22 @@ fn verify_checksums_detects_corruption() {
             .timeout(std::time::Duration::from_secs(TIMEOUT_CMD))
             .assert();
 
-        sync_cmd(&username, &password, &cookie_dir, download_dir.path(), 1)
-            .args(["--skip-videos"])
+        let config_path = sync_config(&cookie_dir, download_dir.path(), "", "skip_videos = true\n");
+        common::cmd()
+            .args([
+                "sync",
+                "--recent",
+                "1",
+                "--username",
+                &username,
+                "--password",
+                &password,
+                "--data-dir",
+                cookie_dir.to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
+                "--no-progress-bar",
+            ])
             .timeout(std::time::Duration::from_secs(TIMEOUT_SYNC))
             .assert()
             .success();
@@ -503,8 +528,27 @@ fn import_existing_custom_folder_structure() {
     common::with_auth_retry(|| {
         let download_dir = tempfile::tempdir().expect("failed to create download dir");
 
-        sync_cmd(&username, &password, &cookie_dir, download_dir.path(), 1)
-            .args(["--folder-structure", "%Y"])
+        let config_path = sync_config(
+            &cookie_dir,
+            download_dir.path(),
+            "folder_structure = \"%Y\"\n",
+            "",
+        );
+        common::cmd()
+            .args([
+                "sync",
+                "--recent",
+                "1",
+                "--username",
+                &username,
+                "--password",
+                &password,
+                "--data-dir",
+                cookie_dir.to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
+                "--no-progress-bar",
+            ])
             .timeout(std::time::Duration::from_secs(TIMEOUT_SYNC))
             .assert()
             .success();

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -46,6 +46,16 @@ fn album() -> &'static str {
     A.get_or_init(|| std::env::var("KEI_TEST_ALBUM").unwrap_or_else(|_| "kei-test".to_string()))
 }
 
+#[derive(Debug, Default)]
+struct SyncToml<'a> {
+    download: &'a str,
+    filters: &'a str,
+    photos: &'a str,
+    watch: &'a str,
+    notifications: &'a str,
+    report: &'a str,
+}
+
 /// Build a sync command targeting the test album.
 fn album_cmd(
     username: &str,
@@ -53,30 +63,84 @@ fn album_cmd(
     cookie_dir: &std::path::Path,
     download_dir: &std::path::Path,
 ) -> assert_cmd::Command {
-    // `--unfiled false` keeps these tests scoped to the album under test.
+    album_cmd_with_toml(
+        username,
+        password,
+        cookie_dir,
+        download_dir,
+        SyncToml::default(),
+    )
+}
+
+fn album_cmd_with_toml(
+    username: &str,
+    password: &str,
+    cookie_dir: &std::path::Path,
+    download_dir: &std::path::Path,
+    toml: SyncToml<'_>,
+) -> assert_cmd::Command {
+    // `[filters].unfiled = false` keeps these tests scoped to the album under test.
     // v0.13's default is `--unfiled true` regardless of `--album`, which
     // would also enumerate every unfiled photo in the live account on
     // every test invocation -- both blowing up wall time and hitting Apple
     // rate limits. Each individual test asserts album-specific behaviour;
     // the unfiled pass is exercised separately by the no-flag tests.
+    let config_path = album_config(cookie_dir, download_dir, toml);
     let mut cmd = common::cmd();
     cmd.args([
         "sync",
-        "--album",
-        album(),
-        "--unfiled",
-        "false",
         "--username",
         username,
         "--password",
         password,
         "--data-dir",
         cookie_dir.to_str().unwrap(),
-        "--download-dir",
-        download_dir.to_str().unwrap(),
+        "--config",
+        config_path.to_str().unwrap(),
         "--no-progress-bar",
     ]);
     cmd
+}
+
+fn album_config(
+    data_dir: &std::path::Path,
+    download_dir: &std::path::Path,
+    toml: SyncToml<'_>,
+) -> std::path::PathBuf {
+    let mut body = format!(
+        "[download]\ndirectory = {}\n{}[filters]\n",
+        common::toml_string(&download_dir.to_string_lossy()),
+        toml.download,
+    );
+    if !toml.filters.contains("albums") {
+        body.push_str(&format!("albums = [{}]\n", common::toml_string(album())));
+    }
+    if !toml.filters.contains("unfiled") {
+        body.push_str("unfiled = false\n");
+    }
+    body.push_str(toml.filters);
+    for (section, content) in [
+        ("photos", toml.photos),
+        ("watch", toml.watch),
+        ("notifications", toml.notifications),
+        ("report", toml.report),
+    ] {
+        if !content.is_empty() {
+            body.push_str(&format!("[{section}]\n{content}"));
+        }
+    }
+    common::write_toml_config(data_dir, "sync-live", &body)
+}
+
+fn config_for_download_dir(
+    data_dir: &std::path::Path,
+    download_dir: &std::path::Path,
+) -> std::path::PathBuf {
+    let body = format!(
+        "[download]\ndirectory = {}\n",
+        common::toml_string(&download_dir.to_string_lossy())
+    );
+    common::write_toml_config(data_dir, "sync-live", &body)
 }
 
 // ── Metadata (no downloads) ─────────────────────────────────────────────
@@ -251,11 +315,19 @@ fn sync_skip_videos_excludes_video_files() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(
@@ -287,11 +359,19 @@ fn sync_skip_photos_excludes_image_files() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--skip-photos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                filters: "skip_photos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         let image_files: Vec<_> = files.iter().filter(|p| is_image_ext(p)).collect();
@@ -318,11 +398,19 @@ fn sync_skip_live_photos_excludes_companions() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--live-photo-mode", "skip"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                photos: "live_photo_mode = \"skip\"\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
 
@@ -345,17 +433,21 @@ fn sync_skip_all_media_rejected_at_startup() {
 
     let download_dir = tempdir().expect("tempdir");
 
-    album_cmd(&username, &password, &cookie_dir, download_dir.path())
-        .args([
-            "--skip-videos",
-            "--skip-photos",
-            "--live-photo-mode",
-            "skip",
-        ])
-        .timeout(Duration::from_secs(TIMEOUT_META))
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("would download nothing"));
+    album_cmd_with_toml(
+        &username,
+        &password,
+        &cookie_dir,
+        download_dir.path(),
+        SyncToml {
+            filters: "skip_videos = true\nskip_photos = true\n",
+            photos: "live_photo_mode = \"skip\"\n",
+            ..SyncToml::default()
+        },
+    )
+    .timeout(Duration::from_secs(TIMEOUT_META))
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("would download nothing"));
 }
 
 /// Date filters with extreme values should filter everything out.
@@ -420,11 +512,20 @@ fn sync_size_medium_produces_smaller_files() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--size", "medium", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                filters: "skip_videos = true\n",
+                photos: "size = \"medium\"\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(!files.is_empty(), "should download files at medium size");
@@ -458,11 +559,19 @@ fn sync_force_size_succeeds_when_available() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--size", "medium", "--force-size"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                photos: "size = \"medium\"\nforce_size = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(
@@ -497,11 +606,19 @@ fn sync_name_id7_appends_asset_id() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--file-match-policy", "name-id7"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                photos: "file_match_policy = \"name-id7\"\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(!files.is_empty(), "name-id7 should download files");
@@ -553,11 +670,19 @@ fn sync_custom_folder_structure() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--folder-structure-albums", "%Y"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "folder_structure_albums = \"%Y\"\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(!files.is_empty(), "should download files");
@@ -591,11 +716,19 @@ fn sync_keep_unicode_preserves_special_chars() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--keep-unicode-in-filenames"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                photos: "keep_unicode_in_filenames = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         assert!(
@@ -627,11 +760,20 @@ fn sync_set_exif_datetime_embeds_date() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--set-exif-datetime", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "set_exif_datetime = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         let jpeg_files: Vec<_> = files
@@ -675,11 +817,20 @@ fn sync_set_exif_rating_embeds_rating() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--set-exif-rating", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "set_exif_rating = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let jpeg = first_jpeg(&download_dir.path());
         use xmp_toolkit::{OpenFileOptions, XmpFile};
@@ -705,11 +856,20 @@ fn sync_set_exif_gps_embeds_gps() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--set-exif-gps", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "set_exif_gps = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let jpeg = first_jpeg(&download_dir.path());
         use xmp_toolkit::{OpenFileOptions, XmpFile};
@@ -735,11 +895,20 @@ fn sync_set_exif_description_embeds_description() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--set-exif-description", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "set_exif_description = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let jpeg = first_jpeg(&download_dir.path());
         use xmp_toolkit::{OpenFileOptions, XmpFile};
@@ -764,11 +933,20 @@ fn sync_embed_xmp_writes_xmp_packet() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--embed-xmp", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "embed_xmp = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let jpeg = first_jpeg(&download_dir.path());
         use xmp_toolkit::{OpenFileOptions, XmpFile};
@@ -799,11 +977,20 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--xmp-sidecar", "--skip-videos"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "xmp_sidecar = true\n",
+                filters: "skip_videos = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         let sidecars: Vec<_> = files
@@ -840,11 +1027,19 @@ fn sync_embed_xmp_on_heic_writes_mime_item() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--embed-xmp"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "embed_xmp = true\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let files = common::walkdir(download_dir.path());
         let heics: Vec<_> = files
@@ -913,11 +1108,19 @@ fn sync_align_raw_controls_raw_naming() {
     common::with_auth_retry(|| {
         for variant in ["as-is", "original", "alternative"] {
             let dir = tempdir().expect("tempdir");
-            album_cmd(&username, &password, &cookie_dir, dir.path())
-                .args(["--align-raw", variant])
-                .timeout(Duration::from_secs(TIMEOUT_SECS))
-                .assert()
-                .success();
+            album_cmd_with_toml(
+                &username,
+                &password,
+                &cookie_dir,
+                dir.path(),
+                SyncToml {
+                    photos: &format!("align_raw = {variant:?}\n"),
+                    ..SyncToml::default()
+                },
+            )
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .assert()
+            .success();
 
             let files = common::walkdir(dir.path());
             assert!(
@@ -942,11 +1145,19 @@ fn sync_live_photo_mov_policy_controls_naming() {
     common::with_auth_retry(|| {
         for policy in ["suffix", "original"] {
             let dir = tempdir().expect("tempdir");
-            album_cmd(&username, &password, &cookie_dir, dir.path())
-                .args(["--live-photo-mov-filename-policy", policy])
-                .timeout(Duration::from_secs(TIMEOUT_SECS))
-                .assert()
-                .success();
+            album_cmd_with_toml(
+                &username,
+                &password,
+                &cookie_dir,
+                dir.path(),
+                SyncToml {
+                    photos: &format!("live_photo_mov_filename_policy = {policy:?}\n"),
+                    ..SyncToml::default()
+                },
+            )
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .assert()
+            .success();
 
             let files = common::walkdir(dir.path());
             assert!(
@@ -969,11 +1180,19 @@ fn sync_temp_suffix_leaves_no_remnants() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--temp-suffix", ".downloading"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "temp_suffix = \".downloading\"\n",
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let all_files = common::walkdir(download_dir.path());
         assert!(
@@ -1000,11 +1219,20 @@ fn sync_threads_reflected_in_log() {
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
 
-        let assertion = album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--threads", "1", "--log-level", "info"])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        let assertion = album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                download: "threads = 1\n",
+                ..SyncToml::default()
+            },
+        )
+        .args(["--log-level", "info"])
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let stderr = String::from_utf8_lossy(&assertion.get_output().stderr);
         let clean = common::strip_ansi(&stderr);
@@ -1082,11 +1310,22 @@ fn sync_notification_script_fires_event() {
             std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--notification-script", script_path.to_str().unwrap()])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                notifications: &format!(
+                    "script = {}\n",
+                    common::toml_string(&script_path.to_string_lossy())
+                ),
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         assert!(
             marker.exists(),
@@ -1112,11 +1351,22 @@ fn sync_pid_file_cleaned_up_after_sync() {
         let pid_dir = tempdir().expect("tempdir");
         let pid_file = pid_dir.path().join("test.pid");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--pid-file", pid_file.to_str().unwrap()])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                watch: &format!(
+                    "pid_file = {}\n",
+                    common::toml_string(&pid_file.to_string_lossy())
+                ),
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         assert!(
             !pid_file.exists(),
@@ -1142,21 +1392,18 @@ fn sync_bare_invocation_works_like_sync() {
 
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
+        let config_path = album_config(&cookie_dir, download_dir.path(), SyncToml::default());
 
         common::cmd()
             .args([
-                "--album",
-                album(),
-                "--unfiled",
-                "false",
                 "--username",
                 &username,
                 "--password",
                 &password,
                 "--data-dir",
                 cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--no-progress-bar",
             ])
             .timeout(Duration::from_secs(TIMEOUT_SECS))
@@ -1182,6 +1429,7 @@ fn sync_bare_invocation_works_like_sync() {
 #[ignore]
 fn sync_without_directory_fails() {
     let (username, password, cookie_dir) = common::require_preauth();
+    let config_path = common::write_toml_config(&cookie_dir, "sync-live-empty", "");
 
     common::cmd()
         .args([
@@ -1192,6 +1440,8 @@ fn sync_without_directory_fails() {
             &password,
             "--data-dir",
             cookie_dir.to_str().unwrap(),
+            "--config",
+            config_path.to_str().unwrap(),
             "--no-progress-bar",
         ])
         .timeout(Duration::from_secs(TIMEOUT_META))
@@ -1211,20 +1461,26 @@ fn sync_nonexistent_album_fails() {
 
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
+        let config_path = album_config(
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                filters: "albums = [\"ThisAlbumDefinitelyDoesNotExist999\"]\nunfiled = false\n",
+                ..SyncToml::default()
+            },
+        );
 
         common::cmd()
             .args([
                 "sync",
-                "--album",
-                "ThisAlbumDefinitelyDoesNotExist999",
                 "--username",
                 &username,
                 "--password",
                 &password,
                 "--data-dir",
                 cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--no-progress-bar",
             ])
             .timeout(Duration::from_secs(TIMEOUT_META))
@@ -1241,20 +1497,23 @@ fn sync_nonexistent_library_fails() {
 
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
+        let body = format!(
+            "[download]\ndirectory = {}\n[filters]\nlibraries = [\"NonExistentLibrary-ZZZZZ\"]\n",
+            common::toml_string(&download_dir.path().to_string_lossy())
+        );
+        let config_path = common::write_toml_config(&cookie_dir, "sync-live", &body);
 
         common::cmd()
             .args([
                 "sync",
-                "--library",
-                "NonExistentLibrary-ZZZZZ",
                 "--username",
                 &username,
                 "--password",
                 &password,
                 "--data-dir",
                 cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--no-progress-bar",
             ])
             .timeout(Duration::from_secs(TIMEOUT_META))
@@ -1321,6 +1580,7 @@ fn sync_retry_failed_flag() {
 
     common::with_auth_retry(|| {
         let download_dir = tempdir().expect("tempdir");
+        let config_path = config_for_download_dir(&cookie_dir, download_dir.path());
 
         // sync --retry-failed with no prior failures should succeed (noop)
         common::cmd()
@@ -1333,8 +1593,8 @@ fn sync_retry_failed_flag() {
                 &password,
                 "--data-dir",
                 cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--no-progress-bar",
             ])
             .timeout(Duration::from_secs(TIMEOUT_SECS))
@@ -1361,25 +1621,8 @@ fn sync_incremental_second_run_skips_download() {
         assert!(first_count >= 3, "first sync should download files");
 
         // Second sync: incremental.
-        let output = common::cmd()
-            .args([
-                "sync",
-                "--album",
-                album(),
-                "--unfiled",
-                "false",
-                "--username",
-                &username,
-                "--password",
-                &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
-                "--no-progress-bar",
-                "--log-level",
-                "debug",
-            ])
+        let output = album_cmd(&username, &password, &cookie_dir, download_dir.path())
+            .args(["--log-level", "debug"])
             .timeout(Duration::from_secs(TIMEOUT_SECS))
             .output()
             .unwrap();
@@ -1421,25 +1664,27 @@ fn sync_watch_runs_multiple_cycles() {
         use std::time::Instant;
 
         let download_dir = tempdir().expect("tempdir");
+        let config_path = album_config(
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                watch: "interval = 60\n",
+                ..SyncToml::default()
+            },
+        );
         let bin = env!("CARGO_BIN_EXE_kei");
         let mut child = Command::new(bin)
             .args([
                 "sync",
-                "--album",
-                album(),
-                "--unfiled",
-                "false",
                 "--username",
                 &username,
                 "--password",
                 &password,
                 "--data-dir",
                 cookie_dir.to_str().unwrap(),
-                "--download-dir",
-                download_dir.path().to_str().unwrap(),
+                "--config",
+                config_path.to_str().unwrap(),
                 "--no-progress-bar",
-                "--watch-with-interval",
-                "60",
                 "--log-level",
                 "info",
             ])
@@ -1526,11 +1771,22 @@ fn sync_report_json_writes_valid_schema() {
         let report_dir = tempdir().expect("tempdir");
         let report_path = report_dir.path().join("report.json");
 
-        album_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--report-json", report_path.to_str().unwrap()])
-            .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .assert()
-            .success();
+        album_cmd_with_toml(
+            &username,
+            &password,
+            &cookie_dir,
+            download_dir.path(),
+            SyncToml {
+                report: &format!(
+                    "json = {}\n",
+                    common::toml_string(&report_path.to_string_lossy())
+                ),
+                ..SyncToml::default()
+            },
+        )
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .assert()
+        .success();
 
         let body = std::fs::read_to_string(&report_path).expect("report file");
         let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
@@ -1676,6 +1932,7 @@ fn sync_truncated_file_does_not_cause_data_loss() {
 fn zz_bad_credentials_fails() {
     let cookie_dir = tempdir().expect("tempdir");
     let download_dir = tempdir().expect("tempdir");
+    let config_path = config_for_download_dir(cookie_dir.path(), download_dir.path());
 
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
@@ -1688,8 +1945,8 @@ fn zz_bad_credentials_fails() {
             "wrong-password",
             "--data-dir",
             cookie_dir.path().to_str().unwrap(),
-            "--download-dir",
-            download_dir.path().to_str().unwrap(),
+            "--config",
+            config_path.to_str().unwrap(),
             "--no-progress-bar",
         ])
         .timeout(Duration::from_secs(60))

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -87,14 +87,12 @@ fn album_cmd_with_toml(
     // the unfiled pass is exercised separately by the no-flag tests.
     let config_path = album_config(cookie_dir, download_dir, toml);
     let mut cmd = common::cmd();
+    cmd.env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", cookie_dir);
     cmd.args([
         "sync",
-        "--username",
-        username,
         "--password",
         password,
-        "--data-dir",
-        cookie_dir.to_str().unwrap(),
         "--config",
         config_path.to_str().unwrap(),
         "--no-progress-bar",
@@ -152,14 +150,9 @@ fn list_albums_prints_album_names() {
 
     common::with_auth_retry(|| {
         common::cmd()
-            .args([
-                "list",
-                "albums",
-                "--username",
-                &username,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["list", "albums"])
             .timeout(Duration::from_secs(TIMEOUT_META))
             .assert()
             .success()
@@ -174,14 +167,9 @@ fn list_libraries_prints_output() {
 
     common::with_auth_retry(|| {
         common::cmd()
-            .args([
-                "list",
-                "libraries",
-                "--username",
-                &username,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["list", "libraries"])
             .timeout(Duration::from_secs(TIMEOUT_META))
             .assert()
             .success()
@@ -1395,13 +1383,11 @@ fn sync_bare_invocation_works_like_sync() {
         let config_path = album_config(&cookie_dir, download_dir.path(), SyncToml::default());
 
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -1432,14 +1418,12 @@ fn sync_without_directory_fails() {
     let config_path = common::write_toml_config(&cookie_dir, "sync-live-empty", "");
 
     common::cmd()
+        .env("ICLOUD_USERNAME", &username)
+        .env("KEI_DATA_DIR", &cookie_dir)
         .args([
             "sync",
-            "--username",
-            &username,
             "--password",
             &password,
-            "--data-dir",
-            cookie_dir.to_str().unwrap(),
             "--config",
             config_path.to_str().unwrap(),
             "--no-progress-bar",
@@ -1471,14 +1455,12 @@ fn sync_nonexistent_album_fails() {
         );
 
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -1504,14 +1486,12 @@ fn sync_nonexistent_library_fails() {
         let config_path = common::write_toml_config(&cookie_dir, "sync-live", &body);
 
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -1536,15 +1516,9 @@ fn login_authenticates_successfully() {
 
     common::with_auth_retry(|| {
         common::cmd()
-            .args([
-                "login",
-                "--username",
-                &username,
-                "--password",
-                &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["login", "--password", &password])
             .timeout(Duration::from_secs(60))
             .assert()
             .success();
@@ -1558,14 +1532,9 @@ fn list_albums_new_syntax() {
 
     common::with_auth_retry(|| {
         common::cmd()
-            .args([
-                "list",
-                "albums",
-                "--username",
-                &username,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
-            ])
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args(["list", "albums"])
             .timeout(Duration::from_secs(60))
             .assert()
             .success()
@@ -1584,15 +1553,13 @@ fn sync_retry_failed_flag() {
 
         // sync --retry-failed with no prior failures should succeed (noop)
         common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
                 "--retry-failed",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -1674,14 +1641,12 @@ fn sync_watch_runs_multiple_cycles() {
         );
         let bin = env!("CARGO_BIN_EXE_kei");
         let mut child = Command::new(bin)
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
             .args([
                 "sync",
-                "--username",
-                &username,
                 "--password",
                 &password,
-                "--data-dir",
-                cookie_dir.to_str().unwrap(),
                 "--config",
                 config_path.to_str().unwrap(),
                 "--no-progress-bar",
@@ -1937,14 +1902,12 @@ fn zz_bad_credentials_fails() {
     common::cmd()
         .env_remove("ICLOUD_USERNAME")
         .env_remove("ICLOUD_PASSWORD")
+        .env("ICLOUD_USERNAME", "nonexistent-xyz@icloud.com")
+        .env("KEI_DATA_DIR", cookie_dir.path())
         .args([
             "sync",
-            "--username",
-            "nonexistent-xyz@icloud.com",
             "--password",
             "wrong-password",
-            "--data-dir",
-            cookie_dir.path().to_str().unwrap(),
             "--config",
             config_path.to_str().unwrap(),
             "--no-progress-bar",


### PR DESCRIPTION
## Summary
- Makes TOML the durable sync config surface. Public `sync` flags are now runtime/action inputs; persistent sync settings resolve from TOML-backed owner structs.
- Removes public durable globals from the CLI: `--username`, `--domain`, and `--data-dir`. `ICLOUD_USERNAME` and `KEI_DATA_DIR` stay as bootstrap/container env inputs.
- Updates Docker to start `kei service run --config /config/config.toml`, with state under `/config` and downloads supplied by `[download].directory`.
- Updates migration docs and test helpers so v0.20 examples, shell suites, live smokes, and Docker checks write TOML instead of old env/flag config.
- Adds branch coverage for `config show`, Docker defaults, migration docs, removed sync env mirrors, and Windows-safe fixture reads.

## Review notes
- This is the PR 2 TOML-primary scope from the v0.20 plan. PR 3 selection literal escapes and PR 5 import alignment stay separate.
- `config show` now emits canonical v0.20 TOML. It doesn't preserve old flag/env spellings.
- The stale-flag grep still matches removed-flag assertions and migration-guide mapping rows.

## Risk
- This intentionally breaks old durable sync flags and env mirrors. Users need to move persistent settings into `config.toml`.
- Docker users should mount `/config/config.toml`; the image now runs service mode by default and keeps state in `/config`.

## Tests
- `cargo check` - passed
- `cargo fmt --check` - passed
- `cargo clippy --all-targets --all-features -- -D warnings` - passed
- `cargo test` - passed outside sandbox
- `cargo test --test behavioral` - passed
- `cargo test --test branch_static` - passed
- `cargo run -- sync --help` - verified reduced sync surface
- `cargo run -- sync --download-dir /tmp --help` - verified removed flag rejection
- `cargo run -- service run --help` - verified service runtime help
- `ICLOUD_USERNAME=test@example.com KEI_DATA_DIR=/tmp/kei-config-show cargo run -- config show` - verified TOML output
- `bash -n scripts/just/live-env.sh scripts/full-test/run_all.sh scripts/full-test/run_shell_suites.sh scripts/full-test/run_live_smokes.sh tests/shell/lib.sh tests/shell/concurrency.sh tests/shell/state-machine.sh tests/shell/docker.sh` - passed
- `rg -n -- '--username|--domain|--data-dir|KEI_DOMAIN|KEI_FRIENDLY' src tests scripts Dockerfile docker-compose.yml justfile docs README.md .github/workflows` - reviewed expected hits
- GitHub CI for PR #403 - green, including `cargo clippy --all-targets --no-default-features -- -D warnings` and `Test (windows-latest)`
