### PR TITLE
Add TOML media selection filters

### DIFF
--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -176,7 +176,7 @@ password for future runs.
 | `--folder-structure "{:%Y/%m/%d}"` | `[download].folder_structure = "%Y/%m/%d"` | Python wrapper syntax is still accepted. Use `folder_structure_albums` and `folder_structure_smart_folders` for the other passes. |
 | `--size original` | `[photos].size = "original"` | Values: `original`, `medium`, `thumb`, `adjusted`, `alternative`. kei accepts one size per run. |
 | `--threads-num` | `[download].threads` | Default is 10. With `[download].bandwidth_limit` and no explicit thread count, default drops to 1. |
-| `--skip-videos`, `--skip-photos` | `[filters].skip_videos`, `[filters].skip_photos` | Boolean TOML settings replace the sync flags. |
+| `--skip-videos`, `--skip-photos` | `[filters].media` | Use `media = ["photos", "live-photos"]` to skip videos, or `media = ["videos", "live-photos"]` to skip normal photos. |
 | `--skip-live-photos` | `[photos].live_photo_mode = "skip"` | The old flag was removed in v0.20. |
 | `--recent 100` | `--recent 100` | Count form works for sync and import. |
 | `--recent 30d` | `--recent 30d` for sync | Import rejects the days form. |

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1117,8 +1117,7 @@ mod wiremock_tests {
             folder_structure_smart_folders: Arc::from("{smart-folder}"),
             library: Arc::from(crate::icloud::photos::PRIMARY_ZONE_NAME),
             size: AssetVersionSize::Original,
-            skip_videos: false,
-            skip_photos: false,
+            media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]
@@ -1829,15 +1828,15 @@ mod wiremock_tests {
         assert_eq!(stats.matched, 1);
     }
 
-    // ── Tests: skip_videos / skip_photos ──────────────────────────────
+    // ── Tests: media filters ──────────────────────────────────────────
 
-    /// `skip_videos` filtering happens via `is_asset_filtered`, which
+    /// Media filtering happens via `is_asset_filtered`, which
     /// `import_assets` now invokes upstream of `expected_paths_for`. The
     /// previous incarnation of this test asserted `matched == 0` without
     /// staging a file, so it would have passed even if the gate were
     /// missing entirely (no file → no match for an unrelated reason). Stage
     /// the file the matcher would land on AND verify `is_asset_filtered`
-    /// classifies it as a video-skip; if the gate disappears, `matched`
+    /// classifies it as a media skip; if the gate disappears, `matched`
     /// becomes 1 and `unmatched` stays 0, failing this test loudly.
     #[tokio::test]
     async fn skip_videos_excludes_movie_assets() {
@@ -1846,7 +1845,7 @@ mod wiremock_tests {
         let dl = tmp.path().join("photos");
         std::fs::create_dir_all(&dl).unwrap();
         let mut config = base_config(&dl);
-        config.skip_videos = true;
+        config.media.videos = false;
 
         let asset = WiremockAsset::new("VID1", "MOV_0001.MOV", "com.apple.quicktime-movie").orig(
             5000,
@@ -1855,30 +1854,30 @@ mod wiremock_tests {
         );
 
         // Stage the file at the path expected_paths_for *would* emit if the
-        // gate were missing. Without skip_videos honored, this would match.
-        let probe_config = base_config(&dl); // skip_videos defaults to false
+        // gate were missing. With all media enabled, this would match.
+        let probe_config = base_config(&dl);
         let expected_if_unfiltered = expected_paths_for(&asset.to_photo_asset(), &probe_config);
         assert_eq!(
             expected_if_unfiltered.len(),
             1,
-            "probe: video should have one expected path when skip_videos=false",
+            "probe: video should have one expected path when media is unrestricted",
         );
         stage_file(
             &expected_if_unfiltered[0].path,
             expected_if_unfiltered[0].size,
         );
 
-        // is_asset_filtered must classify a movie under skip_videos as filtered.
+        // is_asset_filtered must classify a movie excluded by media as filtered.
         assert!(
             crate::download::filter::is_asset_filtered(&asset.to_photo_asset(), &config).is_some(),
-            "skip_videos must filter movie assets via is_asset_filtered",
+            "media filter must drop movie assets via is_asset_filtered",
         );
 
         let db = open_db(&tmp).await;
         let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
 
         assert_eq!(stats.total, 1, "asset still enumerated");
-        assert_eq!(stats.matched, 0, "skip_videos must drop the movie");
+        assert_eq!(stats.matched, 0, "media filter must drop the movie");
         assert_eq!(
             stats.unmatched, 0,
             "filter happens before path derivation; unmatched stays 0",
@@ -2002,8 +2001,8 @@ mod wiremock_tests {
     }
 
     /// Verifies `import_assets` actually invokes `is_asset_filtered`. We
-    /// can't easily flip skip_videos through `build_import_download_config`
-    /// (it hardcodes false), but `exclude_asset_ids` is honored by
+    /// can't easily flip media selection through `build_import_download_config`,
+    /// but `exclude_asset_ids` is honored by
     /// `is_asset_filtered` and we can set it directly on the test
     /// `DownloadConfig`. If `import_assets` ever stops calling the gate,
     /// this test fails with `matched=1` instead of `matched=0`.
@@ -2053,7 +2052,7 @@ mod wiremock_tests {
     // `is_asset_filtered_blocks_excluded_asset_id` already pin the gate
     // for two filter sources. The branch's commit "honor is_asset_filtered"
     // (05356d2) ties the import path to ALL filter sources, not just two.
-    // These pin skip_photos / date / filename-exclude so a future change
+    // These pin media / date / filename-exclude so a future change
     // that loses one of them surfaces here.
     //
     // Each test stages the file the matcher would land on without the
@@ -2072,13 +2071,13 @@ mod wiremock_tests {
         let dl = tmp.path().join("photos");
         std::fs::create_dir_all(&dl).unwrap();
         let mut config = base_config(&dl);
-        config.skip_photos = true;
+        config.media.photos = false;
         stage_expected(&asset.to_photo_asset(), &base_config(&dl));
 
         let db = open_db(&tmp).await;
         let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
         assert_eq!(stats.total, 1);
-        assert_eq!(stats.matched, 0, "skip_photos must drop the still");
+        assert_eq!(stats.matched, 0, "media filter must drop the still");
         assert_eq!(stats.unmatched, 0, "filter fires before resolve_match_path");
         assert_eq!(stats.filtered, 1);
         assert!(all_downloaded(db.as_ref()).await.is_empty());

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -786,10 +786,12 @@ fn build_import_download_config(
         },
         toml,
     );
+    let media = config::resolve_media_selection(toml.and_then(|t| t.filters.as_ref()), None, None)?;
 
     Ok(download::DownloadConfig::for_path_derivation_only(
         directory,
         path_fields,
+        media,
         args.dry_run,
         args.no_progress_bar,
     ))
@@ -2761,7 +2763,7 @@ mod build_config_tests {
     //! parse path that production uses.
     use super::build_import_download_config;
     use crate::cli::{Cli, Command};
-    use crate::config::{Config, GlobalArgs, TomlConfig, TomlPhotos};
+    use crate::config::{Config, GlobalArgs, MediaKind, TomlConfig, TomlFilters, TomlPhotos};
     use crate::types::{
         AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
         LivePhotoSize, RawTreatmentPolicy, VersionSize,
@@ -2797,6 +2799,12 @@ mod build_config_tests {
     fn toml_with_photos(p: TomlPhotos) -> TomlConfig {
         let mut t = empty_toml();
         t.photos = Some(p);
+        t
+    }
+
+    fn toml_with_filters(f: TomlFilters) -> TomlConfig {
+        let mut t = empty_toml();
+        t.filters = Some(f);
         t
     }
 
@@ -2943,6 +2951,21 @@ mod build_config_tests {
         assert_eq!(cfg.align_raw, RawTreatmentPolicy::PreferOriginal);
         assert!(cfg.force_size);
         assert!(cfg.keep_unicode_in_filenames);
+    }
+
+    #[test]
+    fn build_import_download_config_uses_toml_media_filter() {
+        let args = parse_import_args(&[]);
+        let toml = toml_with_filters(TomlFilters {
+            media: Some(vec![MediaKind::Photos, MediaKind::LivePhotos]),
+            ..TomlFilters::default()
+        });
+
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+
+        assert!(cfg.media.photos);
+        assert!(!cfg.media.videos);
+        assert!(cfg.media.live_photos);
     }
 
     /// CG-1: documented defaults when neither CLI nor TOML set the field.

--- a/src/config.rs
+++ b/src/config.rs
@@ -433,7 +433,7 @@ pub(crate) fn resolve_library_selector(
     crate::selection::parse_library_selector(&raw)
 }
 
-fn resolve_media_selection(
+pub(crate) fn resolve_media_selection(
     toml_filters: Option<&TomlFilters>,
     skip_videos_override: Option<bool>,
     skip_photos_override: Option<bool>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use crate::types::{
 };
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 // ── TOML config structs ─────────────────────────────────────────────
@@ -110,12 +111,65 @@ pub(crate) struct TomlFilters {
     pub smart_folders: Option<Vec<String>>,
     /// Unfiled-pass toggle. Default: `true`.
     pub unfiled: Option<bool>,
+    pub media: Option<Vec<MediaKind>>,
     pub filename_exclude: Option<Vec<String>>,
-    pub skip_videos: Option<bool>,
-    pub skip_photos: Option<bool>,
     pub recent: Option<crate::cli::RecentLimit>,
     pub skip_created_before: Option<String>,
     pub skip_created_after: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum MediaKind {
+    Photos,
+    Videos,
+    LivePhotos,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MediaSelection {
+    pub photos: bool,
+    pub videos: bool,
+    pub live_photos: bool,
+}
+
+impl Default for MediaSelection {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl MediaSelection {
+    pub(crate) const fn all() -> Self {
+        Self {
+            photos: true,
+            videos: true,
+            live_photos: true,
+        }
+    }
+
+    pub(crate) const fn skip_videos(self) -> bool {
+        !self.videos
+    }
+
+    pub(crate) const fn skip_photos(self) -> bool {
+        !self.photos
+    }
+
+    pub(crate) const fn is_all(self) -> bool {
+        self.photos && self.videos && self.live_photos
+    }
+
+    pub(crate) fn to_kinds(self) -> Vec<MediaKind> {
+        [
+            (self.photos, MediaKind::Photos),
+            (self.videos, MediaKind::Videos),
+            (self.live_photos, MediaKind::LivePhotos),
+        ]
+        .into_iter()
+        .filter_map(|(enabled, kind)| enabled.then_some(kind))
+        .collect()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -231,12 +285,24 @@ pub struct DownloadSettings {
 
 #[derive(Debug)]
 pub struct FilterConfig {
+    #[allow(
+        dead_code,
+        reason = "legacy album shape stays during v0.20 migration while runtime uses Selection"
+    )]
     pub albums: AlbumSelection,
+    #[allow(
+        dead_code,
+        reason = "legacy album exclude shape stays during v0.20 migration while runtime uses Selection"
+    )]
     pub exclude_albums: Vec<String>,
     pub selection: crate::selection::Selection,
+    pub media: MediaSelection,
     pub skip_created_before: Option<DateTime<Local>>,
     pub skip_created_after: Option<DateTime<Local>>,
     pub recent: Option<u32>,
+    pub persistent_recent: Option<crate::cli::RecentLimit>,
+    pub persistent_skip_created_before: Option<String>,
+    pub persistent_skip_created_after: Option<String>,
     pub skip_videos: bool,
     pub skip_photos: bool,
 }
@@ -367,6 +433,59 @@ pub(crate) fn resolve_library_selector(
     crate::selection::parse_library_selector(&raw)
 }
 
+fn resolve_media_selection(
+    toml_filters: Option<&TomlFilters>,
+    skip_videos_override: Option<bool>,
+    skip_photos_override: Option<bool>,
+) -> anyhow::Result<MediaSelection> {
+    let mut selection = if let Some(kinds) = toml_filters.and_then(|f| f.media.as_ref()) {
+        anyhow::ensure!(!kinds.is_empty(), "[filters] media must not be empty");
+        let mut seen = BTreeSet::new();
+        let mut selection = MediaSelection {
+            photos: false,
+            videos: false,
+            live_photos: false,
+        };
+        for kind in kinds {
+            anyhow::ensure!(
+                seen.insert(*kind),
+                "[filters] media contains duplicate `{}`",
+                media_kind_name(*kind)
+            );
+            match kind {
+                MediaKind::Photos => selection.photos = true,
+                MediaKind::Videos => selection.videos = true,
+                MediaKind::LivePhotos => selection.live_photos = true,
+            }
+        }
+        selection
+    } else {
+        MediaSelection::all()
+    };
+
+    if let Some(skip_videos) = skip_videos_override {
+        selection.videos = !skip_videos;
+    }
+    if let Some(skip_photos) = skip_photos_override {
+        selection.photos = !skip_photos;
+    }
+
+    anyhow::ensure!(
+        selection.photos || selection.videos || selection.live_photos,
+        "[filters] media must select at least one media category"
+    );
+
+    Ok(selection)
+}
+
+const fn media_kind_name(kind: MediaKind) -> &'static str {
+    match kind {
+        MediaKind::Photos => "photos",
+        MediaKind::Videos => "videos",
+        MediaKind::LivePhotos => "live-photos",
+    }
+}
+
 /// Which albums to sync.
 ///
 /// v0.13 default is `All`. `-a all` (explicit), no `-a` flag, and the
@@ -388,6 +507,10 @@ pub enum AlbumSelection {
 
 impl AlbumSelection {
     /// Serialize to a `Vec<String>` for TOML persistence and JSON reports.
+    #[allow(
+        dead_code,
+        reason = "legacy report/test helper kept while runtime selection uses Selection::to_raw"
+    )]
     pub fn to_vec(&self) -> Vec<String> {
         match self {
             Self::LibraryOnly => Vec::new(),
@@ -571,6 +694,10 @@ fn warn_implicit_unfiled_pass() {
 /// `unfiled_override` is `Some(b)` when the user passed `--unfiled` (or set
 /// `[filters].unfiled` in TOML) and `None` otherwise. When `None`, unfiled
 /// defaults to `true` regardless of `--album` (v0.13 semantics).
+#[allow(
+    dead_code,
+    reason = "kept as a pure adapter for selection truth-table tests and future config refactors"
+)]
 pub(crate) fn derive_selection(
     albums: &AlbumSelection,
     exclude_albums: &[String],
@@ -1228,14 +1355,10 @@ impl Config {
         validate_template_tokens(&folder_structure_albums, TemplateKind::Albums)?;
         validate_template_tokens(&folder_structure_smart_folders, TemplateKind::SmartFolders)?;
 
-        let skip_videos = resolve_flag(
-            overrides.skip_videos,
-            toml_filters.and_then(|f| f.skip_videos),
-        );
-        let skip_photos = resolve_flag(
-            overrides.skip_photos,
-            toml_filters.and_then(|f| f.skip_photos),
-        );
+        let media =
+            resolve_media_selection(toml_filters, overrides.skip_videos, overrides.skip_photos)?;
+        let skip_videos = media.skip_videos();
+        let skip_photos = media.skip_photos();
         let live_photo_mode_pre_resolved: Option<LivePhotoMode> = overrides
             .live_photo_mode
             .or_else(|| toml_photos.and_then(|p| p.live_photo_mode));
@@ -1248,17 +1371,17 @@ impl Config {
             .unfiled
             .or_else(|| toml_filters.and_then(|f| f.unfiled));
 
-        // Build the v0.13 [`Selection`] that the new resolver (`resolve_passes`)
-        // consumes. The legacy `albums` / `exclude_albums` fields stay on
-        // Config for the sync-token invalidation hash and the report.json
-        // emission; the Selection is the source of truth for pass execution.
-        let selection = derive_selection(
-            &albums,
-            &exclude_albums,
-            &library_selector,
-            &raw_smart_folders,
-            unfiled_override,
-        )?;
+        // Build the [`Selection`] that the pass resolver consumes directly
+        // from raw TOML/override values. Keep the legacy `albums` /
+        // `exclude_albums` fields for report compatibility, but don't route
+        // TOML serialization through them: that would erase escaped literal
+        // sentinel names such as `=all`.
+        let selection = crate::selection::Selection {
+            albums: crate::selection::parse_album_selector(&raw_albums, true)?,
+            smart_folders: crate::selection::parse_smart_folder_selector(&raw_smart_folders)?,
+            libraries: library_selector.clone(),
+            unfiled: unfiled_override.unwrap_or_else(unfiled_default),
+        };
         if should_warn_implicit_unfiled(unfiled_override, &selection.albums) {
             warn_implicit_unfiled_pass();
         }
@@ -1274,10 +1397,14 @@ impl Config {
                     .map_err(|e| anyhow::anyhow!("invalid --filename-exclude pattern '{p}': {e}"))
             })
             .collect::<anyhow::Result<_>>()?;
-        let recent_raw = sync.recent.or_else(|| toml_filters.and_then(|f| f.recent));
+        let persistent_recent = toml_filters.and_then(|f| f.recent);
+        let recent_raw = sync.recent.or(persistent_recent);
+        let persistent_skip_created_before =
+            toml_filters.and_then(|f| f.skip_created_before.clone());
+        let persistent_skip_created_after = toml_filters.and_then(|f| f.skip_created_after.clone());
         let explicit_skip_created_before_str = sync
             .skip_created_before
-            .or_else(|| toml_filters.and_then(|f| f.skip_created_before.clone()));
+            .or_else(|| persistent_skip_created_before.clone());
 
         // Split the RecentLimit: Count(n) is a post-enumeration cap held on
         // config.recent. Days(n) translates into a skip_created_before cutoff
@@ -1302,7 +1429,7 @@ impl Config {
         };
         let skip_created_after_str = sync
             .skip_created_after
-            .or_else(|| toml_filters.and_then(|f| f.skip_created_after.clone()));
+            .or_else(|| persistent_skip_created_after.clone());
 
         let skip_created_before = skip_created_before_str
             .as_deref()
@@ -1422,26 +1549,15 @@ impl Config {
             },
         };
 
-        // Reject combinations that would produce zero downloads. When both
-        // skip flags are set, the only live-photo modes that still produce
-        // output are `both` and `video-only` (Live Photo MOV companions
-        // download even with stills suppressed); `skip` and `image-only`
-        // suppress the MOV too and produce nothing.
-        let mode_name = match live_photo_mode {
-            LivePhotoMode::Skip => Some("skip"),
-            LivePhotoMode::ImageOnly => Some("image-only"),
-            LivePhotoMode::VideoOnly | LivePhotoMode::Both => None,
-        };
-        if skip_videos && skip_photos {
-            if let Some(mode) = mode_name {
-                anyhow::bail!(
-                    "`--skip-videos` + `--skip-photos` + `--live-photo-mode {mode}` \
-                     would download nothing. Unset one of the skip flags, use \
-                     `--live-photo-mode video-only` if you only want Live Photo \
-                     video companions, or use `--dry-run` for an \
-                     auth-free test."
-                );
-            }
+        if !media.photos
+            && !media.videos
+            && media.live_photos
+            && live_photo_mode == LivePhotoMode::Skip
+        {
+            anyhow::bail!(
+                "[filters] media selects only live-photos, but [photos] live_photo_mode = \"skip\" \
+                 would download nothing. Enable photos or videos, or change live_photo_mode."
+            );
         }
 
         Ok(Self {
@@ -1469,9 +1585,13 @@ impl Config {
                 albums,
                 exclude_albums,
                 selection,
+                media,
                 skip_created_before,
                 skip_created_after,
                 recent,
+                persistent_recent,
+                persistent_skip_created_before,
+                persistent_skip_created_after,
                 skip_videos,
                 skip_photos,
             },
@@ -1679,6 +1799,11 @@ impl Config {
                 } else {
                     Some(false)
                 },
+                media: if self.filters.media.is_all() {
+                    None
+                } else {
+                    Some(self.filters.media.to_kinds())
+                },
                 filename_exclude: if self.download.filename_exclude.is_empty() {
                     None
                 } else {
@@ -1690,19 +1815,9 @@ impl Config {
                             .collect(),
                     )
                 },
-                skip_videos: if self.filters.skip_videos {
-                    Some(true)
-                } else {
-                    None
-                },
-                skip_photos: if self.filters.skip_photos {
-                    Some(true)
-                } else {
-                    None
-                },
-                recent: None,              // per-run
-                skip_created_before: None, // per-run
-                skip_created_after: None,  // per-run
+                recent: self.filters.persistent_recent,
+                skip_created_before: self.filters.persistent_skip_created_before.clone(),
+                skip_created_after: self.filters.persistent_skip_created_after.clone(),
             }),
             photos: Some(TomlPhotos {
                 size: if self.photos.size == VersionSize::Original {
@@ -2163,8 +2278,7 @@ mod tests {
             [filters]
             libraries = ["PrimarySync"]
             albums = ["Favorites"]
-            skip_videos = false
-            skip_photos = false
+            media = ["photos", "videos", "live-photos"]
             recent = 500
             skip_created_before = "2024-01-01"
             skip_created_after = "2025-01-01"
@@ -2829,7 +2943,7 @@ mod tests {
             set_exif_datetime = true
 
             [filters]
-            skip_videos = true
+            media = ["photos", "live-photos"]
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
@@ -2899,7 +3013,7 @@ mod tests {
     fn test_build_cli_flag_overrides_toml_false() {
         let toml_str = r#"
             [filters]
-            skip_videos = false
+            media = ["photos", "videos", "live-photos"]
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
@@ -2913,7 +3027,7 @@ mod tests {
     fn test_build_cli_false_overrides_toml_true() {
         let toml_str = r#"
             [filters]
-            skip_videos = true
+            media = ["photos", "live-photos"]
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
@@ -3508,8 +3622,7 @@ mod tests {
             [filters]
             libraries = ["SharedSync-ABC"]
             albums = ["A", "B"]
-            skip_videos = true
-            skip_photos = true
+            media = ["photos", "videos", "live-photos"]
             recent = 100
             skip_created_before = "2024-01-01"
             skip_created_after = "2025-12-31"
@@ -3521,8 +3634,10 @@ mod tests {
             Some(&["SharedSync-ABC".to_string()][..])
         );
         assert_eq!(f.albums, Some(vec!["A".to_string(), "B".to_string()]));
-        assert_eq!(f.skip_videos, Some(true));
-        assert_eq!(f.skip_photos, Some(true));
+        assert_eq!(
+            f.media.as_deref(),
+            Some(&[MediaKind::Photos, MediaKind::Videos, MediaKind::LivePhotos,][..])
+        );
 
         assert_eq!(f.recent, Some(crate::cli::RecentLimit::Count(100)));
         assert_eq!(f.skip_created_before.as_deref(), Some("2024-01-01"));
@@ -4375,22 +4490,21 @@ mod tests {
         assert_eq!(pd.live_photo_size, LivePhotoSize::Adjusted);
     }
 
-    // ── Config::build: boolean flag merge exhaustive ───────────────
+    // ── Config::build: boolean/media merge exhaustive ─────────────
 
     #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_from_toml() {
-        // `skip_photos = true` is intentionally omitted: combining it with
-        // `skip_videos = true` and `live_photo_mode = "skip"` would download
-        // nothing and is rejected at Config::build. See
-        // `test_build_skip_videos_and_photos_with_live_skip_rejected`.
+        // `media` replaces the old durable skip booleans. This keeps the
+        // test anchored to the TOML-first filter surface while still checking
+        // the derived runtime skip flags.
         let toml_str = r#"
             [download]
             set_exif_datetime = true
             no_progress_bar = true
 
             [filters]
-            skip_videos = true
+            media = ["photos", "live-photos"]
 
             [photos]
             live_photo_mode = "skip"
@@ -4421,8 +4535,8 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_cli_overrides() {
-        // `skip_photos = Some(true)` is intentionally omitted here too; see
-        // the matching TOML test above.
+        // Programmatic skip overrides still feed the same media owner type
+        // for tests and internal call sites.
         let mut sync = default_sync();
         sync.config_overrides.set_exif_datetime = Some(true);
         sync.no_progress_bar = Some(true);
@@ -4446,8 +4560,7 @@ mod tests {
     fn test_build_boolean_flags_false_in_toml_stays_false() {
         let toml_str = r#"
             [filters]
-            skip_videos = false
-            skip_photos = false
+            media = ["photos", "videos", "live-photos"]
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
@@ -4745,7 +4858,7 @@ mod tests {
             [filters]
             libraries = ["SharedSync-FULL"]
             albums = ["Album1"]
-            skip_videos = true
+            media = ["photos", "live-photos"]
             recent = 50
 
             [photos]
@@ -5418,6 +5531,51 @@ mod tests {
         assert!(filters.recent.is_none());
         assert!(filters.skip_created_before.is_none());
         assert!(filters.skip_created_after.is_none());
+    }
+
+    #[test]
+    fn test_to_toml_persists_filter_recent_and_dates_from_toml() {
+        let toml_str = r#"
+            [filters]
+            recent = 100
+            skip_created_before = "2024-01-01"
+            skip_created_after = "30d"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        let serialized = cfg.to_toml();
+        let filters = serialized.filters.as_ref().unwrap();
+        assert_eq!(filters.recent, Some(crate::cli::RecentLimit::Count(100)));
+        assert_eq!(filters.skip_created_before.as_deref(), Some("2024-01-01"));
+        assert_eq!(filters.skip_created_after.as_deref(), Some("30d"));
+    }
+
+    #[test]
+    fn test_to_toml_roundtrip_media() {
+        let toml_str = r#"
+            [filters]
+            media = ["photos", "live-photos"]
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        let serialized = cfg.to_toml();
+        let filters = serialized.filters.as_ref().unwrap();
+        assert_eq!(
+            filters.media.as_deref(),
+            Some(&[MediaKind::Photos, MediaKind::LivePhotos][..])
+        );
     }
 
     #[test]
@@ -6552,12 +6710,83 @@ mod tests {
         assert!(err.contains("--recent 7d"), "{err}");
     }
 
-    // ── skip-videos + skip-photos empty-result guard ──────────────────
+    // ── media empty-result guard ─────────────────────────────────────
+
+    #[test]
+    fn test_build_live_photos_only_with_live_skip_rejected() {
+        let toml_str = r#"
+            [filters]
+            media = ["live-photos"]
+
+            [photos]
+            live_photo_mode = "skip"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("would download nothing"),
+            "error should explain the outcome; got: {err}"
+        );
+        assert!(
+            err.contains("live_photo_mode"),
+            "error should name the conflicting field; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_empty_media_rejected() {
+        let toml_str = r#"
+            [filters]
+            media = []
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("media must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn test_build_duplicate_media_rejected() {
+        let toml_str = r#"
+            [filters]
+            media = ["photos", "photos"]
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("duplicate `photos`"), "{err}");
+    }
+
+    #[test]
+    fn test_build_legacy_skip_media_toml_keys_rejected() {
+        for key in ["skip_videos", "skip_photos"] {
+            let toml_str = format!("[filters]\n{key} = true\n");
+            let err = toml::from_str::<TomlConfig>(&toml_str).unwrap_err();
+            assert!(err.to_string().contains(&format!("unknown field `{key}`")));
+        }
+    }
 
     #[test]
     fn test_build_skip_videos_and_photos_with_live_skip_rejected() {
-        // Classic "user thought these were orthogonal" mistake: both flags
-        // true with live-photo-mode skip means nothing at all downloads.
         let mut sync = default_sync();
         sync.config_overrides.skip_videos = Some(true);
         sync.config_overrides.skip_photos = Some(true);
@@ -6570,28 +6799,20 @@ mod tests {
             "error should explain the outcome; got: {err}"
         );
         assert!(
-            err.contains("--live-photo-mode skip"),
-            "error should name the specific mode; got: {err}"
-        );
-        assert!(
-            err.contains("video-only"),
-            "error should suggest the escape hatch; got: {err}"
+            err.contains("live_photo_mode"),
+            "error should name the conflicting field; got: {err}"
         );
     }
 
     #[test]
-    fn test_build_skip_videos_and_photos_with_image_only_rejected() {
-        // image-only drops Live Photo MOVs, so combined with both skip
-        // flags the result is still nothing. Same error applies.
+    fn test_build_skip_videos_and_photos_with_image_only_allowed() {
         let mut sync = default_sync();
         sync.config_overrides.skip_videos = Some(true);
         sync.config_overrides.skip_photos = Some(true);
         sync.config_overrides.live_photo_mode = Some(LivePhotoMode::ImageOnly);
-        let err = Config::build(&default_globals(), &default_password(), sync, None)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("would download nothing"), "{err}");
-        assert!(err.contains("--live-photo-mode image-only"), "{err}");
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        assert_eq!(cfg.filters.media.to_kinds(), vec![MediaKind::LivePhotos]);
+        assert_eq!(cfg.photos.live_photo_mode, LivePhotoMode::ImageOnly);
     }
 
     #[test]
@@ -6641,25 +6862,24 @@ mod tests {
     }
 
     #[test]
-    fn test_build_skip_videos_and_photos_from_toml_rejected() {
-        // TOML version of the same check.
+    fn test_build_media_from_toml() {
         let toml_str = r#"
             [filters]
-            skip_videos = true
-            skip_photos = true
-
-            [photos]
-            live_photo_mode = "skip"
+            media = ["videos", "live-photos"]
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
-        let err = Config::build(
+        let cfg = Config::build(
             &default_globals(),
             &default_password(),
             default_sync(),
             Some(&toml),
         )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("would download nothing"), "{err}");
+        .unwrap();
+        assert_eq!(
+            cfg.filters.media.to_kinds(),
+            vec![MediaKind::Videos, MediaKind::LivePhotos]
+        );
+        assert!(cfg.filters.skip_photos);
+        assert!(!cfg.filters.skip_videos);
     }
 }

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -378,12 +378,19 @@ pub(crate) fn is_asset_filtered(
         tracing::debug!(asset_id = %asset.id(), "Skipping (excluded album asset)");
         return Some(FilterReason::ExcludedAlbum);
     }
-    if config.skip_videos && asset.item_type() == Some(AssetItemType::Movie) {
-        tracing::debug!(asset_id = %asset.id(), "Skipping video (skip_videos enabled)");
+    if asset.is_live_photo() && !config.media.live_photos {
+        tracing::debug!(asset_id = %asset.id(), "Skipping live photo (media filter)");
         return Some(FilterReason::MediaType);
     }
-    if config.skip_photos && asset.item_type() == Some(AssetItemType::Image) {
-        tracing::debug!(asset_id = %asset.id(), "Skipping photo (skip_photos enabled)");
+    if !config.media.videos && asset.item_type() == Some(AssetItemType::Movie) {
+        tracing::debug!(asset_id = %asset.id(), "Skipping video (media filter)");
+        return Some(FilterReason::MediaType);
+    }
+    if !config.media.photos
+        && asset.item_type() == Some(AssetItemType::Image)
+        && !asset.is_live_photo()
+    {
+        tracing::debug!(asset_id = %asset.id(), "Skipping photo (media filter)");
         return Some(FilterReason::MediaType);
     }
     if config.live_photo_mode == LivePhotoMode::Skip && asset.is_live_photo() {
@@ -2024,7 +2031,7 @@ mod tests {
             .orig_checksum("vid_ck")
             .build();
         let mut config = test_config();
-        config.skip_videos = true;
+        config.media.videos = false;
         assert_eq!(
             is_asset_filtered(&asset, &config),
             Some(FilterReason::MediaType)
@@ -2051,11 +2058,39 @@ mod tests {
     fn test_filter_skips_photos_when_configured() {
         let asset = TestPhotoAsset::new("TEST_1").build();
         let mut config = test_config();
-        config.skip_photos = true;
+        config.media.photos = false;
         assert_eq!(
             is_asset_filtered(&asset, &config),
             Some(FilterReason::MediaType)
         );
+    }
+
+    #[test]
+    fn test_filter_live_photos_only_skips_normal_photos_and_videos() {
+        let photo = TestPhotoAsset::new("PHOTO_1").build();
+        let video = TestPhotoAsset::new("VID_1")
+            .filename("movie.mov")
+            .item_type("com.apple.quicktime-movie")
+            .orig_file_type("com.apple.quicktime-movie")
+            .orig_size(50000)
+            .orig_url("https://p01.icloud-content.com/vid")
+            .orig_checksum("vid_ck")
+            .build();
+        let live = test_live_photo_asset();
+        let mut config = test_config();
+        config.media.photos = false;
+        config.media.videos = false;
+        config.media.live_photos = true;
+
+        assert_eq!(
+            is_asset_filtered(&photo, &config),
+            Some(FilterReason::MediaType)
+        );
+        assert_eq!(
+            is_asset_filtered(&video, &config),
+            Some(FilterReason::MediaType)
+        );
+        assert_eq!(is_asset_filtered(&live, &config), None);
     }
 
     #[test]
@@ -2644,7 +2679,7 @@ mod tests {
             .orig_checksum("vid_ck")
             .build();
         let mut config = test_config();
-        config.skip_videos = true;
+        config.media.videos = false;
         assert_eq!(
             is_asset_filtered(&asset, &config),
             Some(FilterReason::MediaType)
@@ -2655,7 +2690,7 @@ mod tests {
     fn test_extract_skip_candidates_skip_photos() {
         let asset = TestPhotoAsset::new("TEST_1").build();
         let mut config = test_config();
-        config.skip_photos = true;
+        config.media.photos = false;
         assert_eq!(
             is_asset_filtered(&asset, &config),
             Some(FilterReason::MediaType)

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -585,6 +585,7 @@ impl DownloadConfig {
     pub(crate) fn for_path_derivation_only(
         directory: Arc<Path>,
         fields: crate::config::PathDerivationFields,
+        media: crate::config::MediaSelection,
         dry_run: bool,
         no_progress_bar: bool,
     ) -> Self {
@@ -597,7 +598,7 @@ impl DownloadConfig {
             ),
             library: Arc::from(crate::icloud::photos::PRIMARY_ZONE_NAME),
             size: fields.size.into(),
-            media: crate::config::MediaSelection::all(),
+            media,
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -276,8 +276,7 @@ struct SharedHashFields<'a> {
     skip_created_before: Option<DateTime<Utc>>,
     skip_created_after: Option<DateTime<Utc>>,
     force_size: bool,
-    skip_videos: bool,
-    skip_photos: bool,
+    media: crate::config::MediaSelection,
     live_photo_mode: LivePhotoMode,
     filename_exclude: &'a [glob::Pattern],
 }
@@ -308,8 +307,9 @@ fn hash_shared_fields(hasher: &mut sha2::Sha256, f: &SharedHashFields<'_>) {
     hash_optional_date(hasher, truncate_date_to_day(f.skip_created_before));
     hash_optional_date(hasher, truncate_date_to_day(f.skip_created_after));
     hasher.update([u8::from(f.force_size)]);
-    hasher.update([u8::from(f.skip_videos)]);
-    hasher.update([u8::from(f.skip_photos)]);
+    hasher.update([u8::from(f.media.photos)]);
+    hasher.update([u8::from(f.media.videos)]);
+    hasher.update([u8::from(f.media.live_photos)]);
     hasher.update([f.live_photo_mode as u8]);
     // filename_exclude patterns affect which assets are eligible
     let mut sorted_excludes: Vec<&str> = f
@@ -351,8 +351,7 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
             skip_created_before: config.skip_created_before,
             skip_created_after: config.skip_created_after,
             force_size: config.force_size,
-            skip_videos: config.skip_videos,
-            skip_photos: config.skip_photos,
+            media: config.media,
             live_photo_mode: config.live_photo_mode,
             filename_exclude: &config.filename_exclude,
         },
@@ -403,8 +402,7 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
             skip_created_before,
             skip_created_after,
             force_size: config.photos.force_size,
-            skip_videos: config.filters.skip_videos,
-            skip_photos: config.filters.skip_photos,
+            media: config.filters.media,
             live_photo_mode: config.photos.live_photo_mode,
             filename_exclude: &config.download.filename_exclude,
         },
@@ -421,27 +419,9 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Tag byte distinguishes the three selection modes so switching between
     // them (e.g. `-a A` -> `-a all`) invalidates the sync token even if no
     // explicit album name changed.
-    match &config.filters.albums {
-        crate::config::AlbumSelection::LibraryOnly => hasher.update([0]),
-        crate::config::AlbumSelection::All => hasher.update([1]),
-        crate::config::AlbumSelection::Named(names) => {
-            hasher.update([2]);
-            for album in names {
-                hasher.update(album.as_bytes());
-                hasher.update(b"\0");
-            }
-        }
-    }
-    let mut sorted_excludes: Vec<&str> = config
-        .filters
-        .exclude_albums
-        .iter()
-        .map(std::string::String::as_str)
-        .collect();
-    sorted_excludes.sort_unstable();
-    for name in &sorted_excludes {
-        hasher.update(b"exclude:");
-        hasher.update(name.as_bytes());
+    for entry in config.filters.selection.albums.to_raw() {
+        hasher.update(b"album:");
+        hasher.update(entry.as_bytes());
         hasher.update(b"\0");
     }
     // Library selector: stable tag bytes per shape so changing the resolved
@@ -487,8 +467,7 @@ pub(crate) struct DownloadConfig {
     /// Behind `Arc<str>` for the same reason as `folder_structure_albums`.
     pub(crate) folder_structure_smart_folders: Arc<str>,
     pub(crate) size: AssetVersionSize,
-    pub(crate) skip_videos: bool,
-    pub(crate) skip_photos: bool,
+    pub(crate) media: crate::config::MediaSelection,
     pub(crate) skip_created_before: Option<DateTime<Utc>>,
     pub(crate) skip_created_after: Option<DateTime<Utc>>,
     #[cfg(feature = "xmp")]
@@ -618,8 +597,7 @@ impl DownloadConfig {
             ),
             library: Arc::from(crate::icloud::photos::PRIMARY_ZONE_NAME),
             size: fields.size.into(),
-            skip_videos: false,
-            skip_photos: false,
+            media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]
@@ -763,8 +741,7 @@ impl std::fmt::Debug for DownloadConfig {
                 &self.folder_structure_smart_folders,
             )
             .field("size", &self.size)
-            .field("skip_videos", &self.skip_videos)
-            .field("skip_photos", &self.skip_photos)
+            .field("media", &self.media)
             .field("skip_created_before", &self.skip_created_before)
             .field("skip_created_after", &self.skip_created_after);
         #[cfg(feature = "xmp")]
@@ -816,8 +793,7 @@ impl DownloadConfig {
                 crate::config::DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS,
             ),
             size: AssetVersionSize::Original,
-            skip_videos: false,
-            skip_photos: false,
+            media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]
@@ -2660,11 +2636,11 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_download_config_changes_on_skip_videos() {
+    fn test_hash_download_config_changes_on_media_videos() {
         let mut config1 = test_config();
-        config1.skip_videos = false;
+        config1.media.videos = true;
         let mut config2 = test_config();
-        config2.skip_videos = true;
+        config2.media.videos = false;
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
@@ -2672,11 +2648,11 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_download_config_changes_on_skip_photos() {
+    fn test_hash_download_config_changes_on_media_photos() {
         let mut config1 = test_config();
-        config1.skip_photos = false;
+        config1.media.photos = true;
         let mut config2 = test_config();
-        config2.skip_photos = true;
+        config2.media.photos = false;
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
@@ -2738,8 +2714,8 @@ mod tests {
 
         // Verify album changes produce a different hash
         let mut config_with_album = app_config;
-        config_with_album.filters.albums =
-            crate::config::AlbumSelection::Named(vec!["Favorites".to_string()]);
+        config_with_album.filters.selection.albums =
+            crate::selection::parse_album_selector(&["Favorites".to_string()], true).unwrap();
         let hash3 = compute_config_hash(&config_with_album);
         assert_ne!(hash1, hash3, "adding an album must change the hash");
     }
@@ -3553,8 +3529,8 @@ mod tests {
         use crate::commands::PassKind;
         let mut config = test_config();
         config.folder_structure_albums = Arc::from("{album}/%Y");
-        config.skip_videos = true;
-        config.skip_photos = true;
+        config.media.photos = false;
+        config.media.videos = false;
         config.live_photo_mode = LivePhotoMode::ImageOnly;
         config.force_size = true;
         config.keep_unicode_in_filenames = true;
@@ -3566,8 +3542,8 @@ mod tests {
         config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
         config.temp_suffix = std::sync::Arc::from(".custom-tmp");
         let derived = config.with_pass(&make_pass(PassKind::Album, "Test"));
-        assert!(derived.skip_videos);
-        assert!(derived.skip_photos);
+        assert!(!derived.media.photos);
+        assert!(!derived.media.videos);
         assert_eq!(derived.live_photo_mode, LivePhotoMode::ImageOnly);
         assert!(derived.force_size);
         assert!(derived.keep_unicode_in_filenames);
@@ -3636,7 +3612,7 @@ mod tests {
         let config = test_config();
         let hash = hash_download_config(&config);
         assert_eq!(
-            hash, "6500d91b19aec487",
+            hash, "2f00bc3c8c25ebd3",
             "hash_download_config golden hash changed -- this will trigger full re-syncs"
         );
     }
@@ -3664,8 +3640,7 @@ mod tests {
         );
         config.recent = Some(500);
         config.force_size = true;
-        config.skip_videos = true;
-        config.skip_photos = false;
+        config.media.videos = false;
         config.live_photo_mode = LivePhotoMode::ImageOnly;
         config.filename_exclude = std::sync::Arc::from(vec![
             glob::Pattern::new("*.AAE").unwrap(),
@@ -3673,7 +3648,7 @@ mod tests {
         ]);
         let hash = hash_download_config(&config);
         assert_eq!(
-            hash, "265311b50bfaeb17",
+            hash, "982597ed8d530291",
             "hash_download_config golden hash changed -- this will trigger full re-syncs"
         );
     }
@@ -3684,7 +3659,7 @@ mod tests {
         let config = build_config_with(tmp.path(), "/photos", |_| {});
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "90467ca7a96e1e77",
+            hash, "8cee1ab323f75f43",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }
@@ -3701,7 +3676,7 @@ mod tests {
         });
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "3c7e94d9830cb812",
+            hash, "76240320547a5e90",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }
@@ -3718,7 +3693,7 @@ mod tests {
         });
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "1dd59701ae38f405",
+            hash, "3db6469af693c9d8",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }
@@ -3735,7 +3710,7 @@ mod tests {
         });
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "898b49b4a29fd1e8",
+            hash, "0eb3687e0905dea6",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4409,8 +4409,7 @@ mod tests {
                 crate::config::DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS,
             ),
             size: AssetVersionSize::Original,
-            skip_videos: false,
-            skip_photos: false,
+            media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]
@@ -4511,8 +4510,7 @@ mod tests {
                 crate::config::DEFAULT_FOLDER_STRUCTURE_SMART_FOLDERS,
             ),
             size: AssetVersionSize::Original,
-            skip_videos: false,
-            skip_photos: false,
+            media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
             #[cfg(feature = "xmp")]
@@ -4625,7 +4623,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut config = DownloadConfig::test_default();
         config.directory = std::sync::Arc::from(dir.path());
-        config.skip_videos = true;
+        config.media.videos = false;
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -114,7 +114,7 @@ impl RunOptions {
             live_photo_mode: format!("{:?}", config.photos.live_photo_mode).to_lowercase(),
             live_photo_size: format!("{:?}", config.photos.live_photo_size).to_lowercase(),
             file_match_policy: format!("{:?}", config.photos.file_match_policy).to_lowercase(),
-            albums: config.filters.albums.to_vec(),
+            albums: config.filters.selection.albums.to_raw(),
             library: config.filters.selection.libraries.to_raw().join(","),
             skip_videos: config.filters.skip_videos,
             skip_photos: config.filters.skip_photos,

--- a/src/report.rs
+++ b/src/report.rs
@@ -91,6 +91,7 @@ pub(crate) struct RunOptions {
     pub file_match_policy: String,
     pub albums: Vec<String>,
     pub library: String,
+    pub media: Vec<crate::config::MediaKind>,
     pub skip_videos: bool,
     pub skip_photos: bool,
     pub set_exif_datetime: bool,
@@ -116,6 +117,7 @@ impl RunOptions {
             file_match_policy: format!("{:?}", config.photos.file_match_policy).to_lowercase(),
             albums: config.filters.selection.albums.to_raw(),
             library: config.filters.selection.libraries.to_raw().join(","),
+            media: config.filters.media.to_kinds(),
             skip_videos: config.filters.skip_videos,
             skip_photos: config.filters.skip_photos,
             #[cfg(feature = "xmp")]
@@ -282,6 +284,7 @@ mod tests {
                 file_match_policy: "name-size-dedup".to_string(),
                 albums: vec!["Favorites".to_string()],
                 library: "personal".to_string(),
+                media: crate::config::MediaSelection::all().to_kinds(),
                 skip_videos: false,
                 skip_photos: false,
                 set_exif_datetime: true,
@@ -371,6 +374,48 @@ mod tests {
     }
 
     #[test]
+    fn run_options_from_config_reports_media_selection() {
+        let download_dir = tempfile::tempdir().expect("download dir");
+        let globals = crate::config::GlobalArgs {
+            username: Some("report@example.com".to_string()),
+            domain: None,
+            data_dir: None,
+        };
+        let sync = crate::cli::SyncArgs {
+            config_overrides: crate::config::SyncConfigOverrides {
+                download_dir: Some(download_dir.path().display().to_string()),
+                ..Default::default()
+            },
+            ..crate::cli::SyncArgs::default()
+        };
+        let toml: crate::config::TomlConfig =
+            toml::from_str("[filters]\nmedia = [\"photos\", \"videos\"]\n")
+                .expect("parse media config");
+        let config = crate::config::Config::build(
+            &globals,
+            &crate::cli::PasswordArgs::default(),
+            sync,
+            Some(&toml),
+        )
+        .expect("build config");
+
+        let options = RunOptions::from_config(&config);
+
+        assert_eq!(
+            options.media,
+            vec![
+                crate::config::MediaKind::Photos,
+                crate::config::MediaKind::Videos,
+            ],
+        );
+        assert!(!options.skip_videos);
+        assert!(!options.skip_photos);
+
+        let json = serde_json::to_value(&options).expect("serialize options");
+        assert_eq!(json["media"], serde_json::json!(["photos", "videos"]));
+    }
+
+    #[test]
     fn failed_assets_are_omitted_when_empty() {
         // serde(skip_serializing_if = "Vec::is_empty") on failed_assets
         // and is_zero_usize on failed_assets_truncated must keep clean-run
@@ -390,6 +435,7 @@ mod tests {
                 file_match_policy: String::new(),
                 albums: vec![],
                 library: String::new(),
+                media: crate::config::MediaSelection::all().to_kinds(),
                 skip_videos: false,
                 skip_photos: false,
                 set_exif_datetime: false,
@@ -438,6 +484,7 @@ mod tests {
                 file_match_policy: String::new(),
                 albums: vec![],
                 library: String::new(),
+                media: crate::config::MediaSelection::all().to_kinds(),
                 skip_videos: false,
                 skip_photos: false,
                 set_exif_datetime: false,
@@ -481,6 +528,7 @@ mod tests {
                 file_match_policy: String::new(),
                 albums: vec![],
                 library: String::new(),
+                media: crate::config::MediaSelection::all().to_kinds(),
                 skip_videos: false,
                 skip_photos: false,
                 set_exif_datetime: false,
@@ -525,6 +573,7 @@ mod tests {
                 file_match_policy: "name-size-dedup".to_string(),
                 albums: vec![],
                 library: "personal".to_string(),
+                media: crate::config::MediaSelection::all().to_kinds(),
                 skip_videos: false,
                 skip_photos: false,
                 set_exif_datetime: false,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -133,10 +133,50 @@ impl Default for Selection {
 
 // ── Parsing ─────────────────────────────────────────────────────────────────
 
-/// Parse a single raw album entry. Returns the canonical token plus a flag
-/// indicating whether it was an exclusion (`!name`).
-fn split_exclusion(raw: &str) -> (&str, bool) {
-    raw.strip_prefix('!').map_or((raw, false), |r| (r, true))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SelectorToken<'a> {
+    name: &'a str,
+    exclude: bool,
+    escaped: bool,
+}
+
+/// Parse a raw selector entry. A leading `=` escapes sentinel grammar so
+/// names like `all`, `none`, or `!Drafts` can be selected literally.
+fn selector_token<'a>(raw: &'a str, flag: &str) -> anyhow::Result<SelectorToken<'a>> {
+    if let Some(literal) = raw.strip_prefix('=') {
+        anyhow::ensure!(
+            !literal.is_empty(),
+            "--{flag} literal value must not be empty"
+        );
+        return Ok(SelectorToken {
+            name: literal,
+            exclude: false,
+            escaped: true,
+        });
+    }
+
+    let (name, exclude) = raw.strip_prefix('!').map_or((raw, false), |r| (r, true));
+    anyhow::ensure!(!name.is_empty(), "--{flag} value must not be empty");
+    anyhow::ensure!(
+        !name.starts_with('='),
+        "`!=value` is not supported for --{flag}; use `=value` for a literal value or `!value` for an exclusion"
+    );
+    Ok(SelectorToken {
+        name,
+        exclude,
+        escaped: false,
+    })
+}
+
+fn escape_if_needed(name: &str, sentinels: &[&str]) -> String {
+    if name.starts_with('!')
+        || name.starts_with('=')
+        || sentinels.iter().any(|s| name.eq_ignore_ascii_case(s))
+    {
+        format!("={name}")
+    } else {
+        name.to_string()
+    }
 }
 
 /// Insert into a BTreeSet, bailing if the value was already present. The
@@ -179,20 +219,21 @@ pub(crate) fn parse_album_selector(
     for entry in raw {
         let trimmed = entry.trim();
         anyhow::ensure!(!trimmed.is_empty(), "--album value must not be empty");
-        let (name, is_exclude) = split_exclusion(trimmed);
-        if name.eq_ignore_ascii_case("all") {
+        let token = selector_token(trimmed, "album")?;
+        let name = token.name;
+        if name.eq_ignore_ascii_case("all") && !token.escaped {
             anyhow::ensure!(
-                !is_exclude,
+                !token.exclude,
                 "'!all' is not a valid --album value; pass --album none instead"
             );
             has_all = true;
-        } else if name.eq_ignore_ascii_case("none") {
+        } else if name.eq_ignore_ascii_case("none") && !token.escaped {
             anyhow::ensure!(
-                !is_exclude,
+                !token.exclude,
                 "'!none' is not a valid --album value; just omit it"
             );
             has_none = true;
-        } else if is_exclude {
+        } else if token.exclude {
             insert_unique(&mut excluded, name.to_string(), "album", || {
                 format!("!{name}")
             })?;
@@ -245,20 +286,24 @@ pub(crate) fn parse_smart_folder_selector(raw: &[String]) -> anyhow::Result<Smar
             !trimmed.is_empty(),
             "--smart-folder value must not be empty"
         );
-        let (name, is_exclude) = split_exclusion(trimmed);
-        if name.eq_ignore_ascii_case("all") {
-            anyhow::ensure!(!is_exclude, "'!all' is not a valid --smart-folder value");
+        let token = selector_token(trimmed, "smart-folder")?;
+        let name = token.name;
+        if name.eq_ignore_ascii_case("all") && !token.escaped {
+            anyhow::ensure!(!token.exclude, "'!all' is not a valid --smart-folder value");
             has_all = true;
-        } else if name.eq_ignore_ascii_case("all-with-sensitive") {
+        } else if name.eq_ignore_ascii_case("all-with-sensitive") && !token.escaped {
             anyhow::ensure!(
-                !is_exclude,
+                !token.exclude,
                 "'!all-with-sensitive' is not a valid --smart-folder value"
             );
             has_all_sensitive = true;
-        } else if name.eq_ignore_ascii_case("none") {
-            anyhow::ensure!(!is_exclude, "'!none' is not a valid --smart-folder value");
+        } else if name.eq_ignore_ascii_case("none") && !token.escaped {
+            anyhow::ensure!(
+                !token.exclude,
+                "'!none' is not a valid --smart-folder value"
+            );
             has_none = true;
-        } else if is_exclude {
+        } else if token.exclude {
             insert_unique(&mut excluded, name.to_string(), "smart-folder", || {
                 format!("!{name}")
             })?;
@@ -327,7 +372,8 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
     for entry in raw {
         let trimmed = entry.trim();
         anyhow::ensure!(!trimmed.is_empty(), "--library value must not be empty");
-        let (name, is_exclude) = split_exclusion(trimmed);
+        let token = selector_token(trimmed, "library")?;
+        let name = token.name;
         // CloudKit zone names use `-`, never `:`. The `:` forms are an old
         // friendly-alias surface ("shared:Owner Name") that kei does not
         // resolve. Bail at parse time with the supported alternatives so
@@ -338,29 +384,29 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
                  friendly forms like '{name}' are not supported. Run `kei list libraries` to see every zone."
             );
         }
-        if name.eq_ignore_ascii_case("all") {
-            anyhow::ensure!(!is_exclude, "'!all' is not a valid --library value");
+        if name.eq_ignore_ascii_case("all") && !token.escaped {
+            anyhow::ensure!(!token.exclude, "'!all' is not a valid --library value");
             has_all = true;
-        } else if name.eq_ignore_ascii_case("none") {
-            anyhow::ensure!(!is_exclude, "'!none' is not a valid --library value");
+        } else if name.eq_ignore_ascii_case("none") && !token.escaped {
+            anyhow::ensure!(!token.exclude, "'!none' is not a valid --library value");
             has_none = true;
-        } else if name.eq_ignore_ascii_case("primary") {
-            if is_exclude {
+        } else if name.eq_ignore_ascii_case("primary") && !token.escaped {
+            if token.exclude {
                 insert_unique(&mut sel.excluded, "primary".to_string(), "library", || {
                     "!primary".to_string()
                 })?;
             } else {
                 sel.primary = true;
             }
-        } else if name.eq_ignore_ascii_case("shared") {
-            if is_exclude {
+        } else if name.eq_ignore_ascii_case("shared") && !token.escaped {
+            if token.exclude {
                 insert_unique(&mut sel.excluded, "shared".to_string(), "library", || {
                     "!shared".to_string()
                 })?;
             } else {
                 sel.shared_all = true;
             }
-        } else if is_exclude {
+        } else if token.exclude {
             insert_unique(&mut sel.excluded, name.to_string(), "library", || {
                 format!("!{name}")
             })?;
@@ -443,7 +489,7 @@ impl AlbumSelector {
                 .collect(),
             Self::Named { included, excluded } => included
                 .iter()
-                .cloned()
+                .map(|n| escape_if_needed(n, &["all", "none"]))
                 .chain(excluded.iter().map(|n| format!("!{n}")))
                 .collect(),
         }
@@ -469,7 +515,7 @@ impl SmartFolderSelector {
             }
             Self::Named { included, excluded } => included
                 .iter()
-                .cloned()
+                .map(|n| escape_if_needed(n, &["all", "all-with-sensitive", "none"]))
                 .chain(excluded.iter().map(|n| format!("!{n}")))
                 .collect(),
         }
@@ -489,7 +535,7 @@ impl LibrarySelector {
                 out.push("shared".to_string());
             }
             for n in &self.named {
-                out.push(n.clone());
+                out.push(escape_if_needed(n, &["primary", "shared", "all", "none"]));
             }
         }
         for n in &self.excluded {
@@ -652,6 +698,21 @@ mod tests {
         assert!(err.to_string().contains("'!all'"));
     }
 
+    #[test]
+    fn album_escape_selects_literal_sentinel_names() {
+        for (raw, expected) in [("=all", "all"), ("=none", "none"), ("=!Drafts", "!Drafts")] {
+            let r = parse_album_selector(&s(&[raw]), false).unwrap();
+            assert_eq!(
+                r,
+                AlbumSelector::Named {
+                    included: set(&[expected]),
+                    excluded: BTreeSet::new(),
+                },
+                "raw: {raw}"
+            );
+        }
+    }
+
     /// CG-8 (2026-05-03 test review): cross-category sentinel collision.
     /// `primary` and `shared` are sentinels in `--library`, not `--album`.
     /// A user with an iCloud album literally named `Primary` (or `primary`,
@@ -782,6 +843,26 @@ mod tests {
         assert!(err.to_string().contains("'--smart-folder none'"));
     }
 
+    #[test]
+    fn smart_folder_escape_selects_literal_sentinel_names() {
+        for (raw, expected) in [
+            ("=all", "all"),
+            ("=all-with-sensitive", "all-with-sensitive"),
+            ("=none", "none"),
+            ("=!Hidden", "!Hidden"),
+        ] {
+            let r = parse_smart_folder_selector(&s(&[raw])).unwrap();
+            assert_eq!(
+                r,
+                SmartFolderSelector::Named {
+                    included: set(&[expected]),
+                    excluded: BTreeSet::new(),
+                },
+                "raw: {raw}"
+            );
+        }
+    }
+
     // ── LibrarySelector ────────────────────────────────────────────────
 
     #[test]
@@ -831,6 +912,31 @@ mod tests {
         let r = parse_library_selector(&s(&["SharedSync-A1B2C3D4"])).unwrap();
         assert!(!r.primary);
         assert_eq!(r.named, set(&["SharedSync-A1B2C3D4"]));
+    }
+
+    #[test]
+    fn library_escape_selects_literal_sentinel_names() {
+        for (raw, expected) in [
+            ("=primary", "primary"),
+            ("=shared", "shared"),
+            ("=all", "all"),
+            ("=none", "none"),
+        ] {
+            let r = parse_library_selector(&s(&[raw])).unwrap();
+            assert_eq!(
+                r.named,
+                set(&[expected]),
+                "raw {raw} should be a named zone"
+            );
+            assert!(!r.primary);
+            assert!(!r.shared_all);
+        }
+    }
+
+    #[test]
+    fn bang_equals_escape_form_is_rejected() {
+        let err = parse_library_selector(&s(&["!=primary"])).unwrap_err();
+        assert!(err.to_string().contains("not supported"));
     }
 
     #[test]
@@ -972,6 +1078,21 @@ mod tests {
     }
 
     #[test]
+    fn selection_album_to_raw_escapes_literal_sentinel_names() {
+        let original = AlbumSelector::Named {
+            included: set(&["all", "none", "!Drafts", "=Pinned"]),
+            excluded: BTreeSet::new(),
+        };
+        let raw = original.to_raw();
+        let parsed = parse_album_selector(&raw, false).unwrap();
+        assert_eq!(parsed, original);
+        assert!(raw.iter().any(|r| r == "=all"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "=none"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "=!Drafts"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "==Pinned"), "raw: {raw:?}");
+    }
+
+    #[test]
     fn selection_smart_folder_to_raw_round_trips_named_with_excludes() {
         let original = SmartFolderSelector::Named {
             included: set(&["Favorites", "Videos"]),
@@ -997,6 +1118,23 @@ mod tests {
             raw.iter().any(|r| r == "all-with-sensitive"),
             "all-with-sensitive sentinel must serialize verbatim; got {raw:?}"
         );
+    }
+
+    #[test]
+    fn selection_smart_folder_to_raw_escapes_literal_sentinel_names() {
+        let original = SmartFolderSelector::Named {
+            included: set(&["all", "all-with-sensitive", "none"]),
+            excluded: BTreeSet::new(),
+        };
+        let raw = original.to_raw();
+        let parsed = parse_smart_folder_selector(&raw).unwrap();
+        assert_eq!(parsed, original);
+        assert!(raw.iter().any(|r| r == "=all"), "raw: {raw:?}");
+        assert!(
+            raw.iter().any(|r| r == "=all-with-sensitive"),
+            "raw: {raw:?}"
+        );
+        assert!(raw.iter().any(|r| r == "=none"), "raw: {raw:?}");
     }
 
     #[test]
@@ -1031,6 +1169,23 @@ mod tests {
         // Pin the wire shape so the `["all", "!Foo"]` collapsing branch
         // can't silently drop the `all` sentinel or reorder.
         assert_eq!(raw, vec!["all".to_string(), "!Foo".to_string()]);
+    }
+
+    #[test]
+    fn selection_library_to_raw_escapes_literal_sentinel_names() {
+        let original = LibrarySelector {
+            primary: false,
+            shared_all: false,
+            named: set(&["primary", "shared", "all", "none"]),
+            excluded: BTreeSet::new(),
+        };
+        let raw = original.to_raw();
+        let parsed = parse_library_selector(&raw).unwrap();
+        assert_eq!(parsed, original);
+        assert!(raw.iter().any(|r| r == "=primary"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "=shared"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "=all"), "raw: {raw:?}");
+        assert!(raw.iter().any(|r| r == "=none"), "raw: {raw:?}");
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1237,11 +1237,10 @@ fn generate_toml(answers: &SetupAnswers) -> String {
             writeln!(out, "filename_exclude = [{}]", pat_strs.join(", "))?;
         }
         if answers.skip_videos {
-            writeln!(out, "skip_videos = true")?;
+            writeln!(out, "media = [\"photos\", \"live-photos\"]")?;
         } else {
-            writeln!(out, "# skip_videos = false")?;
+            writeln!(out, "# media = [\"photos\", \"videos\", \"live-photos\"]")?;
         }
-        writeln!(out, "# skip_photos = false")?;
         // `live_photo_mode` is emitted in the [photos] section below.
         match answers.recent {
             Some(n) => writeln!(out, "recent = {n}")?,
@@ -1574,7 +1573,7 @@ mod tests {
         assert!(toml_str.contains("smart_folders = [\"all\"]"));
         assert!(toml_str.contains("unfiled = false"));
         assert!(toml_str.contains("filename_exclude = [\"IMG_screenshot*.png\"]"));
-        assert!(toml_str.contains("skip_videos = true"));
+        assert!(toml_str.contains("media = [\"photos\", \"live-photos\"]"));
         assert!(toml_str.contains("size = \"medium\""));
         // live_photo_mode = "both" is the default; emitting it explicitly is
         // also fine, but the test above sets `Some(Both)` so we expect it.
@@ -1683,7 +1682,15 @@ mod tests {
             filters.filename_exclude.as_deref(),
             Some(&["*.tmp".to_string()][..])
         );
-        assert_eq!(filters.skip_videos, Some(true));
+        assert_eq!(
+            filters.media.as_deref(),
+            Some(
+                &[
+                    crate::config::MediaKind::Photos,
+                    crate::config::MediaKind::LivePhotos,
+                ][..]
+            )
+        );
         assert!(
             filters.libraries.is_none(),
             "empty libraries vec must produce a comment, not an array"
@@ -1807,6 +1814,8 @@ mod tests {
                 "skip_live_photos =",
                 "[filters].skip_live_photos -> [photos].live_photo_mode",
             ),
+            ("skip_videos =", "[filters].skip_videos -> [filters].media"),
+            ("skip_photos =", "[filters].skip_photos -> [filters].media"),
             (
                 "threads_num =",
                 "[download].threads_num -> [download].threads",

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -663,8 +663,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             folder_structure_smart_folders: Arc::clone(&cfg_folder_structure_smart_folders),
             library,
             size: config.photos.size.into(),
-            skip_videos: config.filters.skip_videos,
-            skip_photos: config.filters.skip_photos,
+            media: config.filters.media,
             skip_created_before,
             skip_created_after,
             #[cfg(feature = "xmp")]
@@ -1556,7 +1555,7 @@ async fn run_cycle(
     // sync tokens so the subsequent lookup falls back to full enumeration
     // -- the stored incremental token would miss assets that are newly
     // eligible under the changed config (e.g. a user switching --size or
-    // adding --skip-videos). The hash is cycle-invariant across libraries,
+    // changing [filters].media). The hash is cycle-invariant across libraries,
     // so this runs once per cycle, not once per library.
     //
     // The metadata key `enum_config_hash` is distinct from the download

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -3349,6 +3349,41 @@ fn config_show_emits_libraries_when_repeatable_named_zone() {
     );
 }
 
+#[test]
+fn config_show_round_trips_persistent_recent_and_dates() {
+    let (stdout, _) = run_config_show(
+        "\n[filters]\nrecent = 100\nskip_created_before = \"2024-01-01\"\nskip_created_after = \"30d\"\n",
+    );
+    assert!(stdout.contains("recent = 100"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("skip_created_before = \"2024-01-01\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("skip_created_after = \"30d\""),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn config_show_round_trips_media_filter() {
+    let (stdout, _) = run_config_show("\n[filters]\nmedia = [\"photos\", \"live-photos\"]\n");
+    assert!(stdout.contains("media"), "stdout: {stdout}");
+    assert!(stdout.contains("photos"), "stdout: {stdout}");
+    assert!(stdout.contains("live-photos"), "stdout: {stdout}");
+}
+
+#[test]
+fn config_show_round_trips_escaped_selection_values() {
+    let (stdout, _) = run_config_show(
+        "\n[filters]\nalbums = [\"=all\", \"=!Drafts\"]\nsmart_folders = [\"=none\"]\nlibraries = [\"=primary\"]\n",
+    );
+    assert!(stdout.contains("\"=all\""), "stdout: {stdout}");
+    assert!(stdout.contains("\"=!Drafts\""), "stdout: {stdout}");
+    assert!(stdout.contains("\"=none\""), "stdout: {stdout}");
+    assert!(stdout.contains("\"=primary\""), "stdout: {stdout}");
+}
+
 // ── Removed v0.20 selection aliases ───────────────────────────────
 #[test]
 fn removed_exclude_album_cli_flag_errors() {
@@ -3367,6 +3402,8 @@ fn removed_toml_filter_aliases_error() {
             "\n[filters]\nexclude_albums = [\"Drafts\", \"Family\"]\n",
         ),
         ("library", "\n[filters]\nlibrary = \"PrimarySync\"\n"),
+        ("skip_videos", "\n[filters]\nskip_videos = true\n"),
+        ("skip_photos", "\n[filters]\nskip_photos = true\n"),
     ] {
         let stderr = run_config_show_error(body);
         assert!(

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -924,7 +924,7 @@ fn roundtrip_name_id7_sync_skips_after_import() {
     });
 }
 
-/// Import with `--skip-videos`, sync without it. Sync still must NOT
+/// Import with videos disabled, sync without that filter. Sync still must NOT
 /// re-download the photos imported. Videos (which import skipped) should
 /// also be skipped by sync because the state DB has nothing on them and
 /// the on-disk files match.
@@ -935,14 +935,13 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
     let (download_dir, _sync_data_dir) = fixture();
 
     common::with_auth_retry(|| {
-        // import-existing doesn't expose --skip-videos as a flag (it
-        // builds DownloadConfig with skip_videos=false hard-coded). Use
-        // TOML to force it.
+        // import-existing doesn't expose media selection as a flag. Use TOML
+        // to force it.
         let test_data = tempdir().unwrap();
         let toml_path = write_kei_toml(
             test_data.path(),
             download_dir,
-            "[filters]\nskip_videos = true\n",
+            "[filters]\nmedia = [\"photos\", \"live-photos\"]\n",
         );
 
         let recent = ROUNDTRIP_RECENT.to_string();
@@ -961,7 +960,7 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
         .clone();
         let summary = parse_summary(&String::from_utf8_lossy(&import_out.stdout));
         if summary.matched == 0 {
-            eprintln!("skip: skip_videos import matched nothing; round-trip not applicable");
+            eprintln!("skip: media-filtered import matched nothing; round-trip not applicable");
             return;
         }
 
@@ -969,7 +968,7 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
             run_sync_against_fixture(&username, &password, download_dir, test_data.path(), "");
         assert_eq!(
             downloaded, 0,
-            "sync re-downloaded {downloaded} after skip_videos import; matched={}",
+            "sync re-downloaded {downloaded} after media-filtered import; matched={}",
             summary.matched,
         );
     });

--- a/tests/shell/state-machine.sh
+++ b/tests/shell/state-machine.sh
@@ -184,9 +184,9 @@ kei_sync "$DIR" --dry-run >/dev/null
 echo ""
 echo "=== 9. Filter flag changes config hash ==="
 HASH_BEFORE=$(get_hash)
-OUTPUT=$(KEI_SYNC_FILTERS_TOML=$'skip_videos = true\n' kei_sync "$DIR")
+OUTPUT=$(KEI_SYNC_FILTERS_TOML=$'media = ["photos", "live-photos"]\n' kei_sync "$DIR")
 echo "$OUTPUT" | grep -E "config|changed|cleared|token|download|completed"
-[ "$HASH_BEFORE" != "$(get_hash)" ]; kei_check "hash changed with --skip-videos"
+[ "$HASH_BEFORE" != "$(get_hash)" ]; kei_check "hash changed with media filter"
 
 # ── 10. Session reuse check ─────────────────────────────────────────────
 echo ""

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -378,7 +378,12 @@ fn verify_checksums_detects_corruption() {
             .timeout(std::time::Duration::from_secs(TIMEOUT_CMD))
             .assert();
 
-        let config_path = sync_config(&cookie_dir, download_dir.path(), "", "skip_videos = true\n");
+        let config_path = sync_config(
+            &cookie_dir,
+            download_dir.path(),
+            "",
+            "media = [\"photos\", \"live-photos\"]\n",
+        );
         common::cmd()
             .env("ICLOUD_USERNAME", &username)
             .env("KEI_DATA_DIR", &cookie_dir)

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -292,9 +292,10 @@ fn sync_idempotent_second_run_noop() {
     });
 }
 
-// ── Filter flags ────────────────────────────────────────────────────────
+// ── Media filters ───────────────────────────────────────────────────────
 
-/// --skip-videos should exclude all .mov/.mp4 files but still download images.
+/// `[filters].media` without videos should exclude all .mov/.mp4 files but
+/// still download images.
 #[test]
 #[ignore]
 fn sync_skip_videos_excludes_video_files() {
@@ -309,7 +310,7 @@ fn sync_skip_videos_excludes_video_files() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -327,7 +328,7 @@ fn sync_skip_videos_excludes_video_files() {
         let video_files: Vec<_> = files.iter().filter(|p| is_video_ext(p)).collect();
         assert!(
             video_files.is_empty(),
-            "--skip-videos should exclude all video files, found: {video_files:?}"
+            "media filter should exclude all video files, found: {video_files:?}"
         );
 
         let image_files: Vec<_> = files.iter().filter(|p| is_image_ext(p)).collect();
@@ -338,7 +339,8 @@ fn sync_skip_videos_excludes_video_files() {
     });
 }
 
-/// --skip-photos should exclude all image files but still download videos.
+/// `[filters].media` without photos should exclude all image files but still
+/// download videos.
 #[test]
 #[ignore]
 fn sync_skip_photos_excludes_image_files() {
@@ -353,7 +355,7 @@ fn sync_skip_photos_excludes_image_files() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                filters: "skip_photos = true\n",
+                filters: "media = [\"videos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -365,7 +367,7 @@ fn sync_skip_photos_excludes_image_files() {
         let image_files: Vec<_> = files.iter().filter(|p| is_image_ext(p)).collect();
         assert!(
             image_files.is_empty(),
-            "--skip-photos should exclude all image files, found: {image_files:?}"
+            "media filter should exclude all image files, found: {image_files:?}"
         );
 
         let video_files: Vec<_> = files.iter().filter(|p| is_video_ext(p)).collect();
@@ -411,9 +413,9 @@ fn sync_skip_live_photos_excludes_companions() {
     });
 }
 
-/// `--skip-videos` + `--skip-photos` + a live-photo mode that drops everything
-/// is rejected at startup (since v0.11.x's flag-audit) rather than silently
-/// completing with zero downloads.
+/// A media filter that selects only live photos plus a live-photo mode that
+/// drops them is rejected at startup rather than silently completing with zero
+/// downloads.
 #[test]
 #[ignore]
 fn sync_skip_all_media_rejected_at_startup() {
@@ -427,7 +429,7 @@ fn sync_skip_all_media_rejected_at_startup() {
         &cookie_dir,
         download_dir.path(),
         SyncToml {
-            filters: "skip_videos = true\nskip_photos = true\n",
+            filters: "media = [\"live-photos\"]\n",
             photos: "live_photo_mode = \"skip\"\n",
             ..SyncToml::default()
         },
@@ -506,7 +508,7 @@ fn sync_size_medium_produces_smaller_files() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 photos: "size = \"medium\"\n",
                 ..SyncToml::default()
             },
@@ -755,7 +757,7 @@ fn sync_set_exif_datetime_embeds_date() {
             download_dir.path(),
             SyncToml {
                 download: "set_exif_datetime = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -812,7 +814,7 @@ fn sync_set_exif_rating_embeds_rating() {
             download_dir.path(),
             SyncToml {
                 download: "set_exif_rating = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -851,7 +853,7 @@ fn sync_set_exif_gps_embeds_gps() {
             download_dir.path(),
             SyncToml {
                 download: "set_exif_gps = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -890,7 +892,7 @@ fn sync_set_exif_description_embeds_description() {
             download_dir.path(),
             SyncToml {
                 download: "set_exif_description = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -928,7 +930,7 @@ fn sync_embed_xmp_writes_xmp_packet() {
             download_dir.path(),
             SyncToml {
                 download: "embed_xmp = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )
@@ -972,7 +974,7 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
             download_dir.path(),
             SyncToml {
                 download: "xmp_sidecar = true\n",
-                filters: "skip_videos = true\n",
+                filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
         )


### PR DESCRIPTION
## Summary
- Replaced durable `[filters].skip_videos` / `[filters].skip_photos` with `[filters].media`.
- Added media selection through config resolution, download filtering, setup output, and sync-token hashing.
- Added `=` escaping for album, smart-folder, and library selector sentinel names so literal names round-trip through `config show`.
- Kept `sync_report.json` schema v2 skip booleans derived from media selection.

## Review notes
Start with `src/config.rs` and `src/download/filter.rs`. `src/selection.rs` is the selector escape grammar follow-through.

## Risk
This intentionally rejects old TOML `skip_videos` and `skip_photos` keys as part of the v0.20 cleanup. The setup wizard now writes `[filters].media`; existing report consumers still get `skip_videos` and `skip_photos` in schema v2.

Media selection participates in the sync-token config hash, so changing it clears stale incremental tokens and forces the next run to re-enumerate eligible assets.

## Tests
- `cargo check` - pass
- `cargo fmt --check` - pass
- `cargo clippy --all-targets --all-features -- -D warnings` - pass
- `cargo test -- --test-threads=1` - pass
- `cargo run -- sync --help` - pass
- `cargo run -- config show --config /tmp/kei-pr3-pr-probe.toml` - pass
