### PR TITLE
Separate download pipeline controls from config

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -703,7 +703,7 @@ pub(crate) async fn run_import_existing(
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<()> {
     let db_path = super::super::get_db_path(globals, toml)?;
-    let download_config = build_import_download_config(&args, toml)?;
+    let download_config = build_import_download_config(toml)?;
     let directory = Arc::clone(&download_config.directory);
     let strict_import = resolve_import_strict(&args, toml);
     let strict_verifier = strict_import.then(HttpStrictImportVerifier::new);
@@ -941,7 +941,6 @@ fn resolve_import_strict(args: &cli::ImportArgs, toml: Option<&config::TomlConfi
 /// `import-existing` never instantiates a download pipeline, so those values
 /// are unused.
 fn build_import_download_config(
-    args: &cli::ImportArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<download::DownloadConfig> {
     let toml_dl = toml.and_then(|t| t.download.as_ref());
@@ -976,13 +975,7 @@ fn build_import_download_config(
     )?;
     let media = config::resolve_media_selection(toml.and_then(|t| t.filters.as_ref()), None, None)?;
 
-    let config = download::DownloadConfig::for_path_derivation_only(
-        directory,
-        path_fields,
-        media,
-        args.dry_run,
-        args.no_progress_bar,
-    );
+    let config = download::DownloadConfig::for_path_derivation_only(directory, path_fields, media);
     Ok(config)
 }
 
@@ -1321,7 +1314,6 @@ mod wiremock_tests {
             embed_xmp: false,
             #[cfg(feature = "xmp")]
             xmp_sidecar: false,
-            dry_run: false,
             concurrent_downloads: 1,
             recent: None,
             retry: RetryConfig::default(),
@@ -1331,9 +1323,6 @@ mod wiremock_tests {
             edited: false,
             alternative: false,
             raw_policy: RawPolicy::AsIs,
-            no_progress_bar: true,
-            only_print_filenames: false,
-            personality_mode: crate::personality::Mode::Off,
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             force_resolution: false,
             keep_unicode_in_filenames: false,
@@ -3170,7 +3159,6 @@ mod build_config_tests {
     /// every field that import-existing needs to stay aligned with sync.
     #[test]
     fn build_import_download_config_uses_toml_path_photo_and_media_settings() {
-        let args = parse_import_args(&[]);
         let toml = toml_with_download(
             r#"
             folder_structure = "%Y/%m"
@@ -3190,7 +3178,7 @@ mod build_config_tests {
             "#,
         );
 
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        let cfg = build_import_download_config(Some(&toml)).unwrap();
 
         assert_eq!(cfg.folder_structure, "%Y/%m");
         assert_eq!(cfg.resolution, crate::types::PhotoResolution::Medium);
@@ -3213,9 +3201,8 @@ mod build_config_tests {
     /// download directory.
     #[test]
     fn build_import_download_config_falls_through_to_default() {
-        let args = parse_import_args(&[]);
         let toml = toml_with_download("");
-        let cfg = build_import_download_config(&args, Some(&toml)).unwrap();
+        let cfg = build_import_download_config(Some(&toml)).unwrap();
         assert_eq!(cfg.resolution, crate::types::PhotoResolution::Original);
         assert_eq!(
             cfg.file_match_policy,
@@ -3235,9 +3222,7 @@ mod build_config_tests {
 
     #[test]
     fn build_import_download_config_empty_directory_bails() {
-        let args = parse_import_args(&[]);
-        let err =
-            build_import_download_config(&args, None).expect_err("empty directory should bail");
+        let err = build_import_download_config(None).expect_err("empty directory should bail");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("[download] directory is required for import-existing"),
@@ -3268,8 +3253,7 @@ mod build_config_tests {
         "#;
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
 
-        let import_args = parse_import_args(&[]);
-        let import_cfg = build_import_download_config(&import_args, Some(&toml)).unwrap();
+        let import_cfg = build_import_download_config(Some(&toml)).unwrap();
 
         let sync = SyncArgs::default();
         let globals = GlobalArgs {
@@ -3318,7 +3302,6 @@ mod build_config_tests {
     fn sync_and_import_reject_system_directory_with_same_message() {
         use crate::cli::SyncArgs;
 
-        let import_args = parse_import_args(&[]);
         let toml: TomlConfig = toml::from_str(
             r#"
             [download]
@@ -3326,8 +3309,8 @@ mod build_config_tests {
             "#,
         )
         .unwrap();
-        let import_err = build_import_download_config(&import_args, Some(&toml))
-            .expect_err("import: system dir must reject");
+        let import_err =
+            build_import_download_config(Some(&toml)).expect_err("import: system dir must reject");
 
         let sync = SyncArgs::default();
         let globals = GlobalArgs {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -71,6 +71,75 @@ pub enum SyncMode {
     },
 }
 
+/// One-shot runtime behavior for a sync pass.
+///
+/// Kept outside [`DownloadConfig`] so path/filter/download decisions do not
+/// grow presentation-only flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DownloadRunMode {
+    Download,
+    DryRun,
+    PrintFilenames,
+}
+
+impl DownloadRunMode {
+    pub(crate) fn is_dry_run(self) -> bool {
+        matches!(self, Self::DryRun)
+    }
+
+    pub(crate) fn only_print_filenames(self) -> bool {
+        matches!(self, Self::PrintFilenames)
+    }
+}
+
+/// Presentation knobs for the download pipeline.
+///
+/// The core config owns what to download. This owns how progress and friendly
+/// narration are shown while that work runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DownloadReporting {
+    pub(crate) no_progress_bar: bool,
+    pub(crate) personality_mode: crate::personality::Mode,
+}
+
+impl DownloadReporting {
+    pub(crate) const fn new(
+        no_progress_bar: bool,
+        personality_mode: crate::personality::Mode,
+    ) -> Self {
+        Self {
+            no_progress_bar,
+            personality_mode,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn hidden() -> Self {
+        Self::new(true, crate::personality::Mode::Off)
+    }
+}
+
+/// Per-run behavior that does not affect download path or filter decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DownloadControls {
+    pub(crate) run_mode: DownloadRunMode,
+    pub(crate) reporting: DownloadReporting,
+}
+
+impl DownloadControls {
+    pub(crate) const fn new(run_mode: DownloadRunMode, reporting: DownloadReporting) -> Self {
+        Self {
+            run_mode,
+            reporting,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn download_hidden() -> Self {
+        Self::new(DownloadRunMode::Download, DownloadReporting::hidden())
+    }
+}
+
 /// Result of a sync cycle, including the optional new syncToken.
 #[derive(Debug)]
 pub struct SyncResult {
@@ -488,7 +557,6 @@ pub(crate) struct DownloadConfig {
     /// the same composed XMP packet.
     #[cfg(feature = "xmp")]
     pub(crate) xmp_sidecar: bool,
-    pub(crate) dry_run: bool,
     pub(crate) concurrent_downloads: usize,
     pub(crate) recent: Option<u32>,
     pub(crate) retry: RetryConfig,
@@ -498,12 +566,6 @@ pub(crate) struct DownloadConfig {
     pub(crate) edited: bool,
     pub(crate) alternative: bool,
     pub(crate) raw_policy: RawPolicy,
-    pub(crate) no_progress_bar: bool,
-    pub(crate) only_print_filenames: bool,
-    /// Friendly UX mode: drives bar template / spinner glyphs / progress chars.
-    /// Defaults to `Mode::Off` so existing callers see v0.13 behaviour
-    /// byte-for-byte until they opt in.
-    pub(crate) personality_mode: crate::personality::Mode,
     pub(crate) file_match_policy: FileMatchPolicy,
     pub(crate) force_resolution: bool,
     pub(crate) keep_unicode_in_filenames: bool,
@@ -590,8 +652,6 @@ impl DownloadConfig {
         directory: Arc<Path>,
         fields: crate::config::PathDerivationFields,
         media: crate::config::MediaSelection,
-        dry_run: bool,
-        no_progress_bar: bool,
     ) -> Self {
         Self {
             directory,
@@ -613,7 +673,6 @@ impl DownloadConfig {
             embed_xmp: false,
             #[cfg(feature = "xmp")]
             xmp_sidecar: false,
-            dry_run,
             concurrent_downloads: 1,
             recent: None,
             retry: RetryConfig::default(),
@@ -623,9 +682,6 @@ impl DownloadConfig {
             edited: fields.edited,
             alternative: fields.alternative,
             raw_policy: fields.raw_policy,
-            no_progress_bar,
-            only_print_filenames: false,
-            personality_mode: crate::personality::Mode::Off,
             file_match_policy: fields.file_match_policy,
             force_resolution: fields.force_resolution,
             keep_unicode_in_filenames: fields.keep_unicode_in_filenames,
@@ -754,8 +810,7 @@ impl std::fmt::Debug for DownloadConfig {
         #[cfg(feature = "xmp")]
         s.field("embed_xmp", &self.embed_xmp)
             .field("xmp_sidecar", &self.xmp_sidecar);
-        s.field("dry_run", &self.dry_run)
-            .field("concurrent_downloads", &self.concurrent_downloads)
+        s.field("concurrent_downloads", &self.concurrent_downloads)
             .field("recent", &self.recent)
             .field("retry", &self.retry)
             .field("live_photo_mode", &self.live_photo_mode)
@@ -767,8 +822,6 @@ impl std::fmt::Debug for DownloadConfig {
             .field("edited", &self.edited)
             .field("alternative", &self.alternative)
             .field("raw_policy", &self.raw_policy)
-            .field("no_progress_bar", &self.no_progress_bar)
-            .field("only_print_filenames", &self.only_print_filenames)
             .field("file_match_policy", &self.file_match_policy)
             .field("force_resolution", &self.force_resolution)
             .field("keep_unicode_in_filenames", &self.keep_unicode_in_filenames)
@@ -809,7 +862,6 @@ impl DownloadConfig {
             embed_xmp: false,
             #[cfg(feature = "xmp")]
             xmp_sidecar: false,
-            dry_run: false,
             concurrent_downloads: 1,
             recent: None,
             retry: crate::retry::RetryConfig::default(),
@@ -819,9 +871,6 @@ impl DownloadConfig {
             edited: false,
             alternative: false,
             raw_policy: RawPolicy::AsIs,
-            no_progress_bar: true,
-            only_print_filenames: false,
-            personality_mode: crate::personality::Mode::Off,
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             force_resolution: false,
             keep_unicode_in_filenames: false,
@@ -1349,6 +1398,7 @@ pub async fn download_photos_with_sync(
     download_client: &Client,
     passes: &[crate::commands::AlbumPass],
     config: Arc<DownloadConfig>,
+    controls: DownloadControls,
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let sync_started_at = chrono::Utc::now().timestamp();
@@ -1386,6 +1436,7 @@ pub async fn download_photos_with_sync(
                 download_client,
                 passes,
                 &config,
+                controls,
                 shutdown_token.clone(),
             )
             .await
@@ -1405,6 +1456,7 @@ pub async fn download_photos_with_sync(
                 download_client,
                 passes,
                 &config,
+                controls,
                 shutdown_token.clone(),
             )
             .await
@@ -1421,6 +1473,7 @@ pub async fn download_photos_with_sync(
                 download_client,
                 passes,
                 &config,
+                controls,
                 shutdown_token.clone(),
             )
             .await
@@ -1432,6 +1485,7 @@ pub async fn download_photos_with_sync(
                 passes,
                 &config,
                 &token,
+                controls,
                 shutdown_token.clone(),
             )
             .await
@@ -1464,6 +1518,7 @@ pub async fn download_photos_with_sync(
                             download_client,
                             passes,
                             &config,
+                            controls,
                             shutdown_token.clone(),
                         )
                         .await
@@ -1575,6 +1630,7 @@ async fn download_photos_full_with_token(
     download_client: &Client,
     passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
@@ -1651,7 +1707,7 @@ async fn download_photos_full_with_token(
             })
             .collect();
         let divider = crate::personality::album_divider::AlbumDivider::new(
-            config.personality_mode,
+            controls.reporting.personality_mode,
             &pass_labels,
         );
 
@@ -1674,16 +1730,17 @@ async fn download_photos_full_with_token(
             // in scrollback so completed albums don't disappear.
             let pass_start = Instant::now();
             let (pass_pb, pass_bytes) = crate::download::pipeline::create_progress_bar_for_passes(
-                config.no_progress_bar,
-                config.only_print_filenames,
+                controls.reporting.no_progress_bar,
+                controls.run_mode.only_print_filenames(),
                 count,
-                config.personality_mode,
+                controls.reporting.personality_mode,
             );
 
             let result = stream_and_download_from_stream(
                 download_client,
                 stream,
                 pass_config,
+                controls,
                 count,
                 shutdown_token.clone(),
                 Some(pass_pb.clone()),
@@ -1746,6 +1803,7 @@ async fn download_photos_full_with_token(
             download_client,
             combined,
             &merged_config,
+            controls,
             total,
             shutdown_token.clone(),
             None,
@@ -1773,7 +1831,10 @@ async fn download_photos_full_with_token(
     // suppression because the recorded `total` is missing those passes.
     let pagination_undercount = if len_errors > 0 {
         true
-    } else if total > 0 && !config.only_print_filenames && !config.dry_run {
+    } else if total > 0
+        && !controls.run_mode.only_print_filenames()
+        && !controls.run_mode.is_dry_run()
+    {
         let decision = classify_pagination_shortfall(total, streaming_result.assets_seen);
         match decision {
             PaginationShortfall::Match => false,
@@ -1806,7 +1867,7 @@ async fn download_photos_full_with_token(
     // Don't advance the token for read-only operations, or when pagination
     // was incomplete (would permanently skip missed assets).
     let mut sync_token = None;
-    if !config.only_print_filenames && !pagination_undercount {
+    if !controls.run_mode.only_print_filenames() && !pagination_undercount {
         for rx in token_receivers {
             if let Ok(Some(token)) = rx.await {
                 sync_token = Some(token);
@@ -1826,6 +1887,7 @@ async fn download_photos_full_with_token(
         download_client,
         passes,
         config,
+        controls,
         streaming_result,
         started,
         shutdown_token,
@@ -1864,6 +1926,7 @@ async fn download_photos_incremental(
     passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
     zone_sync_token: &str,
+    controls: DownloadControls,
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
@@ -2121,7 +2184,7 @@ async fn download_photos_incremental(
         });
     }
 
-    if config.only_print_filenames {
+    if controls.run_mode.only_print_filenames() {
         #[allow(
             clippy::print_stdout,
             reason = "--only-print-filenames writes target paths to stdout so callers can pipe to xargs/etc"
@@ -2154,8 +2217,7 @@ async fn download_photos_incremental(
         retry_config: &config.retry,
         metadata: MetadataFlags::from(config.as_ref()),
         concurrency: config.concurrent_downloads,
-        no_progress_bar: config.no_progress_bar,
-        personality_mode: config.personality_mode,
+        reporting: controls.reporting,
         temp_suffix: Arc::clone(&config.temp_suffix),
         shutdown_token,
         state_db: config.state_db.clone(),
@@ -2364,10 +2426,8 @@ mod tests {
     fn test_hash_download_config_ignores_unrelated_fields() {
         let mut config1 = test_config();
         config1.concurrent_downloads = 1;
-        config1.dry_run = false;
         let mut config2 = test_config();
         config2.concurrent_downloads = 16;
-        config2.dry_run = true;
         // These fields don't affect download paths, so hash should be the same
         assert_eq!(
             hash_download_config(&config1),
@@ -3535,7 +3595,6 @@ mod tests {
         config.live_photo_mode = LivePhotoMode::ImageOnly;
         config.force_resolution = true;
         config.keep_unicode_in_filenames = true;
-        config.dry_run = true;
         config.set_exif_datetime = true;
         config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
         config.temp_suffix = std::sync::Arc::from(".custom-tmp");
@@ -3545,7 +3604,6 @@ mod tests {
         assert_eq!(derived.live_photo_mode, LivePhotoMode::ImageOnly);
         assert!(derived.force_resolution);
         assert!(derived.keep_unicode_in_filenames);
-        assert!(derived.dry_run);
         assert!(derived.set_exif_datetime);
         assert_eq!(derived.filename_exclude.len(), 1);
         assert_eq!(&*derived.temp_suffix, ".custom-tmp");

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -138,6 +138,11 @@ impl DownloadControls {
     pub(crate) const fn download_hidden() -> Self {
         Self::new(DownloadRunMode::Download, DownloadReporting::hidden())
     }
+
+    #[cfg(test)]
+    pub(crate) const fn dry_run_hidden() -> Self {
+        Self::new(DownloadRunMode::DryRun, DownloadReporting::hidden())
+    }
 }
 
 /// Result of a sync cycle, including the optional new syncToken.

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4593,10 +4593,7 @@ mod tests {
             &reqwest::Client::new(),
             stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
             &config,
-            DownloadControls::new(
-                super::super::DownloadRunMode::DryRun,
-                DownloadReporting::hidden(),
-            ),
+            DownloadControls::dry_run_hidden(),
             1,
             CancellationToken::new(),
             None,
@@ -4623,18 +4620,16 @@ mod tests {
         let mut config = DownloadConfig::test_default();
         config.directory = std::sync::Arc::from(dir.path());
         let config = Arc::new(config);
-        let controls = DownloadControls::new(
-            super::super::DownloadRunMode::DryRun,
-            DownloadReporting::hidden(),
-        );
+        let controls = DownloadControls::dry_run_hidden();
         let asset = TestPhotoAsset::new("DRY_RUN_PARTIAL")
             .orig_size(123)
             .orig_url("https://p01.icloud-content.com/dry-run-partial.jpg")
             .orig_checksum("ck_dry_run_partial")
             .build();
+        let client = reqwest::Client::new();
 
         let streaming_result = stream_and_download_from_stream(
-            &reqwest::Client::new(),
+            &client,
             stream::iter(vec![
                 Ok::<PhotoAsset, anyhow::Error>(asset),
                 Err(anyhow::anyhow!("malformed page")),
@@ -4649,7 +4644,7 @@ mod tests {
         .await
         .expect("dry run should continue past enumeration errors");
         let (outcome, stats) = build_download_outcome(
-            &reqwest::Client::new(),
+            &client,
             &[],
             &config,
             controls,
@@ -5171,10 +5166,7 @@ mod tests {
             &client,
             &[],
             &config,
-            DownloadControls::new(
-                super::super::DownloadRunMode::DryRun,
-                DownloadReporting::hidden(),
-            ),
+            DownloadControls::dry_run_hidden(),
             streaming_result,
             Instant::now(),
             CancellationToken::new(),

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -2102,7 +2102,7 @@ pub(super) async fn build_download_outcome(
         } else {
             tracing::info!("No new photos to download");
         }
-        if (retry_exhausted > 0 || enumeration_errors > 0) && !run_mode.is_dry_run() {
+        if retry_exhausted > 0 || enumeration_errors > 0 {
             return Ok((
                 DownloadOutcome::PartialFailure {
                     failed_count: retry_exhausted + enumeration_errors,
@@ -2117,6 +2117,7 @@ pub(super) async fn build_download_outcome(
         let stats = super::SyncStats {
             assets_seen: streaming_result.assets_seen,
             downloaded,
+            enumeration_errors,
             skipped: skip_breakdown,
             elapsed_secs: started.elapsed().as_secs_f64(),
             interrupted: shutdown_token.is_cancelled(),
@@ -2130,6 +2131,14 @@ pub(super) async fn build_download_outcome(
         }
         tracing::info!(destination = %config.directory.display(), "  destination");
         tracing::info!(concurrency = config.concurrent_downloads, "  concurrency");
+        if enumeration_errors > 0 {
+            return Ok((
+                DownloadOutcome::PartialFailure {
+                    failed_count: enumeration_errors,
+                },
+                stats,
+            ));
+        }
         return Ok((DownloadOutcome::Success, stats));
     }
 
@@ -4604,6 +4613,65 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn dry_run_mode_reports_enumeration_errors_without_downloading() {
+        use crate::download::{DownloadConfig, DownloadOutcome};
+        use crate::icloud::photos::PhotoAsset;
+        use futures_util::stream;
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        let config = Arc::new(config);
+        let controls = DownloadControls::new(
+            super::super::DownloadRunMode::DryRun,
+            DownloadReporting::hidden(),
+        );
+        let asset = TestPhotoAsset::new("DRY_RUN_PARTIAL")
+            .orig_size(123)
+            .orig_url("https://p01.icloud-content.com/dry-run-partial.jpg")
+            .orig_checksum("ck_dry_run_partial")
+            .build();
+
+        let streaming_result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![
+                Ok::<PhotoAsset, anyhow::Error>(asset),
+                Err(anyhow::anyhow!("malformed page")),
+            ]),
+            &config,
+            controls,
+            2,
+            CancellationToken::new(),
+            None,
+            None,
+        )
+        .await
+        .expect("dry run should continue past enumeration errors");
+        let (outcome, stats) = build_download_outcome(
+            &reqwest::Client::new(),
+            &[],
+            &config,
+            controls,
+            streaming_result,
+            Instant::now(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("dry-run outcome should build");
+
+        assert!(
+            matches!(outcome, DownloadOutcome::PartialFailure { failed_count: 1 }),
+            "dry-run enumeration errors must produce PartialFailure, got {outcome:?}"
+        );
+        assert_eq!(stats.downloaded, 1);
+        assert_eq!(stats.enumeration_errors, 1);
+        assert!(
+            fs::read_dir(dir.path()).unwrap().next().is_none(),
+            "dry-run mode must not create downloaded files"
+        );
+    }
+
     /// End-to-end regression for issue #211. A pending row carried over from
     /// a prior sync, combined with a filter that excludes the asset in the
     /// current sync, must not have its `last_seen_at` bumped by the producer.
@@ -5087,6 +5155,37 @@ mod tests {
             "expected PartialFailure with failed_count=3, got {outcome:?}"
         );
         assert_eq!(stats.enumeration_errors, 3);
+    }
+
+    #[tokio::test]
+    async fn dry_run_zero_downloads_with_enumeration_errors_returns_partial_failure() {
+        use crate::download::{DownloadConfig, DownloadOutcome};
+
+        let streaming_result = StreamingResult {
+            enumeration_errors: 2,
+            ..StreamingResult::default()
+        };
+        let client = reqwest::Client::new();
+        let config = Arc::new(DownloadConfig::test_default());
+        let (outcome, stats) = build_download_outcome(
+            &client,
+            &[],
+            &config,
+            DownloadControls::new(
+                super::super::DownloadRunMode::DryRun,
+                DownloadReporting::hidden(),
+            ),
+            streaming_result,
+            Instant::now(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("should not error");
+        assert!(
+            matches!(outcome, DownloadOutcome::PartialFailure { failed_count: 2 }),
+            "expected dry-run PartialFailure with failed_count=2, got {outcome:?}"
+        );
+        assert_eq!(stats.enumeration_errors, 2);
     }
 
     /// When SIGTERM fires mid-sync, the .part files must not be promoted

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -28,7 +28,9 @@ use super::filter::{
     determine_media_type, extract_skip_candidates, filter_asset_to_tasks, is_asset_filtered,
     pre_ensure_asset_dir, DownloadTask, FilterReason, NormalizedPath,
 };
-use super::{paths, DownloadConfig, DownloadContext, DownloadOutcome};
+use super::{
+    paths, DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome, DownloadReporting,
+};
 
 /// Outcome of `batch_forecast_decision` — either keep queueing, emit a
 /// one-shot warn, or stop enqueuing so the caller cancels the sync.
@@ -921,8 +923,7 @@ pub(super) struct PassConfig<'a> {
     pub(super) retry_config: &'a RetryConfig,
     pub(super) metadata: MetadataFlags,
     pub(super) concurrency: usize,
-    pub(super) no_progress_bar: bool,
-    pub(super) personality_mode: crate::personality::Mode,
+    pub(super) reporting: DownloadReporting,
     pub(super) temp_suffix: Arc<str>,
     pub(super) shutdown_token: CancellationToken,
     pub(super) state_db: Option<Arc<dyn StateDb>>,
@@ -941,7 +942,7 @@ impl std::fmt::Debug for PassConfig<'_> {
         f.debug_struct("PassConfig")
             .field("metadata", &self.metadata)
             .field("concurrency", &self.concurrency)
-            .field("no_progress_bar", &self.no_progress_bar)
+            .field("reporting", &self.reporting)
             .field("temp_suffix", &self.temp_suffix)
             .field("state_db", &self.state_db.as_ref().map(|_| ".."))
             .finish_non_exhaustive()
@@ -977,6 +978,7 @@ pub(super) async fn stream_and_download_from_stream<S>(
     download_client: &Client,
     combined: S,
     config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
     total: u64,
     shutdown_token: CancellationToken,
     shared_pb: Option<ProgressBar>,
@@ -987,6 +989,8 @@ where
         + Send
         + 'static,
 {
+    let reporting = controls.reporting;
+
     // When the caller passes a `shared_pb`, they own its lifecycle (we only
     // advance position and update the message). Otherwise we create our own
     // bar and finish_and_clear it before returning. The shared-bar path is
@@ -1003,10 +1007,10 @@ where
         shared_bytes.unwrap_or_else(|| std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)));
     let pb = shared_pb.unwrap_or_else(|| {
         create_progress_bar(
-            config.no_progress_bar,
-            config.only_print_filenames,
+            reporting.no_progress_bar,
+            controls.run_mode.only_print_filenames(),
             total,
-            config.personality_mode,
+            reporting.personality_mode,
             Some(std::sync::Arc::clone(&bytes_counter)),
         )
     });
@@ -1025,10 +1029,10 @@ where
     let listing_cycler = crate::personality::cycler::PhaseCycler::spawn(
         pb.clone(),
         config.pass_label().to_string(),
-        config.personality_mode,
+        reporting.personality_mode,
     );
 
-    if config.only_print_filenames {
+    if controls.run_mode.only_print_filenames() {
         // Load state DB context so we skip already-downloaded assets,
         // matching the incremental path's behavior.
         let download_ctx = if let Some(db) = &config.state_db {
@@ -1104,7 +1108,7 @@ where
         });
     }
 
-    if config.dry_run {
+    if controls.run_mode.is_dry_run() {
         tokio::pin!(combined);
         let mut count = 0usize;
         let mut enum_errors = 0usize;
@@ -1152,7 +1156,7 @@ where
     let metadata_flags = MetadataFlags::from(config.as_ref());
     let concurrency = config.concurrent_downloads;
     let state_db = config.state_db.clone();
-    let mode = config.personality_mode;
+    let mode = reporting.personality_mode;
 
     // Pre-load download context for O(1) skip decisions
     let download_ctx = if let Some(db) = &state_db {
@@ -2041,10 +2045,12 @@ pub(super) async fn build_download_outcome(
     download_client: &Client,
     passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
     streaming_result: StreamingResult,
     started: Instant,
     shutdown_token: CancellationToken,
 ) -> Result<(DownloadOutcome, super::SyncStats)> {
+    let run_mode = controls.run_mode;
     let downloaded = streaming_result.downloaded;
     let mut exif_failures = streaming_result.exif_failures;
     let failed_tasks = streaming_result.failed;
@@ -2089,14 +2095,14 @@ pub(super) async fn build_download_outcome(
             interrupted: shutdown_token.is_cancelled(),
             ..super::SyncStats::default()
         };
-        if config.dry_run {
+        if run_mode.is_dry_run() {
             tracing::info!("── Dry Run Summary ──");
             tracing::info!("  0 files would be downloaded");
             tracing::info!(destination = %config.directory.display(), "  destination");
         } else {
             tracing::info!("No new photos to download");
         }
-        if (retry_exhausted > 0 || enumeration_errors > 0) && !config.dry_run {
+        if (retry_exhausted > 0 || enumeration_errors > 0) && !run_mode.is_dry_run() {
             return Ok((
                 DownloadOutcome::PartialFailure {
                     failed_count: retry_exhausted + enumeration_errors,
@@ -2107,7 +2113,7 @@ pub(super) async fn build_download_outcome(
         return Ok((DownloadOutcome::Success, stats));
     }
 
-    if config.dry_run {
+    if run_mode.is_dry_run() {
         let stats = super::SyncStats {
             assets_seen: streaming_result.assets_seen,
             downloaded,
@@ -2187,8 +2193,7 @@ pub(super) async fn build_download_outcome(
         retry_config: &config.retry,
         metadata: MetadataFlags::from(config.as_ref()),
         concurrency: cleanup_concurrency,
-        no_progress_bar: config.no_progress_bar,
-        personality_mode: config.personality_mode,
+        reporting: controls.reporting,
         temp_suffix: Arc::clone(&config.temp_suffix),
         shutdown_token: shutdown_token.clone(),
         state_db: config.state_db.clone(),
@@ -2296,10 +2301,10 @@ pub(super) async fn run_download_pass(
     // average, so the bandwidth display reads as the cleanup-only rate.
     let cleanup_bytes_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let pb = create_progress_bar(
-        config.no_progress_bar,
+        config.reporting.no_progress_bar,
         false,
         tasks.len() as u64,
-        config.personality_mode,
+        config.reporting.personality_mode,
         Some(std::sync::Arc::clone(&cleanup_bytes_counter)),
     );
     let client = config.client.clone();
@@ -2312,7 +2317,7 @@ pub(super) async fn run_download_pass(
     let rate_limit_counter = Arc::clone(&config.rate_limit_counter);
     let bandwidth_limiter = config.bandwidth_limiter.clone();
     let library: Arc<str> = Arc::clone(&config.library);
-    let mode = config.personality_mode;
+    let mode = config.reporting.personality_mode;
 
     let mut download_stream = stream::iter(tasks)
         .take_while(|_| std::future::ready(!shutdown_token.is_cancelled()))
@@ -3698,8 +3703,7 @@ mod tests {
                             retry_config: &retry,
                             metadata: MetadataFlags::default(),
                             concurrency: 1,
-                            no_progress_bar: true,
-                            personality_mode: crate::personality::Mode::Off,
+                            reporting: DownloadReporting::hidden(),
                             temp_suffix: std::sync::Arc::from(".kei-tmp"),
                             shutdown_token: token,
                             state_db: None,
@@ -3753,8 +3757,7 @@ mod tests {
                             retry_config: &retry,
                             metadata: MetadataFlags::default(),
                             concurrency: 1,
-                            no_progress_bar: true,
-                            personality_mode: crate::personality::Mode::Off,
+                            reporting: DownloadReporting::hidden(),
                             temp_suffix: std::sync::Arc::from(".kei-tmp"),
                             shutdown_token: token,
                             state_db: None,
@@ -4415,7 +4418,6 @@ mod tests {
             embed_xmp: false,
             #[cfg(feature = "xmp")]
             xmp_sidecar: false,
-            dry_run: false,
             concurrent_downloads: 10,
             recent: None,
             retry: crate::retry::RetryConfig {
@@ -4429,9 +4431,6 @@ mod tests {
             edited: false,
             alternative: false,
             raw_policy: RawPolicy::AsIs,
-            no_progress_bar: true,
-            only_print_filenames: false,
-            personality_mode: crate::personality::Mode::Off,
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             force_resolution: false,
             keep_unicode_in_filenames: false,
@@ -4465,6 +4464,7 @@ mod tests {
             &client,
             asset_stream,
             &config,
+            DownloadControls::download_hidden(),
             10_000,
             shutdown_token,
             None,
@@ -4513,7 +4513,6 @@ mod tests {
             embed_xmp: false,
             #[cfg(feature = "xmp")]
             xmp_sidecar: false,
-            dry_run: false,
             concurrent_downloads: 1,
             recent: None,
             retry: RetryConfig::default(),
@@ -4523,9 +4522,6 @@ mod tests {
             edited: false,
             alternative: false,
             raw_policy: RawPolicy::AsIs,
-            no_progress_bar: true,
-            only_print_filenames: false,
-            personality_mode: crate::personality::Mode::Off,
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             force_resolution: false,
             keep_unicode_in_filenames: false,
@@ -4555,6 +4551,7 @@ mod tests {
             &client,
             panicking_stream,
             &config,
+            DownloadControls::download_hidden(),
             0,
             shutdown_token,
             None,
@@ -4565,6 +4562,45 @@ mod tests {
         assert!(
             err.to_string().contains("producer panicked"),
             "Expected producer panic error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_mode_uses_stream_pipeline_without_downloading() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use futures_util::stream;
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        let config = Arc::new(config);
+        let asset = TestPhotoAsset::new("DRY_RUN_MODE")
+            .orig_size(123)
+            .orig_url("https://p01.icloud-content.com/dry-run.jpg")
+            .orig_checksum("ck_dry_run")
+            .build();
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
+            &config,
+            DownloadControls::new(
+                super::super::DownloadRunMode::DryRun,
+                DownloadReporting::hidden(),
+            ),
+            1,
+            CancellationToken::new(),
+            None,
+            None,
+        )
+        .await
+        .expect("dry run should scan through the real stream pipeline");
+
+        assert_eq!(result.downloaded, 1);
+        assert!(result.failed.is_empty());
+        assert!(
+            fs::read_dir(dir.path()).unwrap().next().is_none(),
+            "dry-run mode must not create downloaded files"
         );
     }
 
@@ -4624,6 +4660,7 @@ mod tests {
             &client,
             stream1,
             &config,
+            DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
             None,
@@ -4651,6 +4688,7 @@ mod tests {
             &client,
             stream2,
             &config,
+            DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
             None,
@@ -4739,6 +4777,7 @@ mod tests {
             &client,
             stream1,
             &config,
+            DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
             None,
@@ -4836,6 +4875,7 @@ mod tests {
             &client,
             stream1,
             &config,
+            DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
             None,
@@ -5035,6 +5075,7 @@ mod tests {
             &client,
             &[],
             &config,
+            DownloadControls::download_hidden(),
             streaming_result,
             Instant::now(),
             CancellationToken::new(),

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -730,7 +730,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             embed_xmp: config.metadata.embed_xmp,
             #[cfg(feature = "xmp")]
             xmp_sidecar: config.metadata.xmp_sidecar,
-            dry_run: config.runtime.dry_run,
             concurrent_downloads: config.download.threads_num as usize,
             recent: config.filters.recent,
             retry: retry_config,
@@ -740,9 +739,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             edited: config.photos.edited,
             alternative: config.photos.alternative,
             raw_policy: config.photos.raw_policy,
-            no_progress_bar: config.download.no_progress_bar,
-            only_print_filenames: config.runtime.only_print_filenames,
-            personality_mode: config.ui.personality_mode,
             file_match_policy: config.photos.file_match_policy,
             force_resolution: config.photos.force_resolution,
             keep_unicode_in_filenames: config.photos.keep_unicode_in_filenames,
@@ -758,6 +754,20 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             bandwidth_limiter: bandwidth_limiter.clone(),
         })
     };
+    let run_mode = if config.runtime.only_print_filenames {
+        download::DownloadRunMode::PrintFilenames
+    } else if config.runtime.dry_run {
+        download::DownloadRunMode::DryRun
+    } else {
+        download::DownloadRunMode::Download
+    };
+    let download_controls = download::DownloadControls::new(
+        run_mode,
+        download::DownloadReporting::new(
+            config.download.no_progress_bar,
+            config.ui.personality_mode,
+        ),
+    );
 
     let shutdown_token = shutdown::install_signal_handler(sd_notifier, config.ui.personality_mode)?;
 
@@ -913,6 +923,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 state_db.as_deref(),
                 is_retry_failed,
                 &build_download_config,
+                download_controls,
                 &shared_session,
                 &shutdown_token,
             )
@@ -1588,6 +1599,7 @@ async fn run_cycle(
     state_db: Option<&dyn state::StateDb>,
     is_retry_failed: bool,
     build_download_config: &BuildDownloadConfigFn<'_>,
+    download_controls: download::DownloadControls,
     shared_session: &auth::SharedSession,
     shutdown_token: &CancellationToken,
 ) -> anyhow::Result<CycleResult> {
@@ -1677,6 +1689,7 @@ async fn run_cycle(
             &download_client,
             &lib_state.plan.passes,
             download_config,
+            download_controls,
             shutdown_token.clone(),
         )
         .await?;
@@ -4310,6 +4323,7 @@ mod tests {
             Some(db.as_ref()),
             false,
             &build_download_config,
+            download::DownloadControls::download_hidden(),
             &shared_session,
             &CancellationToken::new(),
         )
@@ -4360,6 +4374,7 @@ mod tests {
             Some(db.as_ref()),
             false,
             &build_download_config,
+            download::DownloadControls::download_hidden(),
             &shared_session,
             &CancellationToken::new(),
         )


### PR DESCRIPTION
## Summary
- Split run-only download behavior out of `DownloadConfig` into `DownloadRunMode`, `DownloadReporting`, and `DownloadControls`.
- Kept `DownloadConfig` focused on path, filter, download, and state decisions.
- Updated full, incremental, cleanup, and import-existing call sites to pass narrow run/reporting controls instead of storing presentation flags in the core config.
- Added a stream-pipeline dry-run test that exercises the real producer path without writing files.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test dry_run_mode_uses_stream_pipeline_without_downloading -- --test-threads=1`
- `cargo test zero_downloads_with_enumeration_errors_returns_partial_failure -- --test-threads=1`
- `cargo test build_import_download_config -- --test-threads=1`
- `cargo run --quiet -- sync --help`
- `cargo run --quiet -- import-existing --help`
