### PR TITLE
v0.20 PR6 retry, UI, and metadata cleanup

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,6 +6,12 @@
 
 [advisories]
 ignore = [
+    # `paste 1.0.15` is pulled in by little_exif, which backs JPEG/TIFF
+    # EXIF writes when kei is built without the default `xmp` feature.
+    # The advisory is unmaintained-only, not a known vulnerability.
+    # Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
+    "RUSTSEC-2024-0436",
+
     # `rand 0.9.2` unsound with a custom logger. kei's direct
     # rand=0.10.1 is unaffected; the 0.9.2 copy reaches us only
     # transitively via reqwest -> quinn -> quinn-proto.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -258,6 +279,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -501,6 +543,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1426,6 +1483,7 @@ dependencies = [
  "indicatif",
  "keyring",
  "libc",
+ "little_exif",
  "memchr",
  "mp4-atom",
  "num-bigint",
@@ -1545,6 +1603,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "little_exif"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eeb58b22d31be8dc5c625004fcd4b9b385cd3c05df575f523bcca382c51122"
+dependencies = [
+ "brotli",
+ "crc",
+ "log",
+ "miniz_oxide",
+ "paste",
+ "quick-xml 0.37.5",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1663,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -1795,6 +1876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,7 +1923,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -1978,6 +2065,15 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ path = "src/main.rs"
 [features]
 # XMP metadata embedding + sidecar writing. Default-on; build with
 # `--no-default-features` on platforms where Adobe's vendored C++ XMP
-# Toolkit does not compile (notably FreeBSD — see #256). Disabling drops
-# the `--embed-xmp`, `--xmp-sidecar`, and `--set-exif-*` CLI flags and the
-# code paths behind them; HEIC container edits go with it because the
-# XMP packet serializer lives in xmp_toolkit.
+# Toolkit does not compile (notably FreeBSD — see #256). Disabling drops XMP
+# embedding, sidecars, and HEIC container edits; native JPEG/TIFF EXIF writes
+# remain available through little_exif.
 default = ["xmp"]
 xmp = ["dep:xmp_toolkit"]
 # Re-exports parser entry points for cargo-fuzz harnesses (`fuzz/`).
@@ -91,6 +90,10 @@ console = "0.16"
 # Optional (behind the `xmp` feature, default-on) so platforms without a
 # working C++ toolchain for the vendored sources can opt out. See #256.
 xmp_toolkit = { version = "1", optional = true }
+
+# Native EXIF writing used by `set_exif_*` settings, including builds that
+# disable the default `xmp` feature.
+little_exif = "0.6"
 
 # ISO-BMFF (MP4 / HEIF / HEIC) atom parsing + encoding. HEIC's XMP packet
 # lives in a `mime`-type item inside the `meta` box; mp4-atom gives us the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,7 @@ little_exif = "0.6"
 #           metadata embed on HDR HEICs (kei #269, #276)
 #   - #157  bound `Vec::with_capacity` in `parse_vorbis_comment` / `Avcc`,
 #           fixes the fuzz-found OOM (upstream #154)
-#   - #161  drops the unmaintained `paste` dep in favor of `pastey`,
-#           clearing RUSTSEC-2024-0436 (kei #310)
+#   - #161  drops mp4-atom's unmaintained `paste` dep in favor of `pastey`
 # Switch back to a crates.io version once a release containing these ships.
 mp4-atom = { git = "https://github.com/kixelated/mp4-atom", rev = "3366b08671a6d6d7292532b922d1973f6718d5a1" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ xmp = ["dep:xmp_toolkit"]
 # Off by default; production builds never see the `kei::__fuzz` module.
 __fuzz_internals = []
 
+[package.metadata.cargo-udeps.ignore]
+# Used only by no-default-features builds (`#[cfg(not(feature = "xmp"))]`).
+# The unused-deps CI job runs the default feature set, so cargo-udeps cannot
+# see the native EXIF path even though `cargo test --no-default-features`
+# exercises it.
+normal = ["little_exif"]
+
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1634,6 +1634,9 @@ mod tests {
 
             let flag = format!("--no-progress-bar={value}");
             assert!(Cli::try_parse_from(["kei", "sync", flag.as_str()]).is_err());
+
+            let flag = format!("--no-progress-bar={value}");
+            assert!(Cli::try_parse_from(["kei", flag.as_str(), "sync"]).is_err());
         }
     }
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,8 +206,8 @@ pub struct SyncArgs {
     pub dry_run: bool,
 
     /// Disable progress bar
-    #[arg(long, num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
-    pub no_progress_bar: Option<bool>,
+    #[arg(long)]
+    pub no_progress_bar: bool,
 
     /// Skip assets created before this ISO date or interval (e.g., 2025-01-02 or 20d)
     #[arg(long)]
@@ -627,9 +627,7 @@ impl SyncArgs {
             self.recent = fallback.recent;
         }
         self.dry_run = self.dry_run || fallback.dry_run;
-        if self.no_progress_bar.is_none() {
-            self.no_progress_bar = fallback.no_progress_bar;
-        }
+        self.no_progress_bar = self.no_progress_bar || fallback.no_progress_bar;
         if self.skip_created_before.is_none() {
             self.skip_created_before
                 .clone_from(&fallback.skip_created_before);
@@ -1624,7 +1622,19 @@ mod tests {
         let mut args = base_args();
         args.push("--no-progress-bar");
         let cli = parse(&args);
-        assert_eq!(cli.sync.no_progress_bar, Some(true));
+        assert!(cli.sync.no_progress_bar);
+    }
+    #[test]
+    fn test_no_progress_bar_rejects_value() {
+        for value in ["true", "false"] {
+            let mut args = base_args();
+            args.push("--no-progress-bar");
+            args.push(value);
+            assert!(Cli::try_parse_from(&args).is_err());
+
+            let flag = format!("--no-progress-bar={value}");
+            assert!(Cli::try_parse_from(["kei", "sync", flag.as_str()]).is_err());
+        }
     }
     #[test]
     fn test_keep_unicode_in_filenames_flag() {
@@ -2315,9 +2325,6 @@ mod tests {
     // are added: every flag in this list must (a) be parseable at the
     // top level, and (b) be rejected when combined with `status`.
     //
-    // Boolean flags declared with `num_args = 0..=1` must use the `=value`
-    // form when followed by a subcommand, otherwise clap eats the
-    // subcommand name as the flag's value.
     #[test]
     fn validate_rejects_each_sync_only_flag_with_status() {
         let cases: &[(&str, &[&str])] = &[
@@ -2325,7 +2332,7 @@ mod tests {
             ("skip_photos", &["--skip-photos=true"]),
             ("unfiled", &["--unfiled=true"]),
             ("force_size", &["--force-size=true"]),
-            ("no_progress_bar", &["--no-progress-bar=true"]),
+            ("no_progress_bar", &["--no-progress-bar"]),
             ("keep_unicode", &["--keep-unicode-in-filenames=true"]),
             ("notify_systemd", &["--notify-systemd=true"]),
             ("dry_run", &["--dry-run"]),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1627,15 +1627,14 @@ mod tests {
     #[test]
     fn test_no_progress_bar_rejects_value() {
         for value in ["true", "false"] {
+            let flag = format!("--no-progress-bar={value}");
+
             let mut args = base_args();
             args.push("--no-progress-bar");
             args.push(value);
             assert!(Cli::try_parse_from(&args).is_err());
 
-            let flag = format!("--no-progress-bar={value}");
             assert!(Cli::try_parse_from(["kei", "sync", flag.as_str()]).is_err());
-
-            let flag = format!("--no-progress-bar={value}");
             assert!(Cli::try_parse_from(["kei", flag.as_str(), "sync"]).is_err());
         }
     }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1313,13 +1313,9 @@ mod wiremock_tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1339,9 +1339,8 @@ impl Config {
             overrides.xmp_sidecar,
             toml_metadata.and_then(|m| m.xmp_sidecar),
         );
-        let no_progress_bar = sync
-            .no_progress_bar
-            .unwrap_or_else(|| !toml_ui.and_then(|u| u.progress_bar).unwrap_or(true));
+        let no_progress_bar =
+            sync.no_progress_bar || !toml_ui.and_then(|u| u.progress_bar).unwrap_or(true);
 
         // Re-validate; clap range attrs run on CLI only.
         let max_retries = resolve(
@@ -4646,7 +4645,7 @@ mod tests {
         // for tests and internal call sites.
         let mut sync = default_sync();
         sync.config_overrides.set_exif_datetime = Some(true);
-        sync.no_progress_bar = Some(true);
+        sync.no_progress_bar = true;
         sync.config_overrides.skip_videos = Some(true);
         sync.config_overrides.live_photo_mode = Some(LivePhotoMode::Skip);
         sync.config_overrides.force_resolution = Some(true);
@@ -5621,7 +5620,7 @@ mod tests {
     fn test_no_progress_bar_cli_overrides_toml_progress_bar_true() {
         let parsed: TomlConfig = toml::from_str("[ui]\nprogress_bar = true\n").unwrap();
         let mut sync = default_sync();
-        sync.no_progress_bar = Some(true);
+        sync.no_progress_bar = true;
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&parsed)).unwrap();
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub(crate) struct TomlConfig {
     pub filters: Option<TomlFilters>,
     pub photos: Option<TomlPhotos>,
     pub import: Option<TomlImport>,
+    pub metadata: Option<TomlMetadata>,
     pub watch: Option<TomlWatch>,
     pub notifications: Option<TomlNotifications>,
     pub server: Option<TomlServer>,
@@ -36,6 +37,9 @@ pub(crate) struct TomlUi {
     /// `--log-level` / `RUST_LOG` contexts. The CLI flags `--friendly` and
     /// `--no-friendly` override this value for one invocation.
     pub friendly: Option<bool>,
+    /// Durable progress-bar default. Defaults to true. The CLI
+    /// `--no-progress-bar` flag remains a one-run disable override.
+    pub progress_bar: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -73,32 +77,31 @@ pub(crate) struct TomlDownload {
     pub threads: Option<u16>,
     pub bandwidth_limit: Option<String>,
     pub temp_suffix: Option<String>,
-    #[cfg(feature = "xmp")]
-    pub set_exif_datetime: Option<bool>,
-    #[cfg(feature = "xmp")]
-    pub set_exif_rating: Option<bool>,
-    #[cfg(feature = "xmp")]
-    pub set_exif_gps: Option<bool>,
-    #[cfg(feature = "xmp")]
-    pub set_exif_description: Option<bool>,
-    #[cfg(feature = "xmp")]
-    pub embed_xmp: Option<bool>,
-    #[cfg(feature = "xmp")]
-    pub xmp_sidecar: Option<bool>,
-    pub no_progress_bar: Option<bool>,
     pub retry: Option<TomlRetry>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TomlRetry {
-    pub max_retries: Option<u32>,
+    /// Retries within a single transfer.
+    pub per_transfer: Option<u32>,
     /// Lifetime cap on download attempts per asset across syncs (default
-    /// `10`). The same value as the `--max-download-attempts` CLI flag /
-    /// `KEI_MAX_DOWNLOAD_ATTEMPTS` env var; CLI > TOML > default. Distinct
-    /// from `max_retries`, which only caps retries within a single
-    /// download. `0` disables the cap.
-    pub max_download_attempts: Option<u32>,
+    /// `10`). Distinct from `per_transfer`, which only caps retries within a
+    /// single download. `0` disables the cap.
+    pub per_asset: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlMetadata {
+    pub set_exif_datetime: Option<bool>,
+    pub set_exif_rating: Option<bool>,
+    pub set_exif_gps: Option<bool>,
+    pub set_exif_description: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub embed_xmp: Option<bool>,
+    #[cfg(feature = "xmp")]
+    pub xmp_sidecar: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -241,13 +244,9 @@ pub(crate) struct SyncConfigOverrides {
     pub folder_structure: Option<String>,
     pub folder_structure_albums: Option<String>,
     pub folder_structure_smart_folders: Option<String>,
-    #[cfg(feature = "xmp")]
     pub set_exif_datetime: Option<bool>,
-    #[cfg(feature = "xmp")]
     pub set_exif_rating: Option<bool>,
-    #[cfg(feature = "xmp")]
     pub set_exif_gps: Option<bool>,
-    #[cfg(feature = "xmp")]
     pub set_exif_description: Option<bool>,
     #[cfg(feature = "xmp")]
     pub embed_xmp: Option<bool>,
@@ -371,13 +370,9 @@ pub struct UiConfig {
 
 #[derive(Debug)]
 pub struct MetadataConfig {
-    #[cfg(feature = "xmp")]
     pub set_exif_datetime: bool,
-    #[cfg(feature = "xmp")]
     pub set_exif_rating: bool,
-    #[cfg(feature = "xmp")]
     pub set_exif_gps: bool,
-    #[cfg(feature = "xmp")]
     pub set_exif_description: bool,
     #[cfg(feature = "xmp")]
     pub embed_xmp: bool,
@@ -1045,13 +1040,13 @@ pub(crate) fn resolve_notify_systemd(
     cli.or(toml).unwrap_or(notify_socket_present)
 }
 
-/// Smart initial retry delay (seconds) derived from `--max-retries`.
+/// Smart initial retry delay (seconds) derived from retry `per_transfer`.
 ///
 /// Higher max implies the user is patient and wants retries to give failing
 /// services time to recover (rate limits, 5xx, slow endpoints). Lower max
 /// implies "fail fast" and retries should be quick.
 ///
-/// `max_retries == 0` means no retries happen so the delay is irrelevant;
+/// `per_transfer == 0` means no retries happen so the delay is irrelevant;
 /// returns 5 (within the validation range) as a non-load-bearing placeholder.
 pub(crate) fn smart_retry_delay(max_retries: u32) -> u64 {
     match max_retries {
@@ -1256,6 +1251,8 @@ impl Config {
         let toml_filters = toml.and_then(|t| t.filters.as_ref());
         let toml_photos = toml.and_then(|t| t.photos.as_ref());
         let toml_import = toml.and_then(|t| t.import.as_ref());
+        let toml_metadata = toml.and_then(|t| t.metadata.as_ref());
+        let toml_ui = toml.and_then(|t| t.ui.as_ref());
         let toml_watch = toml.and_then(|t| t.watch.as_ref());
         let toml_server = toml.and_then(|t| t.server.as_ref());
 
@@ -1319,42 +1316,42 @@ impl Config {
             toml_dl.and_then(|d| d.temp_suffix.clone()),
             ".kei-tmp".to_string(),
         );
-        #[cfg(feature = "xmp")]
         let set_exif_datetime = resolve_flag(
             overrides.set_exif_datetime,
-            toml_dl.and_then(|d| d.set_exif_datetime),
+            toml_metadata.and_then(|m| m.set_exif_datetime),
         );
-        #[cfg(feature = "xmp")]
         let set_exif_rating = resolve_flag(
             overrides.set_exif_rating,
-            toml_dl.and_then(|d| d.set_exif_rating),
+            toml_metadata.and_then(|m| m.set_exif_rating),
         );
-        #[cfg(feature = "xmp")]
-        let set_exif_gps =
-            resolve_flag(overrides.set_exif_gps, toml_dl.and_then(|d| d.set_exif_gps));
-        #[cfg(feature = "xmp")]
+        let set_exif_gps = resolve_flag(
+            overrides.set_exif_gps,
+            toml_metadata.and_then(|m| m.set_exif_gps),
+        );
         let set_exif_description = resolve_flag(
             overrides.set_exif_description,
-            toml_dl.and_then(|d| d.set_exif_description),
+            toml_metadata.and_then(|m| m.set_exif_description),
         );
         #[cfg(feature = "xmp")]
-        let embed_xmp = resolve_flag(overrides.embed_xmp, toml_dl.and_then(|d| d.embed_xmp));
+        let embed_xmp = resolve_flag(overrides.embed_xmp, toml_metadata.and_then(|m| m.embed_xmp));
         #[cfg(feature = "xmp")]
-        let xmp_sidecar = resolve_flag(overrides.xmp_sidecar, toml_dl.and_then(|d| d.xmp_sidecar));
-        let no_progress_bar = resolve_flag(
-            sync.no_progress_bar,
-            toml_dl.and_then(|d| d.no_progress_bar),
+        let xmp_sidecar = resolve_flag(
+            overrides.xmp_sidecar,
+            toml_metadata.and_then(|m| m.xmp_sidecar),
         );
+        let no_progress_bar = sync
+            .no_progress_bar
+            .unwrap_or_else(|| !toml_ui.and_then(|u| u.progress_bar).unwrap_or(true));
 
         // Re-validate; clap range attrs run on CLI only.
         let max_retries = resolve(
             overrides.max_retries,
-            toml_retry.and_then(|r| r.max_retries),
+            toml_retry.and_then(|r| r.per_transfer),
             3,
         );
         anyhow::ensure!(
             max_retries <= 100,
-            "retry max_retries must be <= 100, got {max_retries}"
+            "retry per_transfer must be <= 100, got {max_retries}"
         );
         // Lifetime cap on download attempts per asset (0 disables). CLI >
         // TOML > 10, matching every other resolved value. The runtime
@@ -1362,7 +1359,7 @@ impl Config {
         // when this is 0, so 0 is a valid (cap-off) sentinel.
         let max_download_attempts = resolve(
             overrides.max_download_attempts,
-            toml_retry.and_then(|r| r.max_download_attempts),
+            toml_retry.and_then(|r| r.per_asset),
             10,
         );
         let retry_delay_secs = smart_retry_delay(max_retries);
@@ -1664,13 +1661,9 @@ impl Config {
                 friendly_request,
             },
             metadata: MetadataConfig {
-                #[cfg(feature = "xmp")]
                 set_exif_datetime,
-                #[cfg(feature = "xmp")]
                 set_exif_rating,
-                #[cfg(feature = "xmp")]
                 set_exif_gps,
-                #[cfg(feature = "xmp")]
                 set_exif_description,
                 #[cfg(feature = "xmp")]
                 embed_xmp,
@@ -1742,54 +1735,13 @@ impl Config {
                 } else {
                     Some(self.download.temp_suffix.clone())
                 },
-                #[cfg(feature = "xmp")]
-                set_exif_datetime: if self.metadata.set_exif_datetime {
-                    Some(true)
-                } else {
-                    None
-                },
-                #[cfg(feature = "xmp")]
-                set_exif_rating: if self.metadata.set_exif_rating {
-                    Some(true)
-                } else {
-                    None
-                },
-                #[cfg(feature = "xmp")]
-                set_exif_gps: if self.metadata.set_exif_gps {
-                    Some(true)
-                } else {
-                    None
-                },
-                #[cfg(feature = "xmp")]
-                set_exif_description: if self.metadata.set_exif_description {
-                    Some(true)
-                } else {
-                    None
-                },
-                #[cfg(feature = "xmp")]
-                embed_xmp: if self.metadata.embed_xmp {
-                    Some(true)
-                } else {
-                    None
-                },
-                #[cfg(feature = "xmp")]
-                xmp_sidecar: if self.metadata.xmp_sidecar {
-                    Some(true)
-                } else {
-                    None
-                },
-                no_progress_bar: if self.download.no_progress_bar {
-                    Some(true)
-                } else {
-                    None
-                },
                 retry: Some(TomlRetry {
-                    max_retries: Some(self.retry.max_retries),
-                    // Emit `max_download_attempts` only when the user has
+                    per_transfer: Some(self.retry.max_retries),
+                    // Emit `per_asset` only when the user has
                     // overridden the default of 10. Keeps the round-trip
                     // clean for the common case and surfaces explicit
                     // overrides in `kei config show`.
-                    max_download_attempts: if self.retry.max_download_attempts == 10 {
+                    per_asset: if self.retry.max_download_attempts == 10 {
                         None
                     } else {
                         Some(self.retry.max_download_attempts)
@@ -1908,6 +1860,57 @@ impl Config {
             } else {
                 None
             },
+            metadata: if self.metadata.set_exif_datetime
+                || self.metadata.set_exif_rating
+                || self.metadata.set_exif_gps
+                || self.metadata.set_exif_description
+                || {
+                    #[cfg(feature = "xmp")]
+                    {
+                        self.metadata.embed_xmp || self.metadata.xmp_sidecar
+                    }
+                    #[cfg(not(feature = "xmp"))]
+                    {
+                        false
+                    }
+                } {
+                Some(TomlMetadata {
+                    set_exif_datetime: if self.metadata.set_exif_datetime {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                    set_exif_rating: if self.metadata.set_exif_rating {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                    set_exif_gps: if self.metadata.set_exif_gps {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                    set_exif_description: if self.metadata.set_exif_description {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                    #[cfg(feature = "xmp")]
+                    embed_xmp: if self.metadata.embed_xmp {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                    #[cfg(feature = "xmp")]
+                    xmp_sidecar: if self.metadata.xmp_sidecar {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                })
+            } else {
+                None
+            },
             watch: if self.watch.interval.is_some()
                 || self.watch.notify_systemd
                 || self.watch.pid_file.is_some()
@@ -1954,13 +1957,20 @@ impl Config {
             report: self.report.json.as_ref().map(|p| TomlReport {
                 json: Some(p.display().to_string()),
             }),
-            // Only emit `[ui]` when the user actually expressed a preference.
-            // Omitting the section when `friendly_request` is `None` keeps
-            // `kei config show` output unchanged for users who never opted
-            // in or out, and lets the default-on-for-TTY policy apply.
-            ui: self.ui.friendly_request.map(|friendly| TomlUi {
-                friendly: Some(friendly),
-            }),
+            // Only emit `[ui]` when the user actually expressed a preference
+            // or disabled the durable progress bar default.
+            ui: if self.ui.friendly_request.is_some() || self.download.no_progress_bar {
+                Some(TomlUi {
+                    friendly: self.ui.friendly_request,
+                    progress_bar: if self.download.no_progress_bar {
+                        Some(false)
+                    } else {
+                        None
+                    },
+                })
+            } else {
+                None
+            },
         }
     }
 }
@@ -2024,24 +2034,12 @@ pub(crate) fn persist_first_run_config(
             threads: None,
             bandwidth_limit: None,
             temp_suffix: None,
-            #[cfg(feature = "xmp")]
-            set_exif_datetime: None,
-            #[cfg(feature = "xmp")]
-            set_exif_rating: None,
-            #[cfg(feature = "xmp")]
-            set_exif_gps: None,
-            #[cfg(feature = "xmp")]
-            set_exif_description: None,
-            #[cfg(feature = "xmp")]
-            embed_xmp: None,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: None,
-            no_progress_bar: None,
             retry: None,
         }),
         filters: None,
         photos: None,
         import: None,
+        metadata: None,
         watch: None,
         notifications: None,
         server: None,
@@ -2314,10 +2312,9 @@ mod tests {
             folder_structure = "%Y/%m/%d"
             threads = 10
             temp_suffix = ".kei-tmp"
-            no_progress_bar = false
 
             [download.retry]
-            max_retries = 3
+            per_transfer = 3
 
             [filters]
             libraries = ["PrimarySync"]
@@ -2350,7 +2347,7 @@ mod tests {
         assert_eq!(dl.threads, Some(10));
 
         let retry = dl.retry.unwrap();
-        assert_eq!(retry.max_retries, Some(3));
+        assert_eq!(retry.per_transfer, Some(3));
 
         let filters = config.filters.unwrap();
         assert_eq!(filters.albums, Some(vec!["Favorites".to_string()]));
@@ -2395,11 +2392,11 @@ mod tests {
     fn test_toml_nested_retry() {
         let toml_str = r#"
             [download.retry]
-            max_retries = 5
+            per_transfer = 5
         "#;
         let config: TomlConfig = toml::from_str(toml_str).unwrap();
         let retry = config.download.unwrap().retry.unwrap();
-        assert_eq!(retry.max_retries, Some(5));
+        assert_eq!(retry.per_transfer, Some(5));
     }
 
     #[test]
@@ -2973,11 +2970,10 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_boolean_flag_from_toml() {
         let toml_str = r#"
-            [download]
+            [metadata]
             set_exif_datetime = true
 
             [filters]
@@ -2999,7 +2995,7 @@ mod tests {
     #[test]
     fn test_build_embed_xmp_and_sidecar_from_toml() {
         let toml_str = r#"
-            [download]
+            [metadata]
             embed_xmp = true
             xmp_sidecar = true
         "#;
@@ -3019,7 +3015,7 @@ mod tests {
     #[test]
     fn test_cli_embed_xmp_overrides_toml() {
         let toml_str = r#"
-            [download]
+            [metadata]
             embed_xmp = true
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
@@ -3213,7 +3209,7 @@ mod tests {
     fn test_build_max_retries_above_upper_bound_from_toml_rejected() {
         let toml_str = r#"
             [download.retry]
-            max_retries = 9999
+            per_transfer = 9999
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let result = Config::build(
@@ -3222,11 +3218,11 @@ mod tests {
             default_sync(),
             Some(&toml),
         );
-        assert!(result.is_err(), "TOML max_retries > 100 must be rejected");
+        assert!(result.is_err(), "TOML per_transfer > 100 must be rejected");
         let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("max_retries") && msg.contains("100"),
-            "Error should mention max_retries and the bound: {msg}"
+            msg.contains("per_transfer") && msg.contains("100"),
+            "Error should mention per_transfer and the bound: {msg}"
         );
     }
 
@@ -3234,7 +3230,7 @@ mod tests {
     fn test_build_retry_clamp_accepts_upper_bound_from_toml() {
         let toml_str = r#"
             [download.retry]
-            max_retries = 100
+            per_transfer = 100
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
@@ -3243,7 +3239,7 @@ mod tests {
             default_sync(),
             Some(&toml),
         )
-        .expect("max_retries=100 must be accepted");
+        .expect("per_transfer=100 must be accepted");
         assert_eq!(cfg.retry.max_retries, 100);
         assert_eq!(cfg.retry.retry_delay_secs, 30);
     }
@@ -3630,7 +3626,6 @@ mod tests {
         assert_eq!(config.auth.unwrap().password.as_deref(), Some("secret"));
     }
 
-    #[cfg(feature = "xmp")]
     #[test]
     fn test_toml_download_all_fields() {
         let toml_str = r#"
@@ -3639,8 +3634,12 @@ mod tests {
             folder_structure = "%Y-%m"
             threads = 4
             temp_suffix = ".part"
+
+            [metadata]
             set_exif_datetime = true
-            no_progress_bar = true
+
+            [ui]
+            progress_bar = false
         "#;
         let config: TomlConfig = toml::from_str(toml_str).unwrap();
         let dl = config.download.unwrap();
@@ -3648,8 +3647,8 @@ mod tests {
         assert_eq!(dl.folder_structure.as_deref(), Some("%Y-%m"));
         assert_eq!(dl.threads, Some(4));
         assert_eq!(dl.temp_suffix.as_deref(), Some(".part"));
-        assert_eq!(dl.set_exif_datetime, Some(true));
-        assert_eq!(dl.no_progress_bar, Some(true));
+        assert_eq!(config.metadata.unwrap().set_exif_datetime, Some(true));
+        assert_eq!(config.ui.unwrap().progress_bar, Some(false));
     }
 
     #[test]
@@ -3975,7 +3974,6 @@ mod tests {
         assert_eq!(cfg.download.folder_structure, "%Y/%m/%d");
         assert_eq!(cfg.download.threads_num, 10);
         assert_eq!(cfg.download.temp_suffix, ".kei-tmp");
-        #[cfg(feature = "xmp")]
         assert!(!cfg.metadata.set_exif_datetime);
         assert!(!cfg.download.no_progress_bar);
         // Retry
@@ -4125,7 +4123,7 @@ mod tests {
     fn test_build_max_retries_cli_overrides_toml() {
         let toml_str = r#"
             [download.retry]
-            max_retries = 5
+            per_transfer = 5
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
@@ -4153,7 +4151,7 @@ mod tests {
         // TOML-only: resolved value matches the TOML setting.
         let toml_str = r#"
             [download.retry]
-            max_download_attempts = 25
+            per_asset = 25
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
@@ -4171,7 +4169,7 @@ mod tests {
         // CLI flag wins over TOML, mirroring every other resolved value.
         let toml_str = r#"
             [download.retry]
-            max_download_attempts = 25
+            per_asset = 25
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let mut sync = default_sync();
@@ -4187,7 +4185,7 @@ mod tests {
         // must accept it through TOML the same as through CLI.
         let toml_str = r#"
             [download.retry]
-            max_download_attempts = 0
+            per_asset = 0
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
@@ -4214,7 +4212,7 @@ mod tests {
         assert_eq!(cfg.retry.max_download_attempts, 10);
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
-        assert_eq!(retry.max_download_attempts, None);
+        assert_eq!(retry.per_asset, None);
     }
 
     #[test]
@@ -4225,7 +4223,7 @@ mod tests {
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
-        assert_eq!(retry.max_download_attempts, Some(42));
+        assert_eq!(retry.per_asset, Some(42));
     }
 
     #[test]
@@ -4565,18 +4563,53 @@ mod tests {
         }
     }
 
+    #[test]
+    fn old_retry_toml_names_are_rejected() {
+        for key in ["max_retries", "max_download_attempts"] {
+            let toml = format!("[download.retry]\n{key} = 3\n");
+            let err = toml::from_str::<TomlConfig>(&toml)
+                .expect_err(&format!("old download.retry.{key} key should hard-error"));
+            assert!(
+                err.message().contains(&format!("unknown field `{key}`")),
+                "unexpected error for {key}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn old_download_metadata_and_progress_names_are_rejected() {
+        for key in [
+            "set_exif_datetime",
+            "set_exif_rating",
+            "set_exif_gps",
+            "set_exif_description",
+            "embed_xmp",
+            "xmp_sidecar",
+            "no_progress_bar",
+        ] {
+            let toml = format!("[download]\n{key} = true\n");
+            let err = toml::from_str::<TomlConfig>(&toml)
+                .expect_err(&format!("old download.{key} key should hard-error"));
+            assert!(
+                err.message().contains(&format!("unknown field `{key}`")),
+                "unexpected error for {key}: {err}"
+            );
+        }
+    }
+
     // ── Config::build: boolean/media merge exhaustive ─────────────
 
-    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_from_toml() {
         // `media` replaces the old durable skip booleans. This keeps the
         // test anchored to the TOML-first filter surface while still checking
         // the derived runtime skip flags.
         let toml_str = r#"
-            [download]
+            [metadata]
             set_exif_datetime = true
-            no_progress_bar = true
+
+            [ui]
+            progress_bar = false
 
             [filters]
             media = ["photos", "live-photos"]
@@ -4607,7 +4640,6 @@ mod tests {
         assert!(cfg.watch.notify_systemd);
     }
 
-    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_cli_overrides() {
         // Programmatic skip overrides still feed the same media owner type
@@ -4924,11 +4956,15 @@ mod tests {
             folder_structure = "%Y"
             threads = 2
             temp_suffix = ".full-tmp"
+
+            [metadata]
             set_exif_datetime = true
-            no_progress_bar = true
+
+            [ui]
+            progress_bar = false
 
             [download.retry]
-            max_retries = 1
+            per_transfer = 1
 
             [filters]
             libraries = ["SharedSync-FULL"]
@@ -5480,12 +5516,14 @@ mod tests {
             filters: None,
             photos: None,
             import: None,
+            metadata: None,
             watch: None,
             notifications: None,
             server: None,
             report: None,
             ui: Some(TomlUi {
                 friendly: Some(true),
+                progress_bar: None,
             }),
         };
         let cfg = Config::build(
@@ -5514,12 +5552,14 @@ mod tests {
             filters: None,
             photos: None,
             import: None,
+            metadata: None,
             watch: None,
             notifications: None,
             server: None,
             report: None,
             ui: Some(TomlUi {
                 friendly: Some(false),
+                progress_bar: None,
             }),
         };
         let cfg = Config::build(
@@ -5538,12 +5578,68 @@ mod tests {
     }
 
     #[test]
+    fn test_config_build_defaults_progress_bar_enabled() {
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            !cfg.download.no_progress_bar,
+            "progress bar should be enabled by default"
+        );
+        assert!(
+            cfg.to_toml().ui.is_none(),
+            "default progress-bar behavior should not create [ui]"
+        );
+    }
+
+    #[test]
+    fn test_config_build_captures_toml_progress_bar_false() {
+        let parsed: TomlConfig = toml::from_str("[ui]\nprogress_bar = false\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&parsed),
+        )
+        .unwrap();
+        assert!(
+            cfg.download.no_progress_bar,
+            "[ui].progress_bar = false should durably disable progress"
+        );
+        assert_eq!(
+            cfg.to_toml().ui.and_then(|u| u.progress_bar),
+            Some(false),
+            "to_toml should round-trip the durable progress-bar opt-out"
+        );
+    }
+
+    #[test]
+    fn test_no_progress_bar_cli_overrides_toml_progress_bar_true() {
+        let parsed: TomlConfig = toml::from_str("[ui]\nprogress_bar = true\n").unwrap();
+        let mut sync = default_sync();
+        sync.no_progress_bar = Some(true);
+        let cfg =
+            Config::build(&default_globals(), &default_password(), sync, Some(&parsed)).unwrap();
+        assert!(
+            cfg.download.no_progress_bar,
+            "--no-progress-bar should disable progress for this run even when TOML enables it"
+        );
+    }
+
+    #[test]
     fn test_toml_ui_parses_friendly_key() {
         let parsed: TomlConfig = toml::from_str("[ui]\nfriendly = false\n").unwrap();
         assert_eq!(parsed.ui.unwrap().friendly, Some(false));
 
         let parsed: TomlConfig = toml::from_str("[ui]\nfriendly = true\n").unwrap();
         assert_eq!(parsed.ui.unwrap().friendly, Some(true));
+
+        let parsed: TomlConfig = toml::from_str("[ui]\nprogress_bar = false\n").unwrap();
+        assert_eq!(parsed.ui.unwrap().progress_bar, Some(false));
 
         let empty: TomlConfig = toml::from_str("").unwrap();
         assert!(empty.ui.is_none());
@@ -5782,6 +5878,7 @@ mod tests {
             filters: None,
             photos: None,
             import: None,
+            metadata: None,
             watch: None,
             notifications: None,
             server: None,
@@ -5808,6 +5905,7 @@ mod tests {
             filters: None,
             photos: None,
             import: None,
+            metadata: None,
             watch: None,
             notifications: None,
             server: None,
@@ -6595,7 +6693,7 @@ mod tests {
         assert!(!resolve_notify_systemd(None, None, false));
     }
 
-    // ── Smart retry delay from max_retries ────────────────────────────
+    // ── Smart retry delay from per_transfer ───────────────────────────
 
     #[test]
     fn test_smart_retry_delay_table() {
@@ -6613,7 +6711,7 @@ mod tests {
 
     #[test]
     fn test_build_retry_delay_smart_default_from_max_retries() {
-        // No explicit retry-delay anywhere; max_retries=5 should pull the
+        // No explicit retry-delay anywhere; per_transfer=5 should pull the
         // 4..=6 bucket from the smart table (10s).
         let mut sync = default_sync();
         sync.config_overrides.max_retries = Some(5);
@@ -6639,14 +6737,14 @@ mod tests {
 
     #[test]
     fn test_to_toml_omits_delay_when_matches_smart_default() {
-        // Smart default for max_retries=3 is 5. to_toml should NOT write
+        // Smart default for per_transfer=3 is 5. to_toml should NOT write
         // `delay = 5` back out because it's redundant (and deprecated).
         let mut sync = default_sync();
         sync.config_overrides.max_retries = Some(3);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
         let toml = cfg.to_toml();
         let retry = toml.download.unwrap().retry.unwrap();
-        assert_eq!(retry.max_retries, Some(3));
+        assert_eq!(retry.per_transfer, Some(3));
     }
 
     #[test]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -2154,6 +2154,36 @@ mod native_tests {
                 _ => None,
             });
         assert_eq!(description, Some("Beach day"));
+
+        let rating = metadata
+            .get_tag(&ExifTag::UnknownINT16U(
+                Vec::new(),
+                WINDOWS_RATING_TAG,
+                ExifTagGroup::GENERIC,
+            ))
+            .next()
+            .and_then(|tag| match tag {
+                ExifTag::UnknownINT16U(values, tag, _) if *tag == WINDOWS_RATING_TAG => {
+                    values.first().copied()
+                }
+                _ => None,
+            });
+        assert_eq!(rating, Some(5));
+
+        let rating_percent = metadata
+            .get_tag(&ExifTag::UnknownINT16U(
+                Vec::new(),
+                WINDOWS_RATING_PERCENT_TAG,
+                ExifTagGroup::GENERIC,
+            ))
+            .next()
+            .and_then(|tag| match tag {
+                ExifTag::UnknownINT16U(values, tag, _) if *tag == WINDOWS_RATING_PERCENT_TAG => {
+                    values.first().copied()
+                }
+                _ => None,
+            });
+        assert_eq!(rating_percent, Some(99));
     }
 
     #[test]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -1,32 +1,47 @@
 //! Embedded metadata (XMP + native EXIF/IPTC reconciliation).
 //!
-//! For JPEG / PNG / TIFF / MP4 / MOV, the writer runs through
-//! [`xmp_toolkit::XmpFile`] — Adobe's vendored XMPFiles implementation, which
-//! also reconciles XMP with native EXIF/IPTC blocks so consumers that read
-//! only EXIF still see values like `Rating`, GPS, and `DateTimeOriginal`.
+//! With the default `xmp` feature, JPEG / PNG / TIFF / MP4 / MOV run through
+//! Adobe's XMPFiles implementation, which reconciles XMP with native EXIF/IPTC
+//! blocks so EXIF-only consumers still see values like `Rating`, GPS, and
+//! `DateTimeOriginal`. HEIC / HEIF / AVIF route through the ISO-BMFF helper in
+//! [`super::heif`].
 //!
-//! HEIC / HEIF / AVIF have no XMP Toolkit handler, so those formats route
-//! through [`super::heif`], which edits the ISO-BMFF container directly with
-//! [`mp4_atom`]. Both paths build the XMP packet via the same
-//! [`apply_to_xmp`] helper, so the embedded content is identical.
+//! Without the `xmp` feature, kei still writes the native EXIF subset supported
+//! by `little_exif` for JPEG/TIFF and quietly skips formats that need XMP
+//! serialization.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+#[cfg(feature = "xmp")]
 use std::sync::Once;
 
 use anyhow::{Context, Result};
+#[cfg(not(feature = "xmp"))]
+use little_exif::exif_tag::ExifTag;
+#[cfg(not(feature = "xmp"))]
+use little_exif::filetype::FileExtension;
+#[cfg(not(feature = "xmp"))]
+use little_exif::metadata::Metadata;
+#[cfg(not(feature = "xmp"))]
+use little_exif::rational::uR64;
+#[cfg(feature = "xmp")]
 use xmp_toolkit::{xmp_ns, OpenFileOptions, XmpFile, XmpMeta, XmpValue};
 
+#[cfg(feature = "xmp")]
 use super::heif;
 use crate::fs_util::atomic_install;
 
 /// Custom XMP namespace for kei-specific fields that don't fit standard
 /// schemas (`hidden`, `archived`, `mediaSubtype`, `burstId`). Consumers that
 /// care about these know to look for the `kei` prefix.
+#[cfg(feature = "xmp")]
 const KEI_XMP_NS: &str = "https://github.com/rhoopr/kei/ns/1.0/";
+#[cfg(feature = "xmp")]
 const KEI_XMP_PREFIX: &str = "kei";
 
+#[cfg(feature = "xmp")]
 static INIT: Once = Once::new();
 
+#[cfg(feature = "xmp")]
 fn ensure_initialized() {
     INIT.call_once(|| {
         // Registering the same namespace twice is fine; XMP Toolkit returns
@@ -37,7 +52,7 @@ fn ensure_initialized() {
 }
 
 /// Snapshot of existing metadata fields that gate write decisions. Populated
-/// from whatever XMP Toolkit sees in the file (XMP + reconciled EXIF/IPTC).
+/// from XMP Toolkit in default builds or native EXIF in no-`xmp` builds.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ExifProbe {
     pub(crate) datetime_original: Option<String>,
@@ -56,6 +71,18 @@ pub(crate) struct ExifProbe {
 /// (today's behavior); callers gate retries on the planned write being
 /// non-empty, so a false-negative probe is recoverable.
 pub(crate) fn probe_exif(path: &Path) -> Result<ExifProbe> {
+    #[cfg(feature = "xmp")]
+    {
+        probe_exif_xmp(path)
+    }
+    #[cfg(not(feature = "xmp"))]
+    {
+        Ok(probe_exif_native(path))
+    }
+}
+
+#[cfg(feature = "xmp")]
+fn probe_exif_xmp(path: &Path) -> Result<ExifProbe> {
     ensure_initialized();
     if is_heif_file(path) {
         Ok(probe_exif_heif(path))
@@ -64,6 +91,7 @@ pub(crate) fn probe_exif(path: &Path) -> Result<ExifProbe> {
     }
 }
 
+#[cfg(feature = "xmp")]
 fn probe_exif_xmp_toolkit(path: &Path) -> Result<ExifProbe> {
     let mut file = XmpFile::new().context("creating XmpFile handle")?;
     if file
@@ -78,6 +106,7 @@ fn probe_exif_xmp_toolkit(path: &Path) -> Result<ExifProbe> {
     Ok(probe_from_meta(&meta))
 }
 
+#[cfg(feature = "xmp")]
 fn probe_exif_heif(path: &Path) -> ExifProbe {
     let bytes = match std::fs::read(path) {
         Ok(b) => b,
@@ -102,12 +131,45 @@ fn probe_exif_heif(path: &Path) -> ExifProbe {
     }
 }
 
+#[cfg(feature = "xmp")]
 fn probe_from_meta(meta: &XmpMeta) -> ExifProbe {
     let datetime_original = meta
         .property(xmp_ns::EXIF, "DateTimeOriginal")
         .map(|v| v.value);
     let has_gps = meta.contains_property(xmp_ns::EXIF, "GPSLatitude")
         || meta.contains_property(xmp_ns::EXIF, "GPSLongitude");
+    ExifProbe {
+        datetime_original,
+        has_gps,
+    }
+}
+
+#[cfg(not(feature = "xmp"))]
+fn probe_exif_native(path: &Path) -> ExifProbe {
+    let Ok(input) = std::fs::read(path) else {
+        return ExifProbe::default();
+    };
+    let Some(file_type) = native_file_type(&input, path) else {
+        return ExifProbe::default();
+    };
+    let Ok(meta) = Metadata::new_from_vec(&input, file_type) else {
+        return ExifProbe::default();
+    };
+    let datetime_original = meta
+        .get_tag(&ExifTag::DateTimeOriginal(String::new()))
+        .next()
+        .and_then(|tag| match tag {
+            ExifTag::DateTimeOriginal(s) => Some(s.clone()),
+            _ => None,
+        });
+    let has_gps = meta
+        .get_tag(&ExifTag::GPSLatitude(Vec::new()))
+        .next()
+        .is_some()
+        || meta
+            .get_tag(&ExifTag::GPSLongitude(Vec::new()))
+            .next()
+            .is_some();
     ExifProbe {
         datetime_original,
         has_gps,
@@ -158,12 +220,13 @@ impl MetadataWrite {
     }
 }
 
-/// Write the requested metadata into the file's XMP packet, with EXIF/IPTC
-/// reconciliation where the container supports it.
+/// Write the requested metadata into the file, using XMP Toolkit/HEIF packet
+/// rewriting in default builds and native EXIF for JPEG/TIFF in no-`xmp`
+/// builds.
 ///
-/// Atomic: we copy the input to a sibling `.meta-tmp`, patch it in place,
-/// then rename over the target. A crash mid-write leaves the original
-/// untouched.
+/// Atomic: we copy the input to a sibling temp file named with `temp_suffix`,
+/// patch it in place, then rename over the target. A crash mid-write leaves the
+/// original untouched.
 ///
 /// Dispatch is content-based: the first 12 bytes are inspected for an
 /// ISO-BMFF `ftyp` box with a HEIF-family brand. The download pipeline
@@ -172,14 +235,19 @@ impl MetadataWrite {
 /// back to extension-based dispatch only when the read itself fails, so
 /// callers operating on a transient/unreadable file degrade to today's
 /// behavior rather than spuriously routing everything to XMP Toolkit.
-pub(crate) fn apply_metadata(path: &Path, write: &MetadataWrite) -> Result<()> {
+pub(crate) fn apply_metadata(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
     if write.is_empty() {
         return Ok(());
     }
+    #[cfg(not(feature = "xmp"))]
+    {
+        return apply_metadata_native(path, write, temp_suffix);
+    }
+    #[cfg(feature = "xmp")]
     if is_heif_file(path) {
-        apply_metadata_heif(path, write)
+        apply_metadata_heif(path, write, temp_suffix)
     } else {
-        apply_metadata_xmp_toolkit(path, write)
+        apply_metadata_xmp_toolkit(path, write, temp_suffix)
     }
 }
 
@@ -187,6 +255,7 @@ pub(crate) fn apply_metadata(path: &Path, write: &MetadataWrite) -> Result<()> {
 /// On read error, fall back to extension-based detection — preserves the
 /// pre-content-sniff behavior for any caller that hands us an unreadable
 /// path, rather than misclassifying every such call as non-HEIF.
+#[cfg(feature = "xmp")]
 fn is_heif_file(path: &Path) -> bool {
     use std::io::Read;
     let mut head = [0u8; 12];
@@ -200,15 +269,52 @@ fn is_heif_file(path: &Path) -> bool {
 /// can patch. JPEG / PNG / TIFF / MP4 / MOV go through XMP Toolkit;
 /// HEIC / HEIF / AVIF go through [`super::heif`].
 pub(crate) fn is_embed_writable_path(path: &Path) -> bool {
+    let mut head = [0u8; 12];
+    if let Ok(n) = std::fs::File::open(path).and_then(|mut f| {
+        use std::io::Read;
+        f.read(&mut head)
+    }) {
+        let head = head.get(..n).unwrap_or(&[]);
+        if head.starts_with(&[0xff, 0xd8, 0xff])
+            || head.starts_with(b"II*\0")
+            || head.starts_with(b"MM\0*")
+        {
+            return true;
+        }
+        #[cfg(feature = "xmp")]
+        if heif::is_heif_content(head) {
+            return true;
+        }
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    if ext
+        .as_deref()
+        .is_some_and(|e| matches!(e, "jpg" | "jpeg" | "tif" | "tiff"))
+    {
+        return true;
+    }
+    #[cfg(feature = "xmp")]
     if heif::is_heif_path(path) {
         return true;
     }
-    path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
-        matches!(
-            e.to_ascii_lowercase().as_str(),
-            "jpg" | "jpeg" | "png" | "tif" | "tiff" | "mp4" | "mov"
-        )
-    })
+    #[cfg(feature = "xmp")]
+    {
+        ext.as_deref()
+            .is_some_and(|e| matches!(e, "png" | "mp4" | "mov"))
+    }
+    #[cfg(not(feature = "xmp"))]
+    {
+        false
+    }
+}
+
+fn temp_path_for(path: &Path, temp_suffix: &str) -> PathBuf {
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(temp_suffix);
+    path.with_file_name(tmp_name)
 }
 
 /// Write `write` as a `.xmp` sidecar next to the media file, atomically.
@@ -218,7 +324,12 @@ pub(crate) fn is_embed_writable_path(path: &Path) -> bool {
 /// rather than overwriting the whole packet. A malformed existing sidecar
 /// falls back to a fresh packet — kei's enriched view wins over a file we
 /// can't parse.
-pub(crate) fn write_sidecar(media_path: &Path, write: &MetadataWrite) -> Result<()> {
+#[cfg(feature = "xmp")]
+pub(crate) fn write_sidecar(
+    media_path: &Path,
+    write: &MetadataWrite,
+    temp_suffix: &str,
+) -> Result<()> {
     if write.is_empty() {
         return Ok(());
     }
@@ -230,9 +341,7 @@ pub(crate) fn write_sidecar(media_path: &Path, write: &MetadataWrite) -> Result<
     let mut sidecar_name = name.to_os_string();
     sidecar_name.push(".xmp");
     let sidecar_path = media_path.with_file_name(&sidecar_name);
-    let mut tmp_name = sidecar_name;
-    tmp_name.push(".meta-tmp");
-    let tmp_path = sidecar_path.with_file_name(&tmp_name);
+    let tmp_path = temp_path_for(&sidecar_path, temp_suffix);
 
     // Seed the packet with any existing sidecar content so user-authored
     // ratings / keywords / develop settings from another tool survive.
@@ -274,9 +383,8 @@ pub(crate) fn write_sidecar(media_path: &Path, write: &MetadataWrite) -> Result<
     Ok(())
 }
 
-/// Remove the tmp file on drop unless disarmed. Protects `.meta-tmp` against
-/// a panic across the xmp_toolkit FFI boundary; no orphan sweep matches this
-/// suffix.
+/// Remove the tmp file on drop unless disarmed. Protects metadata temp files
+/// against panics or writer failures; no orphan sweep matches this suffix.
 #[derive(Debug)]
 struct TmpGuard<'a> {
     path: &'a Path,
@@ -301,12 +409,11 @@ impl Drop for TmpGuard<'_> {
     }
 }
 
-fn apply_metadata_xmp_toolkit(path: &Path, write: &MetadataWrite) -> Result<()> {
+#[cfg(feature = "xmp")]
+fn apply_metadata_xmp_toolkit(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
     ensure_initialized();
 
-    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
-    tmp_name.push(".meta-tmp");
-    let tmp_path = path.with_file_name(&tmp_name);
+    let tmp_path = temp_path_for(path, temp_suffix);
     std::fs::copy(path, &tmp_path)
         .with_context(|| format!("Copying {} -> {}", path.display(), tmp_path.display()))?;
 
@@ -346,9 +453,106 @@ fn apply_metadata_xmp_toolkit(path: &Path, write: &MetadataWrite) -> Result<()> 
     Ok(())
 }
 
+#[cfg(not(feature = "xmp"))]
+fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
+    let input = std::fs::read(path)
+        .with_context(|| format!("Reading {} for native EXIF update", path.display()))?;
+    let Some(file_type) = native_file_type(&input, path) else {
+        tracing::debug!(
+            path = %path.display(),
+            "Native EXIF writer supports JPEG/TIFF only; skipping metadata write"
+        );
+        return Ok(());
+    };
+
+    let mut metadata = match Metadata::new_from_vec(&input, file_type) {
+        Ok(metadata) => metadata,
+        Err(e) if e.to_string().contains("No EXIF data found") => Metadata::new(),
+        Err(e) => return Err(e).with_context(|| format!("Reading EXIF from {}", path.display())),
+    };
+    if let Some(dt) = &write.datetime {
+        metadata.set_tag(ExifTag::DateTimeOriginal(dt.clone()));
+        metadata.set_tag(ExifTag::CreateDate(dt.clone()));
+        metadata.set_tag(ExifTag::ModifyDate(dt.clone()));
+    }
+    if let Some(desc) = &write.description {
+        metadata.set_tag(ExifTag::ImageDescription(desc.clone()));
+    }
+    if let Some(gps) = write.gps {
+        metadata.set_tag(ExifTag::GPSLatitudeRef(if gps.latitude >= 0.0 {
+            "N".to_string()
+        } else {
+            "S".to_string()
+        }));
+        metadata.set_tag(ExifTag::GPSLatitude(dms_rational(gps.latitude)));
+        metadata.set_tag(ExifTag::GPSLongitudeRef(if gps.longitude >= 0.0 {
+            "E".to_string()
+        } else {
+            "W".to_string()
+        }));
+        metadata.set_tag(ExifTag::GPSLongitude(dms_rational(gps.longitude)));
+        if let Some(alt) = gps.altitude {
+            metadata.set_tag(ExifTag::GPSAltitudeRef(vec![u8::from(alt < 0.0)]));
+            metadata.set_tag(ExifTag::GPSAltitude(vec![uR64::from(alt.abs())]));
+        }
+    }
+    if write.rating.is_some() {
+        tracing::debug!(
+            path = %path.display(),
+            "Native EXIF writer has no standard rating tag; skipping rating"
+        );
+    }
+
+    let mut output = input;
+    metadata
+        .write_to_vec(&mut output, file_type)
+        .with_context(|| format!("Writing native EXIF into {}", path.display()))?;
+    let tmp_path = temp_path_for(path, temp_suffix);
+    std::fs::write(&tmp_path, &output)
+        .with_context(|| format!("Writing native EXIF temp {}", tmp_path.display()))?;
+    let guard = TmpGuard::new(&tmp_path);
+    atomic_install(&tmp_path, path)
+        .with_context(|| format!("Installing native EXIF {}", path.display()))?;
+    guard.disarm();
+    tracing::debug!(path = %path.display(), "Applied native EXIF metadata");
+    Ok(())
+}
+
+#[cfg(not(feature = "xmp"))]
+fn native_file_type(bytes: &[u8], path: &Path) -> Option<FileExtension> {
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some(FileExtension::JPEG);
+    }
+    if bytes.starts_with(b"II*\0") || bytes.starts_with(b"MM\0*") {
+        return Some(FileExtension::TIFF);
+    }
+    path.extension()
+        .and_then(|e| e.to_str())
+        .and_then(|e| match e.to_ascii_lowercase().as_str() {
+            "jpg" | "jpeg" => Some(FileExtension::JPEG),
+            "tif" | "tiff" => Some(FileExtension::TIFF),
+            _ => None,
+        })
+}
+
+#[cfg(not(feature = "xmp"))]
+fn dms_rational(decimal: f64) -> Vec<uR64> {
+    let abs = decimal.abs();
+    let degrees = abs.floor();
+    let minutes_full = (abs - degrees) * 60.0;
+    let minutes = minutes_full.floor();
+    let seconds = (minutes_full - minutes) * 60.0;
+    vec![
+        uR64::from(degrees),
+        uR64::from(minutes),
+        uR64::from(seconds),
+    ]
+}
+
 /// Apply the requested metadata fields to an `XmpMeta`. Single source of
 /// truth — both the xmp_toolkit-backed and ISO-BMFF-backed writers route
 /// through here so the two paths produce identical XMP content.
+#[cfg(feature = "xmp")]
 fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpResult<()> {
     if let Some(dt) = &write.datetime {
         // XMP uses ISO 8601; our stored form is EXIF-style "YYYY:MM:DD HH:MM:SS".
@@ -446,7 +650,8 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
 /// insert the resulting packet as a MIME item inside the HEIC's `meta` box.
 /// Operates on file bytes directly via ISO-BMFF atom editing so the encoded
 /// image data in `mdat` stays byte-for-byte identical — invariant 2.
-fn apply_metadata_heif(path: &Path, write: &MetadataWrite) -> Result<()> {
+#[cfg(feature = "xmp")]
+fn apply_metadata_heif(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
     ensure_initialized();
 
     let input = std::fs::read(path)
@@ -470,9 +675,7 @@ fn apply_metadata_heif(path: &Path, write: &MetadataWrite) -> Result<()> {
     apply_to_xmp(&mut meta, write)?;
     let xmp_bytes = meta.to_string().into_bytes();
 
-    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
-    tmp_name.push(".meta-tmp");
-    let tmp_path = path.with_file_name(&tmp_name);
+    let tmp_path = temp_path_for(path, temp_suffix);
 
     // Stream the rewrite straight to disk and keep the descriptor open
     // through the post-rewrite validation: the old Vec<u8> output from
@@ -518,6 +721,7 @@ fn apply_metadata_heif(path: &Path, write: &MetadataWrite) -> Result<()> {
 /// malformed rewrite never lands on disk. Reads from the still-open
 /// rewrite handle (seeks back to 0) to avoid reopening `tmp_path`
 /// immediately after `sync_all`; the path is only used for diagnostics.
+#[cfg(feature = "xmp")]
 fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Result<()> {
     use std::io::{Read, Seek, SeekFrom};
     file.seek(SeekFrom::Start(0))
@@ -540,7 +744,7 @@ fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Resu
 /// Build a standalone XMP packet from a bundle of fields. Thin convenience
 /// over [`apply_to_xmp`] for callers (mostly tests) that want the serialized
 /// packet bytes directly.
-#[cfg(test)]
+#[cfg(all(test, feature = "xmp"))]
 fn build_xmp_packet(write: &MetadataWrite) -> Result<Vec<u8>> {
     let mut meta = XmpMeta::new().context("creating XmpMeta")?;
     apply_to_xmp(&mut meta, write)?;
@@ -554,6 +758,7 @@ fn build_xmp_packet(write: &MetadataWrite) -> Result<Vec<u8>> {
     clippy::indexing_slicing,
     reason = "indices 4, 7, 10 are provably in-bounds under the `bytes.len() == 19` guard"
 )]
+#[cfg(feature = "xmp")]
 fn exif_datetime_to_iso(s: &str) -> String {
     let bytes = s.as_bytes();
     if bytes.len() == 19 && bytes[4] == b':' && bytes[7] == b':' && bytes[10] == b' ' {
@@ -576,6 +781,7 @@ fn exif_datetime_to_iso(s: &str) -> String {
 
 /// Encode decimal degrees in the EXIF-in-XMP form `"DEG,MIN.FRACHEMI"` used
 /// by [Xmp.exif.GPSLatitude] / `Xmp.exif.GPSLongitude`.
+#[cfg(feature = "xmp")]
 fn encode_gps(decimal: f64, pos: char, neg: char) -> String {
     let hemisphere = if decimal >= 0.0 { pos } else { neg };
     let abs = decimal.abs();
@@ -591,6 +797,7 @@ fn encode_gps(decimal: f64, pos: char, neg: char) -> String {
 }
 
 /// XMP `exif:GPSAltitude` is a rational; we use `meters/1` (scale of 1).
+#[cfg(feature = "xmp")]
 fn encode_altitude(meters: f64) -> String {
     #[allow(
         clippy::cast_possible_truncation,
@@ -601,9 +808,24 @@ fn encode_altitude(meters: f64) -> String {
     format!("{scaled}/1000")
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "xmp"))]
 #[allow(clippy::unused_result_ok, reason = "test cleanup is best-effort")]
 mod tests {
+    fn apply_metadata_with_default_suffix(
+        path: &std::path::Path,
+        write: &super::MetadataWrite,
+    ) -> super::Result<()> {
+        super::apply_metadata(path, write, ".meta-tmp")
+    }
+
+    #[cfg(feature = "xmp")]
+    fn write_sidecar_with_default_suffix(
+        path: &std::path::Path,
+        write: &super::MetadataWrite,
+    ) -> super::Result<()> {
+        super::write_sidecar(path, write, ".meta-tmp")
+    }
+
     use super::*;
     use std::fs;
     use std::path::PathBuf;
@@ -754,9 +976,38 @@ mod tests {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "noop.jpg");
         let before = fs::read(&path).unwrap();
-        apply_metadata(&path, &MetadataWrite::default()).unwrap();
+        apply_metadata_with_default_suffix(&path, &MetadataWrite::default()).unwrap();
         let after = fs::read(&path).unwrap();
         assert_eq!(before, after, "empty write must not touch the file");
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn apply_metadata_uses_configured_temp_suffix() {
+        let dir = test_tmp_dir("meta_tests");
+        let path = fresh_jpeg(&dir, "custom_suffix.jpg");
+        let default_tmp = dir.join("custom_suffix.jpg.meta-tmp");
+        let configured_tmp = dir.join("custom_suffix.jpg.kei-tmp");
+        fs::write(&default_tmp, b"sentinel").unwrap();
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2024:06:15 10:00:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+        assert_eq!(
+            fs::read(&default_tmp).unwrap(),
+            b"sentinel",
+            "metadata rewrite must not use the old .meta-tmp suffix"
+        );
+        assert!(
+            !configured_tmp.exists(),
+            "configured metadata temp path must be installed or cleaned up"
+        );
+        fs::remove_file(&default_tmp).ok();
         fs::remove_file(&path).ok();
     }
 
@@ -764,7 +1015,7 @@ mod tests {
     fn apply_metadata_datetime_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "dt.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
@@ -781,7 +1032,7 @@ mod tests {
     fn apply_metadata_rating_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "rating.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(4),
@@ -799,7 +1050,7 @@ mod tests {
     fn apply_metadata_rating_clamps_above_5() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "rating_clamp.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(99),
@@ -817,7 +1068,7 @@ mod tests {
     fn apply_metadata_gps_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "gps.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 gps: Some(GpsCoords {
@@ -843,7 +1094,7 @@ mod tests {
     fn apply_metadata_description_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "desc.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 description: Some("Beach day".to_string()),
@@ -863,7 +1114,7 @@ mod tests {
     fn apply_metadata_title_and_keywords_roundtrip() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "tags.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 title: Some("Vacation shot".to_string()),
@@ -892,7 +1143,7 @@ mod tests {
     fn apply_metadata_people_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "people.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 people: vec!["Alice".into(), "Bob".into()],
@@ -913,7 +1164,7 @@ mod tests {
     fn apply_metadata_kei_namespace_fields() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "kei_ns.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 is_hidden: true,
@@ -942,7 +1193,7 @@ mod tests {
     fn apply_metadata_all_fields_single_pass() {
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "all.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
@@ -975,7 +1226,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("corrupt.jpg");
         fs::write(&path, b"not a jpeg").unwrap();
-        let result = apply_metadata(
+        let result = apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(3),
@@ -1076,7 +1327,7 @@ mod tests {
     fn apply_metadata_heic_rating_and_title() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "rating.heic");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(5),
@@ -1099,7 +1350,7 @@ mod tests {
     fn apply_metadata_heic_gps_roundtrips() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "gps.heic");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 gps: Some(GpsCoords {
@@ -1127,7 +1378,7 @@ mod tests {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "preserve.heic");
         let original_bytes = SAMPLE_HEIC.to_vec();
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(3),
@@ -1167,7 +1418,7 @@ mod tests {
     fn apply_metadata_heic_preserves_existing_xmp_on_rewrite() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "preserve_xmp.heic");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 title: Some("First".into()),
@@ -1175,7 +1426,7 @@ mod tests {
             },
         )
         .unwrap();
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(4),
@@ -1207,9 +1458,9 @@ mod tests {
             ..MetadataWrite::default()
         };
 
-        apply_metadata(&path, &write).unwrap();
+        apply_metadata_with_default_suffix(&path, &write).unwrap();
         let first = fs::read(&path).unwrap();
-        apply_metadata(&path, &write).unwrap();
+        apply_metadata_with_default_suffix(&path, &write).unwrap();
         let second = fs::read(&path).unwrap();
 
         // Rewriting with the same data must not accumulate XMP items or
@@ -1312,7 +1563,7 @@ mod tests {
     fn probe_exif_heic_reports_datetime_after_apply() {
         let dir = test_tmp_dir("probe_heic_tests");
         let path = fresh_heic(&dir, "probe_dt.heic");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
@@ -1337,7 +1588,7 @@ mod tests {
     fn probe_exif_heic_reports_gps_after_apply() {
         let dir = test_tmp_dir("probe_heic_tests");
         let path = fresh_heic(&dir, "probe_gps.heic");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 gps: Some(GpsCoords {
@@ -1390,7 +1641,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC.kei-tmp");
         fs::write(&path, SAMPLE_HEIC).unwrap();
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
@@ -1421,7 +1672,7 @@ mod tests {
         // reconciled EXIF datetime — the refactor doesn't regress JPEG.
         let dir = test_tmp_dir("probe_heic_tests");
         let path = fresh_jpeg(&dir, "probe_jpeg_dt.jpg");
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
@@ -1457,7 +1708,7 @@ mod tests {
         // suffix shadowing the real `.heic` extension.
         let path = dir.join("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.kei-tmp");
         fs::write(&path, SAMPLE_HEIC).unwrap();
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(4),
@@ -1527,7 +1778,7 @@ mod tests {
         let path = dir.join("uri_infe.heic");
         fs::write(&path, &bytes).unwrap();
 
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(3),
@@ -1553,7 +1804,7 @@ mod tests {
         let path = dir.join("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB.kei-tmp");
         fs::create_dir_all(&dir).unwrap();
         fs::write(&path, minimal_jpeg()).unwrap();
-        apply_metadata(
+        apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
                 rating: Some(2),
@@ -1596,7 +1847,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let media_path = dir.join("empty.jpg");
         std::fs::write(&media_path, b"placeholder").unwrap();
-        write_sidecar(&media_path, &MetadataWrite::default()).unwrap();
+        write_sidecar_with_default_suffix(&media_path, &MetadataWrite::default()).unwrap();
         let sidecar = dir.join("empty.jpg.xmp");
         assert!(
             !sidecar.exists(),
@@ -1619,7 +1870,7 @@ mod tests {
             people: vec!["Alice".into()],
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &write).expect("sidecar write");
+        write_sidecar_with_default_suffix(&media_path, &write).expect("sidecar write");
         let sidecar = dir.join("photo.jpg.xmp");
         assert!(sidecar.exists(), "sidecar should be written next to media");
 
@@ -1646,13 +1897,13 @@ mod tests {
             title: Some("Before".into()),
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &first).unwrap();
+        write_sidecar_with_default_suffix(&media_path, &first).unwrap();
 
         let second = MetadataWrite {
             title: Some("After".into()),
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &second).unwrap();
+        write_sidecar_with_default_suffix(&media_path, &second).unwrap();
 
         let sidecar = dir.join("rewrite.jpg.xmp");
         let s = fs::read_to_string(&sidecar).unwrap();
@@ -1696,7 +1947,7 @@ mod tests {
             rating: Some(4),
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &write).expect("sidecar merge");
+        write_sidecar_with_default_suffix(&media_path, &write).expect("sidecar merge");
 
         let merged = fs::read_to_string(&sidecar_path).unwrap();
         assert!(
@@ -1746,7 +1997,7 @@ mod tests {
             keywords: vec!["vacation".to_string()],
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &write).expect("sidecar merge");
+        write_sidecar_with_default_suffix(&media_path, &write).expect("sidecar merge");
 
         let merged = fs::read_to_string(&sidecar_path).unwrap();
         for expected in ["history_end", "xmp_version", "raw_params", "gc5ghbmY2k8"] {
@@ -1783,7 +2034,7 @@ mod tests {
             title: Some("Clean".into()),
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &write).expect("fallback to fresh packet");
+        write_sidecar_with_default_suffix(&media_path, &write).expect("fallback to fresh packet");
 
         let out = fs::read_to_string(&sidecar_path).unwrap();
         assert!(out.contains("Clean"), "fallback write must land: {out}");
@@ -1804,7 +2055,7 @@ mod tests {
             rating: Some(3),
             ..MetadataWrite::default()
         };
-        write_sidecar(&media_path, &write).unwrap();
+        write_sidecar_with_default_suffix(&media_path, &write).unwrap();
 
         let after = fs::read(&media_path).unwrap();
         assert_eq!(
@@ -1816,5 +2067,163 @@ mod tests {
         let sidecar = dir.join("untouched.jpg.xmp");
         fs::remove_file(&sidecar).ok();
         fs::remove_file(&media_path).ok();
+    }
+}
+
+#[cfg(all(test, not(feature = "xmp")))]
+mod native_tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Minimal valid JPEG (SOI + APP0 JFIF + EOI).
+    fn minimal_jpeg() -> Vec<u8> {
+        vec![
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+        ]
+    }
+
+    fn fresh_jpeg(dir: &Path, name: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, minimal_jpeg()).unwrap();
+        path
+    }
+
+    #[test]
+    fn native_apply_metadata_writes_jpeg_exif_without_xmp_feature() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fresh_jpeg(dir.path(), "native.jpg");
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2024:06:15 10:00:00".to_string()),
+                description: Some("Beach day".to_string()),
+                gps: Some(GpsCoords {
+                    latitude: 37.7749,
+                    longitude: -122.4194,
+                    altitude: Some(17.0),
+                }),
+                rating: Some(5),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        let probe = probe_exif(&path).unwrap();
+        assert_eq!(
+            probe.datetime_original.as_deref(),
+            Some("2024:06:15 10:00:00")
+        );
+        assert!(probe.has_gps);
+
+        let metadata = Metadata::new_from_path(&path).unwrap();
+        let description = metadata
+            .get_tag(&ExifTag::ImageDescription(String::new()))
+            .next()
+            .and_then(|tag| match tag {
+                ExifTag::ImageDescription(s) => Some(s.as_str()),
+                _ => None,
+            });
+        assert_eq!(description, Some("Beach day"));
+    }
+
+    #[test]
+    fn native_probe_reads_exif_from_temp_suffix_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fresh_jpeg(dir.path(), "probe.jpg.kei-tmp");
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2024:06:15 10:00:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+        )
+        .unwrap();
+
+        let probe = probe_exif(&path).unwrap();
+        assert_eq!(
+            probe.datetime_original.as_deref(),
+            Some("2024:06:15 10:00:00")
+        );
+    }
+
+    #[test]
+    fn native_apply_metadata_uses_configured_temp_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fresh_jpeg(dir.path(), "native_suffix.jpg");
+        let default_tmp = dir.path().join("native_suffix.jpg.meta-tmp");
+        let configured_tmp = dir.path().join("native_suffix.jpg.kei-tmp");
+        fs::write(&default_tmp, b"sentinel").unwrap();
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2024:06:15 10:00:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(&default_tmp).unwrap(),
+            b"sentinel",
+            "native metadata rewrite must not use the old .meta-tmp suffix"
+        );
+        assert!(
+            !configured_tmp.exists(),
+            "configured native metadata temp path must be installed or cleaned up"
+        );
+    }
+
+    #[test]
+    fn native_apply_metadata_skips_heic_without_xmp_feature() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("image.heic");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0x18_u32.to_be_bytes());
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(&0_u32.to_be_bytes());
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(b"mif1");
+        fs::write(&path, &bytes).unwrap();
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2024:06:15 10:00:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            bytes,
+            "HEIC should be skipped unchanged when XMP support is disabled"
+        );
+        assert!(!dir.path().join("image.heic.kei-tmp").exists());
+    }
+
+    #[test]
+    fn native_tmp_guard_cleans_configured_temp_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("guarded.kei-tmp");
+        fs::write(&path, b"pending").unwrap();
+        {
+            let _guard = TmpGuard::new(&path);
+            assert!(path.exists(), "precondition: tmp file exists");
+        }
+        assert!(
+            !path.exists(),
+            "TmpGuard Drop must remove configured metadata temp files"
+        );
     }
 }

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -20,6 +20,8 @@ use little_exif::exif_tag::ExifTag;
 #[cfg(not(feature = "xmp"))]
 use little_exif::filetype::FileExtension;
 #[cfg(not(feature = "xmp"))]
+use little_exif::ifd::ExifTagGroup;
+#[cfg(not(feature = "xmp"))]
 use little_exif::metadata::Metadata;
 #[cfg(not(feature = "xmp"))]
 use little_exif::rational::uR64;
@@ -496,11 +498,18 @@ fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) 
             metadata.set_tag(ExifTag::GPSAltitude(vec![uR64::from(alt.abs())]));
         }
     }
-    if write.rating.is_some() {
-        tracing::debug!(
-            path = %path.display(),
-            "Native EXIF writer has no standard rating tag; skipping rating"
-        );
+    if let Some(rating) = write.rating {
+        let rating = u16::from(rating.min(5));
+        metadata.set_tag(ExifTag::UnknownINT16U(
+            vec![rating],
+            WINDOWS_RATING_TAG,
+            ExifTagGroup::GENERIC,
+        ));
+        metadata.set_tag(ExifTag::UnknownINT16U(
+            vec![windows_rating_percent(rating)],
+            WINDOWS_RATING_PERCENT_TAG,
+            ExifTagGroup::GENERIC,
+        ));
     }
 
     let mut output = input;
@@ -547,6 +556,23 @@ fn dms_rational(decimal: f64) -> Vec<uR64> {
         uR64::from(minutes),
         uR64::from(seconds),
     ]
+}
+
+#[cfg(not(feature = "xmp"))]
+const WINDOWS_RATING_TAG: u16 = 0x4746;
+#[cfg(not(feature = "xmp"))]
+const WINDOWS_RATING_PERCENT_TAG: u16 = 0x4749;
+
+#[cfg(not(feature = "xmp"))]
+const fn windows_rating_percent(rating: u16) -> u16 {
+    match rating {
+        0 => 0,
+        1 => 1,
+        2 => 25,
+        3 => 50,
+        4 => 75,
+        _ => 99,
+    }
 }
 
 /// Apply the requested metadata fields to an `XmpMeta`. Single source of

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -2116,6 +2116,20 @@ mod native_tests {
         path
     }
 
+    fn first_unknown_int16(metadata: &Metadata, tag_id: u16) -> Option<u16> {
+        metadata
+            .get_tag(&ExifTag::UnknownINT16U(
+                Vec::new(),
+                tag_id,
+                ExifTagGroup::GENERIC,
+            ))
+            .next()
+            .and_then(|tag| match tag {
+                ExifTag::UnknownINT16U(values, tag, _) if *tag == tag_id => values.first().copied(),
+                _ => None,
+            })
+    }
+
     #[test]
     fn native_apply_metadata_writes_jpeg_exif_without_xmp_feature() {
         let dir = tempfile::tempdir().unwrap();
@@ -2155,35 +2169,11 @@ mod native_tests {
             });
         assert_eq!(description, Some("Beach day"));
 
-        let rating = metadata
-            .get_tag(&ExifTag::UnknownINT16U(
-                Vec::new(),
-                WINDOWS_RATING_TAG,
-                ExifTagGroup::GENERIC,
-            ))
-            .next()
-            .and_then(|tag| match tag {
-                ExifTag::UnknownINT16U(values, tag, _) if *tag == WINDOWS_RATING_TAG => {
-                    values.first().copied()
-                }
-                _ => None,
-            });
-        assert_eq!(rating, Some(5));
-
-        let rating_percent = metadata
-            .get_tag(&ExifTag::UnknownINT16U(
-                Vec::new(),
-                WINDOWS_RATING_PERCENT_TAG,
-                ExifTagGroup::GENERIC,
-            ))
-            .next()
-            .and_then(|tag| match tag {
-                ExifTag::UnknownINT16U(values, tag, _) if *tag == WINDOWS_RATING_PERCENT_TAG => {
-                    values.first().copied()
-                }
-                _ => None,
-            });
-        assert_eq!(rating_percent, Some(99));
+        assert_eq!(first_unknown_int16(&metadata, WINDOWS_RATING_TAG), Some(5));
+        assert_eq!(
+            first_unknown_int16(&metadata, WINDOWS_RATING_PERCENT_TAG),
+            Some(99)
+        );
     }
 
     #[test]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -241,7 +241,7 @@ pub(crate) fn apply_metadata(path: &Path, write: &MetadataWrite, temp_suffix: &s
     }
     #[cfg(not(feature = "xmp"))]
     {
-        return apply_metadata_native(path, write, temp_suffix);
+        apply_metadata_native(path, write, temp_suffix)
     }
     #[cfg(feature = "xmp")]
     if is_heif_file(path) {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2699,7 +2699,7 @@ mod tests {
                     resolution: Some(crate::types::PhotoResolution::Original),
                     ..Default::default()
                 },
-                no_progress_bar: Some(true),
+                no_progress_bar: true,
                 ..Default::default()
             },
             None,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod filter;
 #[cfg(feature = "xmp")]
 pub(crate) mod heif;
 pub(crate) mod limiter;
-#[cfg(feature = "xmp")]
 pub mod metadata;
 pub mod paths;
 pub(crate) mod pipeline;
@@ -477,13 +476,9 @@ pub(crate) struct DownloadConfig {
     pub(crate) media: crate::config::MediaSelection,
     pub(crate) skip_created_before: Option<DateTime<Utc>>,
     pub(crate) skip_created_after: Option<DateTime<Utc>>,
-    #[cfg(feature = "xmp")]
     pub(crate) set_exif_datetime: bool,
-    #[cfg(feature = "xmp")]
     pub(crate) set_exif_rating: bool,
-    #[cfg(feature = "xmp")]
     pub(crate) set_exif_gps: bool,
-    #[cfg(feature = "xmp")]
     pub(crate) set_exif_description: bool,
     /// Embed the full XMP packet (title, keywords, people, hidden/archived,
     /// media subtype, burst id) into the file bytes on supported formats.
@@ -610,13 +605,9 @@ impl DownloadConfig {
             media,
             skip_created_before: None,
             skip_created_after: None,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,
@@ -756,12 +747,12 @@ impl std::fmt::Debug for DownloadConfig {
             .field("media", &self.media)
             .field("skip_created_before", &self.skip_created_before)
             .field("skip_created_after", &self.skip_created_after);
-        #[cfg(feature = "xmp")]
         s.field("set_exif_datetime", &self.set_exif_datetime)
             .field("set_exif_rating", &self.set_exif_rating)
             .field("set_exif_gps", &self.set_exif_gps)
-            .field("set_exif_description", &self.set_exif_description)
-            .field("embed_xmp", &self.embed_xmp)
+            .field("set_exif_description", &self.set_exif_description);
+        #[cfg(feature = "xmp")]
+        s.field("embed_xmp", &self.embed_xmp)
             .field("xmp_sidecar", &self.xmp_sidecar);
         s.field("dry_run", &self.dry_run)
             .field("concurrent_downloads", &self.concurrent_downloads)
@@ -810,13 +801,9 @@ impl DownloadConfig {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,
@@ -3549,10 +3536,7 @@ mod tests {
         config.force_resolution = true;
         config.keep_unicode_in_filenames = true;
         config.dry_run = true;
-        #[cfg(feature = "xmp")]
-        {
-            config.set_exif_datetime = true;
-        }
+        config.set_exif_datetime = true;
         config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
         config.temp_suffix = std::sync::Arc::from(".custom-tmp");
         let derived = config.with_pass(&make_pass(PassKind::Album, "Test"));
@@ -3562,7 +3546,6 @@ mod tests {
         assert!(derived.force_resolution);
         assert!(derived.keep_unicode_in_filenames);
         assert!(derived.dry_run);
-        #[cfg(feature = "xmp")]
         assert!(derived.set_exif_datetime);
         assert_eq!(derived.filename_exclude.len(), 1);
         assert_eq!(&*derived.temp_suffix, ".custom-tmp");

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -342,7 +342,6 @@ async fn update_metadata_marker(
 /// metadata drifted from the stored hash (or that already carries a marker
 /// from a prior sync). No-op when metadata writing is off or the state DB
 /// is absent. Shared by the trust-state and on-disk-skip producer branches.
-#[cfg(feature = "xmp")]
 async fn tag_metadata_rewrites(
     state_db: Option<&dyn StateDb>,
     config: &DownloadConfig,
@@ -350,7 +349,7 @@ async fn tag_metadata_rewrites(
     candidates: &[(VersionSizeKey, &str)],
     ctx: &DownloadContext,
 ) {
-    if !(config.embed_xmp || config.xmp_sidecar) {
+    if MetadataFlags::from(config).is_empty() {
         return;
     }
     let Some(db) = state_db else {
@@ -377,17 +376,6 @@ async fn tag_metadata_rewrites(
             );
         }
     }
-}
-
-/// No-op when the `xmp` feature is disabled at build time.
-#[cfg(not(feature = "xmp"))]
-async fn tag_metadata_rewrites(
-    _state_db: Option<&dyn StateDb>,
-    _config: &DownloadConfig,
-    _asset: &PhotoAsset,
-    _candidates: &[(VersionSizeKey, &str)],
-    _ctx: &DownloadContext,
-) {
 }
 
 /// Retry all pending state writes that failed during the download loop.
@@ -467,7 +455,6 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
 
 /// Maximum assets processed per metadata-rewrite invocation. Bounds worst-case
 /// tail work at sync end; anything beyond this rolls into the next sync.
-#[cfg_attr(not(feature = "xmp"), allow(dead_code))]
 const METADATA_REWRITE_BATCH: usize = 500;
 
 /// Drain persisted metadata-rewrite markers: for each asset whose
@@ -475,10 +462,10 @@ const METADATA_REWRITE_BATCH: usize = 500;
 /// re-apply EXIF/XMP using the stored provider metadata. On success clears
 /// the marker and refreshes `metadata_hash`; on failure leaves the marker so
 /// the next sync retries.
-#[cfg(feature = "xmp")]
 async fn run_metadata_rewrites(
     db: &dyn StateDb,
     metadata_flags: MetadataFlags,
+    temp_suffix: Arc<str>,
     shutdown_token: &CancellationToken,
 ) {
     let pending = match db
@@ -540,6 +527,7 @@ async fn run_metadata_rewrites(
                 let embed_path = path.clone();
                 let embed_payload = payload.clone();
                 let embed_created = created_local;
+                let embed_temp_suffix = Arc::clone(&temp_suffix);
                 match tokio::task::spawn_blocking(move || {
                     let probe = match super::metadata::probe_exif(&embed_path) {
                         Ok(p) => p,
@@ -557,7 +545,7 @@ async fn run_metadata_rewrites(
                     if write.is_empty() {
                         return Ok::<(), anyhow::Error>(());
                     }
-                    super::metadata::apply_metadata(&embed_path, &write)
+                    super::metadata::apply_metadata(&embed_path, &write, &embed_temp_suffix)
                 })
                 .await
                 {
@@ -584,40 +572,50 @@ async fn run_metadata_rewrites(
                 true
             };
 
-        let sidecar_ok = if metadata_flags.contains(MetadataFlags::XMP_SIDECAR) {
-            let sidecar_path = path.clone();
-            let sidecar_payload = payload.clone();
-            let sidecar_created = created_local;
-            match tokio::task::spawn_blocking(move || {
-                let write = plan_sidecar_write(&sidecar_payload, &sidecar_created);
-                if write.is_empty() {
-                    return Ok::<(), anyhow::Error>(());
-                }
-                super::metadata::write_sidecar(&sidecar_path, &write)
-            })
-            .await
+        let sidecar_ok = {
+            #[cfg(feature = "xmp")]
             {
-                Ok(Ok(())) => true,
-                Ok(Err(e)) => {
-                    tracing::warn!(
-                        asset_id = %record.id,
-                        path = %path.display(),
-                        error = %e,
-                        "Metadata rewrite (sidecar) failed; leaving marker for future retry"
-                    );
-                    false
-                }
-                Err(join_err) => {
-                    tracing::warn!(
-                        asset_id = %record.id,
-                        error = %join_err,
-                        "Metadata rewrite (sidecar) task panicked"
-                    );
-                    false
+                if metadata_flags.contains(MetadataFlags::XMP_SIDECAR) {
+                    let sidecar_path = path.clone();
+                    let sidecar_payload = payload.clone();
+                    let sidecar_created = created_local;
+                    let sidecar_temp_suffix = Arc::clone(&temp_suffix);
+                    match tokio::task::spawn_blocking(move || {
+                        let write = plan_sidecar_write(&sidecar_payload, &sidecar_created);
+                        if write.is_empty() {
+                            return Ok::<(), anyhow::Error>(());
+                        }
+                        super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix)
+                    })
+                    .await
+                    {
+                        Ok(Ok(())) => true,
+                        Ok(Err(e)) => {
+                            tracing::warn!(
+                                asset_id = %record.id,
+                                path = %path.display(),
+                                error = %e,
+                                "Metadata rewrite (sidecar) failed; leaving marker for future retry"
+                            );
+                            false
+                        }
+                        Err(join_err) => {
+                            tracing::warn!(
+                                asset_id = %record.id,
+                                error = %join_err,
+                                "Metadata rewrite (sidecar) task panicked"
+                            );
+                            false
+                        }
+                    }
+                } else {
+                    true
                 }
             }
-        } else {
-            true
+            #[cfg(not(feature = "xmp"))]
+            {
+                true
+            }
         };
 
         if embed_ok && sidecar_ok {
@@ -870,14 +868,13 @@ fn create_progress_bar(
 
 bitflags::bitflags! {
     /// Per-tag write toggles. `any_embed()` drives the `.part`-and-modify-before-rename
-    /// flow; individual flags gate which fields get written in the XMP packet.
+    /// flow; individual flags gate which fields get embedded into the media file.
     ///
     /// `EMBED_XMP` enables the XMP-only fields that have no native EXIF equivalent
     /// (title, keywords, people, hidden/archived, media subtype, burst id).
     /// `XMP_SIDECAR` is orthogonal — it writes a `.xmp` file next to the photo
     /// without touching the photo bytes.
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     pub(super) struct MetadataFlags: u8 {
         const DATETIME    = 1 << 0;
         const RATING      = 1 << 1;
@@ -896,30 +893,25 @@ impl MetadataFlags {
     const EMBED_MASK: Self = Self::all().difference(Self::XMP_SIDECAR);
 
     /// Whether any flag needs the downloaded bytes to stay as a `.part` file
-    /// for in-place XMP editing before the atomic rename.
-    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    /// for in-place metadata editing before the atomic rename.
     pub(super) fn any_embed(self) -> bool {
         self.intersects(Self::EMBED_MASK)
     }
 }
 
 impl From<&DownloadConfig> for MetadataFlags {
-    #[cfg(feature = "xmp")]
     fn from(config: &DownloadConfig) -> Self {
         let mut flags = Self::empty();
         flags.set(Self::DATETIME, config.set_exif_datetime);
         flags.set(Self::RATING, config.set_exif_rating);
         flags.set(Self::GPS, config.set_exif_gps);
         flags.set(Self::DESCRIPTION, config.set_exif_description);
-        flags.set(Self::EMBED_XMP, config.embed_xmp);
-        flags.set(Self::XMP_SIDECAR, config.xmp_sidecar);
+        #[cfg(feature = "xmp")]
+        {
+            flags.set(Self::EMBED_XMP, config.embed_xmp);
+            flags.set(Self::XMP_SIDECAR, config.xmp_sidecar);
+        }
         flags
-    }
-
-    /// Build with every flag forced false when the `xmp` feature is off.
-    #[cfg(not(feature = "xmp"))]
-    fn from(_config: &DownloadConfig) -> Self {
-        Self::empty()
     }
 }
 
@@ -1982,11 +1974,16 @@ where
     // from a previous one). This re-applies EXIF/XMP on the existing files
     // without re-downloading bytes; the alternative was to leave markers
     // accumulating in the DB forever.
-    #[cfg(feature = "xmp")]
     if let Some(db) = &state_db {
         let metadata_flags = MetadataFlags::from(config.as_ref());
         if metadata_flags.any_embed() || metadata_flags.contains(MetadataFlags::XMP_SIDECAR) {
-            run_metadata_rewrites(db.as_ref(), metadata_flags, &shutdown_token).await;
+            run_metadata_rewrites(
+                db.as_ref(),
+                metadata_flags,
+                Arc::clone(&config.temp_suffix),
+                &shutdown_token,
+            )
+            .await;
         }
     }
 
@@ -2513,7 +2510,6 @@ fn maybe_warn_rate_limit_pressure(stats: &super::SyncStats) {
     }
 }
 
-#[cfg(feature = "xmp")]
 fn gps_from_payload(payload: &MetadataPayload) -> Option<super::metadata::GpsCoords> {
     match (payload.latitude, payload.longitude) {
         (Some(lat), Some(lng)) => Some(super::metadata::GpsCoords {
@@ -2556,7 +2552,6 @@ fn plan_sidecar_write(
 /// - **rating / description**: flag gate only — iCloud is the source of truth.
 /// - **XMP-only fields** (title, keywords, people, hidden/archived,
 ///   media_subtype, burst_id): gated on the `EMBED_XMP` flag.
-#[cfg(feature = "xmp")]
 fn plan_metadata_write(
     flags: MetadataFlags,
     payload: &MetadataPayload,
@@ -2577,6 +2572,7 @@ fn plan_metadata_write(
     if flags.contains(MetadataFlags::DESCRIPTION) {
         write.description.clone_from(&payload.description);
     }
+    #[cfg(feature = "xmp")]
     if flags.contains(MetadataFlags::EMBED_XMP) {
         write.title.clone_from(&payload.title);
         write.keywords.clone_from(&payload.keywords);
@@ -2598,7 +2594,7 @@ async fn download_single_task(
     client: &Client,
     task: &DownloadTask,
     retry_config: &RetryConfig,
-    #[cfg_attr(not(feature = "xmp"), allow(unused_variables))] metadata_flags: MetadataFlags,
+    metadata_flags: MetadataFlags,
     temp_suffix: &str,
     rate_limit_counter: Option<&std::sync::atomic::AtomicUsize>,
     bandwidth_limiter: Option<&super::BandwidthLimiter>,
@@ -2617,14 +2613,11 @@ async fn download_single_task(
     );
 
     // Embed writes happen on the .part file before the atomic rename; sidecar
-    // writes happen after, on the final path. Without the `xmp` feature at
-    // build time there's no writer and no extension gate to consult, so
-    // `needs_exif` is unconditionally false and the embed path is compiled out.
-    #[cfg(feature = "xmp")]
+    // writes happen after, on the final path. The extension gate is based on
+    // the intended final path before download, then the writer sniffs the
+    // downloaded part bytes so the temp suffix does not hide the media type.
     let needs_exif =
         metadata_flags.any_embed() && super::metadata::is_embed_writable_path(&task.download_path);
-    #[cfg(not(feature = "xmp"))]
-    let needs_exif = false;
 
     let bytes_downloaded = Box::pin(super::file::download_file_with_mode(
         client,
@@ -2664,13 +2657,12 @@ async fn download_single_task(
         None
     };
 
-    #[cfg_attr(not(feature = "xmp"), allow(unused_mut))]
     let mut exif_ok = true;
-    #[cfg(feature = "xmp")]
     if let Some(part) = &part_path {
         let exif_path = part.clone();
         let payload = task.metadata.clone();
         let created_local = task.created_local;
+        let metadata_temp_suffix = temp_suffix.to_string();
         // Probe + plan + apply all run on the blocking pool so no file I/O
         // happens on the async runtime's poll thread.
         let exif_result = tokio::task::spawn_blocking(move || {
@@ -2685,7 +2677,9 @@ async fn download_single_task(
             if write.is_empty() {
                 return true;
             }
-            if let Err(e) = super::metadata::apply_metadata(&exif_path, &write) {
+            if let Err(e) =
+                super::metadata::apply_metadata(&exif_path, &write, &metadata_temp_suffix)
+            {
                 tracing::warn!(path = %exif_path.display(), error = %e, "Failed to write metadata");
                 false
             } else {
@@ -2727,12 +2721,15 @@ async fn download_single_task(
         let sidecar_path = task.download_path.clone();
         let payload = task.metadata.clone();
         let created_local = task.created_local;
+        let sidecar_temp_suffix = temp_suffix.to_string();
         let sidecar_result = tokio::task::spawn_blocking(move || {
             let write = plan_sidecar_write(&payload, &created_local);
             if write.is_empty() {
                 return true;
             }
-            if let Err(e) = super::metadata::write_sidecar(&sidecar_path, &write) {
+            if let Err(e) =
+                super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix)
+            {
                 tracing::warn!(path = %sidecar_path.display(), error = %e, "Failed to write XMP sidecar");
                 false
             } else {
@@ -4411,13 +4408,9 @@ mod tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,
@@ -4513,13 +4506,9 @@ mod tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,
@@ -4937,7 +4926,7 @@ mod tests {
 
         let flags = MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
         let token = CancellationToken::new();
-        run_metadata_rewrites(&db, flags, &token).await;
+        run_metadata_rewrites(&db, flags, std::sync::Arc::from(".meta-tmp"), &token).await;
 
         // Marker must be gone; row must still be `downloaded`.
         let remaining = db.get_pending_metadata_rewrites(32).await.unwrap();
@@ -5018,7 +5007,7 @@ mod tests {
 
         let flags = MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
         let token = CancellationToken::new();
-        run_metadata_rewrites(&db, flags, &token).await;
+        run_metadata_rewrites(&db, flags, std::sync::Arc::from(".meta-tmp"), &token).await;
 
         let still_pending = db.get_pending_metadata_rewrites(32).await.unwrap();
         assert_eq!(

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -8,10 +8,9 @@ use std::path::Path;
 /// silently dropping errors that violated the "no silent failures"
 /// invariant.
 ///
-/// Gated on the `xmp` feature because the only sync caller is
-/// `download/metadata.rs::TmpGuard::drop`, which is itself xmp-gated.
-/// The async sibling `log_remove_async` is unconditionally compiled.
-#[cfg(feature = "xmp")]
+/// Used by both the default XMP writer and the native no-`xmp` EXIF writer.
+/// The async sibling `log_remove_async` is available for callers already on a
+/// tokio task.
 pub(crate) fn log_remove(path: &Path) {
     if let Err(e) = std::fs::remove_file(path) {
         if e.kind() != std::io::ErrorKind::NotFound {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,7 +601,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     let (cmd_no_progress_bar, cmd_only_print_filenames, cmd_report_json, cmd_service_run) =
         match &resolved_for_personality {
             cli::Command::Sync { sync, .. } => (
-                sync.no_progress_bar.unwrap_or(false),
+                sync.no_progress_bar,
                 sync.only_print_filenames,
                 toml_report_json,
                 false,

--- a/src/report.rs
+++ b/src/report.rs
@@ -132,22 +132,10 @@ impl RunOptions {
             media: config.filters.media.to_kinds(),
             skip_videos: config.filters.skip_videos,
             skip_photos: config.filters.skip_photos,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: config.metadata.set_exif_datetime,
-            #[cfg(not(feature = "xmp"))]
-            set_exif_datetime: false,
-            #[cfg(feature = "xmp")]
             set_exif_rating: config.metadata.set_exif_rating,
-            #[cfg(not(feature = "xmp"))]
-            set_exif_rating: false,
-            #[cfg(feature = "xmp")]
             set_exif_gps: config.metadata.set_exif_gps,
-            #[cfg(not(feature = "xmp"))]
-            set_exif_gps: false,
-            #[cfg(feature = "xmp")]
             set_exif_description: config.metadata.set_exif_description,
-            #[cfg(not(feature = "xmp"))]
-            set_exif_description: false,
             #[cfg(feature = "xmp")]
             embed_xmp: config.metadata.embed_xmp,
             #[cfg(not(feature = "xmp"))]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -92,7 +92,6 @@ struct SetupAnswers {
     /// `parse_bandwidth_limit` on next sync. Empty = no limit.
     bandwidth_limit: Option<String>,
     keep_unicode_in_filenames: bool,
-    #[cfg(feature = "xmp")]
     set_exif_datetime: bool,
     #[cfg(feature = "xmp")]
     embed_xmp: bool,
@@ -140,7 +139,6 @@ impl Default for SetupAnswers {
             max_retries: None,
             bandwidth_limit: None,
             keep_unicode_in_filenames: false,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
             #[cfg(feature = "xmp")]
             embed_xmp: false,
@@ -1020,13 +1018,13 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
         .default(false)
         .interact()?;
 
+    answers.set_exif_datetime = Confirm::new()
+        .with_prompt("Write EXIF date tag if missing from photo?")
+        .default(false)
+        .interact()?;
+
     #[cfg(feature = "xmp")]
     {
-        answers.set_exif_datetime = Confirm::new()
-            .with_prompt("Write EXIF date tag if missing from photo?")
-            .default(false)
-            .interact()?;
-
         answers.embed_xmp = Confirm::new()
             .with_prompt("Embed XMP metadata (rating, GPS, description) into photos?")
             .default(false)
@@ -1156,16 +1154,29 @@ fn generate_toml(answers: &SetupAnswers) -> String {
                 "# bandwidth_limit = \"10MB\"  # blank/comment = no limit"
             )?,
         };
+        writeln!(out, "# temp_suffix = \".kei-tmp\"")?;
+
+        // [download.retry]
+        writeln!(out)?;
+        writeln!(out, "[download.retry]")?;
+        match answers.max_retries {
+            Some(n) => writeln!(out, "per_transfer = {n}")?,
+            None => writeln!(out, "# per_transfer = 3")?,
+        };
+
+        // [metadata]
+        writeln!(out)?;
+        writeln!(out, "[metadata]")?;
+        if answers.set_exif_datetime {
+            writeln!(out, "set_exif_datetime = true")?;
+        } else {
+            writeln!(out, "# set_exif_datetime = false")?;
+        }
+        writeln!(out, "# set_exif_rating = false")?;
+        writeln!(out, "# set_exif_gps = false")?;
+        writeln!(out, "# set_exif_description = false")?;
         #[cfg(feature = "xmp")]
         {
-            if answers.set_exif_datetime {
-                writeln!(out, "set_exif_datetime = true")?;
-            } else {
-                writeln!(out, "# set_exif_datetime = false")?;
-            }
-            writeln!(out, "# set_exif_rating = false")?;
-            writeln!(out, "# set_exif_gps = false")?;
-            writeln!(out, "# set_exif_description = false")?;
             if answers.embed_xmp {
                 writeln!(out, "embed_xmp = true")?;
             } else {
@@ -1177,16 +1188,6 @@ fn generate_toml(answers: &SetupAnswers) -> String {
                 writeln!(out, "# xmp_sidecar = false")?;
             }
         }
-        writeln!(out, "# temp_suffix = \".kei-tmp\"")?;
-        writeln!(out, "# no_progress_bar = false")?;
-
-        // [download.retry]
-        writeln!(out)?;
-        writeln!(out, "[download.retry]")?;
-        match answers.max_retries {
-            Some(n) => writeln!(out, "max_retries = {n}")?,
-            None => writeln!(out, "# max_retries = 3")?,
-        };
 
         // [filters]
         writeln!(out)?;
@@ -1552,7 +1553,6 @@ mod tests {
             max_retries: Some(5),
             bandwidth_limit: Some("10MB".to_string()),
             keep_unicode_in_filenames: true,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: true,
             #[cfg(feature = "xmp")]
             embed_xmp: true,
@@ -1589,9 +1589,9 @@ mod tests {
         assert!(toml_str.contains("bandwidth_limit = \"10MB\""));
         assert!(toml_str.contains("file_match_policy = \"name-id7\""));
         assert!(toml_str.contains("log_level = \"debug\""));
+        assert!(toml_str.contains("set_exif_datetime = true"));
         #[cfg(feature = "xmp")]
         {
-            assert!(toml_str.contains("set_exif_datetime = true"));
             assert!(toml_str.contains("embed_xmp = true"));
             // `xmp_sidecar = false` here means it's commented out, not active.
             assert!(toml_str.contains("# xmp_sidecar = false"));
@@ -1637,7 +1637,6 @@ mod tests {
             max_retries: Some(0),
             bandwidth_limit: Some("1Mi".to_string()),
             keep_unicode_in_filenames: true,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: true,
             #[cfg(feature = "xmp")]
             embed_xmp: true,
@@ -1663,14 +1662,15 @@ mod tests {
         assert_eq!(dl.folder_structure_albums.as_deref(), Some("{album}/%Y-%m"));
         assert_eq!(dl.threads, Some(2));
         assert_eq!(dl.bandwidth_limit.as_deref(), Some("1Mi"));
+        let metadata = parsed.metadata.unwrap();
+        assert_eq!(metadata.set_exif_datetime, Some(true));
         #[cfg(feature = "xmp")]
         {
-            assert_eq!(dl.set_exif_datetime, Some(true));
-            assert_eq!(dl.embed_xmp, Some(true));
-            assert_eq!(dl.xmp_sidecar, Some(true));
+            assert_eq!(metadata.embed_xmp, Some(true));
+            assert_eq!(metadata.xmp_sidecar, Some(true));
         }
         let retry = dl.retry.unwrap();
-        assert_eq!(retry.max_retries, Some(0));
+        assert_eq!(retry.per_transfer, Some(0));
 
         let filters = parsed.filters.unwrap();
         assert_eq!(filters.albums.as_deref(), Some(&["A".to_string()][..]));
@@ -1775,7 +1775,6 @@ mod tests {
                 raw_policy: Some(RawPolicy::PreferJpeg),
                 bandwidth_limit: Some("10MB".to_string()),
                 reconcile_every_n_cycles: Some(24),
-                #[cfg(feature = "xmp")]
                 set_exif_datetime: true,
                 #[cfg(feature = "xmp")]
                 embed_xmp: true,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -666,13 +666,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             media: config.filters.media,
             skip_created_before,
             skip_created_after,
-            #[cfg(feature = "xmp")]
             set_exif_datetime: config.metadata.set_exif_datetime,
-            #[cfg(feature = "xmp")]
             set_exif_rating: config.metadata.set_exif_rating,
-            #[cfg(feature = "xmp")]
             set_exif_gps: config.metadata.set_exif_gps,
-            #[cfg(feature = "xmp")]
             set_exif_description: config.metadata.set_exif_description,
             #[cfg(feature = "xmp")]
             embed_xmp: config.metadata.embed_xmp,

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -51,6 +51,7 @@ struct SyncToml<'a> {
     download: &'a str,
     filters: &'a str,
     photos: &'a str,
+    metadata: &'a str,
     watch: &'a str,
     notifications: &'a str,
     report: &'a str,
@@ -119,6 +120,7 @@ fn album_config(
     body.push_str(toml.filters);
     for (section, content) in [
         ("photos", toml.photos),
+        ("metadata", toml.metadata),
         ("watch", toml.watch),
         ("notifications", toml.notifications),
         ("report", toml.report),
@@ -740,7 +742,7 @@ fn sync_keep_unicode_preserves_special_chars() {
 
 // ── EXIF ────────────────────────────────────────────────────────────────
 
-/// --set-exif-datetime should embed DateTimeOriginal in downloaded JPEG files.
+/// [metadata].set_exif_datetime should embed DateTimeOriginal in downloaded JPEG files.
 #[cfg(feature = "xmp")]
 #[test]
 #[ignore]
@@ -756,7 +758,7 @@ fn sync_set_exif_datetime_embeds_date() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "set_exif_datetime = true\n",
+                metadata: "set_exif_datetime = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -786,16 +788,16 @@ fn sync_set_exif_datetime_embeds_date() {
             .expect("open JPEG for XMP read");
         let meta = file
             .xmp()
-            .expect("JPEG should have XMP after --set-exif-datetime");
+            .expect("JPEG should have XMP after set_exif_datetime");
         assert!(
             meta.property(xmp_ns::EXIF, "DateTimeOriginal").is_some()
                 || meta.property(xmp_ns::XMP, "CreateDate").is_some(),
-            "DateTimeOriginal XMP property should be present after --set-exif-datetime"
+            "DateTimeOriginal XMP property should be present after set_exif_datetime"
         );
     });
 }
 
-/// --set-exif-rating should add a Rating property (value depends on the
+/// [metadata].set_exif_rating should add a Rating property (value depends on the
 /// source photo; we assert the sync succeeds and the resulting JPEG has
 /// a writable XMP packet).
 #[cfg(feature = "xmp")]
@@ -813,7 +815,7 @@ fn sync_set_exif_rating_embeds_rating() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "set_exif_rating = true\n",
+                metadata: "set_exif_rating = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -829,12 +831,12 @@ fn sync_set_exif_rating_embeds_rating() {
             .expect("open JPEG for XMP read");
         assert!(
             file.xmp().is_some(),
-            "JPEG should carry an XMP packet after --set-exif-rating"
+            "JPEG should carry an XMP packet after set_exif_rating"
         );
     });
 }
 
-/// --set-exif-gps embeds GPSLatitude/GPSLongitude when the source photo
+/// [metadata].set_exif_gps embeds GPSLatitude/GPSLongitude when the source photo
 /// carries location data. Sync must succeed either way; we only assert
 /// an XMP packet exists.
 #[cfg(feature = "xmp")]
@@ -852,7 +854,7 @@ fn sync_set_exif_gps_embeds_gps() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "set_exif_gps = true\n",
+                metadata: "set_exif_gps = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -868,12 +870,12 @@ fn sync_set_exif_gps_embeds_gps() {
             .expect("open JPEG for XMP read");
         assert!(
             file.xmp().is_some(),
-            "JPEG should carry an XMP packet after --set-exif-gps"
+            "JPEG should carry an XMP packet after set_exif_gps"
         );
     });
 }
 
-/// --set-exif-description embeds a dc:description when the source has
+/// [metadata].set_exif_description embeds a dc:description when the source has
 /// one. Sync must succeed either way; we only assert an XMP packet
 /// exists.
 #[cfg(feature = "xmp")]
@@ -891,7 +893,7 @@ fn sync_set_exif_description_embeds_description() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "set_exif_description = true\n",
+                metadata: "set_exif_description = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -907,12 +909,12 @@ fn sync_set_exif_description_embeds_description() {
             .expect("open JPEG for XMP read");
         assert!(
             file.xmp().is_some(),
-            "JPEG should carry an XMP packet after --set-exif-description"
+            "JPEG should carry an XMP packet after set_exif_description"
         );
     });
 }
 
-/// --embed-xmp writes a full kei-authored XMP packet into the JPEG. Verify
+/// [metadata].embed_xmp writes a full kei-authored XMP packet into the JPEG. Verify
 /// the file carries XMP content that references kei's own namespace URI.
 #[cfg(feature = "xmp")]
 #[test]
@@ -929,7 +931,7 @@ fn sync_embed_xmp_writes_xmp_packet() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "embed_xmp = true\n",
+                metadata: "embed_xmp = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -943,7 +945,7 @@ fn sync_embed_xmp_writes_xmp_packet() {
         let mut file = XmpFile::new().expect("xmp file handle");
         file.open_file(&jpeg, OpenFileOptions::default().for_read())
             .expect("open JPEG for XMP read");
-        let meta = file.xmp().expect("JPEG should carry XMP after --embed-xmp");
+        let meta = file.xmp().expect("JPEG should carry XMP after embed_xmp");
         // kei registers its own namespace (github.com/rhoopr/kei/ns/1.0/)
         // for hidden/archived/mediaSubtype/burstId. Serialize and look for
         // it so we know the packet reached us, not just a remnant from
@@ -956,7 +958,7 @@ fn sync_embed_xmp_writes_xmp_packet() {
     });
 }
 
-/// --xmp-sidecar writes a .xmp sidecar next to every downloaded media file.
+/// [metadata].xmp_sidecar writes a .xmp sidecar next to every downloaded media file.
 /// Verify at least one `.xmp` sits next to a downloaded JPEG.
 #[cfg(feature = "xmp")]
 #[test]
@@ -973,7 +975,7 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "xmp_sidecar = true\n",
+                metadata: "xmp_sidecar = true\n",
                 filters: "media = [\"photos\", \"live-photos\"]\n",
                 ..SyncToml::default()
             },
@@ -993,7 +995,7 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
             .collect();
         assert!(
             !sidecars.is_empty(),
-            "--xmp-sidecar should produce at least one .xmp sidecar, got files: {files:?}"
+            "xmp_sidecar should produce at least one .xmp sidecar, got files: {files:?}"
         );
 
         let bytes = std::fs::read(sidecars[0]).expect("read sidecar");
@@ -1005,10 +1007,11 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
     });
 }
 
-/// --embed-xmp on a HEIC file: kei routes through the mp4-atom HEIC writer
+/// [metadata].embed_xmp on a HEIC file: kei routes through the mp4-atom HEIC writer
 /// rather than xmp_toolkit. The resulting HEIC must carry an XMP packet
 /// as a MIME item inside the `meta` box; we detect it by looking for the
 /// `<x:xmpmeta` magic in the file bytes.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_embed_xmp_on_heic_writes_mime_item() {
@@ -1023,7 +1026,7 @@ fn sync_embed_xmp_on_heic_writes_mime_item() {
             &cookie_dir,
             download_dir.path(),
             SyncToml {
-                download: "embed_xmp = true\n",
+                metadata: "embed_xmp = true\n",
                 ..SyncToml::default()
             },
         )
@@ -1061,7 +1064,7 @@ fn sync_embed_xmp_on_heic_writes_mime_item() {
             .any(|w| w.eq_ignore_ascii_case(needle));
         assert!(
             found,
-            "HEIC `{}` must carry an XMP packet after --embed-xmp",
+            "HEIC `{}` must carry an XMP packet after embed_xmp",
             heics[0].display()
         );
     });


### PR DESCRIPTION
## Summary
- Renamed retry TOML to `[download.retry].per_transfer` and `per_asset`, with old retry keys rejected.
- Moved durable progress to `[ui].progress_bar`, kept default progress enabled, and kept `--no-progress-bar` as a one-run disable.
- Moved metadata settings to `[metadata]`, made JPEG/TIFF EXIF writes work without the `xmp` feature via `little_exif`, and kept full XMP/sidecar/HEIC writes behind `xmp`.
- Routed metadata temp files through configured `download.temp_suffix`.
- Added CI metadata for the no-`xmp` EXIF dependency: cargo-udeps ignores the default-feature false positive, and cargo-audit documents the unmaintained-only `paste` advisory from `little_exif`.

## Review notes
Start with `src/config.rs` for resolver and round-trip behavior, then `src/download/metadata.rs` and `src/download/pipeline.rs` for write paths. `src/setup.rs` and tests are follow-through.

## Tests
- `cargo check`
- `cargo check --no-default-features`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo audit --deny warnings`
- `cargo +nightly udeps --all-targets`
- `cargo test config::tests -- --test-threads=1`
- `cargo test download::metadata::tests -- --test-threads=1`
- `cargo test setup::tests -- --test-threads=1`
- `cargo test download::tests::test_with_pass_preserves_all_fields -- --test-threads=1`
- `cargo test --test sync -- --test-threads=1`
- `cargo test --no-default-features -- --test-threads=1` (run outside sandbox so wiremock and metrics tests can bind localhost)
- `cargo run -- sync --help`
- `cargo run -- --config <tmp> config show`
