### PR TITLE
Improve suspicious sync visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **README scope refreshed.** The README now leads with the current iCloud sync, media, operations, service, Docker, and planned-backend scope, then moves the longer capability list into a `Features` section. The command links now include `reconcile`.
 - **v0.20 deprecation cleanup.** Removed the remaining v0.13 compatibility aliases: `--exclude-album` / `KEI_EXCLUDE_ALBUM`, `{album}` in the base `--folder-structure`, implicit `--album all` promotion from that token, `[filters].album`, `[filters].exclude_albums`, and `[filters].library`. Use `--album '!NAME'`, `--folder-structure-albums`, and the `[filters].albums` / `[filters].libraries` arrays.
 - **`import-existing` is TOML-first.** Import now reads persistent path, photo, and media matching settings from the same TOML config as sync. The old import-only durable flags and env mirrors are gone; keep `--library`, `--recent`, `--dry-run`, `--force-empty`, `--no-progress-bar`, and new `--strict` for one-off import behavior. `[import].strict = true` or `--strict` verifies a small iCloud prefix before adopting a same-name, same-size local file, and the summary reports strict refusals. ([#314])
+- **Operator visibility for suspicious successful syncs.** Deferred state-write retries now log at info level with retry metadata, and a completed full sync that enumerates zero assets warns without changing the exit code. `sync --retry-failed` no-op runs stay quiet. ([#279], [#280])
 
+[#279]: https://github.com/rhoopr/kei/issues/279
+[#280]: https://github.com/rhoopr/kei/issues/280
 [#314]: https://github.com/rhoopr/kei/issues/314
 
 ---

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -90,6 +90,10 @@ impl DownloadRunMode {
     pub(crate) fn only_print_filenames(self) -> bool {
         matches!(self, Self::PrintFilenames)
     }
+
+    pub(crate) fn downloads_files(self) -> bool {
+        matches!(self, Self::Download)
+    }
 }
 
 /// Presentation knobs for the download pipeline.

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -155,6 +155,8 @@ pub struct SyncResult {
     pub sync_token: Option<String>,
     /// Accumulated statistics from this sync run.
     pub stats: SyncStats,
+    /// Whether this result came from a full records/query enumeration.
+    pub(crate) full_enumeration_ran: bool,
 }
 
 /// Accumulated statistics from a sync run, used for JSON reports and notifications.
@@ -1919,6 +1921,7 @@ async fn download_photos_full_with_token(
         outcome,
         sync_token,
         stats,
+        full_enumeration_ran: true,
     })
 }
 
@@ -2046,6 +2049,7 @@ async fn download_photos_incremental(
             outcome: DownloadOutcome::Success,
             sync_token,
             stats,
+            full_enumeration_ran: false,
         });
     }
 
@@ -2186,6 +2190,7 @@ async fn download_photos_incremental(
             outcome: DownloadOutcome::Success,
             sync_token,
             stats,
+            full_enumeration_ran: false,
         });
     }
 
@@ -2207,6 +2212,7 @@ async fn download_photos_incremental(
             outcome: DownloadOutcome::Success,
             sync_token: None,
             stats,
+            full_enumeration_ran: false,
         });
     }
 
@@ -2271,6 +2277,7 @@ async fn download_photos_incremental(
             },
             sync_token,
             stats,
+            full_enumeration_ran: false,
         });
     }
 
@@ -2287,6 +2294,7 @@ async fn download_photos_incremental(
         outcome,
         sync_token,
         stats,
+        full_enumeration_ran: false,
     })
 }
 
@@ -2458,6 +2466,7 @@ mod tests {
             outcome: DownloadOutcome::PartialFailure { failed_count: 3 },
             sync_token: Some("tok".to_string()),
             stats: SyncStats::default(),
+            full_enumeration_ran: false,
         };
         match result.outcome {
             DownloadOutcome::PartialFailure { failed_count } => {
@@ -2475,6 +2484,7 @@ mod tests {
             },
             sync_token: None,
             stats: SyncStats::default(),
+            full_enumeration_ran: false,
         };
         match result.outcome {
             DownloadOutcome::SessionExpired { auth_error_count } => {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -395,7 +395,8 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
     if pending.is_empty() {
         return 0;
     }
-    tracing::debug!(count = pending.len(), "Retrying deferred state writes");
+    let pending_count = pending.len();
+    tracing::info!(pending_count, "Retrying deferred state writes");
     let mut failures = 0;
     for write in pending {
         let mut succeeded = false;
@@ -412,13 +413,22 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
                 .await
             {
                 Ok(()) => {
+                    if attempt > 1 {
+                        tracing::info!(
+                            asset_id = %write.asset_id,
+                            pending_count,
+                            attempt,
+                            "Recovered deferred state write"
+                        );
+                    }
                     succeeded = true;
                     break;
                 }
                 Err(e) => {
                     if attempt < STATE_WRITE_MAX_RETRIES {
-                        tracing::debug!(
+                        tracing::info!(
                             asset_id = %write.asset_id,
+                            pending_count,
                             attempt,
                             error = %e,
                             "State write retry failed, will retry"
@@ -4261,6 +4271,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[tracing_test::traced_test]
     async fn flush_pending_state_writes_recovers_after_transient_failure() {
         // Fail the first attempt, succeed on retry
         let db = FailingStateDb::new(1);
@@ -4275,6 +4286,26 @@ mod tests {
         let failures = flush_pending_state_writes(&db, &pending).await;
         assert_eq!(failures, 0);
         assert_eq!(db.success_count(), 1);
+        assert!(
+            logs_contain("State write retry failed, will retry"),
+            "retry attempt should be visible at info level"
+        );
+        assert!(
+            logs_contain("Recovered deferred state write"),
+            "successful retry should log a recovery breadcrumb"
+        );
+        assert!(
+            logs_contain("pending_count=1"),
+            "retry logs must carry pending_count"
+        );
+        assert!(
+            logs_contain("attempt=1"),
+            "retry logs must carry the failed attempt number"
+        );
+        assert!(
+            logs_contain("attempt=2"),
+            "recovery logs must carry the successful attempt number"
+        );
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1606,6 +1606,7 @@ async fn run_cycle(
     let mut cycle_failed_count = 0usize;
     let mut cycle_session_expired = false;
     let mut cycle_stats = download::SyncStats::default();
+    let mut full_enumeration_ran = false;
 
     // If ANY library entered the cycle with a stale plan (the prior
     // album refresh failed and the previous plan is being reused), suppress
@@ -1659,6 +1660,7 @@ async fn run_cycle(
             &lib_state.zone_name,
         )
         .await;
+        full_enumeration_ran |= matches!(sync_mode, download::SyncMode::Full);
 
         let sync_mode_label = match &sync_mode {
             download::SyncMode::Full => "full",
@@ -1757,6 +1759,24 @@ async fn run_cycle(
                 cycle_failed_count += failed_count;
             }
         }
+    }
+
+    let completed_without_errors = cycle_failed_count == 0
+        && !cycle_session_expired
+        && !cycle_stats.interrupted
+        && cycle_stats.enumeration_errors == 0
+        && !shutdown_token.is_cancelled();
+    if full_enumeration_ran
+        && completed_without_errors
+        && !is_retry_failed
+        && cycle_stats.assets_seen == 0
+    {
+        tracing::warn!(
+            library_count = library_states.len(),
+            assets_seen = cycle_stats.assets_seen,
+            "Sync completed after enumerating zero assets; check iCloud library \
+             access and filters if this was unexpected"
+        );
     }
 
     Ok(CycleResult {
@@ -2693,10 +2713,50 @@ mod tests {
         )
     }
 
+    fn album_count_response(count: u64) -> serde_json::Value {
+        serde_json::json!({
+            "batch": [{"records": [{"fields": {"itemCount": {"value": count}}}]}]
+        })
+    }
+
+    fn make_empty_full_album(zone_sync_token: &str) -> crate::icloud::photos::PhotoAlbum {
+        use serde_json::json;
+        crate::icloud::photos::PhotoAlbum::new(
+            crate::icloud::photos::PhotoAlbumConfig {
+                params: Arc::new(std::collections::HashMap::new()),
+                service_endpoint: Arc::from("https://example.com"),
+                name: Arc::from("TestAlbum"),
+                list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
+                obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
+                query_filter: None,
+                page_size: 100,
+                zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+                retry_config: retry::RetryConfig::default(),
+            },
+            Box::new(
+                crate::test_helpers::MockPhotosSession::new()
+                    .ok(album_count_response(0))
+                    .ok(json!({"records": [], "syncToken": zone_sync_token})),
+            ),
+        )
+    }
+
     fn make_run_cycle_library_state(
         zone: &str,
         sync_token_key: &str,
         zone_sync_token: &str,
+    ) -> LibraryState {
+        make_run_cycle_library_state_with_album(
+            zone,
+            sync_token_key,
+            make_incremental_album(zone_sync_token),
+        )
+    }
+
+    fn make_run_cycle_library_state_with_album(
+        zone: &str,
+        sync_token_key: &str,
+        album: crate::icloud::photos::PhotoAlbum,
     ) -> LibraryState {
         LibraryState {
             library: crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
@@ -2708,7 +2768,7 @@ mod tests {
             plan: crate::commands::AlbumPlan {
                 passes: vec![crate::commands::AlbumPass {
                     kind: crate::commands::PassKind::Unfiled,
-                    album: make_incremental_album(zone_sync_token),
+                    album,
                     exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
                 }],
             },
@@ -2769,6 +2829,35 @@ mod tests {
             None,
         )
         .expect("test config")
+    }
+
+    async fn run_empty_full_cycle(is_retry_failed: bool) -> CycleResult {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_empty_full_album("zone-tok-empty"),
+        );
+        let states = vec![&lib_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            is_retry_failed,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle")
     }
 
     #[test]
@@ -4394,6 +4483,40 @@ mod tests {
                 .as_deref(),
             Some("zone-tok-prev"),
             "failed zone-token write must leave old token in place for replay"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_full_zero_assets_warns_once() {
+        let result = run_empty_full_cycle(false).await;
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert!(
+            logs_contain("Sync completed after enumerating zero assets"),
+            "completed full sync with zero assets should be visible in normal logs"
+        );
+        assert!(
+            logs_contain("library_count=1"),
+            "zero-asset warning should carry structured library_count"
+        );
+        assert!(
+            logs_contain("assets_seen=0"),
+            "zero-asset warning should carry structured assets_seen"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_retry_failed_zero_assets_does_not_warn() {
+        let result = run_empty_full_cycle(true).await;
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert!(
+            !logs_contain("Sync completed after enumerating zero assets"),
+            "retry-failed no-op cycles must stay quiet"
         );
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1606,7 +1606,6 @@ async fn run_cycle(
     let mut cycle_failed_count = 0usize;
     let mut cycle_session_expired = false;
     let mut cycle_stats = download::SyncStats::default();
-    let mut full_enumeration_ran = false;
 
     // If ANY library entered the cycle with a stale plan (the prior
     // album refresh failed and the previous plan is being reused), suppress
@@ -1695,6 +1694,27 @@ async fn run_cycle(
         )
         .await?;
 
+        let library_completed_without_errors = matches!(
+            &sync_result.outcome,
+            download::DownloadOutcome::Success
+        ) && !sync_result.stats.interrupted
+            && sync_result.stats.enumeration_errors == 0
+            && !shutdown_token.is_cancelled();
+        if sync_result.full_enumeration_ran
+            && library_completed_without_errors
+            && download_controls.run_mode.downloads_files()
+            && !is_retry_failed
+            && sync_result.stats.assets_seen == 0
+        {
+            tracing::warn!(
+                library = %lib_state.zone_name,
+                library_count = library_states.len(),
+                assets_seen = sync_result.stats.assets_seen,
+                "Sync completed after enumerating zero assets; check iCloud library \
+                 access and filters if this was unexpected"
+            );
+        }
+
         // Store sync token only when all downloads succeeded.
         // For full sync this is safe (state DB tracks individual failures for retry).
         // For incremental sync, advancing the token on partial failure would lose
@@ -1741,7 +1761,6 @@ async fn run_cycle(
         }
 
         // Accumulate stats across libraries.
-        full_enumeration_ran |= sync_result.full_enumeration_ran;
         cycle_stats.accumulate(&sync_result.stats);
 
         match sync_result.outcome {
@@ -1759,24 +1778,6 @@ async fn run_cycle(
                 cycle_failed_count += failed_count;
             }
         }
-    }
-
-    let completed_without_errors = cycle_failed_count == 0
-        && !cycle_session_expired
-        && !cycle_stats.interrupted
-        && cycle_stats.enumeration_errors == 0
-        && !shutdown_token.is_cancelled();
-    if full_enumeration_ran
-        && completed_without_errors
-        && !is_retry_failed
-        && cycle_stats.assets_seen == 0
-    {
-        tracing::warn!(
-            library_count = library_states.len(),
-            assets_seen = cycle_stats.assets_seen,
-            "Sync completed after enumerating zero assets; check iCloud library \
-             access and filters if this was unexpected"
-        );
     }
 
     Ok(CycleResult {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1694,12 +1694,11 @@ async fn run_cycle(
         )
         .await?;
 
-        let library_completed_without_errors = matches!(
-            &sync_result.outcome,
-            download::DownloadOutcome::Success
-        ) && !sync_result.stats.interrupted
-            && sync_result.stats.enumeration_errors == 0
-            && !shutdown_token.is_cancelled();
+        let library_completed_without_errors =
+            matches!(&sync_result.outcome, download::DownloadOutcome::Success)
+                && !sync_result.stats.interrupted
+                && sync_result.stats.enumeration_errors == 0
+                && !shutdown_token.is_cancelled();
         if sync_result.full_enumeration_ran
             && library_completed_without_errors
             && download_controls.run_mode.downloads_files()
@@ -2720,7 +2719,51 @@ mod tests {
         })
     }
 
-    fn make_empty_full_album(zone_sync_token: &str) -> crate::icloud::photos::PhotoAlbum {
+    fn full_album_page(zone: &str, record_name: &str, sync_token: &str) -> serde_json::Value {
+        serde_json::json!({
+            "records": [
+                {
+                    "recordName": record_name,
+                    "recordType": "CPLMaster",
+                    "fields": {
+                        "filenameEnc": {"value": "cGhvdG8uanBn", "type": "STRING"},
+                        "resOriginalRes": {
+                            "value": {
+                                "downloadURL": "https://p01.icloud-content.com/photo.jpg",
+                                "size": 1024,
+                                "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                            }
+                        },
+                        "resOriginalWidth": {"value": 100, "type": "INT64"},
+                        "resOriginalHeight": {"value": 100, "type": "INT64"},
+                        "resOriginalFileType": {"value": "public.jpeg"},
+                        "itemType": {"value": "public.jpeg"},
+                        "adjustmentRenderType": {"value": 0, "type": "INT64"}
+                    },
+                    "recordChangeTag": "ct-master"
+                },
+                {
+                    "recordName": format!("asset-{record_name}"),
+                    "recordType": "CPLAsset",
+                    "fields": {
+                        "masterRef": {
+                            "value": {"recordName": record_name, "zoneID": {"zoneName": zone}},
+                            "type": "REFERENCE"
+                        },
+                        "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                        "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                    },
+                    "recordChangeTag": "ct-asset"
+                }
+            ],
+            "syncToken": sync_token
+        })
+    }
+
+    fn make_full_album_with_session(
+        zone: &str,
+        session: crate::test_helpers::MockPhotosSession,
+    ) -> crate::icloud::photos::PhotoAlbum {
         use serde_json::json;
         crate::icloud::photos::PhotoAlbum::new(
             crate::icloud::photos::PhotoAlbumConfig {
@@ -2731,14 +2774,42 @@ mod tests {
                 obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
                 query_filter: None,
                 page_size: 100,
-                zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+                zone_id: Arc::new(json!({"zoneName": zone})),
                 retry_config: retry::RetryConfig::default(),
             },
-            Box::new(
-                crate::test_helpers::MockPhotosSession::new()
-                    .ok(album_count_response(0))
-                    .ok(json!({"records": [], "syncToken": zone_sync_token})),
-            ),
+            Box::new(session),
+        )
+    }
+
+    fn make_empty_full_album(zone_sync_token: &str) -> crate::icloud::photos::PhotoAlbum {
+        make_empty_full_album_for_zone("PrimarySync", zone_sync_token)
+    }
+
+    fn make_empty_full_album_for_zone(
+        zone: &str,
+        zone_sync_token: &str,
+    ) -> crate::icloud::photos::PhotoAlbum {
+        make_full_album_with_session(
+            zone,
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(0))
+                .ok(serde_json::json!({"records": [], "syncToken": zone_sync_token})),
+        )
+    }
+
+    fn make_one_photo_full_album_for_zone(
+        zone: &str,
+        zone_sync_token: &str,
+    ) -> crate::icloud::photos::PhotoAlbum {
+        make_full_album_with_session(
+            zone,
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(full_album_page(
+                    zone,
+                    &format!("master-{zone}"),
+                    zone_sync_token,
+                )),
         )
     }
 
@@ -2791,9 +2862,33 @@ mod tests {
         (dir, Arc::new(tokio::sync::RwLock::new(session)))
     }
 
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    struct RunCycleDownloadConfigOptions {
+        media: config::MediaSelection,
+        per_pass_paths: bool,
+    }
+
     fn make_run_cycle_download_config_builder(
         download_dir: &std::path::Path,
         db: Arc<dyn state::StateDb>,
+    ) -> impl Fn(
+        download::SyncMode,
+        Arc<rustc_hash::FxHashSet<String>>,
+        Arc<download::AssetGroupings>,
+        Arc<str>,
+    ) -> Arc<download::DownloadConfig>
+           + '_ {
+        make_run_cycle_download_config_builder_with_options(
+            download_dir,
+            db,
+            RunCycleDownloadConfigOptions::default(),
+        )
+    }
+
+    fn make_run_cycle_download_config_builder_with_options(
+        download_dir: &std::path::Path,
+        db: Arc<dyn state::StateDb>,
+        options: RunCycleDownloadConfigOptions,
     ) -> impl Fn(
         download::SyncMode,
         Arc<rustc_hash::FxHashSet<String>>,
@@ -2807,6 +2902,10 @@ mod tests {
             config.folder_structure = "%Y/%m/%d".to_string();
             config.folder_structure_albums = Arc::from("%Y/%m/%d");
             config.folder_structure_smart_folders = Arc::from("%Y/%m/%d");
+            if options.per_pass_paths {
+                config.folder_structure_albums = Arc::from("{album}");
+            }
+            config.media = options.media;
             config.state_db = Some(Arc::clone(&db));
             config.sync_mode = sync_mode;
             config.exclude_asset_ids = exclude_asset_ids;
@@ -2833,6 +2932,17 @@ mod tests {
     }
 
     async fn run_empty_full_cycle(is_retry_failed: bool) -> CycleResult {
+        run_empty_full_cycle_with_controls(
+            is_retry_failed,
+            download::DownloadControls::download_hidden(),
+        )
+        .await
+    }
+
+    async fn run_empty_full_cycle_with_controls(
+        is_retry_failed: bool,
+        controls: download::DownloadControls,
+    ) -> CycleResult {
         let config = make_run_cycle_config();
         let db = make_state_db();
         let download_dir = tempfile::tempdir().expect("download tempdir");
@@ -2853,7 +2963,38 @@ mod tests {
             Some(db.as_ref()),
             is_retry_failed,
             &build_download_config,
-            download::DownloadControls::download_hidden(),
+            controls,
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle")
+    }
+
+    async fn run_one_photo_full_cycle_with_controls(
+        controls: download::DownloadControls,
+    ) -> CycleResult {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_one_photo_full_album_for_zone("PrimarySync", "zone-tok-one"),
+        );
+        let states = vec![&lib_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            controls,
             &shared_session,
             &CancellationToken::new(),
         )
@@ -4518,6 +4659,142 @@ mod tests {
         assert!(
             !logs_contain("Sync completed after enumerating zero assets"),
             "retry-failed no-op cycles must stay quiet"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_incremental_fallback_zero_assets_warns() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed sync token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_empty_full_album("zone-tok-empty"),
+        );
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                per_pass_paths: true,
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert!(
+            logs_contain("Sync completed after enumerating zero assets"),
+            "incremental requests that fall back to full enumeration must warn"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_warns_for_empty_library_when_another_library_has_assets() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let empty_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_empty_full_album_for_zone("PrimarySync", "zone-tok-empty"),
+        );
+        let nonempty_state = make_run_cycle_library_state_with_album(
+            "SharedSync-TEST",
+            "sync_token:SharedSync-TEST",
+            make_one_photo_full_album_for_zone("SharedSync-TEST", "zone-tok-one"),
+        );
+        let states = vec![&empty_state, &nonempty_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: config::MediaSelection {
+                    photos: false,
+                    videos: true,
+                    live_photos: true,
+                },
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 1);
+        assert!(
+            logs_contain("Sync completed after enumerating zero assets"),
+            "empty library must warn even when the cycle-wide asset count is nonzero"
+        );
+        assert!(
+            logs_contain("library=PrimarySync"),
+            "warning must name the empty library"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_dry_run_nonempty_full_cycle_does_not_warn() {
+        let result =
+            run_one_photo_full_cycle_with_controls(download::DownloadControls::dry_run_hidden())
+                .await;
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert!(
+            !logs_contain("Sync completed after enumerating zero assets"),
+            "dry-run asset scans must not warn just because assets_seen stays zero"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_print_filenames_nonempty_full_cycle_does_not_warn() {
+        let controls = download::DownloadControls::new(
+            download::DownloadRunMode::PrintFilenames,
+            download::DownloadReporting::hidden(),
+        );
+        let result = run_one_photo_full_cycle_with_controls(controls).await;
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert!(
+            !logs_contain("Sync completed after enumerating zero assets"),
+            "print-only asset scans must not warn just because assets_seen stays zero"
         );
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1660,7 +1660,6 @@ async fn run_cycle(
             &lib_state.zone_name,
         )
         .await;
-        full_enumeration_ran |= matches!(sync_mode, download::SyncMode::Full);
 
         let sync_mode_label = match &sync_mode {
             download::SyncMode::Full => "full",
@@ -1742,6 +1741,7 @@ async fn run_cycle(
         }
 
         // Accumulate stats across libraries.
+        full_enumeration_ran |= sync_result.full_enumeration_ran;
         cycle_stats.accumulate(&sync_result.stats);
 
         match sync_result.outcome {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2931,6 +2931,36 @@ mod tests {
         .expect("test config")
     }
 
+    async fn run_full_cycle_with_album(
+        album: crate::icloud::photos::PhotoAlbum,
+        is_retry_failed: bool,
+        controls: download::DownloadControls,
+    ) -> CycleResult {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            is_retry_failed,
+            &build_download_config,
+            controls,
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle")
+    }
+
     async fn run_empty_full_cycle(is_retry_failed: bool) -> CycleResult {
         run_empty_full_cycle_with_controls(
             is_retry_failed,
@@ -2943,64 +2973,26 @@ mod tests {
         is_retry_failed: bool,
         controls: download::DownloadControls,
     ) -> CycleResult {
-        let config = make_run_cycle_config();
-        let db = make_state_db();
-        let download_dir = tempfile::tempdir().expect("download tempdir");
-        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
-
-        let lib_state = make_run_cycle_library_state_with_album(
-            "PrimarySync",
-            "sync_token:PrimarySync",
+        run_full_cycle_with_album(
             make_empty_full_album("zone-tok-empty"),
-        );
-        let states = vec![&lib_state];
-        let build_download_config =
-            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
-
-        run_cycle(
-            &states,
-            &config,
-            Some(db.as_ref()),
             is_retry_failed,
-            &build_download_config,
             controls,
-            &shared_session,
-            &CancellationToken::new(),
         )
         .await
-        .expect("run cycle")
     }
 
     async fn run_one_photo_full_cycle_with_controls(
         controls: download::DownloadControls,
     ) -> CycleResult {
-        let config = make_run_cycle_config();
-        let db = make_state_db();
-        let download_dir = tempfile::tempdir().expect("download tempdir");
-        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
-
-        let lib_state = make_run_cycle_library_state_with_album(
-            "PrimarySync",
-            "sync_token:PrimarySync",
+        run_full_cycle_with_album(
             make_one_photo_full_album_for_zone("PrimarySync", "zone-tok-one"),
-        );
-        let states = vec![&lib_state];
-        let build_download_config =
-            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
-
-        run_cycle(
-            &states,
-            &config,
-            Some(db.as_ref()),
             false,
-            &build_download_config,
             controls,
-            &shared_session,
-            &CancellationToken::new(),
         )
         .await
-        .expect("run cycle")
     }
+
+    const ZERO_ASSET_WARNING_PREFIX: &str = "Sync completed after enumerating zero assets";
 
     #[test]
     fn count_passes_empty_plan_is_all_zero() {
@@ -4636,7 +4628,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
         assert!(
-            logs_contain("Sync completed after enumerating zero assets"),
+            logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "completed full sync with zero assets should be visible in normal logs"
         );
         assert!(
@@ -4657,7 +4649,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
         assert!(
-            !logs_contain("Sync completed after enumerating zero assets"),
+            !logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "retry-failed no-op cycles must stay quiet"
         );
     }
@@ -4704,7 +4696,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
         assert!(
-            logs_contain("Sync completed after enumerating zero assets"),
+            logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "incremental requests that fall back to full enumeration must warn"
         );
     }
@@ -4757,7 +4749,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 1);
         assert!(
-            logs_contain("Sync completed after enumerating zero assets"),
+            logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "empty library must warn even when the cycle-wide asset count is nonzero"
         );
         assert!(
@@ -4776,7 +4768,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
         assert!(
-            !logs_contain("Sync completed after enumerating zero assets"),
+            !logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "dry-run asset scans must not warn just because assets_seen stays zero"
         );
     }
@@ -4793,7 +4785,7 @@ mod tests {
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
         assert!(
-            !logs_contain("Sync completed after enumerating zero assets"),
+            !logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "print-only asset scans must not warn just because assets_seen stays zero"
         );
     }


### PR DESCRIPTION
## Summary
- Promoted deferred state-write retry and recovery breadcrumbs to info logs with `pending_count` and `attempt` fields.
- Added a warning when a completed full sync enumerates zero assets, while keeping `sync --retry-failed` no-op runs quiet.
- Added regression coverage for the retry log fields and zero-asset warning behavior.

## Context
Closes #279.
Closes #280.

## Tests
- `cargo check`
- `cargo test zero_assets --lib`
- `cargo test sync_loop:: --lib`
- `cargo test download::pipeline:: --lib`
- `cargo test --test behavioral -- --test-threads=1`
- `cargo test flush_pending_state_writes_recovers_after_transient_failure --lib`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --help`
