### PR TITLE
Reduce idle watch-mode CloudKit calls

### DIFF
--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2717,6 +2717,31 @@ mod tests {
         (dir, Arc::new(tokio::sync::RwLock::new(session)))
     }
 
+    fn make_run_cycle_download_config_builder(
+        download_dir: &std::path::Path,
+        db: Arc<dyn state::StateDb>,
+    ) -> impl Fn(
+        download::SyncMode,
+        Arc<rustc_hash::FxHashSet<String>>,
+        Arc<download::AssetGroupings>,
+        Arc<str>,
+    ) -> Arc<download::DownloadConfig>
+           + '_ {
+        move |sync_mode, exclude_asset_ids, asset_groupings, library| {
+            let mut config = download::DownloadConfig::test_default();
+            config.directory = Arc::from(download_dir);
+            config.folder_structure = "%Y/%m/%d".to_string();
+            config.folder_structure_albums = Arc::from("%Y/%m/%d");
+            config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
+            config.state_db = Some(Arc::clone(&db));
+            config.sync_mode = sync_mode;
+            config.exclude_asset_ids = exclude_asset_ids;
+            config.asset_groupings = asset_groupings;
+            config.library = library;
+            Arc::new(config)
+        }
+    }
+
     fn make_run_cycle_config() -> config::Config {
         let data_dir = tempfile::tempdir().expect("config data dir");
         let globals = config::GlobalArgs {
@@ -2804,19 +2829,38 @@ mod tests {
         Arc::new(state::SqliteStateDb::open_in_memory().expect("open in-memory state DB"))
     }
 
-    struct FailingSyncTokenSetDb {
-        inner: Arc<dyn state::StateDb>,
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MetadataSetFailure {
+        Exact(&'static str),
+        Prefix(&'static str),
     }
 
-    impl std::fmt::Debug for FailingSyncTokenSetDb {
+    impl MetadataSetFailure {
+        fn matches(self, key: &str) -> bool {
+            match self {
+                Self::Exact(expected) => key == expected,
+                Self::Prefix(prefix) => key.starts_with(prefix),
+            }
+        }
+    }
+
+    struct FailingMetadataSetDb {
+        inner: Arc<dyn state::StateDb>,
+        failure: MetadataSetFailure,
+        message: &'static str,
+    }
+
+    impl std::fmt::Debug for FailingMetadataSetDb {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("FailingSyncTokenSetDb")
+            f.debug_struct("FailingMetadataSetDb")
+                .field("failure", &self.failure)
+                .field("message", &self.message)
                 .finish_non_exhaustive()
         }
     }
 
     #[async_trait::async_trait]
-    impl state::StateDb for FailingSyncTokenSetDb {
+    impl state::StateDb for FailingMetadataSetDb {
         #[cfg(test)]
         async fn should_download(
             &self,
@@ -3006,10 +3050,8 @@ mod tests {
             key: &str,
             value: &str,
         ) -> Result<(), state::error::StateError> {
-            if key.starts_with(SYNC_TOKEN_PREFIX) {
-                Err(state::error::StateError::LockPoisoned(
-                    "simulated sync-token write failure".into(),
-                ))
+            if self.failure.matches(key) {
+                Err(state::error::StateError::LockPoisoned(self.message.into()))
             } else {
                 self.inner.set_metadata(key, value).await
             }
@@ -3808,272 +3850,6 @@ mod tests {
     #[tokio::test]
     async fn check_changes_database_token_persist_failure_does_not_skip() {
         use serde_json::json;
-        // StateDb that succeeds on get_metadata("sync_token:...") but
-        // fails on set_metadata(DB_SYNC_TOKEN_KEY, ...) — the only write
-        // path inside `check_changes_database`.
-        struct PartiallyFailingDb {
-            inner: Arc<dyn state::StateDb>,
-        }
-
-        #[async_trait::async_trait]
-        impl state::StateDb for PartiallyFailingDb {
-            #[cfg(test)]
-            async fn should_download(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-            ) -> Result<bool, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn upsert_seen(
-                &self,
-                _: &state::types::AssetRecord,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_downloaded(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-                _: &str,
-                _: Option<&str>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn import_adopt(
-                &self,
-                _: &state::types::AssetRecord,
-                _: &std::path::Path,
-                _: &str,
-                _: u64,
-                _: Option<i64>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_failed(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed_sample(
-                &self,
-                _: u32,
-            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_pending(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_summary(
-                &self,
-            ) -> Result<state::types::SyncSummary, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_page(
-                &self,
-                _: u64,
-                _: u32,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn complete_sync_run(
-                &self,
-                _: i64,
-                _: &state::types::SyncRunStats,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn list_interrupted_enumerations(
-                &self,
-            ) -> Result<Vec<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_pending_to_failed(
-                &self,
-                _: i64,
-            ) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_ids(
-                &self,
-            ) -> Result<std::collections::HashSet<(String, String, String)>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_all_known_ids(
-                &self,
-            ) -> Result<std::collections::HashSet<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_checksums(
-                &self,
-            ) -> Result<
-                std::collections::HashMap<(String, String, String), String>,
-                state::error::StateError,
-            > {
-                unimplemented!()
-            }
-            async fn get_attempt_counts(
-                &self,
-            ) -> Result<std::collections::HashMap<String, u32>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_metadata(
-                &self,
-                key: &str,
-            ) -> Result<Option<String>, state::error::StateError> {
-                self.inner.get_metadata(key).await
-            }
-            async fn set_metadata(
-                &self,
-                key: &str,
-                _value: &str,
-            ) -> Result<(), state::error::StateError> {
-                if key == DB_SYNC_TOKEN_KEY {
-                    Err(state::error::StateError::LockPoisoned(
-                        "simulated db_sync_token write failure".into(),
-                    ))
-                } else {
-                    Ok(())
-                }
-            }
-            async fn delete_metadata_by_prefix(
-                &self,
-                _: &str,
-            ) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn touch_last_seen_many(
-                &self,
-                _: &str,
-                _: &[&str],
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn add_asset_album(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_all_asset_albums(
-                &self,
-                _: &str,
-            ) -> Result<Vec<(String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_all_asset_people(
-                &self,
-                _: &str,
-            ) -> Result<Vec<(String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_soft_deleted(
-                &self,
-                _: &str,
-                _: &str,
-                _: Option<chrono::DateTime<chrono::Utc>>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_hidden_at_source(
-                &self,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn record_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_metadata_hashes(
-                &self,
-            ) -> Result<
-                std::collections::HashMap<(String, String, String), String>,
-                state::error::StateError,
-            > {
-                unimplemented!()
-            }
-            async fn get_metadata_retry_markers(
-                &self,
-            ) -> Result<std::collections::HashSet<(String, String, String)>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_pending_metadata_rewrites(
-                &self,
-                _: usize,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn update_metadata_hash(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn clear_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn has_downloaded_without_metadata_hash(
-                &self,
-            ) -> Result<bool, state::error::StateError> {
-                unimplemented!()
-            }
-        }
-
         // Inner DB has the stored sync token so the changes/database call
         // is actually attempted.
         let inner = make_state_db();
@@ -4081,7 +3857,11 @@ mod tests {
             .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
             .await
             .expect("seed token");
-        let db: Arc<dyn state::StateDb> = Arc::new(PartiallyFailingDb { inner });
+        let db: Arc<dyn state::StateDb> = Arc::new(FailingMetadataSetDb {
+            inner,
+            failure: MetadataSetFailure::Exact(DB_SYNC_TOKEN_KEY),
+            message: "simulated db_sync_token write failure",
+        });
 
         let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
             "syncToken": "db-tok-bad-write",
@@ -4521,24 +4301,8 @@ mod tests {
             make_run_cycle_library_state("PrimarySync", "sync_token:PrimarySync", "zone-tok-new");
         lib_state.plan_is_stale = true;
         let states = vec![&lib_state];
-        let build_db = Arc::clone(&db);
-        let build_download_config = |sync_mode,
-                                     exclude_asset_ids,
-                                     asset_groupings,
-                                     library|
-         -> Arc<download::DownloadConfig> {
-            let mut config = download::DownloadConfig::test_default();
-            config.directory = Arc::from(download_dir.path());
-            config.folder_structure = "%Y/%m/%d".to_string();
-            config.folder_structure_albums = Arc::from("%Y/%m/%d");
-            config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
-            config.state_db = Some(Arc::clone(&build_db));
-            config.sync_mode = sync_mode;
-            config.exclude_asset_ids = exclude_asset_ids;
-            config.asset_groupings = asset_groupings;
-            config.library = library;
-            Arc::new(config)
-        };
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
 
         let result = run_cycle(
             &states,
@@ -4576,8 +4340,10 @@ mod tests {
             .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
             .await
             .expect("seed zone token");
-        let db: Arc<dyn state::StateDb> = Arc::new(FailingSyncTokenSetDb {
+        let db: Arc<dyn state::StateDb> = Arc::new(FailingMetadataSetDb {
             inner: Arc::clone(&inner),
+            failure: MetadataSetFailure::Prefix(SYNC_TOKEN_PREFIX),
+            message: "simulated sync-token write failure",
         });
         let download_dir = tempfile::tempdir().expect("download tempdir");
         let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
@@ -4585,24 +4351,8 @@ mod tests {
         let lib_state =
             make_run_cycle_library_state("PrimarySync", "sync_token:PrimarySync", "zone-tok-new");
         let states = vec![&lib_state];
-        let build_db = Arc::clone(&db);
-        let build_download_config = |sync_mode,
-                                     exclude_asset_ids,
-                                     asset_groupings,
-                                     library|
-         -> Arc<download::DownloadConfig> {
-            let mut config = download::DownloadConfig::test_default();
-            config.directory = Arc::from(download_dir.path());
-            config.folder_structure = "%Y/%m/%d".to_string();
-            config.folder_structure_albums = Arc::from("%Y/%m/%d");
-            config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
-            config.state_db = Some(Arc::clone(&build_db));
-            config.sync_mode = sync_mode;
-            config.exclude_asset_ids = exclude_asset_ids;
-            config.asset_groupings = asset_groupings;
-            config.library = library;
-            Arc::new(config)
-        };
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
 
         let result = run_cycle(
             &states,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -922,6 +922,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 if !cycle_result.session_expired
                     && cycle_result.failed_count == 0
                     && !cycle_result.stats.interrupted
+                    && cycle_result.db_sync_token_advance_safe
                 {
                     if let Some(db) = state_db.as_deref() {
                         store_db_sync_token(db, token).await;
@@ -1313,6 +1314,7 @@ struct CycleResult {
     failed_count: usize,
     session_expired: bool,
     stats: download::SyncStats,
+    db_sync_token_advance_safe: bool,
 }
 
 /// Re-authenticate via SRP after a session-error signature from CloudKit.
@@ -1607,6 +1609,7 @@ async fn run_cycle(
              token will not advance this cycle"
         );
     }
+    let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
 
     // Check if the download config changed since last sync. If so, clear
     // sync tokens so the subsequent lookup falls back to full enumeration
@@ -1691,16 +1694,32 @@ async fn run_cycle(
             cycle_has_stale_plan,
         );
         if should_store_token {
-            if let Some(token) = &sync_result.sync_token {
-                if let Some(db) = state_db {
+            match (&sync_result.sync_token, state_db) {
+                (Some(token), Some(db)) => {
                     if let Err(e) = db.set_metadata(&lib_state.sync_token_key, token).await {
+                        db_sync_token_advance_safe = false;
                         tracing::warn!(error = %e, "Failed to store sync token");
                     } else {
                         tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
                     }
                 }
+                (Some(_), None) => {
+                    db_sync_token_advance_safe = false;
+                    tracing::debug!(
+                        zone = %lib_state.zone_name,
+                        "Sync token available but no state DB is configured"
+                    );
+                }
+                (None, _) => {
+                    db_sync_token_advance_safe = false;
+                    tracing::debug!(
+                        zone = %lib_state.zone_name,
+                        "Sync token unavailable after successful sync"
+                    );
+                }
             }
         } else if sync_result.sync_token.is_some() {
+            db_sync_token_advance_safe = false;
             tracing::info!(
                 zone = %lib_state.zone_name,
                 "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
@@ -1731,6 +1750,7 @@ async fn run_cycle(
         failed_count: cycle_failed_count,
         session_expired: cycle_session_expired,
         stats: cycle_stats,
+        db_sync_token_advance_safe,
     })
 }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2655,6 +2655,84 @@ mod tests {
         }
     }
 
+    fn make_incremental_album(zone_sync_token: &str) -> crate::icloud::photos::PhotoAlbum {
+        use serde_json::json;
+        crate::icloud::photos::PhotoAlbum::new(
+            crate::icloud::photos::PhotoAlbumConfig {
+                params: Arc::new(std::collections::HashMap::new()),
+                service_endpoint: Arc::from("https://example.com"),
+                name: Arc::from("TestAlbum"),
+                list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
+                obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
+                query_filter: None,
+                page_size: 100,
+                zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+                retry_config: retry::RetryConfig::default(),
+            },
+            Box::new(crate::test_helpers::MockPhotosSession::new().ok(json!({
+                "zones": [{
+                    "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                    "syncToken": zone_sync_token,
+                    "moreComing": false,
+                    "records": []
+                }]
+            }))),
+        )
+    }
+
+    fn make_run_cycle_library_state(
+        zone: &str,
+        sync_token_key: &str,
+        zone_sync_token: &str,
+    ) -> LibraryState {
+        LibraryState {
+            library: crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
+                Box::new(crate::test_helpers::MockPhotosSession::new()),
+                zone,
+            ),
+            zone_name: zone.to_string(),
+            sync_token_key: sync_token_key.to_string(),
+            plan: crate::commands::AlbumPlan {
+                passes: vec![crate::commands::AlbumPass {
+                    kind: crate::commands::PassKind::Unfiled,
+                    album: make_incremental_album(zone_sync_token),
+                    exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+                }],
+            },
+            plan_is_stale: false,
+            plan_needs_refresh: false,
+        }
+    }
+
+    async fn make_shared_session_for_run_cycle() -> (tempfile::TempDir, auth::SharedSession) {
+        let dir = tempfile::tempdir().expect("session tempdir");
+        let session = auth::session::Session::new(
+            dir.path(),
+            "test@example.com",
+            "https://example.com",
+            None,
+        )
+        .await
+        .expect("test session");
+        (dir, Arc::new(tokio::sync::RwLock::new(session)))
+    }
+
+    fn make_run_cycle_config() -> config::Config {
+        let data_dir = tempfile::tempdir().expect("config data dir");
+        let globals = config::GlobalArgs {
+            username: Some("test@example.com".to_string()),
+            domain: None,
+            data_dir: Some(data_dir.path().to_string_lossy().into_owned()),
+        };
+        config::Config::build(
+            &globals,
+            &cli::PasswordArgs::default(),
+            cli::SyncArgs::default(),
+            None,
+        )
+        .expect("test config")
+    }
+
     #[test]
     fn count_passes_empty_plan_is_all_zero() {
         let plan = crate::commands::AlbumPlan { passes: Vec::new() };
@@ -2724,6 +2802,341 @@ mod tests {
 
     fn make_state_db() -> Arc<dyn state::StateDb> {
         Arc::new(state::SqliteStateDb::open_in_memory().expect("open in-memory state DB"))
+    }
+
+    struct FailingSyncTokenSetDb {
+        inner: Arc<dyn state::StateDb>,
+    }
+
+    impl std::fmt::Debug for FailingSyncTokenSetDb {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("FailingSyncTokenSetDb")
+                .finish_non_exhaustive()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl state::StateDb for FailingSyncTokenSetDb {
+        #[cfg(test)]
+        async fn should_download(
+            &self,
+            library: &str,
+            id: &str,
+            version_size: &str,
+            checksum: &str,
+            local_path: &std::path::Path,
+        ) -> Result<bool, state::error::StateError> {
+            self.inner
+                .should_download(library, id, version_size, checksum, local_path)
+                .await
+        }
+
+        async fn upsert_seen(
+            &self,
+            record: &state::types::AssetRecord,
+        ) -> Result<(), state::error::StateError> {
+            self.inner.upsert_seen(record).await
+        }
+
+        async fn mark_downloaded(
+            &self,
+            library: &str,
+            id: &str,
+            version_size: &str,
+            local_path: &std::path::Path,
+            local_checksum: &str,
+            download_checksum: Option<&str>,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .mark_downloaded(
+                    library,
+                    id,
+                    version_size,
+                    local_path,
+                    local_checksum,
+                    download_checksum,
+                )
+                .await
+        }
+
+        async fn import_adopt(
+            &self,
+            record: &state::types::AssetRecord,
+            local_path: &std::path::Path,
+            local_checksum: &str,
+            imported_size: u64,
+            imported_mtime: Option<i64>,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .import_adopt(
+                    record,
+                    local_path,
+                    local_checksum,
+                    imported_size,
+                    imported_mtime,
+                )
+                .await
+        }
+
+        async fn mark_failed(
+            &self,
+            library: &str,
+            id: &str,
+            version_size: &str,
+            error: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .mark_failed(library, id, version_size, error)
+                .await
+        }
+
+        async fn get_failed(
+            &self,
+        ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+            self.inner.get_failed().await
+        }
+
+        async fn get_failed_sample(
+            &self,
+            limit: u32,
+        ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError> {
+            self.inner.get_failed_sample(limit).await
+        }
+
+        async fn get_pending(
+            &self,
+        ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+            self.inner.get_pending().await
+        }
+
+        async fn get_summary(&self) -> Result<state::types::SyncSummary, state::error::StateError> {
+            self.inner.get_summary().await
+        }
+
+        async fn get_downloaded_page(
+            &self,
+            offset: u64,
+            limit: u32,
+        ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+            self.inner.get_downloaded_page(offset, limit).await
+        }
+
+        async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
+            self.inner.start_sync_run().await
+        }
+
+        async fn complete_sync_run(
+            &self,
+            run_id: i64,
+            stats: &state::types::SyncRunStats,
+        ) -> Result<(), state::error::StateError> {
+            self.inner.complete_sync_run(run_id, stats).await
+        }
+
+        async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
+            self.inner.promote_orphaned_sync_runs().await
+        }
+
+        async fn begin_enum_progress(&self, zone: &str) -> Result<(), state::error::StateError> {
+            self.inner.begin_enum_progress(zone).await
+        }
+
+        async fn end_enum_progress(&self, zone: &str) -> Result<(), state::error::StateError> {
+            self.inner.end_enum_progress(zone).await
+        }
+
+        async fn list_interrupted_enumerations(
+            &self,
+        ) -> Result<Vec<String>, state::error::StateError> {
+            self.inner.list_interrupted_enumerations().await
+        }
+
+        async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
+            self.inner.reset_failed().await
+        }
+
+        async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
+            self.inner.prepare_for_retry().await
+        }
+
+        async fn promote_pending_to_failed(
+            &self,
+            seen_since: i64,
+        ) -> Result<u64, state::error::StateError> {
+            self.inner.promote_pending_to_failed(seen_since).await
+        }
+
+        async fn get_downloaded_ids(
+            &self,
+        ) -> Result<std::collections::HashSet<(String, String, String)>, state::error::StateError>
+        {
+            self.inner.get_downloaded_ids().await
+        }
+
+        async fn get_all_known_ids(
+            &self,
+        ) -> Result<std::collections::HashSet<String>, state::error::StateError> {
+            self.inner.get_all_known_ids().await
+        }
+
+        async fn get_downloaded_checksums(
+            &self,
+        ) -> Result<
+            std::collections::HashMap<(String, String, String), String>,
+            state::error::StateError,
+        > {
+            self.inner.get_downloaded_checksums().await
+        }
+
+        async fn get_attempt_counts(
+            &self,
+        ) -> Result<std::collections::HashMap<String, u32>, state::error::StateError> {
+            self.inner.get_attempt_counts().await
+        }
+
+        async fn get_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<String>, state::error::StateError> {
+            self.inner.get_metadata(key).await
+        }
+
+        async fn set_metadata(
+            &self,
+            key: &str,
+            value: &str,
+        ) -> Result<(), state::error::StateError> {
+            if key.starts_with(SYNC_TOKEN_PREFIX) {
+                Err(state::error::StateError::LockPoisoned(
+                    "simulated sync-token write failure".into(),
+                ))
+            } else {
+                self.inner.set_metadata(key, value).await
+            }
+        }
+
+        async fn delete_metadata_by_prefix(
+            &self,
+            prefix: &str,
+        ) -> Result<u64, state::error::StateError> {
+            self.inner.delete_metadata_by_prefix(prefix).await
+        }
+
+        async fn touch_last_seen_many(
+            &self,
+            library: &str,
+            asset_ids: &[&str],
+        ) -> Result<(), state::error::StateError> {
+            self.inner.touch_last_seen_many(library, asset_ids).await
+        }
+
+        async fn add_asset_album(
+            &self,
+            library: &str,
+            asset_id: &str,
+            album_name: &str,
+            source: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .add_asset_album(library, asset_id, album_name, source)
+                .await
+        }
+
+        async fn get_all_asset_albums(
+            &self,
+            library: &str,
+        ) -> Result<Vec<(String, String)>, state::error::StateError> {
+            self.inner.get_all_asset_albums(library).await
+        }
+
+        async fn get_all_asset_people(
+            &self,
+            library: &str,
+        ) -> Result<Vec<(String, String)>, state::error::StateError> {
+            self.inner.get_all_asset_people(library).await
+        }
+
+        async fn mark_soft_deleted(
+            &self,
+            library: &str,
+            asset_id: &str,
+            deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .mark_soft_deleted(library, asset_id, deleted_at)
+                .await
+        }
+
+        async fn mark_hidden_at_source(
+            &self,
+            library: &str,
+            asset_id: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner.mark_hidden_at_source(library, asset_id).await
+        }
+
+        async fn record_metadata_write_failure(
+            &self,
+            library: &str,
+            asset_id: &str,
+            version_size: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .record_metadata_write_failure(library, asset_id, version_size)
+                .await
+        }
+
+        async fn get_downloaded_metadata_hashes(
+            &self,
+        ) -> Result<
+            std::collections::HashMap<(String, String, String), String>,
+            state::error::StateError,
+        > {
+            self.inner.get_downloaded_metadata_hashes().await
+        }
+
+        async fn get_metadata_retry_markers(
+            &self,
+        ) -> Result<std::collections::HashSet<(String, String, String)>, state::error::StateError>
+        {
+            self.inner.get_metadata_retry_markers().await
+        }
+
+        async fn get_pending_metadata_rewrites(
+            &self,
+            limit: usize,
+        ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+            self.inner.get_pending_metadata_rewrites(limit).await
+        }
+
+        async fn update_metadata_hash(
+            &self,
+            library: &str,
+            asset_id: &str,
+            version_size: &str,
+            metadata_hash: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .update_metadata_hash(library, asset_id, version_size, metadata_hash)
+                .await
+        }
+
+        async fn clear_metadata_write_failure(
+            &self,
+            library: &str,
+            asset_id: &str,
+            version_size: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .clear_metadata_write_failure(library, asset_id, version_size)
+                .await
+        }
+
+        async fn has_downloaded_without_metadata_hash(
+            &self,
+        ) -> Result<bool, state::error::StateError> {
+            self.inner.has_downloaded_without_metadata_hash().await
+        }
     }
 
     /// `is_retry_failed=true` MUST force `SyncMode::Full` even when a
@@ -4092,6 +4505,131 @@ mod tests {
         // Only (Success, dry_run=false, stale=false) advances.
         assert!(should_store_sync_token_for_cycle(&success, false, false));
         assert!(!should_store_sync_token_for_cycle(&success, false, true));
+    }
+
+    #[tokio::test]
+    async fn run_cycle_stale_plan_blocks_database_precheck_token() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let mut lib_state =
+            make_run_cycle_library_state("PrimarySync", "sync_token:PrimarySync", "zone-tok-new");
+        lib_state.plan_is_stale = true;
+        let states = vec![&lib_state];
+        let build_db = Arc::clone(&db);
+        let build_download_config = |sync_mode,
+                                     exclude_asset_ids,
+                                     asset_groupings,
+                                     library|
+         -> Arc<download::DownloadConfig> {
+            let mut config = download::DownloadConfig::test_default();
+            config.directory = Arc::from(download_dir.path());
+            config.folder_structure = "%Y/%m/%d".to_string();
+            config.folder_structure_albums = Arc::from("%Y/%m/%d");
+            config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
+            config.state_db = Some(Arc::clone(&build_db));
+            config.sync_mode = sync_mode;
+            config.exclude_asset_ids = exclude_asset_ids;
+            config.asset_groupings = asset_groupings;
+            config.library = library;
+            Arc::new(config)
+        };
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert!(
+            !result.db_sync_token_advance_safe,
+            "database precheck token must wait until stale plans stop suppressing zone tokens"
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "stale plan must leave the old zone token in place for replay"
+        );
+        assert!(!config.runtime.dry_run);
+    }
+
+    #[tokio::test]
+    async fn run_cycle_zone_token_write_failure_blocks_database_precheck_token() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let db: Arc<dyn state::StateDb> = Arc::new(FailingSyncTokenSetDb {
+            inner: Arc::clone(&inner),
+        });
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state =
+            make_run_cycle_library_state("PrimarySync", "sync_token:PrimarySync", "zone-tok-new");
+        let states = vec![&lib_state];
+        let build_db = Arc::clone(&db);
+        let build_download_config = |sync_mode,
+                                     exclude_asset_ids,
+                                     asset_groupings,
+                                     library|
+         -> Arc<download::DownloadConfig> {
+            let mut config = download::DownloadConfig::test_default();
+            config.directory = Arc::from(download_dir.path());
+            config.folder_structure = "%Y/%m/%d".to_string();
+            config.folder_structure_albums = Arc::from("%Y/%m/%d");
+            config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
+            config.state_db = Some(Arc::clone(&build_db));
+            config.sync_mode = sync_mode;
+            config.exclude_asset_ids = exclude_asset_ids;
+            config.asset_groupings = asset_groupings;
+            config.library = library;
+            Arc::new(config)
+        };
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert!(
+            !result.db_sync_token_advance_safe,
+            "database precheck token must not advance after a zone-token write failure"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "failed zone-token write must leave old token in place for replay"
+        );
     }
 
     // Periodic reconciliation cadence. The watch loop calls

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -47,6 +47,59 @@ struct LibraryState {
     /// change events those assets generated and leave `asset_albums`
     /// permanently incomplete.
     plan_is_stale: bool,
+    /// True after an idle watch sleep. Refreshing only when a later
+    /// `changes/database` pre-check finds relevant work avoids burning album
+    /// listing calls on quiet watch cycles.
+    plan_needs_refresh: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum WatchPrecheck {
+    SkipAll,
+    Proceed {
+        changed_zones: Option<rustc_hash::FxHashSet<String>>,
+        db_sync_token_after_success: Option<String>,
+    },
+}
+
+impl WatchPrecheck {
+    fn proceed_all() -> Self {
+        Self::Proceed {
+            changed_zones: None,
+            db_sync_token_after_success: None,
+        }
+    }
+
+    fn changed_zones(&self) -> Option<&rustc_hash::FxHashSet<String>> {
+        match self {
+            Self::SkipAll => None,
+            Self::Proceed { changed_zones, .. } => changed_zones.as_ref(),
+        }
+    }
+
+    fn db_sync_token_after_success(&self) -> Option<&str> {
+        match self {
+            Self::SkipAll => None,
+            Self::Proceed {
+                db_sync_token_after_success,
+                ..
+            } => db_sync_token_after_success.as_deref(),
+        }
+    }
+
+    fn should_sync_zone(&self, zone_name: &str) -> bool {
+        match self {
+            Self::SkipAll => false,
+            Self::Proceed {
+                changed_zones: Some(zones),
+                ..
+            } => zones.contains(zone_name),
+            Self::Proceed {
+                changed_zones: None,
+                ..
+            } => true,
+        }
+    }
 }
 
 /// State-DB metadata key for the first-sync shared-library notice. Bumping
@@ -65,6 +118,9 @@ const ENUM_CONFIG_HASH_KEY: &str = "enum_config_hash";
 /// table. Cleared en masse when [`ENUM_CONFIG_HASH_KEY`] changes so the
 /// next cycle falls back to full enumeration.
 const SYNC_TOKEN_PREFIX: &str = "sync_token:";
+
+/// Metadata key for the database-level token used by `/changes/database`.
+const DB_SYNC_TOKEN_KEY: &str = "db_sync_token";
 
 /// Classify whether an error from `init_photos_service` or
 /// `resolve_libraries` indicates a stale session / routing state that
@@ -743,6 +799,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             sync_token_key,
             plan,
             plan_is_stale: false,
+            plan_needs_refresh: false,
         });
     }
     warn_if_multi_library_paths_commingle(
@@ -807,16 +864,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         cycle_index = cycle_index.saturating_add(1);
 
         // In watch mode with incremental sync, use changes/database as a
-        // cheap pre-check to skip cycles when nothing has changed.
-        // Only used for single-library mode; multi-library skips this optimization.
-        let skip_cycle = match library_states.as_slice() {
-            [only] if is_watch_mode => {
-                check_changes_database(state_db.as_deref(), only, &mut photos_service).await
-            }
-            _ => false,
+        // cheap pre-check before refreshing album plans or running a sync.
+        // No-change cycles should cost one CloudKit request, not a full
+        // album/pass refresh per selected library.
+        let watch_precheck = if is_watch_mode {
+            check_changes_database(state_db.as_deref(), &library_states, &mut photos_service).await
+        } else {
+            WatchPrecheck::proceed_all()
         };
 
-        if skip_cycle {
+        if matches!(watch_precheck, WatchPrecheck::SkipAll) {
             // Skipped cycle (no changes detected) -- still update health so
             // Docker HEALTHCHECK doesn't mark the container unhealthy after
             // the 2-hour staleness window when no new photos are uploaded.
@@ -827,6 +884,19 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 handle.update_health_only(&health).await;
             }
         } else {
+            refresh_needed_library_plans(
+                &mut library_states,
+                &config.filters.selection,
+                watch_precheck.changed_zones(),
+                &mut consecutive_album_refresh_failures,
+            )
+            .await;
+            let cycle_library_states: Vec<&LibraryState> = library_states
+                .iter()
+                .filter(|s| watch_precheck.should_sync_zone(&s.zone_name))
+                .collect();
+            debug_assert!(!cycle_library_states.is_empty());
+
             sd_notifier.notify_status("Syncing...");
             sd_notifier.notify_watchdog();
             notifier.notify(
@@ -838,7 +908,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
             let cycle_started_at = std::time::Instant::now();
             let cycle_result = run_cycle(
-                &library_states,
+                &cycle_library_states,
                 &config,
                 state_db.as_deref(),
                 is_retry_failed,
@@ -847,6 +917,21 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 &shutdown_token,
             )
             .await?;
+
+            if let Some(token) = watch_precheck.db_sync_token_after_success() {
+                if !cycle_result.session_expired
+                    && cycle_result.failed_count == 0
+                    && !cycle_result.stats.interrupted
+                {
+                    if let Some(db) = state_db.as_deref() {
+                        store_db_sync_token(db, token).await;
+                    }
+                } else {
+                    tracing::debug!(
+                        "changes/database token not advanced because the sync cycle did not complete cleanly"
+                    );
+                }
+            }
 
             // One state-DB summary per cycle (friendly mode only). Powers
             // the `Downloaded N new (X → Y)` phase line, the summary
@@ -1182,38 +1267,12 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // Validate session before next cycle; re-authenticate if expired.
             reacquire_session(&shared_session, &config, &password_provider).await;
 
-            // Re-resolve albums per-library to discover newly created iCloud albums.
-            // The unfiled pass re-fetches each selected album's IDs to refresh the
-            // exclusion set; for libraries with many albums this can be slow under
-            // watch mode. PR12+ may add per-album sync-token caching.
+            // Mark album/pass plans stale after an idle sleep, but defer the
+            // CloudKit refresh until `changes/database` says a selected
+            // library actually has work. Quiet watch cycles can then go back
+            // to sleep without listing albums for every selected library.
             for lib_state in &mut library_states {
-                match resolve_passes(&lib_state.library, &config.filters.selection).await {
-                    Ok(refreshed) => {
-                        lib_state.plan = refreshed;
-                        lib_state.plan_is_stale = false;
-                        consecutive_album_refresh_failures = 0;
-                    }
-                    Err(e) => {
-                        consecutive_album_refresh_failures += 1;
-                        // Mark the plan stale so the NEXT cycle's token
-                        // storage gate can suppress advancement.
-                        lib_state.plan_is_stale = true;
-                        if consecutive_album_refresh_failures >= 3 {
-                            tracing::error!(
-                                zone = %lib_state.zone_name,
-                                error = %e,
-                                consecutive_failures = consecutive_album_refresh_failures,
-                                "Repeated album refresh failures, reusing previous set"
-                            );
-                        } else {
-                            tracing::warn!(
-                                zone = %lib_state.zone_name,
-                                error = %e,
-                                "Failed to refresh albums, reusing previous set"
-                            );
-                        }
-                    }
-                }
+                lib_state.plan_needs_refresh = true;
             }
         } else {
             break;
@@ -1522,7 +1581,7 @@ pub(crate) async fn check_and_persist_enum_config_hash(
 
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
 async fn run_cycle(
-    library_states: &[LibraryState],
+    library_states: &[&LibraryState],
     config: &config::Config,
     state_db: Option<&dyn state::StateDb>,
     is_retry_failed: bool,
@@ -1713,49 +1772,127 @@ async fn preload_asset_groupings(
     Arc::new(groupings)
 }
 
+async fn refresh_needed_library_plans(
+    library_states: &mut [LibraryState],
+    selection: &crate::selection::Selection,
+    changed_zones: Option<&rustc_hash::FxHashSet<String>>,
+    consecutive_album_refresh_failures: &mut u32,
+) {
+    for lib_state in library_states {
+        if !lib_state.plan_needs_refresh {
+            continue;
+        }
+        if changed_zones.is_some_and(|zones| !zones.contains(&lib_state.zone_name)) {
+            continue;
+        }
+
+        // Re-resolve albums per-library to discover newly created iCloud albums.
+        // The unfiled pass re-fetches each selected album's IDs to refresh the
+        // exclusion set. This is intentionally delayed until a selected zone has
+        // changes so quiet watch cycles avoid the album-listing traffic.
+        match resolve_passes(&lib_state.library, selection).await {
+            Ok(refreshed) => {
+                lib_state.plan = refreshed;
+                lib_state.plan_is_stale = false;
+                lib_state.plan_needs_refresh = false;
+                *consecutive_album_refresh_failures = 0;
+            }
+            Err(e) => {
+                *consecutive_album_refresh_failures += 1;
+                lib_state.plan_is_stale = true;
+                lib_state.plan_needs_refresh = true;
+                if *consecutive_album_refresh_failures >= 3 {
+                    tracing::error!(
+                        zone = %lib_state.zone_name,
+                        error = %e,
+                        consecutive_failures = *consecutive_album_refresh_failures,
+                        "Repeated album refresh failures, reusing previous set"
+                    );
+                } else {
+                    tracing::warn!(
+                        zone = %lib_state.zone_name,
+                        error = %e,
+                        "Failed to refresh albums, reusing previous set"
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn store_db_sync_token(db: &dyn state::StateDb, token: &str) {
+    if let Err(e) = db.set_metadata(DB_SYNC_TOKEN_KEY, token).await {
+        tracing::warn!(error = %e, "Failed to store db_sync_token");
+    }
+}
+
 async fn check_changes_database(
     state_db: Option<&dyn state::StateDb>,
-    lib_state: &LibraryState,
+    library_states: &[LibraryState],
     photos_service: &mut crate::icloud::photos::PhotosService,
-) -> bool {
+) -> WatchPrecheck {
     let Some(db) = state_db else {
-        return false;
+        return WatchPrecheck::proceed_all();
     };
-    let has_token = db
-        .get_metadata(&lib_state.sync_token_key)
-        .await
-        .ok()
-        .flatten()
-        .is_some_and(|t| !t.is_empty());
-    if !has_token {
-        return false;
+    if library_states.is_empty() {
+        return WatchPrecheck::SkipAll;
+    }
+    for lib_state in library_states {
+        let has_token = db
+            .get_metadata(&lib_state.sync_token_key)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|t| !t.is_empty());
+        if !has_token {
+            return WatchPrecheck::proceed_all();
+        }
     }
     let db_token = db
-        .get_metadata("db_sync_token")
+        .get_metadata(DB_SYNC_TOKEN_KEY)
         .await
         .ok()
         .flatten()
         .filter(|t| !t.is_empty());
     match photos_service.changes_database(db_token.as_deref()).await {
         Ok(db_resp) => {
-            if let Err(e) = db.set_metadata("db_sync_token", &db_resp.sync_token).await {
-                tracing::warn!(error = %e, "Failed to store db_sync_token");
-            }
+            let selected_zones: rustc_hash::FxHashSet<&str> = library_states
+                .iter()
+                .map(|s| s.zone_name.as_str())
+                .collect();
+            let mut changed_selected_zones = rustc_hash::FxHashSet::default();
             if db_resp.more_coming {
                 tracing::debug!("changes/database has more pages (moreComing=true)");
             }
-            if db_resp.zones.is_empty() && !db_resp.more_coming {
-                tracing::info!("No changes detected (changes/database), skipping cycle");
-                true
-            } else {
-                for z in &db_resp.zones {
-                    tracing::debug!(
-                        zone = %z.zone_id.zone_name,
-                        zone_sync_token = %z.sync_token,
-                        "changes/database: zone has changes"
-                    );
+            for z in &db_resp.zones {
+                tracing::debug!(
+                    zone = %z.zone_id.zone_name,
+                    zone_sync_token = %z.sync_token,
+                    "changes/database: zone has changes"
+                );
+                if selected_zones.contains(z.zone_id.zone_name.as_str()) {
+                    changed_selected_zones.insert(z.zone_id.zone_name.clone());
                 }
-                false
+            }
+
+            if changed_selected_zones.is_empty() {
+                store_db_sync_token(db, &db_resp.sync_token).await;
+                if db_resp.more_coming {
+                    return WatchPrecheck::proceed_all();
+                }
+                tracing::info!(
+                    "No selected library changes detected (changes/database), skipping cycle"
+                );
+                return WatchPrecheck::SkipAll;
+            }
+
+            WatchPrecheck::Proceed {
+                changed_zones: if db_resp.more_coming {
+                    None
+                } else {
+                    Some(changed_selected_zones)
+                },
+                db_sync_token_after_success: Some(db_resp.sync_token),
             }
         }
         Err(e) => {
@@ -1763,7 +1900,7 @@ async fn check_changes_database(
                 error = %e,
                 "changes/database pre-check failed, proceeding with sync"
             );
-            false
+            WatchPrecheck::proceed_all()
         }
     }
 }
@@ -2938,7 +3075,32 @@ mod tests {
             sync_token_key: sync_token_key.to_string(),
             plan: crate::commands::AlbumPlan { passes: Vec::new() },
             plan_is_stale: false,
+            plan_needs_refresh: false,
         }
+    }
+
+    fn assert_proceed_changed(precheck: &WatchPrecheck, expected_zone: &str, expected_db: &str) {
+        let WatchPrecheck::Proceed {
+            changed_zones: Some(zones),
+            db_sync_token_after_success: Some(db_token),
+        } = precheck
+        else {
+            panic!("expected changed-zone proceed, got {precheck:?}");
+        };
+        assert_eq!(zones.len(), 1);
+        assert!(
+            zones.contains(expected_zone),
+            "missing zone {expected_zone}"
+        );
+        assert_eq!(db_token, expected_db);
+    }
+
+    async fn check_single_library_changes_database(
+        db: Option<&dyn state::StateDb>,
+        lib_state: &LibraryState,
+        svc: &mut crate::icloud::photos::PhotosService,
+    ) -> WatchPrecheck {
+        check_changes_database(db, std::slice::from_ref(lib_state), svc).await
     }
 
     /// `more_coming=true` with empty zones must NOT skip the cycle.
@@ -2968,16 +3130,23 @@ mod tests {
 
         let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
 
-        let skip = check_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
+        let precheck =
+            check_single_library_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
 
         assert!(
-            !skip,
+            matches!(
+                precheck,
+                WatchPrecheck::Proceed {
+                    changed_zones: None,
+                    db_sync_token_after_success: None
+                }
+            ),
             "more_coming=true must not skip the cycle (more pages pending)"
         );
         // db_sync_token should have been persisted so the next cycle
         // continues paging from where we left off.
         let stored = db
-            .get_metadata("db_sync_token")
+            .get_metadata(DB_SYNC_TOKEN_KEY)
             .await
             .expect("read db_sync_token")
             .expect("token persisted");
@@ -3009,14 +3178,19 @@ mod tests {
 
         let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
 
-        let skip = check_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
+        let precheck =
+            check_single_library_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
 
-        assert!(skip, "empty zones + more_coming=false must skip the cycle");
+        assert_eq!(
+            precheck,
+            WatchPrecheck::SkipAll,
+            "empty zones + more_coming=false must skip the cycle"
+        );
         // The new db_sync_token must still be persisted even on skip:
         // otherwise the next call re-asks from scratch and we'd get an
         // unbounded list of all zones.
         let stored = db
-            .get_metadata("db_sync_token")
+            .get_metadata(DB_SYNC_TOKEN_KEY)
             .await
             .expect("read db_sync_token")
             .expect("token persisted on skip");
@@ -3049,8 +3223,86 @@ mod tests {
 
         let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
 
-        let skip = check_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
-        assert!(!skip, "zones-present response must not skip the cycle");
+        let precheck =
+            check_single_library_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
+        assert_proceed_changed(&precheck, "PrimarySync", "db-tok-4");
+        assert!(
+            db.get_metadata(DB_SYNC_TOKEN_KEY)
+                .await
+                .expect("read db_sync_token")
+                .is_none(),
+            "changed-zone precheck must not advance db_sync_token before the sync succeeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_changes_database_multi_library_runs_only_changed_selected_zone() {
+        use serde_json::json;
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-shared",
+            "moreComing": false,
+            "zones": [
+                {"zoneID": {"zoneName": "SharedSync-ABCD"}, "syncToken": "shared-tok-new"}
+            ]
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "primary-tok-prev")
+            .await
+            .expect("set primary token");
+        db.set_metadata("sync_token:SharedSync-ABCD", "shared-tok-prev")
+            .await
+            .expect("set shared token");
+        db.set_metadata(DB_SYNC_TOKEN_KEY, "db-tok-prev")
+            .await
+            .expect("set db token");
+
+        let states = vec![
+            make_library_state("PrimarySync", "sync_token:PrimarySync"),
+            make_library_state("SharedSync-ABCD", "sync_token:SharedSync-ABCD"),
+        ];
+
+        let precheck = check_changes_database(Some(db.as_ref()), &states, &mut svc).await;
+        assert_proceed_changed(&precheck, "SharedSync-ABCD", "db-tok-shared");
+    }
+
+    #[tokio::test]
+    async fn check_changes_database_unselected_zone_change_skips_selected_libraries() {
+        use serde_json::json;
+        let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
+            "syncToken": "db-tok-unselected",
+            "moreComing": false,
+            "zones": [
+                {"zoneID": {"zoneName": "SharedSync-ABCD"}, "syncToken": "shared-tok-new"}
+            ]
+        }));
+        let mut svc = crate::icloud::photos::PhotosService::for_testing(
+            Box::new(session),
+            std::collections::HashMap::new(),
+        );
+
+        let db: Arc<dyn state::StateDb> = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "primary-tok-prev")
+            .await
+            .expect("set primary token");
+        db.set_metadata(DB_SYNC_TOKEN_KEY, "db-tok-prev")
+            .await
+            .expect("set db token");
+
+        let states = vec![make_library_state("PrimarySync", "sync_token:PrimarySync")];
+
+        let precheck = check_changes_database(Some(db.as_ref()), &states, &mut svc).await;
+        assert_eq!(precheck, WatchPrecheck::SkipAll);
+        let stored = db
+            .get_metadata(DB_SYNC_TOKEN_KEY)
+            .await
+            .expect("read db_sync_token")
+            .expect("token persisted");
+        assert_eq!(stored, "db-tok-unselected");
     }
 
     /// No stored sync token at all must return false (don't
@@ -3069,11 +3321,54 @@ mod tests {
         let db: Arc<dyn state::StateDb> = make_state_db();
         let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
 
-        let skip = check_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
-        assert!(!skip, "no stored token must skip-result false (continue)");
+        let precheck =
+            check_single_library_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
+        assert!(
+            matches!(
+                precheck,
+                WatchPrecheck::Proceed {
+                    changed_zones: None,
+                    db_sync_token_after_success: None
+                }
+            ),
+            "no stored token must continue without a changes/database call"
+        );
     }
 
-    /// A `set_metadata("db_sync_token", ...)` write failure must
+    #[tokio::test]
+    async fn refresh_needed_library_plans_filters_to_changed_zones() {
+        let mut states = vec![
+            make_library_state("PrimarySync", "sync_token:PrimarySync"),
+            make_library_state("SharedSync-ABCD", "sync_token:SharedSync-ABCD"),
+        ];
+        for state in &mut states {
+            state.plan_needs_refresh = true;
+        }
+        let mut changed_zones = rustc_hash::FxHashSet::default();
+        changed_zones.insert("PrimarySync".to_string());
+        let selection = crate::selection::Selection {
+            albums: crate::selection::AlbumSelector::None,
+            smart_folders: crate::selection::SmartFolderSelector::None,
+            libraries: crate::selection::LibrarySelector::default(),
+            unfiled: false,
+        };
+        let mut failures = 0;
+
+        refresh_needed_library_plans(&mut states, &selection, Some(&changed_zones), &mut failures)
+            .await;
+
+        assert!(
+            !states[0].plan_needs_refresh,
+            "changed zone should refresh before syncing"
+        );
+        assert!(
+            states[1].plan_needs_refresh,
+            "unchanged zone must not refresh albums on this cycle"
+        );
+        assert_eq!(failures, 0);
+    }
+
+    /// A `set_metadata(DB_SYNC_TOKEN_KEY, ...)` write failure must
     /// NOT break the cycle. The current implementation logs a warning and
     /// continues. A regression that propagated the error would crash watch
     /// mode whenever a sqlite hiccup hit that single write.
@@ -3081,7 +3376,7 @@ mod tests {
     async fn check_changes_database_token_persist_failure_does_not_skip() {
         use serde_json::json;
         // StateDb that succeeds on get_metadata("sync_token:...") but
-        // fails on set_metadata("db_sync_token", ...) — the only write
+        // fails on set_metadata(DB_SYNC_TOKEN_KEY, ...) — the only write
         // path inside `check_changes_database`.
         struct PartiallyFailingDb {
             inner: Arc<dyn state::StateDb>,
@@ -3237,7 +3532,7 @@ mod tests {
                 key: &str,
                 _value: &str,
             ) -> Result<(), state::error::StateError> {
-                if key == "db_sync_token" {
+                if key == DB_SYNC_TOKEN_KEY {
                     Err(state::error::StateError::LockPoisoned(
                         "simulated db_sync_token write failure".into(),
                     ))
@@ -3369,13 +3664,12 @@ mod tests {
 
         let lib_state = make_library_state("PrimarySync", "sync_token:PrimarySync");
 
-        // The function logs the write failure and continues. zones non-empty
-        // means it must return false (don't skip).
-        let skip = check_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
-        assert!(
-            !skip,
-            "db_sync_token write failure must not propagate as a skip"
-        );
+        // Zone changes hold db_sync_token advancement until after the sync
+        // succeeds, so a db token write failure here must not affect the
+        // pre-check decision.
+        let precheck =
+            check_single_library_changes_database(Some(db.as_ref()), &lib_state, &mut svc).await;
+        assert_proceed_changed(&precheck, "PrimarySync", "db-tok-bad-write");
     }
 
     // ── preload_asset_groupings ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- Moved the watch-mode `changes/database` pre-check ahead of album/pass refresh so idle cycles can skip before extra CloudKit calls.
- Extended the pre-check to multi-library selections and only sync changed selected zones when the response is complete.
- Delayed `db_sync_token` advancement until the selected-zone sync succeeds, while still advancing it immediately for true no-change skips.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test sync_loop::tests -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- sync --help`
