### PR TITLE
Add strict TOML-first import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **README scope refreshed.** The README now leads with the current iCloud sync, media, operations, service, Docker, and planned-backend scope, then moves the longer capability list into a `Features` section. The command links now include `reconcile`.
 - **v0.20 deprecation cleanup.** Removed the remaining v0.13 compatibility aliases: `--exclude-album` / `KEI_EXCLUDE_ALBUM`, `{album}` in the base `--folder-structure`, implicit `--album all` promotion from that token, `[filters].album`, `[filters].exclude_albums`, and `[filters].library`. Use `--album '!NAME'`, `--folder-structure-albums`, and the `[filters].albums` / `[filters].libraries` arrays.
+- **`import-existing` is TOML-first.** Import now reads persistent path, photo, and media matching settings from the same TOML config as sync. The old import-only durable flags and env mirrors are gone; keep `--library`, `--recent`, `--dry-run`, `--force-empty`, `--no-progress-bar`, and new `--strict` for one-off import behavior. `[import].strict = true` or `--strict` verifies a small iCloud prefix before adopting a same-name, same-size local file, and the summary reports strict refusals. ([#314])
+
+[#314]: https://github.com/rhoopr/kei/issues/314
 
 ---
 

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -9,9 +9,9 @@ kei v0.20.
 
 The short version:
 
-1. Run `kei import-existing` against the photo directory you already have.
-2. Use the same path-shaping options Python used.
-3. Run `kei sync` from then on.
+1. Put the existing photo directory in `[download].directory`.
+2. Put the path-shaping options Python used in TOML.
+3. Run `kei import-existing`, then `kei sync` from then on.
 
 kei can't reuse Python's `~/.pyicloud` cookies, so the first run still needs a
 fresh Apple login and 2FA approval. Your local photo files can stay in place.
@@ -20,8 +20,15 @@ fresh Apple login and 2FA approval. Your local photo files can stay in place.
 
 Point kei at the directory that `icloudpd` has been writing to:
 
+```toml
+[download]
+directory = "~/Photos/iCloud"
+```
+
+Then run the import with that config:
+
 ```sh
-ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud
+ICLOUD_USERNAME=you@example.com kei import-existing --config ~/.config/kei/config.toml
 ```
 
 `import-existing` signs in, enumerates the selected iCloud libraries, computes
@@ -29,10 +36,10 @@ the paths kei would use for each asset, and adopts any local file with the
 right path and size into the SQLite state database. The next `kei sync` skips
 those adopted files and downloads only new or previously failed assets.
 
-Run a dry import first when you're not sure the flags are right:
+Run a dry import first when you're not sure the config matches the old tree:
 
 ```sh
-ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud --dry-run
+ICLOUD_USERNAME=you@example.com kei import-existing --config ~/.config/kei/config.toml --dry-run
 ```
 
 If most files show as unmatched, stop and fix the path options before running a
@@ -43,62 +50,84 @@ another copy.
 The import is safe to repeat. Re-importing the same files updates the existing
 state rows.
 
+### Strict adoption check
+
+By default, import matches an existing file by expected path and size, then
+stores kei's own SHA-256 for future verification. If you want a safer first
+adoption pass, enable strict mode:
+
+```toml
+[import]
+strict = true
+```
+
+or use it for one run:
+
+```sh
+kei import-existing --config ~/.config/kei/config.toml --strict
+```
+
+Strict mode fetches a small prefix from iCloud and compares it with the local
+file before adopting a same-name, same-size match. Mismatches show up as
+`Strict refusals` in the import summary. `--dry-run --strict` runs the same
+check without writing state rows.
+
 ## Match Python's path layout
 
 Most failed migrations come from one of these differences.
 
 ### Folder structure
 
-Python's default `--folder-structure "{:%Y/%m/%d}"` can be passed to kei as
-either the Python wrapper form or plain strftime:
+Python's default `--folder-structure "{:%Y/%m/%d}"` maps to plain strftime in TOML:
 
-```sh
-kei import-existing --download-dir ~/Photos/iCloud --folder-structure "%Y/%m/%d"
+```toml
+[download]
+directory = "~/Photos/iCloud"
+folder_structure = "%Y/%m/%d"
 ```
 
-kei 0.13 split folder templates by pass type:
+kei splits folder templates by pass type:
 
-| kei flag | Used for | Default |
+| TOML field | Used for | Default |
 |---|---|---|
-| `--folder-structure` | Unfiled photos | `%Y/%m/%d` |
-| `--folder-structure-albums` | User album passes | `{album}` |
-| `--folder-structure-smart-folders` | Smart folder passes | `{smart-folder}` |
+| `[download].folder_structure` | Unfiled photos | `%Y/%m/%d` |
+| `[download].folder_structure_albums` | User album passes | `{album}` |
+| `[download].folder_structure_smart_folders` | Smart folder passes | `{smart-folder}` |
 
-If your Python tree included album names, put the album template on
-`--folder-structure-albums`:
+If your Python tree included album names, put the album template in TOML:
 
-```sh
-ICLOUD_USERNAME=you@example.com kei import-existing --download-dir ~/Photos/iCloud \
-  --folder-structure-albums "{album}/%Y/%m/%d"
+```toml
+[download]
+directory = "~/Photos/iCloud"
+folder_structure_albums = "{album}/%Y/%m/%d"
 ```
 
-On v0.20 and later, `{album}` is only accepted in
-`--folder-structure-albums`.
+On v0.20 and later, `{album}` is only accepted in `folder_structure_albums`.
 
 ### Filename policy
 
-If Python was run with `--file-match-policy name-id7`, import with the same
-policy:
+If Python was run with `--file-match-policy name-id7`, put the same policy in TOML:
 
-```sh
-kei import-existing --download-dir ~/Photos/iCloud --file-match-policy name-id7
+```toml
+[photos]
+file_match_policy = "name-id7"
 ```
 
 kei also matches Python's size-suffixed duplicate fallback, invalid filename
 replacement, RAW naming, live-photo MOV companions, and Unicode stripping by
-default. If you used `--keep-unicode-in-filenames`, pass that to import too.
+default. If you used `--keep-unicode-in-filenames`, set `[photos].keep_unicode_in_filenames = true` before import.
 
 ### Live photos, RAW, and sizes
 
-Use the same media-shaping flags you used with Python:
+Use the same media-shaping settings you used with Python:
 
-```sh
-kei import-existing --download-dir ~/Photos/iCloud \
-  --size original \
-  --live-photo-mode both \
-  --live-photo-size original \
-  --live-photo-mov-filename-policy suffix \
-  --align-raw as-is
+```toml
+[photos]
+resolution = "original"
+live_photo_mode = "both"
+live_resolution = "original"
+live_photo_mov_filename_policy = "suffix"
+raw_policy = "as-is"
 ```
 
 `import-existing --recent 100` is supported. The days form, such as
@@ -110,7 +139,7 @@ kei defaults to the primary iCloud Photos library. If you want shared libraries
 too, import with the same library selector that sync will read from TOML:
 
 ```sh
-kei import-existing --library all --download-dir ~/Photos/iCloud --config ~/.config/kei/config.toml
+kei import-existing --library all --config ~/.config/kei/config.toml
 ```
 
 ```toml
@@ -127,10 +156,11 @@ kei sync --config ~/.config/kei/config.toml
 For multi-library trees, add `{library}` to the active templates if you want
 zone-separated directories:
 
-```sh
-kei import-existing --library all --download-dir ~/Photos/iCloud \
-  --folder-structure "{library}/%Y/%m/%d" \
-  --folder-structure-albums "{library}/{album}/%Y/%m/%d"
+```toml
+[download]
+directory = "~/Photos/iCloud"
+folder_structure = "{library}/%Y/%m/%d"
+folder_structure_albums = "{library}/{album}/%Y/%m/%d"
 ```
 
 `import-existing` doesn't have `--album`, `--smart-folder`, or `--unfiled` CLI
@@ -167,7 +197,7 @@ password for future runs.
 |---|---|---|
 | `-u`, `--username` | `[auth].username` | `ICLOUD_USERNAME` still works for automation. |
 | `-p`, `--password` | `--password`, `[auth].password_file`, `[auth].password_command`, or `kei password set` | Avoid putting passwords in process lists when you can. |
-| `-d`, `--directory` | `import-existing --download-dir`; sync uses `[download].directory` | `--directory` was removed in v0.20. |
+| `-d`, `--directory` | `[download].directory` | Import and sync read the same TOML directory. |
 | `-a`, `--album` | `[filters].albums = ["Name"]` | Use `["!Name"]` for exclusions. |
 | `--exclude-album NAME` | `[filters].albums = ["!NAME"]` | Removed in v0.20. |
 | `--list-albums` | `kei list albums` | The old flag was removed in v0.20. |
@@ -181,7 +211,7 @@ password for future runs.
 | `--recent 100` | `--recent 100` | Count form works for sync and import. |
 | `--recent 30d` | `--recent 30d` for sync | Import rejects the days form. |
 | `--set-exif-datetime` | `[download].set_exif_datetime = true` | kei also has EXIF rating, GPS, and description settings. |
-| `--keep-unicode-in-filenames` | `[photos].keep_unicode_in_filenames = true` | Match this during import. |
+| `--keep-unicode-in-filenames` | `[photos].keep_unicode_in_filenames = true` | Set this before import. |
 | `--live-photo-mov-filename-policy` | `[photos].live_photo_mov_filename_policy` | `suffix` or `original`. |
 | `--file-match-policy` | `[photos].file_match_policy` | `name-size-dedup-with-suffix` or `name-id7`. |
 | `--align-raw` | `[photos].raw_policy` | `as-is`, `prefer-raw`, or `prefer-jpeg`. |
@@ -284,7 +314,7 @@ inside the container if your credential backend supports it.
 For a one-shot import against an existing mounted tree:
 
 ```sh
-docker exec kei kei import-existing --download-dir /photos
+docker exec kei kei import-existing --config /config/config.toml
 ```
 
 For headless 2FA:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,4 @@
-use crate::types::{
-    FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
-    RawTreatmentPolicy, VersionSize,
-};
+use crate::types::LogLevel;
 use clap::{Args, FromArgMatches, Parser, Subcommand};
 
 /// Reject empty strings at CLI parse time.
@@ -268,62 +265,8 @@ pub struct ImportArgs {
     /// the truncated 8-char `SharedSync-` prefix that `{library}` renders
     /// into paths), the sentinels `primary` / `shared` / `all` / `none`, or
     /// `!name` to exclude.
-    #[arg(long = "library", env = "KEI_LIBRARY", value_parser = non_empty_string)]
+    #[arg(long = "library", value_parser = non_empty_string)]
     pub libraries: Vec<String>,
-
-    /// Local directory containing existing downloads
-    #[arg(short = 'd', long = "download-dir", env = "KEI_DOWNLOAD_DIR", value_parser = non_empty_string)]
-    pub download_dir: Option<String>,
-
-    /// Folder structure used by the unfiled pass when matching files on
-    /// disk (must match `--folder-structure` during sync).
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE")]
-    pub folder_structure: Option<String>,
-
-    /// Folder structure used by every album pass when matching files on
-    /// disk (must match `--folder-structure-albums` during sync). Default
-    /// `{album}`.
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE_ALBUMS")]
-    pub folder_structure_albums: Option<String>,
-
-    /// Folder structure used by every smart-folder pass when matching
-    /// files on disk (must match `--folder-structure-smart-folders` during
-    /// sync). Default `{smart-folder}`.
-    #[arg(long, env = "KEI_FOLDER_STRUCTURE_SMART_FOLDERS")]
-    pub folder_structure_smart_folders: Option<String>,
-
-    /// Keep Unicode in filenames (must match what was used during sync)
-    #[arg(long, env = "KEI_KEEP_UNICODE_IN_FILENAMES", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub keep_unicode_in_filenames: Option<bool>,
-
-    /// File matching and dedup policy (must match what was used during sync)
-    #[arg(long, env = "KEI_FILE_MATCH_POLICY", value_enum)]
-    pub file_match_policy: Option<FileMatchPolicy>,
-
-    /// Image size to import (must match what was used during sync). Default: original.
-    #[arg(long, env = "KEI_SIZE", value_enum)]
-    pub size: Option<VersionSize>,
-
-    /// Live photo handling: both, image-only, video-only, skip
-    /// (must match what was used during sync)
-    #[arg(long, env = "KEI_LIVE_PHOTO_MODE", value_enum)]
-    pub live_photo_mode: Option<LivePhotoMode>,
-
-    /// Live photo video size (must match what was used during sync)
-    #[arg(long, env = "KEI_LIVE_PHOTO_SIZE", value_enum)]
-    pub live_photo_size: Option<LivePhotoSize>,
-
-    /// Live photo MOV filename policy (must match what was used during sync)
-    #[arg(long, env = "KEI_LIVE_PHOTO_MOV_FILENAME_POLICY", value_enum)]
-    pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
-
-    /// RAW treatment policy (must match what was used during sync)
-    #[arg(long, env = "KEI_ALIGN_RAW", value_enum)]
-    pub align_raw: Option<RawTreatmentPolicy>,
-
-    /// Only check the requested size (don't fall back to original)
-    #[arg(long, env = "KEI_FORCE_SIZE", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub force_size: Option<bool>,
 
     /// Number of recent photos to check (`--recent 100`). The `--recent Nd`
     /// days form is only supported in `sync`; import-existing errors on use.
@@ -331,8 +274,8 @@ pub struct ImportArgs {
     pub recent: Option<RecentLimit>,
 
     /// Scan and report matches without writing to the state DB. Useful for
-    /// verifying that `--folder-structure` and `--keep-unicode-in-filenames`
-    /// match the tree you're importing before committing.
+    /// verifying that TOML path and filename settings match the tree you're
+    /// importing before committing.
     #[arg(long)]
     pub dry_run: bool,
 
@@ -350,6 +293,10 @@ pub struct ImportArgs {
     /// has data (the prior-row check is global, not per-zone).
     #[arg(long, env = "KEI_FORCE_EMPTY")]
     pub force_empty: bool,
+
+    /// Verify a cloud prefix before adopting a same-name, same-size local file.
+    #[arg(long)]
+    pub strict: bool,
 }
 
 /// Arguments for the verify command.
@@ -1952,13 +1899,11 @@ mod tests {
 
     #[test]
     fn test_import_existing_subcommand() {
-        let cli =
-            Cli::try_parse_from(["kei", "import-existing", "--download-dir", "/photos"]).unwrap();
+        let cli = Cli::try_parse_from(["kei", "import-existing"]).unwrap();
         if let Some(Command::ImportExisting(args)) = cli.command {
-            assert_eq!(args.download_dir.as_deref(), Some("/photos"));
-
-            assert!(args.folder_structure.is_none());
             assert!(args.recent.is_none());
+            assert!(!args.dry_run);
+            assert!(!args.strict);
         } else {
             panic!("Expected ImportExisting command");
         }
@@ -1966,15 +1911,9 @@ mod tests {
 
     #[test]
     fn test_import_existing_library_flag_single() {
-        let cli = Cli::try_parse_from([
-            "kei",
-            "import-existing",
-            "--library",
-            "SharedSync-ABCD1234",
-            "--download-dir",
-            "/photos",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["kei", "import-existing", "--library", "SharedSync-ABCD1234"])
+                .unwrap();
         if let Some(Command::ImportExisting(args)) = cli.command {
             assert_eq!(args.libraries, vec!["SharedSync-ABCD1234".to_string()]);
         } else {
@@ -1984,9 +1923,7 @@ mod tests {
 
     /// Parity check with `kei sync --library`: import-existing's flag is also
     /// repeatable and accepts mixed sentinels, zone names, and `!name`
-    /// exclusions in one invocation. Pre-v0.13 the flag was a single
-    /// `Option<String>` and a second `--library` silently won, so
-    /// multi-library import had to be configured via TOML.
+    /// exclusions in one invocation.
     #[test]
     fn test_import_existing_library_flag_repeatable_with_mixed_grammar() {
         let cli = Cli::try_parse_from([
@@ -1998,8 +1935,6 @@ mod tests {
             "SharedSync-ABCD1234",
             "--library",
             "!SharedSync-Photos",
-            "--download-dir",
-            "/photos",
         ])
         .unwrap();
         let Some(Command::ImportExisting(args)) = cli.command else {
@@ -2015,17 +1950,8 @@ mod tests {
         );
     }
 
-    // ── import-existing path-derivation flags ──────────────────────────
-    //
-    // Each flag here changes how `expected_paths_for` derives the on-disk
-    // path. A regression in the clap value_parser (e.g. mapping `medium` to
-    // `Original`) is silent unless the parsed variant is asserted -- a
-    // `--help`-driven smoke test catches "spelling vanished" but not
-    // "spelling reaches the wrong variant". These tests pin the
-    // CLI-string -> enum mapping for every accepted value.
-
     fn parse_import(extra: &[&str]) -> ImportArgs {
-        let mut args = vec!["kei", "import-existing", "--download-dir", "/tmp"];
+        let mut args = vec!["kei", "import-existing"];
         args.extend(extra.iter().copied());
         let cli = Cli::try_parse_from(args).unwrap();
         match cli.command {
@@ -2035,84 +1961,14 @@ mod tests {
     }
 
     #[test]
-    fn import_existing_size_flag_parses_to_correct_variant() {
-        for (input, expected) in [
-            ("original", VersionSize::Original),
-            ("medium", VersionSize::Medium),
-            ("thumb", VersionSize::Thumb),
-            ("adjusted", VersionSize::Adjusted),
-            ("alternative", VersionSize::Alternative),
-        ] {
-            let args = parse_import(&["--size", input]);
-            assert_eq!(args.size, Some(expected), "size={input}");
-        }
-    }
-
-    #[test]
-    fn import_existing_live_photo_mode_parses_to_correct_variant() {
-        for (input, expected) in [
-            ("both", LivePhotoMode::Both),
-            ("image-only", LivePhotoMode::ImageOnly),
-            ("video-only", LivePhotoMode::VideoOnly),
-            ("skip", LivePhotoMode::Skip),
-        ] {
-            let args = parse_import(&["--live-photo-mode", input]);
-            assert_eq!(args.live_photo_mode, Some(expected), "mode={input}");
-        }
-    }
-
-    #[test]
-    fn import_existing_live_photo_size_parses_to_correct_variant() {
-        for (input, expected) in [
-            ("original", LivePhotoSize::Original),
-            ("medium", LivePhotoSize::Medium),
-            ("thumb", LivePhotoSize::Thumb),
-            ("adjusted", LivePhotoSize::Adjusted),
-        ] {
-            let args = parse_import(&["--live-photo-size", input]);
-            assert_eq!(args.live_photo_size, Some(expected), "size={input}");
-        }
-    }
-
-    #[test]
-    fn import_existing_live_photo_mov_filename_policy_parses_to_correct_variant() {
-        for (input, expected) in [
-            ("suffix", LivePhotoMovFilenamePolicy::Suffix),
-            ("original", LivePhotoMovFilenamePolicy::Original),
-        ] {
-            let args = parse_import(&["--live-photo-mov-filename-policy", input]);
-            assert_eq!(
-                args.live_photo_mov_filename_policy,
-                Some(expected),
-                "policy={input}"
-            );
-        }
-    }
-
-    #[test]
-    fn import_existing_align_raw_parses_to_correct_variant() {
-        for (input, expected) in [
-            ("as-is", RawTreatmentPolicy::Unchanged),
-            ("original", RawTreatmentPolicy::PreferOriginal),
-            ("alternative", RawTreatmentPolicy::PreferAlternative),
-        ] {
-            let args = parse_import(&["--align-raw", input]);
-            assert_eq!(args.align_raw, Some(expected), "policy={input}");
-        }
-    }
-
-    #[test]
-    fn import_existing_force_size_flag_parses_to_true() {
-        let args = parse_import(&["--force-size"]);
-        assert_eq!(args.force_size, Some(true));
+    fn import_existing_strict_flag_parses_to_true() {
+        let args = parse_import(&["--strict"]);
+        assert!(args.strict);
     }
 
     #[test]
     fn import_existing_force_empty_flag_parses_to_true() {
         let _guard = scrub_auth_env();
-        // SAFETY: scrub_auth_env serializes against the env_var test that
-        // also mutates KEI_FORCE_EMPTY. Clearing here protects against a
-        // developer shell that has KEI_FORCE_EMPTY=true exported.
         unsafe {
             std::env::remove_var("KEI_FORCE_EMPTY");
         }
@@ -2123,7 +1979,6 @@ mod tests {
     #[test]
     fn import_existing_force_empty_default_is_false() {
         let _guard = scrub_auth_env();
-        // SAFETY: same rationale as the flag test above.
         unsafe {
             std::env::remove_var("KEI_FORCE_EMPTY");
         }
@@ -2134,14 +1989,10 @@ mod tests {
     #[test]
     fn import_existing_force_empty_env_var_parses_to_true() {
         let _guard = scrub_auth_env();
-        // SAFETY: scrub_auth_env serializes against any other test that
-        // mutates these env vars; KEI_FORCE_EMPTY is read synchronously by
-        // clap during parse below.
         unsafe {
             std::env::set_var("KEI_FORCE_EMPTY", "true");
         }
-        let cli =
-            Cli::try_parse_from(["kei", "import-existing", "--download-dir", "/tmp"]).unwrap();
+        let cli = Cli::try_parse_from(["kei", "import-existing"]).unwrap();
         unsafe {
             std::env::remove_var("KEI_FORCE_EMPTY");
         }
@@ -2152,44 +2003,28 @@ mod tests {
     }
 
     #[test]
-    fn import_existing_keep_unicode_flag_parses_to_true() {
-        let args = parse_import(&["--keep-unicode-in-filenames"]);
-        assert_eq!(args.keep_unicode_in_filenames, Some(true));
-    }
-
-    #[test]
-    fn import_existing_keep_unicode_env_var_parses_to_true() {
-        let _guard = scrub_auth_env();
-        // SAFETY: scrub_auth_env serializes against any other test that
-        // mutates these env vars; KEI_KEEP_UNICODE_IN_FILENAMES is read
-        // synchronously by clap during parse below.
-        unsafe {
-            std::env::set_var("KEI_KEEP_UNICODE_IN_FILENAMES", "true");
-        }
-        let cli =
-            Cli::try_parse_from(["kei", "import-existing", "--download-dir", "/tmp"]).unwrap();
-        unsafe {
-            std::env::remove_var("KEI_KEEP_UNICODE_IN_FILENAMES");
-        }
-        match cli.command {
-            Some(Command::ImportExisting(args)) => {
-                assert_eq!(args.keep_unicode_in_filenames, Some(true));
-            }
-            _ => panic!("Expected ImportExisting command"),
-        }
-    }
-
-    #[test]
-    fn import_existing_file_match_policy_parses_to_correct_variant() {
-        for (input, expected) in [
-            (
-                "name-size-dedup-with-suffix",
-                FileMatchPolicy::NameSizeDedupWithSuffix,
-            ),
-            ("name-id7", FileMatchPolicy::NameId7),
+    fn import_existing_removed_durable_flags_fail() {
+        for (flag, value) in [
+            ("--download-dir", Some("/tmp")),
+            ("-d", Some("/tmp")),
+            ("--folder-structure", Some("%Y/%m")),
+            ("--folder-structure-albums", Some("{album}")),
+            ("--folder-structure-smart-folders", Some("{smart-folder}")),
+            ("--file-match-policy", Some("name-id7")),
+            ("--size", Some("medium")),
+            ("--live-photo-mode", Some("image-only")),
+            ("--live-photo-size", Some("medium")),
+            ("--live-photo-mov-filename-policy", Some("original")),
+            ("--align-raw", Some("original")),
+            ("--force-size", None),
+            ("--keep-unicode-in-filenames", None),
         ] {
-            let args = parse_import(&["--file-match-policy", input]);
-            assert_eq!(args.file_match_policy, Some(expected), "policy={input}");
+            let mut argv = vec!["kei", "import-existing", flag];
+            if let Some(value) = value {
+                argv.push(value);
+            }
+            let err = Cli::try_parse_from(argv).expect_err("removed flag must fail");
+            assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
         }
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Context;
+use futures_util::future::BoxFuture;
 
 use crate::auth;
 use crate::cli;
@@ -50,6 +51,7 @@ pub(crate) struct ImportStats {
     pub matched: u64,
     pub unmatched: u64,
     pub filtered: u64,
+    pub strict_refused: u64,
     pub hash_errors: u64,
     pub skipped_already_imported: u64,
 }
@@ -60,6 +62,7 @@ impl std::ops::AddAssign for ImportStats {
         self.matched += rhs.matched;
         self.unmatched += rhs.unmatched;
         self.filtered += rhs.filtered;
+        self.strict_refused += rhs.strict_refused;
         self.hash_errors += rhs.hash_errors;
         self.skipped_already_imported += rhs.skipped_already_imported;
     }
@@ -67,6 +70,133 @@ impl std::ops::AddAssign for ImportStats {
 
 /// Default cadence for the `import-existing` heartbeat log line.
 const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+const STRICT_IMPORT_PREFIX_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StrictImportDecision {
+    Accepted,
+    Refused,
+}
+
+pub(crate) trait StrictImportVerifier {
+    fn verify<'a>(
+        &'a self,
+        local_path: &'a Path,
+        cloud_url: &'a str,
+        expected_size: u64,
+    ) -> BoxFuture<'a, anyhow::Result<StrictImportDecision>>;
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ImportRunOptions<'a> {
+    pub(crate) dry_run: bool,
+    pub(crate) show_progress: bool,
+    pub(crate) strict_verifier: Option<&'a dyn StrictImportVerifier>,
+}
+
+impl std::fmt::Debug for ImportRunOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportRunOptions")
+            .field("dry_run", &self.dry_run)
+            .field("show_progress", &self.show_progress)
+            .field("strict", &self.strict_verifier.is_some())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HttpStrictImportVerifier {
+    client: reqwest::Client,
+}
+
+impl HttpStrictImportVerifier {
+    fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl StrictImportVerifier for HttpStrictImportVerifier {
+    fn verify<'a>(
+        &'a self,
+        local_path: &'a Path,
+        cloud_url: &'a str,
+        expected_size: u64,
+    ) -> BoxFuture<'a, anyhow::Result<StrictImportDecision>> {
+        Box::pin(verify_strict_prefix(
+            &self.client,
+            local_path,
+            cloud_url,
+            expected_size,
+        ))
+    }
+}
+
+async fn verify_strict_prefix(
+    client: &reqwest::Client,
+    local_path: &Path,
+    cloud_url: &str,
+    expected_size: u64,
+) -> anyhow::Result<StrictImportDecision> {
+    use futures_util::StreamExt;
+    use tokio::io::AsyncReadExt;
+
+    let prefix_len_u64 = expected_size.min(STRICT_IMPORT_PREFIX_BYTES);
+    let prefix_len = usize::try_from(prefix_len_u64)
+        .context("strict import prefix length does not fit in usize")?;
+    if prefix_len == 0 {
+        return Ok(StrictImportDecision::Accepted);
+    }
+
+    let mut local_prefix = vec![0_u8; prefix_len];
+    let mut local = tokio::fs::File::open(local_path)
+        .await
+        .with_context(|| format!("opening {} for strict import", local_path.display()))?;
+    local
+        .read_exact(&mut local_prefix)
+        .await
+        .with_context(|| format!("reading strict prefix from {}", local_path.display()))?;
+
+    let range_end = prefix_len_u64.saturating_sub(1);
+    let response = client
+        .get(cloud_url)
+        .header(reqwest::header::RANGE, format!("bytes=0-{range_end}"))
+        .send()
+        .await
+        .with_context(|| format!("fetching strict import prefix from {cloud_url}"))?;
+    let status = response.status();
+    if !(status == reqwest::StatusCode::PARTIAL_CONTENT || status == reqwest::StatusCode::OK) {
+        anyhow::bail!("strict import prefix fetch returned HTTP {status}");
+    }
+
+    let mut cloud_prefix = Vec::with_capacity(prefix_len);
+    let mut stream = response.bytes_stream();
+    while cloud_prefix.len() < prefix_len {
+        let Some(chunk) = stream.next().await else {
+            break;
+        };
+        let chunk = chunk.context("reading strict import prefix response")?;
+        let remaining = prefix_len - cloud_prefix.len();
+        let take = chunk.len().min(remaining);
+        let Some(prefix) = chunk.get(..take) else {
+            anyhow::bail!("strict import prefix chunk shorter than expected");
+        };
+        cloud_prefix.extend_from_slice(prefix);
+    }
+    if cloud_prefix.len() < prefix_len {
+        anyhow::bail!(
+            "strict import prefix fetch returned {} bytes, expected {prefix_len}",
+            cloud_prefix.len()
+        );
+    }
+
+    if cloud_prefix == local_prefix {
+        Ok(StrictImportDecision::Accepted)
+    } else {
+        Ok(StrictImportDecision::Refused)
+    }
+}
 
 /// Live counters shared between the scan loop and the heartbeat task.
 ///
@@ -82,6 +212,7 @@ struct HeartbeatState {
     matched: std::sync::atomic::AtomicU64,
     unmatched: std::sync::atomic::AtomicU64,
     filtered: std::sync::atomic::AtomicU64,
+    strict_refused: std::sync::atomic::AtomicU64,
     hash_errors: std::sync::atomic::AtomicU64,
     skipped_already_imported: std::sync::atomic::AtomicU64,
     last_seen_id: std::sync::Mutex<Option<String>>,
@@ -95,6 +226,7 @@ impl HeartbeatState {
             matched: self.matched.load(Ordering::Relaxed),
             unmatched: self.unmatched.load(Ordering::Relaxed),
             filtered: self.filtered.load(Ordering::Relaxed),
+            strict_refused: self.strict_refused.load(Ordering::Relaxed),
             hash_errors: self.hash_errors.load(Ordering::Relaxed),
             skipped_already_imported: self.skipped_already_imported.load(Ordering::Relaxed),
             last_seen_id: self.last_seen_id.lock().ok().and_then(|g| g.clone()),
@@ -108,6 +240,7 @@ struct HeartbeatSnapshot {
     matched: u64,
     unmatched: u64,
     filtered: u64,
+    strict_refused: u64,
     hash_errors: u64,
     skipped_already_imported: u64,
     last_seen_id: Option<String>,
@@ -149,6 +282,7 @@ impl HeartbeatGuard {
                             matched = snap.matched,
                             unmatched = snap.unmatched,
                             filtered = snap.filtered,
+                            strict_refused = snap.strict_refused,
                             hash_errors = snap.hash_errors,
                             skipped_already_imported = snap.skipped_already_imported,
                             last_seen_id = snap.last_seen_id.as_deref().unwrap_or("(none)"),
@@ -267,9 +401,8 @@ pub(crate) async fn import_assets<S>(
     db: &dyn StateDb,
     download_config: &download::DownloadConfig,
     library_label: &str,
-    dry_run: bool,
-    show_progress: bool,
     dir_cache: &mut DirCache,
+    options: ImportRunOptions<'_>,
 ) -> anyhow::Result<ImportStats>
 where
     S: futures_util::Stream<Item = anyhow::Result<PhotoAsset>>,
@@ -376,6 +509,7 @@ where
             path: primary_path,
             size: expected_size,
             checksum,
+            url,
             version_size,
         } in expected
         {
@@ -404,7 +538,43 @@ where
                 }
             };
 
-            if !dry_run {
+            if let Some(verifier) = options.strict_verifier {
+                match verifier
+                    .verify(&expected_path, url.as_ref(), expected_size)
+                    .await
+                {
+                    Ok(StrictImportDecision::Accepted) => {}
+                    Ok(StrictImportDecision::Refused) => {
+                        tracing::warn!(
+                            asset_id = %asset.id(),
+                            version = ?version_size,
+                            path = %expected_path.display(),
+                            "Strict import refused same-name, same-size file: local prefix differs from cloud prefix",
+                        );
+                        stats.strict_refused += 1;
+                        heartbeat_state
+                            .strict_refused
+                            .fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            asset_id = %asset.id(),
+                            version = ?version_size,
+                            path = %expected_path.display(),
+                            error = %e,
+                            "Strict import refused same-name, same-size file: prefix verification failed",
+                        );
+                        stats.strict_refused += 1;
+                        heartbeat_state
+                            .strict_refused
+                            .fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                }
+            }
+
+            if !options.dry_run {
                 // Skip-rehash short-circuit: if a prior adopt left a row
                 // for this (library, id, version_size) at the same path
                 // with the same on-disk size + mtime, the file hasn't
@@ -435,7 +605,7 @@ where
                     heartbeat_state
                         .skipped_already_imported
                         .fetch_add(1, Ordering::Relaxed);
-                    log_progress_milestone(library_label, stats.matched, show_progress);
+                    log_progress_milestone(library_label, stats.matched, options.show_progress);
                     continue;
                 }
 
@@ -495,7 +665,7 @@ where
 
             stats.matched += 1;
             heartbeat_state.matched.fetch_add(1, Ordering::Relaxed);
-            log_progress_milestone(library_label, stats.matched, show_progress);
+            log_progress_milestone(library_label, stats.matched, options.show_progress);
         }
     }
 
@@ -534,6 +704,8 @@ pub(crate) async fn run_import_existing(
     let db_path = super::super::get_db_path(globals, toml)?;
     let download_config = build_import_download_config(&args, toml)?;
     let directory = Arc::clone(&download_config.directory);
+    let strict_import = resolve_import_strict(&args, toml);
+    let strict_verifier = strict_import.then(HttpStrictImportVerifier::new);
 
     let recent_count: Option<u32> = match args.recent {
         None => None,
@@ -661,9 +833,14 @@ pub(crate) async fn run_import_existing(
                 db.as_ref(),
                 &pass_config,
                 zone,
-                args.dry_run,
-                !args.no_progress_bar,
                 &mut dir_cache,
+                ImportRunOptions {
+                    dry_run: args.dry_run,
+                    show_progress: !args.no_progress_bar,
+                    strict_verifier: strict_verifier
+                        .as_ref()
+                        .map(|v| v as &dyn StrictImportVerifier),
+                },
             )
             .await?;
             totals += stats;
@@ -684,6 +861,7 @@ pub(crate) async fn run_import_existing(
     );
     println!("  Unmatched versions:   {}", totals.unmatched);
     println!("  Filtered (no path):   {}", totals.filtered);
+    println!("  Strict refusals:      {}", totals.strict_refused);
     println!("  Hash errors:          {}", totals.hash_errors);
 
     Ok(())
@@ -746,88 +924,64 @@ fn validate_non_empty_libraries(empty_zones: &[&str], prior_db_total: u64) -> an
     );
 }
 
-/// Resolve a [`download::DownloadConfig`] from import-existing CLI args + TOML.
+fn resolve_import_strict(args: &cli::ImportArgs, toml: Option<&config::TomlConfig>) -> bool {
+    args.strict
+        || toml
+            .and_then(|t| t.import.as_ref())
+            .and_then(|i| i.strict)
+            .unwrap_or(false)
+}
+
+/// Resolve a [`download::DownloadConfig`] from import-existing TOML.
 ///
-/// The resolution mirrors sync's CLI/env > TOML > default chain for every
-/// field that affects path derivation. Fields that don't affect path
-/// derivation (state DB handle, retry config, concurrency, sync mode, ...)
-/// are populated with inert defaults: `import-existing` never instantiates a
-/// download pipeline, so those values are unused.
+/// Persistent path/media/photo settings are shared with sync through the TOML
+/// config. Fields that don't affect path derivation (state DB handle, retry
+/// config, concurrency, sync mode, ...) are populated with inert defaults:
+/// `import-existing` never instantiates a download pipeline, so those values
+/// are unused.
 fn build_import_download_config(
     args: &cli::ImportArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<download::DownloadConfig> {
     let toml_dl = toml.and_then(|t| t.download.as_ref());
 
-    let directory_cli = args.download_dir.clone();
-    let directory_str = directory_cli
-        .or_else(|| toml_dl.and_then(|d| d.directory.clone()))
+    let directory_str = toml_dl
+        .and_then(|d| d.directory.clone())
         .unwrap_or_default();
     if directory_str.is_empty() {
-        anyhow::bail!("--download-dir is required for import-existing");
+        anyhow::bail!("[download] directory is required for import-existing");
     }
     let directory_path = config::expand_tilde(&directory_str);
     config::validate_download_dir(&directory_path)?;
     let directory: Arc<Path> = Arc::from(directory_path.as_path());
 
-    let (resolution, edited_from_size, alternative_from_size) = match args.size {
-        Some(crate::types::VersionSize::Adjusted) => (
-            Some(crate::types::PhotoResolution::None),
-            Some(true),
-            Some(false),
-        ),
-        Some(crate::types::VersionSize::Alternative) => (
-            Some(crate::types::PhotoResolution::None),
-            Some(false),
-            Some(true),
-        ),
-        Some(size) => (Some(size.into()), Some(false), Some(false)),
-        None => (None, None, None),
-    };
-    let live_adjusted_from_size = matches!(args.size, Some(crate::types::VersionSize::Adjusted))
-        && args.live_photo_size.is_none();
-    let live_adjusted_from_live_size = matches!(
-        args.live_photo_size,
-        Some(crate::types::LivePhotoSize::Adjusted)
-    );
-    let live_resolution = match args.live_photo_size {
-        Some(crate::types::LivePhotoSize::Adjusted) => {
-            Some(crate::types::LivePhotoResolution::Original)
-        }
-        Some(size) => Some(size.into()),
-        None => None,
-    };
-    let raw_policy = args.align_raw.map(Into::into);
     let path_fields = config::resolve_path_derivation_fields(
         config::PathDerivationCliArgs {
-            folder_structure: args.folder_structure.clone(),
-            folder_structure_albums: args.folder_structure_albums.clone(),
-            folder_structure_smart_folders: args.folder_structure_smart_folders.clone(),
-            resolution,
-            live_photo_mode: args.live_photo_mode,
-            live_resolution,
-            live_photo_mov_filename_policy: args.live_photo_mov_filename_policy,
-            edited: edited_from_size,
-            alternative: alternative_from_size,
-            raw_policy,
-            file_match_policy: args.file_match_policy,
-            force_resolution: args.force_size,
-            keep_unicode_in_filenames: args.keep_unicode_in_filenames,
+            folder_structure: None,
+            folder_structure_albums: None,
+            folder_structure_smart_folders: None,
+            resolution: None,
+            live_photo_mode: None,
+            live_resolution: None,
+            live_photo_mov_filename_policy: None,
+            edited: None,
+            alternative: None,
+            raw_policy: None,
+            file_match_policy: None,
+            force_resolution: None,
+            keep_unicode_in_filenames: None,
         },
         toml,
     )?;
     let media = config::resolve_media_selection(toml.and_then(|t| t.filters.as_ref()), None, None)?;
 
-    let mut config = download::DownloadConfig::for_path_derivation_only(
+    let config = download::DownloadConfig::for_path_derivation_only(
         directory,
         path_fields,
         media,
         args.dry_run,
         args.no_progress_bar,
     );
-    if live_adjusted_from_size || live_adjusted_from_live_size {
-        config.live_resolution = crate::types::AssetVersionSize::LiveAdjusted;
-    }
     Ok(config)
 }
 
@@ -911,10 +1065,13 @@ mod wiremock_tests {
     use rustc_hash::FxHashSet;
     use serde_json::{json, Value};
     use tempfile::TempDir;
-    use wiremock::matchers::{method as wm_method, path as wm_path};
+    use wiremock::matchers::{header, method as wm_method, path as wm_path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::{import_assets, ImportStats};
+    use super::{
+        import_assets, verify_strict_prefix, ImportRunOptions, ImportStats, StrictImportDecision,
+        StrictImportVerifier,
+    };
     use crate::download::filter::expected_paths_for;
     use crate::download::paths::DirCache;
     use crate::download::{AssetGroupings, DownloadConfig, SyncMode};
@@ -1209,6 +1366,13 @@ mod wiremock_tests {
         f.set_len(size).expect("set_len");
     }
 
+    fn stage_file_with_bytes(path: &StdPath, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(path, bytes).expect("write file");
+    }
+
     /// Stage every file `expected_paths_for` would emit for `asset` so
     /// they all match. Returns the list of staged paths.
     fn stage_expected(asset: &PhotoAsset, config: &DownloadConfig) -> Vec<std::path::PathBuf> {
@@ -1231,6 +1395,17 @@ mod wiremock_tests {
         config: &DownloadConfig,
         dry_run: bool,
     ) -> ImportStats {
+        run_import_with_strict(server, assets, db, config, dry_run, None).await
+    }
+
+    async fn run_import_with_strict(
+        server: &MockServer,
+        assets: &[WiremockAsset],
+        db: &dyn StateDb,
+        config: &DownloadConfig,
+        dry_run: bool,
+        strict_verifier: Option<&dyn StrictImportVerifier>,
+    ) -> ImportStats {
         stub_records_query(server, assets).await;
         let album = album_pointed_at(server);
         let (stream, panic_rx) = album.photo_stream(None, None, 1);
@@ -1241,12 +1416,45 @@ mod wiremock_tests {
             db,
             config,
             "test-all",
-            dry_run,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run,
+                show_progress: false,
+                strict_verifier,
+            },
         )
         .await
         .expect("import_assets")
+    }
+
+    #[derive(Debug)]
+    struct TestStrictVerifier {
+        cloud_prefix: Vec<u8>,
+    }
+
+    impl StrictImportVerifier for TestStrictVerifier {
+        fn verify<'a>(
+            &'a self,
+            local_path: &'a StdPath,
+            _cloud_url: &'a str,
+            expected_size: u64,
+        ) -> futures_util::future::BoxFuture<'a, anyhow::Result<StrictImportDecision>> {
+            Box::pin(async move {
+                use tokio::io::AsyncReadExt;
+
+                let prefix_len = usize::try_from(expected_size)
+                    .unwrap_or(usize::MAX)
+                    .min(self.cloud_prefix.len());
+                let mut local_prefix = vec![0_u8; prefix_len];
+                let mut file = tokio::fs::File::open(local_path).await?;
+                file.read_exact(&mut local_prefix).await?;
+                if local_prefix == self.cloud_prefix[..prefix_len] {
+                    Ok(StrictImportDecision::Accepted)
+                } else {
+                    Ok(StrictImportDecision::Refused)
+                }
+            })
+        }
     }
 
     // ── Tests: default flow ───────────────────────────────────────────
@@ -1602,6 +1810,126 @@ mod wiremock_tests {
             all_downloaded(db.as_ref()).await.is_empty(),
             "dry-run must not write rows"
         );
+    }
+
+    #[tokio::test]
+    async fn same_name_same_size_different_content_adopts_without_strict() {
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("STRICT1", "IMG_0001.JPG", "public.jpeg").orig(
+            4,
+            "ck_s1",
+            "public.jpeg",
+        );
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        assert_eq!(expected.len(), 1);
+        stage_file_with_bytes(&expected[0].path, b"bbbb");
+
+        let db = open_db(&tmp).await;
+        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+
+        assert_eq!(stats.matched, 1);
+        assert_eq!(stats.strict_refused, 0);
+        assert_eq!(all_downloaded(db.as_ref()).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn same_name_same_size_different_content_refuses_with_strict() {
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("STRICT2", "IMG_0002.JPG", "public.jpeg").orig(
+            4,
+            "ck_s2",
+            "public.jpeg",
+        );
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        assert_eq!(expected.len(), 1);
+        stage_file_with_bytes(&expected[0].path, b"bbbb");
+        let verifier = TestStrictVerifier {
+            cloud_prefix: b"aaaa".to_vec(),
+        };
+
+        let db = open_db(&tmp).await;
+        let stats = run_import_with_strict(
+            &server,
+            &[asset],
+            db.as_ref(),
+            &config,
+            false,
+            Some(&verifier),
+        )
+        .await;
+
+        assert_eq!(stats.matched, 0);
+        assert_eq!(stats.strict_refused, 1);
+        assert!(all_downloaded(db.as_ref()).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dry_run_strict_reports_refusal_without_writing_db() {
+        let server = MockServer::start().await;
+        let asset = WiremockAsset::new("STRICT3", "IMG_0003.JPG", "public.jpeg").orig(
+            4,
+            "ck_s3",
+            "public.jpeg",
+        );
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        assert_eq!(expected.len(), 1);
+        stage_file_with_bytes(&expected[0].path, b"bbbb");
+        let verifier = TestStrictVerifier {
+            cloud_prefix: b"aaaa".to_vec(),
+        };
+
+        let db = open_db(&tmp).await;
+        let stats = run_import_with_strict(
+            &server,
+            &[asset],
+            db.as_ref(),
+            &config,
+            true,
+            Some(&verifier),
+        )
+        .await;
+
+        assert_eq!(stats.matched, 0);
+        assert_eq!(stats.strict_refused, 1);
+        assert!(all_downloaded(db.as_ref()).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn http_strict_prefix_verifier_fetches_range_and_accepts_match() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/asset"))
+            .and(header("Range", "bytes=0-3"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(b"abcd".to_vec()))
+            .mount(&server)
+            .await;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("IMG_0004.JPG");
+        stage_file_with_bytes(&path, b"abcd");
+
+        let decision = verify_strict_prefix(
+            &reqwest::Client::new(),
+            &path,
+            &format!("{}/asset", server.uri()),
+            4,
+        )
+        .await
+        .expect("strict prefix verify");
+
+        assert_eq!(decision, StrictImportDecision::Accepted);
     }
 
     // ── Tests: idempotency ────────────────────────────────────────────
@@ -2384,9 +2712,12 @@ mod wiremock_tests {
             db.as_ref(),
             &config,
             "test-all",
-            false,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run: false,
+                show_progress: false,
+                strict_verifier: None,
+            },
         )
         .await
         .expect("clean exit must be Ok");
@@ -2417,9 +2748,12 @@ mod wiremock_tests {
             db.as_ref(),
             &config,
             "test-all",
-            false,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run: false,
+                show_progress: false,
+                strict_verifier: None,
+            },
         )
         .await
         .expect_err("must bail on fetcher panic");
@@ -2495,9 +2829,12 @@ mod wiremock_tests {
             db.as_ref(),
             &config,
             "test-all",
-            true,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run: true,
+                show_progress: false,
+                strict_verifier: None,
+            },
         )
         .await
         .expect_err("must bail on fetcher Err");
@@ -2624,9 +2961,12 @@ mod wiremock_tests {
             db.as_ref(),
             &config,
             "PrimarySync",
-            true,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run: true,
+                show_progress: false,
+                strict_verifier: None,
+            },
         )
         .await
         .expect("import_assets");
@@ -2662,9 +3002,12 @@ mod wiremock_tests {
             db.as_ref(),
             &config,
             "PrimarySync",
-            true,
-            false,
             &mut dir_cache,
+            ImportRunOptions {
+                dry_run: true,
+                show_progress: false,
+                strict_verifier: None,
+            },
         )
         .await
         .expect("import_assets");
@@ -2798,15 +3141,14 @@ mod build_config_tests {
     //! parse path that production uses.
     use super::build_import_download_config;
     use crate::cli::{Cli, Command};
-    use crate::config::{Config, GlobalArgs, MediaKind, TomlConfig, TomlFilters, TomlPhotos};
+    use crate::config::{Config, GlobalArgs, TomlConfig};
     use crate::types::{
-        AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
-        PhotoResolution, RawPolicy,
+        AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, RawPolicy,
     };
     use clap::Parser;
 
     fn parse_import_args(extra: &[&str]) -> crate::cli::ImportArgs {
-        let mut argv = vec!["kei", "import-existing", "--download-dir", "/photos"];
+        let mut argv = vec!["kei", "import-existing"];
         argv.extend(extra.iter().copied());
         let cli = Cli::try_parse_from(argv).expect("clap parse");
         match cli.command {
@@ -2815,174 +3157,45 @@ mod build_config_tests {
         }
     }
 
-    fn empty_toml() -> TomlConfig {
-        TomlConfig {
-            data_dir: None,
-            log_level: None,
-            auth: None,
-            download: None,
-            filters: None,
-            photos: None,
-            watch: None,
-            notifications: None,
-            server: None,
-            report: None,
-            ui: None,
-        }
+    fn toml_with_download(body: &str) -> TomlConfig {
+        toml::from_str(&format!(
+            r#"
+            [download]
+            directory = "/photos"
+
+            {body}
+            "#
+        ))
+        .expect("parse TOML")
     }
 
-    fn toml_with_photos(p: TomlPhotos) -> TomlConfig {
-        let mut t = empty_toml();
-        t.photos = Some(p);
-        t
-    }
-
-    fn toml_with_filters(f: TomlFilters) -> TomlConfig {
-        let mut t = empty_toml();
-        t.filters = Some(f);
-        t
-    }
-
-    fn empty_photos() -> TomlPhotos {
-        TomlPhotos {
-            resolution: None,
-            live_resolution: None,
-            live_photo_mode: None,
-            live_photo_mov_filename_policy: None,
-            edited: None,
-            alternative: None,
-            raw_policy: None,
-            file_match_policy: None,
-            force_resolution: None,
-            keep_unicode_in_filenames: None,
-        }
-    }
-
-    /// CG-1 / AT-3: CLI value beats TOML value across every photos field.
-    /// Each row plants a different value at each layer; if the resolver
-    /// reverses precedence on any field, exactly that row fails.
+    /// TOML is the only durable import path/photo source in v0.20. This pins
+    /// every field that import-existing needs to stay aligned with sync.
     #[test]
-    fn build_import_download_config_cli_overrides_toml() {
-        // size: CLI=Medium, TOML=Thumb -> Medium
-        let args = parse_import_args(&["--size", "medium"]);
-        let toml = toml_with_photos(TomlPhotos {
-            resolution: Some(crate::types::PhotoResolution::Thumb),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.resolution,
-            crate::types::PhotoResolution::Medium,
-            "size: CLI must win"
-        );
-
-        // file_match_policy: CLI=NameId7, TOML=NameSizeDedupWithSuffix -> NameId7
-        let args = parse_import_args(&["--file-match-policy", "name-id7"]);
-        let toml = toml_with_photos(TomlPhotos {
-            file_match_policy: Some(FileMatchPolicy::NameSizeDedupWithSuffix),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.file_match_policy,
-            FileMatchPolicy::NameId7,
-            "file_match_policy: CLI must win"
-        );
-
-        // live_photo_mode: CLI=VideoOnly, TOML=ImageOnly -> VideoOnly
-        let args = parse_import_args(&["--live-photo-mode", "video-only"]);
-        let toml = toml_with_photos(TomlPhotos {
-            live_photo_mode: Some(LivePhotoMode::ImageOnly),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.live_photo_mode,
-            LivePhotoMode::VideoOnly,
-            "live_photo_mode: CLI must win"
-        );
-
-        // live_resolution: CLI=Medium, TOML=Thumb -> LiveMedium
-        let args = parse_import_args(&["--live-photo-size", "medium"]);
-        let toml = toml_with_photos(TomlPhotos {
-            live_resolution: Some(crate::types::LivePhotoResolution::Thumb),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.live_resolution,
-            AssetVersionSize::LiveMedium,
-            "live_resolution: CLI must win"
-        );
-
-        // live_photo_mov_filename_policy: CLI=Original, TOML=Suffix -> Original
-        let args = parse_import_args(&["--live-photo-mov-filename-policy", "original"]);
-        let toml = toml_with_photos(TomlPhotos {
-            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Suffix),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.live_photo_mov_filename_policy,
-            LivePhotoMovFilenamePolicy::Original,
-            "live_photo_mov_filename_policy: CLI must win"
-        );
-
-        // legacy --align-raw=original maps to raw_policy=PreferRaw and wins over TOML.
-        let args = parse_import_args(&["--align-raw", "original"]);
-        let toml = toml_with_photos(TomlPhotos {
-            raw_policy: Some(RawPolicy::PreferJpeg),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.raw_policy,
-            RawPolicy::PreferRaw,
-            "raw_policy: CLI must win"
-        );
-
-        // force_resolution: CLI=true, TOML=false -> true
-        let args = parse_import_args(&["--force-size"]);
-        let toml = toml_with_photos(TomlPhotos {
-            force_resolution: Some(false),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert!(
-            cfg.force_resolution,
-            "force_resolution: CLI true must win over TOML false"
-        );
-
-        // keep_unicode_in_filenames: CLI=true, TOML=false -> true
-        let args = parse_import_args(&["--keep-unicode-in-filenames"]);
-        let toml = toml_with_photos(TomlPhotos {
-            keep_unicode_in_filenames: Some(false),
-            ..empty_photos()
-        });
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-        assert!(
-            cfg.keep_unicode_in_filenames,
-            "keep_unicode_in_filenames: CLI true must win over TOML false"
-        );
-    }
-
-    /// CG-1: TOML value beats default when CLI absent.
-    #[test]
-    fn build_import_download_config_uses_toml_when_cli_absent() {
+    fn build_import_download_config_uses_toml_path_photo_and_media_settings() {
         let args = parse_import_args(&[]);
-        let toml = toml_with_photos(TomlPhotos {
-            resolution: Some(crate::types::PhotoResolution::Medium),
-            file_match_policy: Some(FileMatchPolicy::NameId7),
-            live_photo_mode: Some(LivePhotoMode::VideoOnly),
-            live_resolution: Some(crate::types::LivePhotoResolution::Thumb),
-            live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
-            edited: None,
-            alternative: None,
-            raw_policy: Some(RawPolicy::PreferRaw),
-            force_resolution: Some(true),
-            keep_unicode_in_filenames: Some(true),
-        });
+        let toml = toml_with_download(
+            r#"
+            folder_structure = "%Y/%m"
+
+            [photos]
+            resolution = "medium"
+            file_match_policy = "name-id7"
+            live_photo_mode = "video-only"
+            live_resolution = "thumb"
+            live_photo_mov_filename_policy = "original"
+            raw_policy = "prefer-raw"
+            force_resolution = true
+            keep_unicode_in_filenames = true
+
+            [filters]
+            media = ["photos", "live-photos"]
+            "#,
+        );
+
         let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+
+        assert_eq!(cfg.folder_structure, "%Y/%m");
         assert_eq!(cfg.resolution, crate::types::PhotoResolution::Medium);
         assert_eq!(cfg.file_match_policy, FileMatchPolicy::NameId7);
         assert_eq!(cfg.live_photo_mode, LivePhotoMode::VideoOnly);
@@ -2994,30 +3207,18 @@ mod build_config_tests {
         assert_eq!(cfg.raw_policy, RawPolicy::PreferRaw);
         assert!(cfg.force_resolution);
         assert!(cfg.keep_unicode_in_filenames);
-    }
-
-    #[test]
-    fn build_import_download_config_uses_toml_media_filter() {
-        let args = parse_import_args(&[]);
-        let toml = toml_with_filters(TomlFilters {
-            media: Some(vec![MediaKind::Photos, MediaKind::LivePhotos]),
-            ..TomlFilters::default()
-        });
-
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
-
         assert!(cfg.media.photos);
         assert!(!cfg.media.videos);
         assert!(cfg.media.live_photos);
     }
 
-    /// CG-1: documented defaults when neither CLI nor TOML set the field.
-    /// Pinning the *documented* default protects against silent default
-    /// drift (per memory `feedback_default_value_change_test`).
+    /// Documented defaults still apply when TOML only supplies the required
+    /// download directory.
     #[test]
     fn build_import_download_config_falls_through_to_default() {
         let args = parse_import_args(&[]);
-        let cfg = build_import_download_config(&args, None).unwrap();
+        let toml = toml_with_download("");
+        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
         assert_eq!(cfg.resolution, crate::types::PhotoResolution::Original);
         assert_eq!(
             cfg.file_match_policy,
@@ -3036,80 +3237,27 @@ mod build_config_tests {
     }
 
     #[test]
-    fn build_import_download_config_preserves_legacy_adjusted_flags() {
-        let args = parse_import_args(&["--size", "adjusted"]);
-        let cfg = build_import_download_config(&args, None).unwrap();
-        assert_eq!(cfg.resolution, crate::types::PhotoResolution::None);
-        assert!(cfg.edited);
-        assert!(!cfg.alternative);
-        assert_eq!(cfg.live_resolution, AssetVersionSize::LiveAdjusted);
-
-        let args = parse_import_args(&["--live-photo-size", "adjusted"]);
-        let cfg = build_import_download_config(&args, None).unwrap();
-        assert_eq!(cfg.resolution, crate::types::PhotoResolution::Original);
-        assert!(!cfg.edited);
-        assert_eq!(cfg.live_resolution, AssetVersionSize::LiveAdjusted);
-    }
-
-    #[test]
-    fn build_import_download_config_legacy_size_clears_toml_extras() {
-        let toml = toml_with_photos(TomlPhotos {
-            resolution: Some(crate::types::PhotoResolution::Medium),
-            edited: Some(true),
-            alternative: Some(true),
-            ..empty_photos()
-        });
-
-        for (size, resolution, edited, alternative) in [
-            ("original", PhotoResolution::Original, false, false),
-            ("adjusted", PhotoResolution::None, true, false),
-            ("alternative", PhotoResolution::None, false, true),
-        ] {
-            let cfg =
-                build_import_download_config(&parse_import_args(&["--size", size]), Some(&toml))
-                    .unwrap();
-            assert_eq!(cfg.resolution, resolution, "--size {size}");
-            assert_eq!(cfg.edited, edited, "--size {size}");
-            assert_eq!(cfg.alternative, alternative, "--size {size}");
-        }
-    }
-
-    /// CG-9: empty `directory` after TOML resolve produces the documented
-    /// "is required" error rather than a confusing downstream failure.
-    #[test]
     fn build_import_download_config_empty_directory_bails() {
-        // No --download-dir on the CLI, no TOML directory either: bails.
-        let cli = Cli::try_parse_from([
-            "kei",
-            "import-existing",
-            // explicitly absent --download-dir
-        ])
-        .unwrap();
-        let args = match cli.command {
-            Some(Command::ImportExisting(a)) => a,
-            _ => panic!("expected ImportExisting"),
-        };
+        let args = parse_import_args(&[]);
         let err =
             build_import_download_config(&args, None).expect_err("empty directory should bail");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("--download-dir is required"),
-            "error must name the missing flag, got: {msg}"
+            msg.contains("[download] directory is required for import-existing"),
+            "error must name the missing TOML field, got: {msg}"
         );
     }
 
     /// Sync's `Config::build` and import's `build_import_download_config`
-    /// share `resolve_path_derivation_fields`. For the same CLI/TOML
-    /// inputs the path-derivation knobs they emit must agree
-    /// byte-for-byte. If a future change layers extra logic into either
-    /// path without going through the shared resolver, this test catches
-    /// the drift.
+    /// share `resolve_path_derivation_fields`. For the same TOML inputs the
+    /// path-derivation knobs they emit must agree byte-for-byte.
     #[test]
     fn sync_and_import_agree_on_path_derivation_fields() {
         use crate::cli::SyncArgs;
 
         let toml_str = r#"
             [download]
+            directory = "/photos"
             folder_structure = "%Y/%m"
 
             [photos]
@@ -3123,32 +3271,10 @@ mod build_config_tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
 
-        let import_args = parse_import_args(&[
-            "--folder-structure",
-            "%Y/%m",
-            "--file-match-policy",
-            "name-id7",
-            "--live-photo-mov-filename-policy",
-            "original",
-            "--keep-unicode-in-filenames",
-        ]);
+        let import_args = parse_import_args(&[]);
         let import_cfg = build_import_download_config(&import_args, Some(&toml)).unwrap();
 
-        let sync = SyncArgs {
-            config_overrides: crate::config::SyncConfigOverrides {
-                folder_structure: Some("%Y/%m".to_string()),
-                resolution: Some(crate::types::PhotoResolution::Original),
-                edited: Some(true),
-                file_match_policy: Some(FileMatchPolicy::NameId7),
-                live_photo_mov_filename_policy: Some(LivePhotoMovFilenamePolicy::Original),
-                raw_policy: Some(RawPolicy::PreferRaw),
-                force_resolution: Some(true),
-                keep_unicode_in_filenames: Some(true),
-                download_dir: Some("/photos".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
+        let sync = SyncArgs::default();
         let globals = GlobalArgs {
             username: Some("u@example.com".to_string()),
             domain: None,
@@ -3191,37 +3317,34 @@ mod build_config_tests {
         );
     }
 
-    /// Sync's `Config::build` and import's `build_import_download_config`
-    /// share the same `validate_download_dir` system-directory deny list,
-    /// so a path like `/etc` must be rejected by both with the same error
-    /// shape. If a future refactor bypasses the helper from one path,
-    /// this test catches the drift.
     #[test]
     fn sync_and_import_reject_system_directory_with_same_message() {
         use crate::cli::SyncArgs;
 
-        let import_args = {
-            let mut a = parse_import_args(&[]);
-            a.download_dir = Some("/etc".to_string());
-            a
-        };
-        let import_err = build_import_download_config(&import_args, None)
+        let import_args = parse_import_args(&[]);
+        let toml: TomlConfig = toml::from_str(
+            r#"
+            [download]
+            directory = "/etc"
+            "#,
+        )
+        .unwrap();
+        let import_err = build_import_download_config(&import_args, Some(&toml))
             .expect_err("import: system dir must reject");
 
-        let sync = SyncArgs {
-            config_overrides: crate::config::SyncConfigOverrides {
-                download_dir: Some("/etc".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
+        let sync = SyncArgs::default();
         let globals = GlobalArgs {
             username: Some("u@example.com".to_string()),
             domain: None,
             data_dir: None,
         };
-        let sync_err = Config::build(&globals, &crate::cli::PasswordArgs::default(), sync, None)
-            .expect_err("sync: system dir must reject");
+        let sync_err = Config::build(
+            &globals,
+            &crate::cli::PasswordArgs::default(),
+            sync,
+            Some(&toml),
+        )
+        .expect_err("sync: system dir must reject");
 
         let import_msg = format!("{import_err:#}");
         let sync_msg = format!("{sync_err:#}");
@@ -3231,6 +3354,34 @@ mod build_config_tests {
                 "{label} must name the rejection and the path; got: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn resolve_import_strict_uses_toml() {
+        let args = parse_import_args(&[]);
+        let toml: TomlConfig = toml::from_str(
+            r#"
+            [import]
+            strict = true
+            "#,
+        )
+        .unwrap();
+
+        assert!(super::resolve_import_strict(&args, Some(&toml)));
+    }
+
+    #[test]
+    fn resolve_import_strict_cli_overrides_toml_false() {
+        let args = parse_import_args(&["--strict"]);
+        let toml: TomlConfig = toml::from_str(
+            r#"
+            [import]
+            strict = false
+            "#,
+        )
+        .unwrap();
+
+        assert!(super::resolve_import_strict(&args, Some(&toml)));
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -68,6 +68,13 @@ impl std::ops::AddAssign for ImportStats {
     }
 }
 
+fn record_strict_refusal(stats: &mut ImportStats, heartbeat_state: &HeartbeatState) {
+    stats.strict_refused += 1;
+    heartbeat_state
+        .strict_refused
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Default cadence for the `import-existing` heartbeat log line.
 const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 const STRICT_IMPORT_PREFIX_BYTES: u64 = 64 * 1024;
@@ -551,10 +558,7 @@ where
                             path = %expected_path.display(),
                             "Strict import refused same-name, same-size file: local prefix differs from cloud prefix",
                         );
-                        stats.strict_refused += 1;
-                        heartbeat_state
-                            .strict_refused
-                            .fetch_add(1, Ordering::Relaxed);
+                        record_strict_refusal(&mut stats, &heartbeat_state);
                         continue;
                     }
                     Err(e) => {
@@ -565,10 +569,7 @@ where
                             error = %e,
                             "Strict import refused same-name, same-size file: prefix verification failed",
                         );
-                        stats.strict_refused += 1;
-                        heartbeat_state
-                            .strict_refused
-                            .fetch_add(1, Ordering::Relaxed);
+                        record_strict_refusal(&mut stats, &heartbeat_state);
                         continue;
                     }
                 }
@@ -3131,9 +3132,9 @@ mod wiremock_tests {
 #[cfg(test)]
 mod build_config_tests {
     //! Unit tests for [`build_import_download_config`] -- the
-    //! CLI > TOML > default resolution chain for import-existing's
-    //! path-derivation flags. Each new flag added to import-existing
-    //! needs a row in this test mod or the precedence is unverified.
+    //! TOML > default resolution chain for import-existing's path-derivation
+    //! settings. Each new TOML field consumed by import-existing needs a row
+    //! in this test mod or the resolver is unverified.
     //!
     //! Construction of `ImportArgs` happens through `Cli::try_parse_from`
     //! (rather than struct literals) so a regression that reorders

--- a/src/commands/import/wiremock_tests/icloudpd_compat.rs
+++ b/src/commands/import/wiremock_tests/icloudpd_compat.rs
@@ -774,9 +774,12 @@ async fn kei_uses_fingerprint_filename_when_filename_missing() {
         db.as_ref(),
         &config,
         "test-all",
-        false,
-        false,
         &mut dir_cache,
+        ImportRunOptions {
+            dry_run: false,
+            show_progress: false,
+            strict_verifier: None,
+        },
     )
     .await
     .expect("import_assets ok");

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub(crate) struct TomlConfig {
     pub download: Option<TomlDownload>,
     pub filters: Option<TomlFilters>,
     pub photos: Option<TomlPhotos>,
+    pub import: Option<TomlImport>,
     pub watch: Option<TomlWatch>,
     pub notifications: Option<TomlNotifications>,
     pub server: Option<TomlServer>,
@@ -185,6 +186,12 @@ pub(crate) struct TomlPhotos {
     pub file_match_policy: Option<FileMatchPolicy>,
     pub force_resolution: Option<bool>,
     pub keep_unicode_in_filenames: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlImport {
+    pub strict: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -379,7 +386,9 @@ pub struct MetadataConfig {
 }
 
 #[derive(Debug)]
-pub struct ImportConfig {}
+pub struct ImportConfig {
+    pub strict: bool,
+}
 
 #[derive(Debug)]
 pub struct RuntimeConfig {
@@ -1246,6 +1255,7 @@ impl Config {
         let toml_retry = toml_dl.and_then(|d| d.retry.as_ref());
         let toml_filters = toml.and_then(|t| t.filters.as_ref());
         let toml_photos = toml.and_then(|t| t.photos.as_ref());
+        let toml_import = toml.and_then(|t| t.import.as_ref());
         let toml_watch = toml.and_then(|t| t.watch.as_ref());
         let toml_server = toml.and_then(|t| t.server.as_ref());
 
@@ -1667,7 +1677,9 @@ impl Config {
                 #[cfg(feature = "xmp")]
                 xmp_sidecar,
             },
-            import: ImportConfig {},
+            import: ImportConfig {
+                strict: toml_import.and_then(|i| i.strict).unwrap_or(false),
+            },
             runtime: RuntimeConfig {
                 dry_run: sync.dry_run,
                 only_print_filenames: sync.only_print_filenames,
@@ -1891,6 +1903,11 @@ impl Config {
                     None
                 },
             }),
+            import: if self.import.strict {
+                Some(TomlImport { strict: Some(true) })
+            } else {
+                None
+            },
             watch: if self.watch.interval.is_some()
                 || self.watch.notify_systemd
                 || self.watch.pid_file.is_some()
@@ -2024,6 +2041,7 @@ pub(crate) fn persist_first_run_config(
         }),
         filters: None,
         photos: None,
+        import: None,
         watch: None,
         notifications: None,
         server: None,
@@ -5461,6 +5479,7 @@ mod tests {
             download: None,
             filters: None,
             photos: None,
+            import: None,
             watch: None,
             notifications: None,
             server: None,
@@ -5494,6 +5513,7 @@ mod tests {
             download: None,
             filters: None,
             photos: None,
+            import: None,
             watch: None,
             notifications: None,
             server: None,
@@ -5761,6 +5781,7 @@ mod tests {
             download: None,
             filters: None,
             photos: None,
+            import: None,
             watch: None,
             notifications: None,
             server: None,
@@ -5786,6 +5807,7 @@ mod tests {
             download: None,
             filters: None,
             photos: None,
+            import: None,
             watch: None,
             notifications: None,
             server: None,

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -506,6 +506,8 @@ pub(crate) struct ExpectedAssetPath {
     pub(crate) size: u64,
     /// iCloud-side checksum (CloudKit format, not SHA256).
     pub(crate) checksum: Box<str>,
+    /// Signed CDN URL for the selected cloud version.
+    pub(crate) url: Box<str>,
     /// Which version this is (Original, LiveOriginal, Medium, ...). Drives the
     /// state-DB row key and `MediaType` classification.
     pub(crate) version_size: VersionSizeKey,
@@ -914,6 +916,7 @@ pub(crate) fn expected_paths_for(
             path: d.path,
             size: d.size,
             checksum: d.checksum,
+            url: d.url,
             version_size: d.version_size,
         })
         .collect()

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -690,20 +690,22 @@ fn import_existing_requires_directory() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--download-dir is required for import-existing",
+            "[download] directory is required for import-existing",
         ));
 }
 #[test]
 fn import_existing_rejects_nonexistent_directory() {
     let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config.toml");
+    std::fs::write(
+        &config,
+        "[download]\ndirectory = \"/does/not/exist/anywhere\"\n",
+    )
+    .unwrap();
     clean_cmd()
         .env("ICLOUD_USERNAME", "test@example.com")
         .env("KEI_DATA_DIR", dir.path())
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/does/not/exist/anywhere",
-        ])
+        .args(["--config", config.to_str().unwrap(), "import-existing"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -130,7 +130,8 @@ fn import_existing_help_succeeds() {
         .args(["import-existing", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--download-dir"));
+        .stdout(predicate::str::contains("--strict"))
+        .stdout(predicate::str::contains("--download-dir").not());
 }
 
 #[test]
@@ -407,7 +408,7 @@ fn submit_code_requires_code_argument() {
         .stderr(predicate::str::contains("error"));
 }
 
-// ── import-existing requires --download-dir ─────────────────────────────
+// ── import-existing requires TOML directory ─────────────────────────────
 
 #[test]
 fn import_existing_requires_directory() {
@@ -416,7 +417,9 @@ fn import_existing_requires_directory() {
         .args(["import-existing"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--download-dir is required"));
+        .stderr(predicate::str::contains(
+            "[download] directory is required for import-existing",
+        ));
 }
 
 // ── Removed durable boolean flags fail ─────────────────────────────────
@@ -571,26 +574,7 @@ fn log_level_global_flag_works_with_all_subcommands() {
 // ── import-existing subcommand-specific flags ───────────────────────────
 
 #[test]
-fn import_existing_folder_structure_flag() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--folder-structure",
-            "%Y-%m",
-            "--help",
-        ])
-        .assert()
-        .success();
-}
-
-#[test]
 fn import_existing_library_flag_accepts_repeatable_sentinels() {
-    // --library on import-existing was added on the selection-flags-redesign
-    // branch (commit bcbd5b6) but had no parse test of its own. The flag
-    // shares the v0.13 grammar with `kei sync --library`: bare sentinels,
-    // raw zone names, and `!name` exclusions, all repeatable.
     common::cmd()
         .args([
             "import-existing",
@@ -610,16 +594,8 @@ fn import_existing_library_flag_accepts_repeatable_sentinels() {
 
 #[test]
 fn import_existing_dry_run_flag_parses() {
-    // Covers the new --dry-run flag on import-existing. Must parse; actual
-    // DB-skip behavior is covered by the handler-level integration.
     common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--dry-run",
-            "--help",
-        ])
+        .args(["import-existing", "--dry-run", "--help"])
         .assert()
         .success();
 }
@@ -627,57 +603,79 @@ fn import_existing_dry_run_flag_parses() {
 #[test]
 fn import_existing_recent_flag() {
     common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--recent",
-            "100",
-            "--help",
-        ])
+        .args(["import-existing", "--recent", "100", "--help"])
         .assert()
         .success();
 }
 
 #[test]
-fn import_existing_file_match_policy_all_variants() {
-    for variant in ["name-size-dedup-with-suffix", "name-id7"] {
+fn import_existing_strict_flag_parses() {
+    common::cmd()
+        .args(["import-existing", "--strict", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_existing_removed_durable_flags_fail() {
+    for args in [
+        vec!["import-existing", "--download-dir", "/tmp", "--help"],
+        vec!["import-existing", "-d", "/tmp", "--help"],
+        vec!["import-existing", "--folder-structure", "%Y-%m", "--help"],
+        vec![
+            "import-existing",
+            "--folder-structure-albums",
+            "{album}",
+            "--help",
+        ],
+        vec![
+            "import-existing",
+            "--folder-structure-smart-folders",
+            "{smart-folder}",
+            "--help",
+        ],
+        vec![
+            "import-existing",
+            "--file-match-policy",
+            "name-id7",
+            "--help",
+        ],
+        vec!["import-existing", "--size", "medium", "--help"],
+        vec![
+            "import-existing",
+            "--live-photo-mode",
+            "image-only",
+            "--help",
+        ],
+        vec!["import-existing", "--live-photo-size", "medium", "--help"],
+        vec![
+            "import-existing",
+            "--live-photo-mov-filename-policy",
+            "original",
+            "--help",
+        ],
+        vec!["import-existing", "--align-raw", "original", "--help"],
+        vec!["import-existing", "--force-size", "--help"],
+        vec!["import-existing", "--keep-unicode-in-filenames", "--help"],
+    ] {
         common::cmd()
-            .args([
-                "import-existing",
-                "--download-dir",
-                "/tmp",
-                "--file-match-policy",
-                variant,
-                "--help",
-            ])
+            .args(args)
             .assert()
-            .success();
+            .failure()
+            .stderr(predicate::str::contains("unexpected argument"));
     }
 }
 
 #[test]
-fn import_existing_file_match_policy_rejects_invalid() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--file-match-policy",
-            "bogus",
-            "--help",
-        ])
-        .assert()
-        .failure();
-}
-
-#[test]
-fn import_existing_file_match_policy_from_env() {
+fn import_existing_removed_durable_env_vars_are_ignored_by_help() {
     common::cmd()
         .env("KEI_FILE_MATCH_POLICY", "name-id7")
-        .args(["import-existing", "--download-dir", "/tmp", "--help"])
+        .env("KEI_DOWNLOAD_DIR", "/tmp")
+        .args(["import-existing", "--help"])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("--file-match-policy").not())
+        .stdout(predicate::str::contains("--download-dir").not());
 }
 
 // ── Env var credential passthrough ──────────────────────────────────────
@@ -766,14 +764,15 @@ fn only_print_filenames_visible_in_help() {
         .stdout(predicate::str::contains("--only-print-filenames"));
 }
 
-// ── import-existing short -d flag ───────────────────────────────────────
+// ── import-existing short -d flag removed ───────────────────────────────
 
 #[test]
-fn import_existing_short_d_flag() {
+fn import_existing_short_d_flag_removed() {
     common::cmd()
         .args(["import-existing", "-d", "/tmp", "--help"])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 // ── Unknown flags on all subcommands ────────────────────────────────────
@@ -855,34 +854,6 @@ fn import_existing_accepts_no_progress_bar() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--no-progress-bar"));
-}
-
-// ── import-existing path-derivation flags ───────────────────────────────
-//
-// The CLI-string -> enum mapping for each flag (--size, --live-photo-mode,
-// --live-photo-size, --live-photo-mov-filename-policy, --align-raw,
-// --force-size, --keep-unicode-in-filenames, --file-match-policy) is pinned
-// by `Cli::try_parse_from`-driven unit tests in src/cli.rs (search for
-// `import_existing_*_parses_to_correct_variant`). Those assert on parsed
-// variants -- which `--help`-driven subprocess tests cannot.
-//
-// The subprocess-level test below stays because it exercises one thing the
-// unit tests can't: that clap's value rejection produces a non-zero subprocess
-// exit code (the contract Docker / systemd consumers rely on).
-
-#[test]
-fn import_existing_file_match_policy_rejects_bogus_value() {
-    common::cmd()
-        .args([
-            "import-existing",
-            "--download-dir",
-            "/tmp",
-            "--file-match-policy",
-            "bogus",
-            "--help",
-        ])
-        .assert()
-        .failure();
 }
 
 // ── exit codes ────────────────────────────────────────────────────────

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -158,15 +158,18 @@ fn import_cmd(
     // Mirror auth artifacts (not state DB; see fixture()) into the
     // per-test data_dir so import-existing can re-use the trust cookie.
     copy_auth_artifacts(cookie_dir, data_dir);
+    let has_config_override = extra.contains(&"--config");
+    let config_path = (!has_config_override).then(|| write_kei_toml(data_dir, download_dir, ""));
     let mut cmd = common::cmd();
     cmd.env("ICLOUD_USERNAME", username)
         .env("KEI_DATA_DIR", data_dir);
+    if let Some(config_path) = &config_path {
+        cmd.args(["--config", config_path.to_str().unwrap()]);
+    }
     cmd.args([
         "import-existing",
         "--password",
         password,
-        "--download-dir",
-        download_dir.to_str().unwrap(),
         "--no-progress-bar",
     ]);
     cmd.args(extra);
@@ -725,11 +728,9 @@ fn write_kei_toml(dir: &Path, download_dir: &Path, extra: &str) -> std::path::Pa
     path
 }
 
-/// Strip every `KEI_*` env var that overrides a TOML-resolved field.
-/// Live test runners often export several of these; without scrubbing,
-/// the env layer (CLI > env > TOML > default) silently shadows TOML
-/// under test. Apply at every TOML-driven test that asserts what TOML
-/// resolves to.
+/// Strip stale `KEI_*` env vars from older durable-config surfaces.
+/// v0.20 ignores these, but clearing them keeps TOML-driven live tests
+/// explicit about the source of truth.
 fn clear_toml_resolved_env(cmd: &mut assert_cmd::Command) {
     for var in [
         "KEI_FILE_MATCH_POLICY",
@@ -886,13 +887,18 @@ fn roundtrip_name_id7_sync_skips_after_import() {
         // the round-trip on a non-applicable layout.
         let test_data = tempdir().unwrap();
         let recent = ROUNDTRIP_RECENT.to_string();
+        let toml_path = write_kei_toml(
+            test_data.path(),
+            download_dir,
+            "[photos]\nfile_match_policy = \"name-id7\"\n",
+        );
         let import_out = import_cmd(
             &username,
             &password,
             &cookie_dir,
             download_dir,
             test_data.path(),
-            &["--recent", &recent, "--file-match-policy", "name-id7"],
+            &["--recent", &recent, "--config", toml_path.to_str().unwrap()],
         )
         .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
         .assert()
@@ -1069,59 +1075,20 @@ fn verify_checksums_passes_after_import() {
 // `import_reads_toml_for_path_derivation` covers the TOML-only happy
 // path. These cover precedence + invalid-input handling.
 
-/// CLI `--file-match-policy` overrides a conflicting TOML entry. Test:
-/// TOML says one policy, CLI flag says the other; the CLI value wins.
-/// Verify by observing import-existing's match behavior, since the two
-/// policies produce different filenames.
+/// The old `--file-match-policy` import override is gone in v0.20. Import
+/// path matching now reads `[photos].file_match_policy` from TOML.
 #[test]
-#[ignore]
-fn toml_file_match_policy_overridden_by_cli_flag() {
-    let (username, password, cookie_dir) = common::require_preauth();
-    let (download_dir, _sync_data_dir) = fixture();
-
-    common::with_auth_retry(|| {
-        let test_data = tempdir().unwrap();
-        let toml_path = write_kei_toml(
-            test_data.path(),
-            download_dir,
-            "[photos]\nfile_match_policy = \"name-id7\"\n",
-        );
-
-        let recent = ROUNDTRIP_RECENT.to_string();
-        // CLI flag forces back to the default policy. Files on disk
-        // were synced with the default, so this should match a healthy
-        // fraction. If the CLI override didn't take, the import would
-        // run name-id7 (matching nothing).
-        let mut cmd = import_cmd(
-            &username,
-            &password,
-            &cookie_dir,
-            download_dir,
-            test_data.path(),
-            &[
-                "--recent",
-                &recent,
-                "--config",
-                toml_path.to_str().unwrap(),
-                "--file-match-policy",
-                "name-size-dedup-with-suffix",
-            ],
-        );
-        clear_toml_resolved_env(&mut cmd);
-        let out = cmd
-            .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
-            .assert()
-            .success()
-            .get_output()
-            .clone();
-        let summary = parse_summary(&String::from_utf8_lossy(&out.stdout));
-        assert!(
-            summary.matched > 0,
-            "CLI override of TOML file_match_policy did not take effect: \
-             matched={} ({summary:?})",
-            summary.matched,
-        );
-    });
+fn import_file_match_policy_cli_flag_is_removed() {
+    common::cmd()
+        .args([
+            "import-existing",
+            "--file-match-policy",
+            "name-size-dedup-with-suffix",
+            "--help",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
 }
 
 /// Default kicks in when neither TOML nor CLI specify a value. With no
@@ -1230,15 +1197,16 @@ fn import_sigint_then_rerun_is_idempotent() {
         copy_auth_artifacts(&cookie_dir, test_data.path());
         let recent = ROUNDTRIP_RECENT.to_string();
 
+        let config_path = write_kei_toml(test_data.path(), download_dir, "");
         let mut child = kei_std_command()
             .env("ICLOUD_USERNAME", &username)
             .env("KEI_DATA_DIR", test_data.path())
             .args([
+                "--config",
+                config_path.to_str().unwrap(),
                 "import-existing",
                 "--password",
                 &password,
-                "--download-dir",
-                download_dir.to_str().unwrap(),
                 "--recent",
                 &recent,
                 "--no-progress-bar",
@@ -1332,16 +1300,17 @@ fn two_concurrent_imports_do_not_both_succeed_silently() {
         copy_auth_artifacts(&cookie_dir, test_data.path());
         let recent = ROUNDTRIP_RECENT.to_string();
 
+        let config_path = write_kei_toml(test_data.path(), download_dir, "");
         let spawn = || {
             kei_std_command()
                 .env("ICLOUD_USERNAME", &username)
                 .env("KEI_DATA_DIR", test_data.path())
                 .args([
+                    "--config",
+                    config_path.to_str().unwrap(),
                     "import-existing",
                     "--password",
                     &password,
-                    "--download-dir",
-                    download_dir.to_str().unwrap(),
                     "--recent",
                     &recent,
                     "--no-progress-bar",

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -44,6 +44,14 @@ fn sync_config(
     common::write_toml_config(data_dir, "state-auth-sync", &body)
 }
 
+fn import_config(data_dir: &Path, dir: &Path, download_extra: &str) -> std::path::PathBuf {
+    let body = format!(
+        "[download]\ndirectory = {}\n{download_extra}",
+        common::toml_string(&dir.to_string_lossy())
+    );
+    common::write_toml_config(data_dir, "state-auth-import", &body)
+}
+
 fn sync_cmd(
     username: &str,
     password: &str,
@@ -104,15 +112,16 @@ fn import_cmd(
     cookie_dir: &Path,
     dir: &Path,
 ) -> assert_cmd::Command {
+    let config_path = import_config(cookie_dir, dir, "");
     let mut cmd = common::cmd();
     cmd.env("ICLOUD_USERNAME", username)
         .env("KEI_DATA_DIR", cookie_dir);
     cmd.args([
+        "--config",
+        config_path.to_str().unwrap(),
         "import-existing",
         "--password",
         password,
-        "--download-dir",
-        dir.to_str().unwrap(),
     ]);
     cmd
 }
@@ -424,17 +433,22 @@ fn verify_checksums_detects_corruption() {
 #[ignore]
 fn import_existing_with_nonexistent_directory_fails() {
     let (username, password, cookie_dir) = common::require_preauth();
+    let config_path = import_config(
+        &cookie_dir,
+        Path::new("/nonexistent/path/that/does/not/exist"),
+        "",
+    );
 
     common::with_auth_retry(|| {
         common::cmd()
             .env("ICLOUD_USERNAME", &username)
             .env("KEI_DATA_DIR", &cookie_dir)
             .args([
+                "--config",
+                config_path.to_str().unwrap(),
                 "import-existing",
                 "--password",
                 &password,
-                "--download-dir",
-                "/nonexistent/path/that/does/not/exist",
             ])
             .timeout(std::time::Duration::from_secs(60))
             .assert()
@@ -542,8 +556,23 @@ fn import_existing_custom_folder_structure() {
             .assert()
             .success();
 
-        import_cmd(&username, &password, &cookie_dir, download_dir.path())
-            .args(["--folder-structure", "%Y", "--recent", "5"])
+        let import_config = import_config(
+            &cookie_dir,
+            download_dir.path(),
+            "folder_structure = \"%Y\"\n",
+        );
+        common::cmd()
+            .env("ICLOUD_USERNAME", &username)
+            .env("KEI_DATA_DIR", &cookie_dir)
+            .args([
+                "--config",
+                import_config.to_str().unwrap(),
+                "import-existing",
+                "--password",
+                &password,
+                "--recent",
+                "5",
+            ])
             .timeout(std::time::Duration::from_secs(TIMEOUT_SYNC))
             .assert()
             .success()


### PR DESCRIPTION
## Summary
- Makes `import-existing` TOML-first for durable path, photo, and media matching settings.
- Removes import-only durable flags and env mirrors, while keeping one-off controls like `--dry-run`, `--recent`, `--force-empty`, `--no-progress-bar`, and `--library`.
- Adds `[import].strict` and `import-existing --strict` to verify an iCloud prefix before adopting same-name, same-size local files.
- Updates import stats, help, tests, migration docs, and changelog for the new strict refusal path.

Fixes #314.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- import-existing --help`
- `cargo test strict -- --test-threads=1`
- `cargo test build_import_download_config -- --test-threads=1`
- `cargo test --test cli -- --test-threads=1`
- `cargo test --test behavioral import_existing -- --test-threads=1`
- `git diff --check`
