### PR TITLE
Make service install dry-run preview-only

### DIFF
--- a/.github/workflows/service-smoke.yml
+++ b/.github/workflows/service-smoke.yml
@@ -3,13 +3,13 @@ name: Service smoke
 # Per-platform smoke for `kei install` / `kei uninstall`. Builds the
 # release binary on each runner OS, exercises the dry-run install path
 # (which renders the platform artifact without invoking the service
-# manager so no credentials or elevated bus is required), validates
-# artifact syntax with the platform-native linter, then runs
-# `kei uninstall` and asserts the artifact is gone.
+# manager so no credentials or elevated bus is required), validates the
+# rendered artifact or no-op contract with platform-native checks, then
+# runs `kei uninstall` against a clean host.
 #
 # What this catches:
 #   - regressions that produce malformed unit/plist/SCM-preview output
-#   - artifact path changes (uninstall must find what install wrote)
+#   - dry-run regressions that write service-manager artifacts
 #   - cross-platform regressions in the shared install/uninstall
 #     dispatcher
 #
@@ -17,9 +17,8 @@ name: Service smoke
 #   - the service actually starts and reaches `Service: running`
 #   - launchctl bootstrap / systemctl --now / SCM CreateService glue
 #
-# That deeper exercise lives in the Rust integration suites
-# (tests/service_linux.rs etc.) and the maintainer's manual real-install
-# flow against the kei-test album.
+# That deeper exercise lives in the maintainer's manual real-install flow
+# against the kei-test album.
 
 on:
   pull_request:
@@ -73,6 +72,7 @@ jobs:
           set -euxo pipefail
           KEI="$PWD/target/release/kei"
           UNIT="$HOME/.config/systemd/user/kei.service"
+          UNIT_PREVIEW="${RUNNER_TEMP:-/tmp}/kei.service"
 
           # Pre-state: nothing installed.
           # Capture status output to a variable instead of piping into
@@ -84,25 +84,21 @@ jobs:
           status_pre=$("$KEI" status)
           printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
 
-          # Dry-run install renders the unit on disk and skips
-          # daemon-reload / enable / loginctl enable-linger. The runner
-          # user has no active systemd --user bus on hosted runners, so
-          # the non-dry path would fail at daemon-reload regardless.
-          "$KEI" install --user --dry-run
+          # Dry-run prints the unit and writes nothing. The runner user
+          # has no active systemd --user bus on hosted runners, so the
+          # non-dry path would fail at daemon-reload regardless.
+          "$KEI" install --user --dry-run > "$UNIT_PREVIEW"
 
-          test -f "$UNIT"
+          test ! -e "$UNIT"
 
           # Validate the unit syntax. systemd-analyze verify works
           # without an active bus and catches malformed [Unit] / [Service]
           # / [Install] sections, unknown directives, and bad ExecStart
-          # paths. It expects the unit to be reachable from the
-          # systemd unit search path; --user mode plus the standard
-          # ~/.config/systemd/user location works without sudo.
-          systemd-analyze --user verify "$UNIT"
+          # paths.
+          systemd-analyze --user verify "$UNIT_PREVIEW"
 
-          # Uninstall removes the unit even when the bus is unreachable
-          # (the platform branch logs and continues on best-effort
-          # daemon-reload failure).
+          # Uninstall against a clean host should report "nothing to
+          # remove" and exit 0.
           "$KEI" uninstall
 
           test ! -e "$UNIT"
@@ -116,26 +112,27 @@ jobs:
           set -euxo pipefail
           KEI="$PWD/target/release/kei"
           PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
+          PLIST_PREVIEW="${RUNNER_TEMP:-/tmp}/com.rhoopr.kei.plist"
 
           test ! -e "$PLIST"
           status_pre=$("$KEI" status)
           printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
 
-          # Dry-run renders the plist and skips launchctl bootstrap.
+          # Dry-run prints the plist and writes nothing.
           # GitHub-hosted macOS runners have a GUI session, but we
           # avoid the bootstrap step because the worker would fail to
           # auth without credentials and KeepAlive would loop with
           # backoff for the lifetime of the job.
-          "$KEI" install --dry-run
+          "$KEI" install --dry-run > "$PLIST_PREVIEW"
 
-          test -f "$PLIST"
+          test ! -e "$PLIST"
 
           # plutil -lint checks the plist parses as well-formed XML
           # and that every key has a recognized value type. It does
           # not validate launchd-specific keys (that's launchctl's
           # job at bootstrap), but it catches the most common
           # template-rendering regressions.
-          plutil -lint "$PLIST"
+          plutil -lint "$PLIST_PREVIEW"
 
           "$KEI" uninstall
 

--- a/justfile
+++ b/justfile
@@ -402,6 +402,11 @@ service-smoke:
     # placeholder so the smoke does not depend on the operator's .env
     # or saved config.
     export ICLOUD_USERNAME="service-smoke@example.invalid"
+    assert_service_not_installed() {
+        local status
+        status=$("$KEI" status)
+        printf '%s\n' "$status" | grep -q '^Service: not installed'
+    }
     case "$(uname -s)" in
         Linux)
             UNIT="$HOME/.config/systemd/user/kei.service"
@@ -410,26 +415,26 @@ service-smoke:
             # pre-state assertion is meaningful.
             rm -f "$UNIT" "$UNIT_PREVIEW"
             test ! -e "$UNIT"
-            status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
+            assert_service_not_installed
             "$KEI" install --user --dry-run > "$UNIT_PREVIEW"
             test ! -e "$UNIT"
             systemd-analyze --user verify "$UNIT_PREVIEW"
             "$KEI" uninstall
             test ! -e "$UNIT"
-            status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'
+            assert_service_not_installed
             ;;
         Darwin)
             PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
             PLIST_PREVIEW="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/com.rhoopr.kei.plist"
             rm -f "$PLIST" "$PLIST_PREVIEW"
             test ! -e "$PLIST"
-            status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
+            assert_service_not_installed
             "$KEI" install --dry-run > "$PLIST_PREVIEW"
             test ! -e "$PLIST"
             plutil -lint "$PLIST_PREVIEW"
             "$KEI" uninstall
             test ! -e "$PLIST"
-            status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'
+            assert_service_not_installed
             ;;
         *)
             echo "service-smoke is Linux/macOS only; Windows runs in CI" >&2

--- a/justfile
+++ b/justfile
@@ -405,26 +405,28 @@ service-smoke:
     case "$(uname -s)" in
         Linux)
             UNIT="$HOME/.config/systemd/user/kei.service"
+            UNIT_PREVIEW="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/kei.service"
             # Clean any leftover from a previous failed run so the
             # pre-state assertion is meaningful.
-            rm -f "$UNIT"
+            rm -f "$UNIT" "$UNIT_PREVIEW"
             test ! -e "$UNIT"
             status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
-            "$KEI" install --user --dry-run
-            test -f "$UNIT"
-            systemd-analyze --user verify "$UNIT"
+            "$KEI" install --user --dry-run > "$UNIT_PREVIEW"
+            test ! -e "$UNIT"
+            systemd-analyze --user verify "$UNIT_PREVIEW"
             "$KEI" uninstall
             test ! -e "$UNIT"
             status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'
             ;;
         Darwin)
             PLIST="$HOME/Library/LaunchAgents/com.rhoopr.kei.plist"
-            rm -f "$PLIST"
+            PLIST_PREVIEW="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/com.rhoopr.kei.plist"
+            rm -f "$PLIST" "$PLIST_PREVIEW"
             test ! -e "$PLIST"
             status_pre=$("$KEI" status); printf '%s\n' "$status_pre" | grep -q '^Service: not installed'
-            "$KEI" install --dry-run
-            test -f "$PLIST"
-            plutil -lint "$PLIST"
+            "$KEI" install --dry-run > "$PLIST_PREVIEW"
+            test ! -e "$PLIST"
+            plutil -lint "$PLIST_PREVIEW"
             "$KEI" uninstall
             test ! -e "$PLIST"
             status_post=$("$KEI" status); printf '%s\n' "$status_post" | grep -q '^Service: not installed'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -418,10 +418,9 @@ pub enum ConfigAction {
 /// Arguments for `kei install`.
 ///
 /// Per-platform defaults: Linux installs a per-user systemd unit unless
-/// `--system` is passed; macOS installs a per-user launchd agent (system
-/// daemons require root and are out of scope for v0.14); Windows registers
-/// a system service via the Service Control Manager (per-user services
-/// are not a Windows concept).
+/// `--system` is passed; macOS installs a per-user launchd agent; Windows
+/// registers the service with the Service Control Manager under the
+/// current user's account.
 #[derive(Args, Debug, Clone)]
 pub struct InstallArgs {
     /// Install per-user (Linux/macOS default; ignored on Windows).
@@ -433,10 +432,10 @@ pub struct InstallArgs {
     #[arg(long, conflicts_with = "user")]
     pub system: bool,
 
-    /// Render the service file and report what would happen, without
-    /// invoking the platform service manager (no `systemctl daemon-reload`,
-    /// no `launchctl bootstrap`, no SCM `CreateService`). The unit file is
-    /// still written to disk so it can be inspected.
+    /// Render the service artifact and report what would happen, without
+    /// writing files or invoking the platform service manager (no
+    /// `systemctl daemon-reload`, no `launchctl bootstrap`, no SCM
+    /// `CreateService`).
     #[arg(long)]
     pub dry_run: bool,
 }

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -416,21 +416,26 @@ fn is_root() -> bool {
     effective_uid() == 0
 }
 
-fn sudo_user_or_bail() -> Result<String> {
-    match std::env::var("SUDO_USER") {
-        Ok(u) if !u.is_empty() && u != "root" => Ok(u),
-        _ => bail!(
-            "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
-             can be configured to run as your account rather than root"
-        ),
+fn non_root_env_user(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(user) if !user.is_empty() && user != "root" => Some(user),
+        _ => None,
     }
 }
 
+fn sudo_user_or_bail() -> Result<String> {
+    if let Some(user) = non_root_env_user("SUDO_USER") {
+        return Ok(user);
+    }
+    bail!(
+        "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
+         can be configured to run as your account rather than root"
+    )
+}
+
 fn system_preview_user() -> Result<String> {
-    if let Ok(user) = std::env::var("SUDO_USER") {
-        if !user.is_empty() && user != "root" {
-            return Ok(user);
-        }
+    if let Some(user) = non_root_env_user("SUDO_USER") {
+        return Ok(user);
     }
 
     if is_root() {
@@ -441,10 +446,8 @@ fn system_preview_user() -> Result<String> {
     }
 
     for key in ["USER", "LOGNAME"] {
-        if let Ok(user) = std::env::var(key) {
-            if !user.is_empty() && user != "root" {
-                return Ok(user);
-            }
+        if let Some(user) = non_root_env_user(key) {
+            return Ok(user);
         }
     }
     bail!(

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -427,9 +427,22 @@ fn sudo_user_or_bail() -> Result<String> {
 }
 
 fn system_preview_user() -> Result<String> {
-    for key in ["SUDO_USER", "USER", "LOGNAME"] {
+    if let Ok(user) = std::env::var("SUDO_USER") {
+        if !user.is_empty() && user != "root" {
+            return Ok(user);
+        }
+    }
+
+    if is_root() {
+        bail!(
+            "$SUDO_USER not set; rerun via `sudo kei install --system --dry-run` so the service \
+             can be previewed for your account rather than root"
+        );
+    }
+
+    for key in ["USER", "LOGNAME"] {
         if let Ok(user) = std::env::var(key) {
-            if !user.is_empty() {
+            if !user.is_empty() && user != "root" {
                 return Ok(user);
             }
         }

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -14,10 +14,9 @@
 //!   is the one who's expected to run with privilege.
 //!
 //! Unit-file rendering is split out as a pure function so tests can
-//! assert key shape without spawning systemd. The systemd command
-//! pipeline (`daemon-reload`, `enable`, `disable`) is exercised by the
-//! per-platform smoke matrix, since faithful local mocking of
-//! `systemctl --user` requires an active user session.
+//! assert key shape without spawning systemd. CI covers dry-run rendering
+//! and unit syntax; real `daemon-reload` / `enable` / `disable` handoff
+//! still needs an active user session.
 
 #![allow(
     clippy::print_stdout,
@@ -124,25 +123,23 @@ fn system_unit_path() -> PathBuf {
 /// default on Linux).
 pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
+    let contents = render_user_unit(&exe, config_path);
+    if args.dry_run {
+        print!("{contents}");
+        tracing::info!("dry run: rendered per-user systemd unit; no files written");
+        return Ok(());
+    }
+
     let unit_path =
         user_unit_path().ok_or_else(|| anyhow!("could not resolve XDG_CONFIG_HOME or $HOME"))?;
-    let contents = render_user_unit(&exe, config_path);
     write_unit(&unit_path, &contents)?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
         path = %unit_path.display(),
         executable = %exe.display(),
         config = %config_path.display(),
-        dry_run = args.dry_run,
         "wrote per-user systemd unit",
     );
-
-    if args.dry_run {
-        tracing::info!(
-            "dry run: skipped systemctl daemon-reload / enable / loginctl enable-linger"
-        );
-        return Ok(());
-    }
 
     daemon_reload_user().await?;
     enable_now_user().await?;
@@ -158,6 +155,18 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
 
 /// Top-level entry for `kei install --system`.
 pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Result<()> {
+    if args.dry_run {
+        let user = system_preview_user()?;
+        let exe = current_executable()?;
+        let contents = render_system_unit(&exe, config_path, &user);
+        print!("{contents}");
+        tracing::info!(
+            run_as_user = user,
+            "dry run: rendered system-wide systemd unit; no files written"
+        );
+        return Ok(());
+    }
+
     if !is_root() {
         bail!(
             "`kei install --system` must be run as root (EUID=0); \
@@ -177,14 +186,8 @@ pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Re
         executable = %exe.display(),
         config = %config_path.display(),
         run_as_user = user,
-        dry_run = args.dry_run,
         "wrote system-wide systemd unit",
     );
-
-    if args.dry_run {
-        tracing::info!("dry run: skipped systemctl daemon-reload / enable");
-        return Ok(());
-    }
 
     daemon_reload_system().await?;
     enable_now_system().await?;
@@ -421,6 +424,20 @@ fn sudo_user_or_bail() -> Result<String> {
              can be configured to run as your account rather than root"
         ),
     }
+}
+
+fn system_preview_user() -> Result<String> {
+    for key in ["SUDO_USER", "USER", "LOGNAME"] {
+        if let Ok(user) = std::env::var(key) {
+            if !user.is_empty() {
+                return Ok(user);
+            }
+        }
+    }
+    bail!(
+        "could not determine which user the system unit would run as; \
+         set SUDO_USER or USER before running `kei install --system --dry-run`"
+    )
 }
 
 async fn daemon_reload_user() -> Result<()> {

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -1,6 +1,6 @@
 //! macOS backend for `kei install` / `kei uninstall` / `kei service status`.
 //!
-//! Per-user LaunchAgent only. v0.14 deliberately ships no LaunchDaemon
+//! Per-user LaunchAgent only. kei does not ship a LaunchDaemon
 //! (`/Library/LaunchDaemons/`) path because that would require root and
 //! brings a different threat model than the keychain-protected per-user
 //! flow. `--system` therefore errors with a pointer at `--user`.
@@ -19,9 +19,9 @@
 //! entry go too (matching the linux backend).
 //!
 //! Plist rendering is pulled out as a pure function so tests can assert
-//! key shape without spawning launchctl. The actual `launchctl bootstrap
-//! / bootout` calls are exercised by PR 8's macOS smoke matrix; faithful
-//! local mocking would require a live launchd domain.
+//! key shape without spawning launchctl. CI covers dry-run rendering and
+//! plist syntax; real `launchctl bootstrap` / `bootout` handoff needs a
+//! live launchd domain.
 
 #![allow(
     clippy::print_stdout,
@@ -142,9 +142,6 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
     let plist_path = home.join(LAUNCH_AGENTS_SUBDIR).join(PLIST_FILE_NAME);
     let log_dir = home.join(LOG_SUBDIR);
 
-    std::fs::create_dir_all(&log_dir)
-        .with_context(|| format!("failed to create log directory {}", log_dir.display()))?;
-
     let dict = render_user_plist(PlistInputs {
         exec: &exe,
         config: config_path,
@@ -152,6 +149,15 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
         home: &home,
     });
     let xml = serialize_plist(&dict)?;
+    if args.dry_run {
+        print!("{xml}");
+        tracing::info!("dry run: rendered per-user launchd plist; no files written");
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&log_dir)
+        .with_context(|| format!("failed to create log directory {}", log_dir.display()))?;
+
     write_plist(&plist_path, &xml)?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
@@ -159,17 +165,8 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
         executable = %exe.display(),
         config = %config_path.display(),
         log_dir = %log_dir.display(),
-        dry_run = args.dry_run,
         "wrote per-user launchd plist",
     );
-
-    if args.dry_run {
-        tracing::info!(
-            "dry run: skipped launchctl bootstrap (use `launchctl bootstrap gui/$(id -u) {}` to load manually)",
-            plist_path.display(),
-        );
-        return Ok(());
-    }
 
     bootstrap_or_load(&plist_path).await?;
 
@@ -183,13 +180,12 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
 
 /// `--system` rejection. macOS LaunchDaemons require root and a different
 /// security review (system-context FDA, keychain access constraints) that
-/// is explicitly out of scope for v0.14. Errors with a pointer at the
-/// supported flag rather than silently downgrading.
+/// kei does not currently support. Errors with a pointer at the supported
+/// flag rather than silently downgrading.
 pub(crate) fn install_system(_args: &InstallArgs, _config_path: &Path) -> Result<()> {
     bail!(
-        "macOS only ships a per-user LaunchAgent in v0.14; \
-         rerun without --system (or with --user) to install. \
-         System-wide LaunchDaemons (root, /Library/LaunchDaemons) are tracked for a future release."
+        "macOS only ships a per-user LaunchAgent; \
+         rerun without --system (or with --user) to install."
     )
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -177,12 +177,31 @@ happens:
 - **`service-smoke` workflow** - per-platform CI smoke for `kei install`
   / `kei uninstall`. Builds the release binary on
   `ubuntu-latest`/`macos-latest`/`windows-latest`, runs `kei install
-  --dry-run` to render the platform artifact (systemd unit, launchd
-  plist, or Windows SCM preview) without invoking the service manager,
-  validates the artifact with the platform-native linter
-  (`systemd-analyze verify`, `plutil -lint`, or `Get-Service`), then
-  runs `kei uninstall` and asserts the artifact is gone. Catches
-  rendering and path-resolution regressions; doesn't exercise the
-  actual service-manager handoff (that needs credentials and is left
-  to manual real-install testing). Mirrored by `just service-smoke` on
-  Linux and macOS.
+  --dry-run` to print the platform artifact (systemd unit, launchd
+  plist, or Windows SCM preview) without writing files or invoking the
+  service manager, validates the artifact or no-op contract with
+  platform-native checks (`systemd-analyze verify`, `plutil -lint`, or
+  `Get-Service`), then runs `kei uninstall` against a clean host.
+  Catches renderer, dry-run, and shared dispatcher regressions; doesn't
+  exercise the actual service-manager handoff.
+
+## Service testing contract
+
+Automated coverage:
+
+- CLI parse/help for `kei install`, `kei uninstall`, and `kei service`.
+- Pure systemd, launchd, Windows SCM renderers and status formatters.
+- `kei install --dry-run` prints the service artifact and writes nothing.
+- Linux/macOS/Windows smoke validates dry-run output syntax and clean
+  uninstall behavior.
+- Docker packaging defaults to `kei service run` so containers keep the
+  24-hour watch fallback when `[watch].interval` is unset.
+
+Manual real-install coverage:
+
+- `systemctl enable --now` and systemd restart behavior.
+- `launchctl bootstrap` / `bootout` against a live GUI domain.
+- Windows SCM `CreateServiceW`, account password handoff, and service
+  control dispatcher startup.
+- Boot/reboot persistence and a real long-running sync against the
+  `kei-test` album.

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -162,6 +162,21 @@ fn dry_run_install_system_prints_unit_without_requiring_root() {
 }
 
 #[test]
+fn dry_run_install_system_rejects_root_preview_user() {
+    let home = TempDir::new().unwrap();
+    let mut cmd = cmd_with_home(&home);
+    cmd.env("USER", "root");
+    cmd.env_remove("LOGNAME");
+
+    cmd.args(["install", "--system", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "could not determine which user the system unit would run as",
+        ));
+}
+
+#[test]
 fn install_system_without_root_fails_clearly() {
     // CI runs as a non-root user, which is exactly the condition this
     // test wants to exercise. Skipping when EUID==0 (rare local-dev

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -1,10 +1,10 @@
 //! Linux-specific integration tests for `kei install` / `kei uninstall`.
 //!
 //! Exercises the unit-file rendering pipeline end-to-end via `--dry-run`,
-//! which writes the systemd unit file but skips the `systemctl` /
-//! `loginctl` side effects. Faithful coverage of the daemon-reload /
-//! enable / linger steps requires an active user session, so those land
-//! in PR 8's per-platform smoke matrix instead of here.
+//! which prints the systemd unit without writing files or invoking
+//! `systemctl` / `loginctl`. Faithful coverage of the daemon-reload /
+//! enable / linger steps requires an active user session, so that stays
+//! in the manual real-install path.
 
 #![cfg(target_os = "linux")]
 #![allow(
@@ -43,44 +43,62 @@ fn user_unit_path(home: &TempDir) -> std::path::PathBuf {
     home.path().join(".config/systemd/user/kei.service")
 }
 
+fn write_user_unit_fixture(home: &TempDir) -> std::path::PathBuf {
+    let unit = user_unit_path(home);
+    std::fs::create_dir_all(unit.parent().unwrap()).unwrap();
+    std::fs::write(
+        &unit,
+        "[Unit]\nDescription=kei Media Sync Engine\n[Service]\nExecStart=/bin/true\n[Install]\nWantedBy=default.target\n",
+    )
+    .unwrap();
+    unit
+}
+
 #[test]
-fn dry_run_install_user_writes_unit_file_with_expected_keys() {
+fn dry_run_install_user_prints_unit_without_writing_file() {
     let home = TempDir::new().unwrap();
-    cmd_with_home(&home)
+    let assert = cmd_with_home(&home)
         .args(["install", "--user", "--dry-run"])
         .assert()
         .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
 
     let unit = user_unit_path(&home);
-    assert!(unit.exists(), "expected unit at {}", unit.display());
-    let body = std::fs::read_to_string(&unit).unwrap();
+    assert!(
+        !unit.exists(),
+        "dry-run must not write unit file at {}",
+        unit.display()
+    );
 
     // Spot-check the load-bearing keys; the renderer's full shape is
     // covered by unit tests in src/service/linux.rs.
-    assert!(body.contains("[Unit]"), "missing [Unit]:\n{body}");
-    assert!(body.contains("[Service]"), "missing [Service]:\n{body}");
-    assert!(body.contains("[Install]"), "missing [Install]:\n{body}");
-    assert!(body.contains("Type=notify"), "missing Type=notify:\n{body}");
+    assert!(stdout.contains("[Unit]"), "missing [Unit]:\n{stdout}");
+    assert!(stdout.contains("[Service]"), "missing [Service]:\n{stdout}");
+    assert!(stdout.contains("[Install]"), "missing [Install]:\n{stdout}");
     assert!(
-        body.contains("Description=kei Media Sync Engine"),
-        "missing Description:\n{body}"
+        stdout.contains("Type=notify"),
+        "missing Type=notify:\n{stdout}"
     );
     assert!(
-        body.contains("WantedBy=default.target"),
-        "missing WantedBy:\n{body}"
+        stdout.contains("Description=kei Media Sync Engine"),
+        "missing Description:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("WantedBy=default.target"),
+        "missing WantedBy:\n{stdout}"
     );
 
     // ExecStart must point at an absolute path (the actual kei binary
     // canonicalized by current_executable). Verifying the prefix is
     // enough — the path itself is environment-dependent.
     assert!(
-        body.contains("ExecStart=/") && body.contains(" service run --config "),
-        "ExecStart not absolute or missing flags:\n{body}"
+        stdout.contains("ExecStart=/") && stdout.contains(" service run --config "),
+        "ExecStart not absolute or missing flags:\n{stdout}"
     );
 }
 
 #[test]
-fn dry_run_install_user_is_idempotent() {
+fn dry_run_install_user_is_repeatable_without_writing_file() {
     let home = TempDir::new().unwrap();
     for _ in 0..2 {
         cmd_with_home(&home)
@@ -88,14 +106,11 @@ fn dry_run_install_user_is_idempotent() {
             .assert()
             .success();
     }
-    assert!(user_unit_path(&home).exists());
+    assert!(!user_unit_path(&home).exists());
 }
 
 #[test]
-fn dry_run_install_user_writes_to_xdg_config_home_override() {
-    // Ensures we honor XDG_CONFIG_HOME rather than always landing under
-    // $HOME/.config — the systemd convention is XDG-first, and a user
-    // who relocates their config would expect kei to follow.
+fn dry_run_install_user_does_not_write_to_xdg_config_home_override() {
     let home = TempDir::new().unwrap();
     let xdg = TempDir::new().unwrap();
     let mut cmd = common::cmd();
@@ -113,13 +128,36 @@ fn dry_run_install_user_writes_to_xdg_config_home_override() {
     let xdg_unit = xdg.path().join("systemd/user/kei.service");
     let home_unit = home.path().join(".config/systemd/user/kei.service");
     assert!(
-        xdg_unit.exists(),
-        "expected unit under XDG_CONFIG_HOME at {}",
+        !xdg_unit.exists(),
+        "dry-run must not write unit under XDG_CONFIG_HOME at {}",
         xdg_unit.display()
     );
     assert!(
         !home_unit.exists(),
-        "must not fall through to $HOME/.config when XDG_CONFIG_HOME is set"
+        "dry-run must not write unit under $HOME at {}",
+        home_unit.display()
+    );
+}
+
+#[test]
+fn dry_run_install_system_prints_unit_without_requiring_root() {
+    let home = TempDir::new().unwrap();
+    let mut cmd = cmd_with_home(&home);
+    cmd.env("USER", "kei-preview-user");
+
+    let assert = cmd
+        .args(["install", "--system", "--dry-run"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        stdout.contains("User=kei-preview-user"),
+        "system dry-run must show target user:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("WantedBy=multi-user.target"),
+        "system dry-run must render system install target:\n{stdout}"
     );
 }
 
@@ -136,21 +174,16 @@ fn install_system_without_root_fails_clearly() {
 
     let home = TempDir::new().unwrap();
     cmd_with_home(&home)
-        .args(["install", "--system", "--dry-run"])
+        .args(["install", "--system"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("must be run as root"));
 }
 
 #[test]
-fn uninstall_removes_unit_file_after_dry_run_install() {
+fn uninstall_removes_unit_file() {
     let home = TempDir::new().unwrap();
-    cmd_with_home(&home)
-        .args(["install", "--user", "--dry-run"])
-        .assert()
-        .success();
-    let unit = user_unit_path(&home);
-    assert!(unit.exists(), "precondition: unit file written");
+    let unit = write_user_unit_fixture(&home);
 
     // Bare `uninstall` (no --purge) should remove the unit file. It
     // also tries `systemctl --user disable --now`, which is a no-op /
@@ -177,10 +210,7 @@ fn uninstall_purge_removes_kei_state_dir_when_present() {
 
     // Install a unit so uninstall has something to do too — but the
     // assertion is on the purge path.
-    cmd_with_home(&home)
-        .args(["install", "--user", "--dry-run"])
-        .assert()
-        .success();
+    write_user_unit_fixture(&home);
 
     cmd_with_home(&home)
         .args(["uninstall", "--purge"])

--- a/tests/service_macos.rs
+++ b/tests/service_macos.rs
@@ -1,10 +1,10 @@
 //! macOS-specific integration tests for `kei install` / `kei uninstall`.
 //!
 //! Exercises the plist rendering pipeline end-to-end via `--dry-run`,
-//! which writes the launchd property list and creates the log directory
-//! but skips the `launchctl bootstrap` side effect. Faithful coverage of
-//! the bootstrap / bootout / load-fallback path requires a live launchd
-//! GUI domain, so those land in PR 8's per-platform smoke matrix.
+//! which prints the launchd property list without writing files or
+//! invoking `launchctl`. Faithful coverage of the bootstrap / bootout /
+//! load-fallback path requires a live launchd GUI domain, so that stays
+//! in the manual real-install path.
 
 #![cfg(target_os = "macos")]
 #![allow(
@@ -50,26 +50,57 @@ fn kei_state_dir(home: &TempDir) -> std::path::PathBuf {
     home.path().join(".config/kei")
 }
 
+fn write_user_plist_fixture(home: &TempDir) -> std::path::PathBuf {
+    let plist = user_plist_path(home);
+    std::fs::create_dir_all(plist.parent().unwrap()).unwrap();
+    std::fs::write(
+        &plist,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.rhoopr.kei</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/kei</string>
+    <string>service</string>
+    <string>run</string>
+  </array>
+</dict>
+</plist>
+"#,
+    )
+    .unwrap();
+    plist
+}
+
 #[test]
-fn dry_run_install_user_writes_plist_with_expected_keys() {
+fn dry_run_install_user_prints_plist_without_writing_file() {
     let home = TempDir::new().unwrap();
-    cmd_with_home(&home)
+    let assert = cmd_with_home(&home)
         .args(["install", "--user", "--dry-run"])
         .assert()
         .success();
+    let output = assert.get_output();
 
     let plist_path = user_plist_path(&home);
     assert!(
-        plist_path.exists(),
-        "expected plist at {}",
+        !plist_path.exists(),
+        "dry-run must not write plist at {}",
         plist_path.display(),
+    );
+    assert!(
+        !user_log_dir(&home).exists(),
+        "dry-run must not create {}",
+        user_log_dir(&home).display(),
     );
 
     // Spot-check via the plist crate so we're asserting the parsed
     // structure rather than substring-matching XML. The renderer's
     // detailed shape is covered by unit tests in src/service/macos.rs.
     let dict: plist::Dictionary =
-        plist::from_file(&plist_path).expect("plist must parse as a dictionary");
+        plist::from_bytes(&output.stdout).expect("plist must parse as a dictionary");
     assert_eq!(
         dict.get("Label").and_then(|v| v.as_string()),
         Some("com.rhoopr.kei"),
@@ -93,17 +124,11 @@ fn dry_run_install_user_writes_plist_with_expected_keys() {
         "ProgramArguments must carry `service run --config`: {strings:?}",
     );
 
-    // Log directory must be materialized at install time so launchd has
-    // somewhere to redirect stdout/stderr the first time it spawns kei.
-    assert!(
-        user_log_dir(&home).is_dir(),
-        "install must create {}",
-        user_log_dir(&home).display(),
-    );
+    assert!(!output.stdout.is_empty(), "dry-run must print plist XML");
 }
 
 #[test]
-fn dry_run_install_user_is_idempotent() {
+fn dry_run_install_user_is_repeatable_without_writing_file() {
     let home = TempDir::new().unwrap();
     for _ in 0..2 {
         cmd_with_home(&home)
@@ -111,12 +136,13 @@ fn dry_run_install_user_is_idempotent() {
             .assert()
             .success();
     }
-    assert!(user_plist_path(&home).exists());
+    assert!(!user_plist_path(&home).exists());
+    assert!(!user_log_dir(&home).exists());
 }
 
 #[test]
 fn install_system_is_rejected_with_clear_message() {
-    // macOS deliberately does not ship a LaunchDaemon path in v0.14.
+    // macOS deliberately does not ship a LaunchDaemon path.
     // The user-facing error must point operators at `--user` rather than
     // silently downgrading.
     let home = TempDir::new().unwrap();
@@ -128,14 +154,9 @@ fn install_system_is_rejected_with_clear_message() {
 }
 
 #[test]
-fn uninstall_removes_plist_after_dry_run_install() {
+fn uninstall_removes_plist() {
     let home = TempDir::new().unwrap();
-    cmd_with_home(&home)
-        .args(["install", "--user", "--dry-run"])
-        .assert()
-        .success();
-    let plist_path = user_plist_path(&home);
-    assert!(plist_path.exists(), "precondition: plist written");
+    let plist_path = write_user_plist_fixture(&home);
 
     // Bare `uninstall` (no --purge) should remove the plist file. It
     // also tries `launchctl bootout`, which will fail in a
@@ -166,10 +187,7 @@ fn uninstall_purge_removes_kei_state_dir_when_present() {
 
     // Install a plist so uninstall has something to do too — but the
     // assertion is on the purge path.
-    cmd_with_home(&home)
-        .args(["install", "--user", "--dry-run"])
-        .assert()
-        .success();
+    write_user_plist_fixture(&home);
 
     cmd_with_home(&home)
         .args(["uninstall", "--purge"])


### PR DESCRIPTION
## Summary
- Changed `kei install --dry-run` on Linux and macOS to print the service artifact without writing unit/plist files or creating log directories.
- Kept Linux system install previews usable without root by rendering a `--system --dry-run` unit from the current user environment.
- Updated service smoke coverage and test docs to make the automated vs manual service-manager contract explicit.

## Tests
- `cargo check`
- `cargo test service`
- `cargo test --test service_linux`
- `cargo test --test service_cli --test service_status`
- `cargo test -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- install --user --dry-run`
- `cargo run -- install --system --dry-run`
- `target/debug/kei install --user --dry-run > /tmp/kei.service && systemd-analyze --user verify /tmp/kei.service`
