### PR TITLE
Simplify friendly mode internals

### DIFF
--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -854,7 +854,7 @@ fn create_progress_bar(
             // rotation at the 10Hz steady-tick cadence) — slow enough to read
             // as "loading" rather than "frantic". The trailing space is
             // indicatif's "finished" frame.
-            style = style.tick_chars("◐◐◐◐◓◓◓◓◑◑◑◑◒◒◒◒ ");
+            style = style.tick_chars(crate::personality::theme::FRIENDLY_TICK_CHARS);
         }
         pb.set_style(style);
     }
@@ -1026,7 +1026,6 @@ where
         pb.clone(),
         config.pass_label().to_string(),
         config.personality_mode,
-        crate::personality::verbs::Phase::Listing,
     );
 
     if config.only_print_filenames {

--- a/src/personality/bar_render.rs
+++ b/src/personality/bar_render.rs
@@ -91,13 +91,6 @@ impl BarSmoother {
         }
         self.displayed
     }
-
-    /// Return the most recently displayed fraction without advancing.
-    #[allow(dead_code, reason = "introspection helper, used by tests")]
-    #[must_use]
-    pub fn displayed(&self) -> f64 {
-        self.displayed
-    }
 }
 
 /// Render the bar at `fraction` over `width` cells with sub-cell partial
@@ -379,10 +372,10 @@ mod tests {
         let mut sm = BarSmoother::new();
         let start = Instant::now();
         sm.tick_at(0.3, start);
+        let mut f = 0.0;
         for i in 1..50 {
-            sm.tick_at(0.3, start + std::time::Duration::from_millis(100 * i));
+            f = sm.tick_at(0.3, start + std::time::Duration::from_millis(100 * i));
         }
-        let f = sm.displayed();
         assert!(
             (f - 0.3).abs() < 1e-3,
             "displayed should converge to target, got {f}",

--- a/src/personality/cycler.rs
+++ b/src/personality/cycler.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use indicatif::ProgressBar;
 
-use crate::personality::verbs::{Phase, VerbPool};
+use crate::personality::verbs::VerbPool;
 use crate::personality::Mode;
 
 /// Default cadence between verb advances. Slow enough to be readable; fast
@@ -45,8 +45,8 @@ impl PhaseCycler {
     /// task. In off mode, seeds a static "<label> · scanning..." and returns
     /// a no-op cycler whose `cancel` and `Drop` are no-ops.
     #[must_use]
-    pub fn spawn(pb: ProgressBar, pass_label: String, mode: Mode, phase: Phase) -> Self {
-        Self::spawn_with_interval(pb, pass_label, mode, phase, DEFAULT_INTERVAL)
+    pub fn spawn(pb: ProgressBar, pass_label: String, mode: Mode) -> Self {
+        Self::spawn_with_interval(pb, pass_label, mode, DEFAULT_INTERVAL)
     }
 
     /// Seed-and-spawn, parameterised on cycle interval. Tests use this with
@@ -56,7 +56,6 @@ impl PhaseCycler {
         pb: ProgressBar,
         pass_label: String,
         mode: Mode,
-        phase: Phase,
         interval: Duration,
     ) -> Self {
         if !mode.is_friendly() {
@@ -67,7 +66,7 @@ impl PhaseCycler {
         }
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
-        let mut pool = VerbPool::new(phase);
+        let mut pool = VerbPool::new();
         // Seed synchronously so the bar's first frame already shows a verb,
         // even if cancellation or runtime shutdown beats the first interval
         // tick.
@@ -109,15 +108,13 @@ impl Drop for PhaseCycler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::personality::verbs::Phase;
     use crate::personality::Mode;
     use indicatif::ProgressBar;
 
     #[tokio::test]
     async fn off_mode_seeds_scanning_string_and_does_not_cycle() {
         let pb = ProgressBar::hidden();
-        let cycler =
-            PhaseCycler::spawn(pb.clone(), "unfiled".to_string(), Mode::Off, Phase::Listing);
+        let cycler = PhaseCycler::spawn(pb.clone(), "unfiled".to_string(), Mode::Off);
         assert_eq!(pb.message(), "unfiled \u{00b7} scanning...");
         // Off mode must not spawn a cycling task. Wait long enough that any
         // friendly-mode cycler would have ticked, then assert the message
@@ -139,7 +136,6 @@ mod tests {
             pb.clone(),
             "unfiled".to_string(),
             Mode::Friendly,
-            Phase::Listing,
             Duration::from_millis(50),
         );
         // The seed happens inside spawn before the task runs, so the first
@@ -153,8 +149,7 @@ mod tests {
             msg, "unfiled \u{00b7} scanning...",
             "friendly mode must never use the static scanning seed",
         );
-        let first_verb = Phase::Listing.pool()[0];
-        assert_eq!(msg, format!("unfiled \u{00b7} {first_verb}"));
+        assert_eq!(msg, "unfiled \u{00b7} looking around");
         cycler.cancel();
     }
 
@@ -165,7 +160,6 @@ mod tests {
             pb.clone(),
             "trip 2024".to_string(),
             Mode::Friendly,
-            Phase::Listing,
             Duration::from_millis(20),
         );
         let initial = pb.message().to_string();
@@ -200,7 +194,6 @@ mod tests {
             pb.clone(),
             "unfiled".to_string(),
             Mode::Friendly,
-            Phase::Listing,
             Duration::from_millis(10),
         );
         tokio::time::sleep(Duration::from_millis(60)).await;
@@ -224,7 +217,6 @@ mod tests {
             pb.clone(),
             "unfiled".to_string(),
             Mode::Friendly,
-            Phase::Listing,
             Duration::from_millis(50),
         );
         // Mirrors the per-file consumer path: cancel called every iteration
@@ -242,7 +234,6 @@ mod tests {
                 pb.clone(),
                 "unfiled".to_string(),
                 Mode::Friendly,
-                Phase::Listing,
                 Duration::from_millis(10),
             );
             tokio::time::sleep(Duration::from_millis(40)).await;

--- a/src/personality/mod.rs
+++ b/src/personality/mod.rs
@@ -21,14 +21,6 @@ pub mod summary;
 pub mod theme;
 pub mod tracing;
 pub mod tty_echo;
-// Phase::Listing + VerbPool::{new, next} are consumed by `cycler` for the
-// pre-first-file scan gap. Other phases and accessors stay reserved for the
-// remaining delight-B wires (phase narration, sign-off card) so we don't
-// trim the surface and re-grow it in the next PR.
-#[allow(
-    dead_code,
-    reason = "remaining phases/methods consumed by later delight-B wires"
-)]
 pub mod verbs;
 
 use std::env;

--- a/src/personality/sparkline.rs
+++ b/src/personality/sparkline.rs
@@ -146,46 +146,11 @@ impl SparklineState {
         out
     }
 
-    /// ASCII fallback for terminals that fail Unicode width detection.
-    /// Always `capacity` chars wide; left-padded with spaces during fill.
-    #[allow(dead_code, reason = "fallback hook reserved for delight-B")]
-    #[must_use]
-    pub fn render_ascii(&self) -> String {
-        let pad = self.capacity.saturating_sub(self.samples.len());
-        let mut out = String::with_capacity(self.capacity);
-        for _ in 0..pad {
-            out.push(' ');
-        }
-        for &rate in &self.samples {
-            out.push(if rate < RATE_RENDER_FLOOR { ' ' } else { '#' });
-        }
-        out
-    }
-
     /// Latest smoothed per-second rate. Drives the "X.X/s" label paired with
     /// the chart so the number and the chart agree on what's happening.
     #[must_use]
     pub fn rate_per_sec(&self) -> f64 {
         self.smoothed_rate
-    }
-
-    /// Number of retained samples (capped at `capacity`).
-    #[allow(
-        dead_code,
-        reason = "introspection helper, used by tests and delight-B"
-    )]
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.samples.len()
-    }
-
-    #[allow(
-        dead_code,
-        reason = "introspection helper, used by tests and delight-B"
-    )]
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.samples.is_empty()
     }
 }
 
@@ -202,8 +167,7 @@ mod tests {
     #[test]
     fn new_buffer_is_empty() {
         let s = SparklineState::new(12);
-        assert!(s.is_empty());
-        assert_eq!(s.len(), 0);
+        assert!(s.samples.is_empty());
         assert_eq!(s.render(), "            "); // 12 spaces
     }
 
@@ -213,7 +177,7 @@ mod tests {
         let mut t = ticks();
         s.sample_at(100, t.next().unwrap());
         // First sample never produces a delta; buffer stays empty.
-        assert!(s.is_empty());
+        assert!(s.samples.is_empty());
     }
 
     #[test]
@@ -222,7 +186,7 @@ mod tests {
         let mut t = ticks();
         s.sample_at(100, t.next().unwrap());
         s.sample_at(105, t.next().unwrap());
-        assert_eq!(s.len(), 1);
+        assert_eq!(s.samples.len(), 1);
     }
 
     #[test]
@@ -233,7 +197,7 @@ mod tests {
         for i in 1..=10u64 {
             s.sample_at(i * 10, t.next().unwrap());
         }
-        assert_eq!(s.len(), 4);
+        assert_eq!(s.samples.len(), 4);
     }
 
     #[test]
@@ -296,21 +260,6 @@ mod tests {
             assert_eq!(c, ' ', "cell {i} should be space (padding)");
         }
         assert_ne!(chars[7], ' ', "rightmost cell should carry the new sample");
-    }
-
-    #[test]
-    fn render_ascii_falls_back_to_hash_and_space() {
-        let mut s = SparklineState::new(4);
-        let mut t = ticks();
-        s.sample_at(0, t.next().unwrap());
-        s.sample_at(0, t.next().unwrap());
-        s.sample_at(5, t.next().unwrap());
-        s.sample_at(0, t.next().unwrap());
-        s.sample_at(10, t.next().unwrap());
-        let r = s.render_ascii();
-        assert_eq!(r.len(), 4);
-        assert!(r.contains('#'));
-        assert!(r.contains(' '));
     }
 
     #[test]
@@ -402,7 +351,7 @@ mod tests {
         let mut t = ticks();
         s.sample_at(100, t.next().unwrap());
         s.sample_at(50, t.next().unwrap());
-        assert_eq!(s.len(), 1);
+        assert_eq!(s.samples.len(), 1);
     }
 
     #[test]
@@ -413,7 +362,7 @@ mod tests {
         s.sample_at(5, t.next().unwrap());
         s.sample_at(10, t.next().unwrap());
         s.sample_at(15, t.next().unwrap());
-        assert_eq!(s.len(), 1);
+        assert_eq!(s.samples.len(), 1);
         assert_eq!(s.render().chars().count(), 1);
     }
 

--- a/src/personality/theme.rs
+++ b/src/personality/theme.rs
@@ -1,41 +1,14 @@
-//! Visual theme: spinner glyphs, bar templates, semantic color roles.
+//! Visual theme: progress glyphs, bar templates, semantic color roles.
 //!
-//! All glyph sets and templates are static, so the theme can be tested
-//! without a live terminal. Color is applied at render time via
-//! `console::Style`, which honours `NO_COLOR` and TTY detection on its own.
+//! All templates are static, so the theme can be tested without a live
+//! terminal. Color is applied at render time via `console::Style`, which
+//! honours `NO_COLOR` and TTY detection on its own.
 
 use crate::personality::Mode;
 
-/// Spinner glyph set per phase. Indicatif consumes a `&[&str]` of frames.
-#[allow(
-    dead_code,
-    reason = "spinner sets land in delight-B/C with auth/2FA/watch wires"
-)]
-pub mod spinners {
-    /// Auth / session check (Dots, ~80ms).
-    pub const AUTH: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-
-    /// Listing iCloud (Dots2, ~80ms).
-    pub const LISTING: &[&str] = &["⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"];
-
-    /// Verify / hash pass (Dots3, ~120ms).
-    pub const VERIFY: &[&str] = &["⡀", "⡄", "⡆", "⡇", "⠇", "⠃", "⠁", "⠀"];
-
-    /// EXIF / sidecar write (block oscillator, ~100ms).
-    pub const EXIF: &[&str] = &[
-        "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█", "▉", "▊", "▋", "▌", "▍", "▎", "▏", " ",
-    ];
-
-    /// 2FA wait (slow breathing dots, 4-frame ~400ms).
-    pub const TWOFA: &[&str] = &["⠁", "⠂", "⠄", "⠂"];
-
-    /// Watch idle (static dot; included as a single-frame "set" for API
-    /// consistency).
-    pub const WATCH_IDLE: &[&str] = &["·"];
-
-    /// ASCII fallback for terminals that fail Unicode width detection.
-    pub const ASCII: &[&str] = &["|", "/", "-", "\\"];
-}
+/// Friendly bar spinner glyphs. Each visible glyph is repeated four times so
+/// the 10Hz redraw cadence advances one visible phase roughly every 400ms.
+pub(crate) const FRIENDLY_TICK_CHARS: &str = "◐◐◐◐◓◓◓◓◑◑◑◑◒◒◒◒ ";
 
 /// Width tier for adaptive bar templates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -153,12 +126,8 @@ pub fn download_bar_template(
             top_rule: String::new(),
             bottom_rule: String::new(),
         },
-        (Mode::Friendly, WidthTier::Wide) => {
-            friendly_card(cols, total, friendly_bar_width(cols), true, source)
-        }
-        (Mode::Friendly, WidthTier::Medium) => {
-            friendly_card(cols, total, friendly_bar_width(cols), false, source)
-        }
+        (Mode::Friendly, WidthTier::Wide) => friendly_card(cols, total, true, source),
+        (Mode::Friendly, WidthTier::Medium) => friendly_card(cols, total, false, source),
         (Mode::Friendly, WidthTier::Narrow) => BarTemplate {
             template: "{bar:16.cyan/blue} {pos}/{len}".to_string(),
             top_rule: String::new(),
@@ -203,13 +172,7 @@ pub fn friendly_sparkline_width(cols: u16) -> u16 {
 /// Returns the indicatif template (referencing custom keys `{top_rule}`,
 /// `{bottom_rule}`, `{bar_animated}`, `{spinner}`) plus the rendered rule
 /// strings the closures will pulse-color on each redraw.
-fn friendly_card(
-    cols: u16,
-    total: u64,
-    bar_width: u16,
-    with_smart_eta: bool,
-    source: Source,
-) -> BarTemplate {
+fn friendly_card(cols: u16, total: u64, with_smart_eta: bool, source: Source) -> BarTemplate {
     // Rule width: cols - 1 so a final newline / cursor reset doesn't bump the
     // bar onto a phantom line on terminals that auto-wrap at exactly cols.
     let rule_total = cols.saturating_sub(1).max(20) as usize;
@@ -228,21 +191,12 @@ fn friendly_card(
     // ` 1/30` and `30/30` so the counter doesn't shift when crossing a
     // power of ten.
     //
-    // bar_width passes through to the animated-bar custom key (which reads
-    // it from a closure), but indicatif's measure-text-width still reads the
-    // bar's slot in the template, so we encode the width in the placeholder
-    // name itself: `{bar_animated:N}` where N is the visual width. The
-    // closure parses the suffix back out via state metadata.
     let pos_width = total.checked_ilog10().map_or(1, |n| n + 1) as usize;
 
-    // Bar width carries via the closure capture in pipeline.rs; the template
-    // just references the custom key by name. `{bar_animated}` and other
-    // custom keys (`{top_rule}`, `{bottom_rule}`, `{rate_sparkline}`,
-    // `{smart_eta}`) are registered there. `{spinner}` is an indicatif
-    // built-in that animates against the bar's tick chars.
-    //
-    // We embed bar_width into the placeholder name so a future caller could
-    // look it up if needed; the closure ignores it but it documents intent.
+    // `{bar_animated}` and other custom keys (`{top_rule}`, `{bottom_rule}`,
+    // `{rate_sparkline}`, `{smart_eta}`) are registered in pipeline.rs.
+    // `{spinner}` is an indicatif built-in that animates against the bar's
+    // tick chars.
     // Leading `\n` on the template gives the card one blank line of
     // breathing room above the top rule, separating it from prior
     // scrollback (greeting, narration, the previous cycle's sign-off)
@@ -258,7 +212,6 @@ fn friendly_card(
             "\n{{top_rule}}\n│  {{wide_msg}}\n│  {{bar_animated}} {{percent:>3}}% {{spinner}}\n│  {{rate_sparkline}}  {{pos:>{pos_width}}}/{{len}}\n{{bottom_rule}}"
         )
     };
-    let _ = bar_width; // captured via pipeline.rs closure; no template slot.
     BarTemplate {
         template,
         top_rule: top,
@@ -292,6 +245,12 @@ mod tests {
         assert!(chars.contains('█'));
         assert!(chars.contains('▏'));
         assert!(chars.ends_with(' '));
+    }
+
+    #[test]
+    fn friendly_tick_chars_include_finished_frame() {
+        assert!(FRIENDLY_TICK_CHARS.contains('◐'));
+        assert!(FRIENDLY_TICK_CHARS.ends_with(' '));
     }
 
     #[test]
@@ -505,23 +464,5 @@ mod tests {
         assert!(!template.contains("{smart_eta}"));
         assert!(medium.top_rule.starts_with('╭') && medium.top_rule.ends_with('╮'));
         assert!(medium.bottom_rule.starts_with('╰') && medium.bottom_rule.ends_with('╯'));
-    }
-
-    #[test]
-    fn spinner_sets_are_non_empty() {
-        for set in [
-            spinners::AUTH,
-            spinners::LISTING,
-            spinners::VERIFY,
-            spinners::EXIF,
-            spinners::TWOFA,
-            spinners::WATCH_IDLE,
-            spinners::ASCII,
-        ] {
-            assert!(!set.is_empty(), "spinner set must have at least one frame");
-            for frame in set {
-                assert!(!frame.is_empty(), "spinner frame must be non-empty");
-            }
-        }
     }
 }

--- a/src/personality/verbs.rs
+++ b/src/personality/verbs.rs
@@ -1,129 +1,37 @@
-//! Verb pools per phase. Friendly mode rotates through pool entries every few
-//! seconds so the active spinner label feels alive without changing semantics.
+//! Verb pool for the active listing label.
 //!
-//! Pools are static; the cycler is a stateful struct that remembers the last
-//! index and avoids picking it again. Pure code, no I/O.
+//! The download bar starts before the first file is available, so friendly mode
+//! rotates a few listing verbs to show that enumeration is still alive. Other
+//! phase narration is handled directly in `narration.rs`.
 
-/// Sync phase that owns a verb pool.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Phase {
-    Auth,
-    Listing,
-    Download,
-    Hashing,
-    Exif,
-    Verify,
-    Stalled,
-    TwoFaWait,
-    RetryCountdown,
-    WatchIdle,
-}
+const LISTING_VERBS: &[&str] = &[
+    "looking around",
+    "counting albums",
+    "asking iCloud what is new",
+];
 
-impl Phase {
-    /// Pool of label alternates rotated every few seconds when friendly is on.
-    /// First entry is the canonical noun; alternates add flavour.
-    #[must_use]
-    pub fn pool(self) -> &'static [&'static str] {
-        match self {
-            Phase::Auth => &[
-                "saying hi to iCloud",
-                "checking the doormat",
-                "waking up the session",
-            ],
-            Phase::Listing => &[
-                "looking around",
-                "counting albums",
-                "asking iCloud what is new",
-            ],
-            Phase::Download => &[
-                "bringing them home",
-                "wrangling pixels",
-                "carrying boxes upstairs",
-                "fetching the next batch",
-            ],
-            Phase::Hashing => &["hashing", "comparing fingerprints", "checking for twins"],
-            Phase::Exif => &["reading EXIF", "tagging metadata", "writing sidecar"],
-            Phase::Verify => &[
-                "double-checking",
-                "matching fingerprints",
-                "making sure nothing got lost in the mail",
-            ],
-            Phase::Stalled => &["still here, just slow internet"],
-            Phase::TwoFaWait => &["waiting on your tap", "still listening", "any moment now"],
-            Phase::RetryCountdown => &["retrying soon"],
-            Phase::WatchIdle => &["sleeping"],
-        }
-    }
-
-    /// Default (off-mode) noun that survives in scrollback. Matches the
-    /// canonical first entry of the pool but lower-stakes, used when friendly
-    /// is off and we just want a one-word phase label.
-    #[must_use]
-    pub fn noun(self) -> &'static str {
-        match self {
-            Phase::Auth => "authenticating",
-            Phase::Listing => "listing",
-            Phase::Download => "downloading",
-            Phase::Hashing => "hashing",
-            Phase::Exif => "writing metadata",
-            Phase::Verify => "verifying",
-            Phase::Stalled => "waiting",
-            Phase::TwoFaWait => "waiting for 2FA",
-            Phase::RetryCountdown => "retrying",
-            Phase::WatchIdle => "idle",
-        }
-    }
-}
-
-/// Rotates through a phase's verb pool, never picking the same index twice
+/// Rotates through the listing verb pool, never picking the same index twice
 /// in a row.
 #[derive(Debug, Clone)]
 pub struct VerbPool {
-    phase: Phase,
     index: Option<usize>,
 }
 
 impl VerbPool {
     #[must_use]
-    pub fn new(phase: Phase) -> Self {
-        Self { phase, index: None }
+    pub fn new() -> Self {
+        Self { index: None }
     }
 
-    /// Return the current label without advancing.
-    ///
-    /// Falls back to `""` if the underlying pool is empty, which is a programmer
-    /// error caught by `every_phase_has_a_non_empty_pool`. The fallback is just
-    /// to keep this function panic-free at runtime.
-    #[must_use]
-    pub fn current(&self) -> &'static str {
-        let pool = self.phase.pool();
-        let idx = self.index.unwrap_or(0);
-        if pool.is_empty() {
-            ""
-        } else {
-            pool.get(idx % pool.len()).copied().unwrap_or("")
-        }
-    }
-
-    /// Advance to the next label and return it. With pools of size >=2, the
-    /// returned label is guaranteed to differ from the previous one.
+    /// Advance to the next label and return it. The listing pool has at least
+    /// two entries, so the returned label differs from the previous one.
     pub fn next(&mut self) -> &'static str {
-        let pool = self.phase.pool();
-        if pool.is_empty() {
-            return "";
-        }
         let next = match self.index {
             None => 0,
-            Some(prev) if pool.len() <= 1 => prev,
-            Some(prev) => (prev + 1) % pool.len(),
+            Some(prev) => (prev + 1) % LISTING_VERBS.len(),
         };
         self.index = Some(next);
-        pool.get(next).copied().unwrap_or("")
-    }
-
-    #[must_use]
-    pub fn phase(&self) -> Phase {
-        self.phase
+        LISTING_VERBS.get(next).copied().unwrap_or("")
     }
 }
 
@@ -132,84 +40,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn every_phase_has_a_non_empty_pool() {
-        for phase in [
-            Phase::Auth,
-            Phase::Listing,
-            Phase::Download,
-            Phase::Hashing,
-            Phase::Exif,
-            Phase::Verify,
-            Phase::Stalled,
-            Phase::TwoFaWait,
-            Phase::RetryCountdown,
-            Phase::WatchIdle,
-        ] {
-            let pool = phase.pool();
-            assert!(!pool.is_empty(), "{phase:?} has empty pool");
-            for entry in pool {
-                assert!(!entry.is_empty(), "{phase:?} has empty entry");
-            }
+    fn listing_pool_has_multiple_non_empty_entries() {
+        assert!(
+            LISTING_VERBS.len() >= 2,
+            "listing pool must have enough entries to rotate"
+        );
+        for entry in LISTING_VERBS {
+            assert!(!entry.is_empty(), "listing verb must be non-empty");
         }
     }
 
     #[test]
-    fn every_phase_has_a_noun() {
-        for phase in [Phase::Auth, Phase::Listing, Phase::Download, Phase::Verify] {
-            assert!(!phase.noun().is_empty());
+    fn cycling_never_repeats_consecutively() {
+        let mut pool = VerbPool::new();
+        let mut prev = pool.next();
+        for _ in 0..20 {
+            let cur = pool.next();
+            assert_ne!(prev, cur, "repeated listing label {cur}");
+            prev = cur;
         }
-    }
-
-    #[test]
-    fn cycling_never_repeats_consecutively_for_multi_entry_pools() {
-        let multi_phases = [
-            Phase::Auth,
-            Phase::Listing,
-            Phase::Download,
-            Phase::Hashing,
-            Phase::Exif,
-            Phase::Verify,
-            Phase::TwoFaWait,
-        ];
-        for phase in multi_phases {
-            let mut pool = VerbPool::new(phase);
-            let mut prev = pool.next();
-            for _ in 0..20 {
-                let cur = pool.next();
-                assert_ne!(prev, cur, "phase {phase:?} repeated label {cur}");
-                prev = cur;
-            }
-        }
-    }
-
-    #[test]
-    fn single_entry_pool_returns_same_label() {
-        let mut pool = VerbPool::new(Phase::Stalled);
-        let first = pool.next();
-        let second = pool.next();
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn current_returns_canonical_before_advancing() {
-        let pool = VerbPool::new(Phase::Download);
-        assert_eq!(pool.current(), Phase::Download.pool()[0]);
     }
 
     #[test]
     fn next_eventually_visits_every_entry() {
-        let mut pool = VerbPool::new(Phase::Download);
-        let pool_len = Phase::Download.pool().len();
+        let mut pool = VerbPool::new();
         let mut seen = std::collections::HashSet::new();
-        for _ in 0..(pool_len * 4) {
+        for _ in 0..(LISTING_VERBS.len() * 4) {
             seen.insert(pool.next());
         }
-        assert_eq!(seen.len(), pool_len, "should visit every entry");
-    }
-
-    #[test]
-    fn phase_accessor_returns_construction_phase() {
-        let pool = VerbPool::new(Phase::Verify);
-        assert_eq!(pool.phase(), Phase::Verify);
+        assert_eq!(seen.len(), LISTING_VERBS.len(), "should visit every entry");
     }
 }


### PR DESCRIPTION
## Summary
- Removed friendly-mode scaffolding that wasn't wired into current behavior: reserved phase verbs, unused spinner sets, ASCII sparkline fallback, and dead-code helper accessors.
- Kept the active friendly paths intact: listing verb cycling, animated progress card, sparkline, summary, narration, and TTY gating.
- Replaced stale future-delight comments with current behavior and narrowed the friendly tick glyph constant to crate scope.

## Tests
- `cargo check`
- `cargo test personality`
- `cargo run -- sync --help`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
