### PR TITLE
Handle mid-download shutdown safely

### DIFF
--- a/src/download/error.rs
+++ b/src/download/error.rs
@@ -32,6 +32,9 @@ pub(crate) enum DownloadError {
     #[error("Invalid content for {path}: {reason}")]
     InvalidContent { path: Box<str>, reason: Box<str> },
 
+    #[error("Download interrupted for {path} after {bytes_written} bytes")]
+    Interrupted { path: Box<str>, bytes_written: u64 },
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -53,7 +56,7 @@ impl DownloadError {
             Self::ContentLengthMismatch { .. }
             | Self::InvalidContent { .. }
             | Self::Http { .. } => true,
-            Self::Disk(_) | Self::Other(_) => false,
+            Self::Disk(_) | Self::Interrupted { .. } | Self::Other(_) => false,
         }
     }
 
@@ -81,6 +84,10 @@ impl DownloadError {
                 ..
             }
         )
+    }
+
+    pub const fn is_interrupted(&self) -> bool {
+        matches!(self, Self::Interrupted { .. })
     }
 }
 
@@ -201,6 +208,22 @@ mod tests {
     fn test_other_not_retryable() {
         let e = DownloadError::Other(anyhow::anyhow!("unknown"));
         assert!(!e.is_retryable());
+    }
+
+    #[test]
+    fn interrupted_not_retryable_and_is_classified() {
+        let e = DownloadError::Interrupted {
+            path: "photo.jpg".into(),
+            bytes_written: 512,
+        };
+
+        assert!(!e.is_retryable());
+        assert!(e.is_interrupted());
+        assert!(!e.is_session_expired());
+        assert!(
+            e.to_string().contains("512"),
+            "display should include bytes written"
+        );
     }
 
     #[test]

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -8,6 +8,7 @@ use futures_util::{Stream, StreamExt};
 use reqwest::Client;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
+use tokio_util::sync::CancellationToken;
 
 use super::error::DownloadError;
 use super::limiter::BandwidthLimiter;
@@ -114,6 +115,7 @@ pub(super) struct DownloadOpts {
 pub(super) struct DownloadLimits<'a> {
     pub rate_limit_counter: Option<&'a std::sync::atomic::AtomicUsize>,
     pub bandwidth_limiter: Option<&'a BandwidthLimiter>,
+    pub shutdown_token: Option<&'a CancellationToken>,
 }
 
 /// Test-only off-mode wrapper. Production calls `download_file_with_mode`
@@ -188,6 +190,7 @@ pub(super) async fn download_file_with_mode<C: DownloadClient>(
                 opts.skip_rename,
                 opts.expected_size,
                 limits.bandwidth_limiter,
+                limits.shutdown_token,
             ))
             .await
         },
@@ -218,6 +221,7 @@ async fn attempt_download<C: DownloadClient>(
     skip_rename: bool,
     expected_size: Option<u64>,
     bandwidth_limiter: Option<&BandwidthLimiter>,
+    shutdown_token: Option<&CancellationToken>,
 ) -> Result<u64, DownloadError> {
     let path_str = download_path.display().to_string();
 
@@ -381,7 +385,25 @@ async fn attempt_download<C: DownloadClient>(
 
     let mut stream = response.stream;
     let stream_result: Result<(), DownloadError> = async {
-        while let Some(chunk) = stream.next().await {
+        loop {
+            let next_chunk = if let Some(token) = shutdown_token {
+                tokio::select! {
+                    () = token.cancelled() => {
+                        return Err(DownloadError::Interrupted {
+                            path: path_str.clone().into(),
+                            bytes_written,
+                        });
+                    }
+                    chunk = stream.next() => chunk,
+                }
+            } else {
+                stream.next().await
+            };
+
+            let Some(chunk) = next_chunk else {
+                break;
+            };
+
             let chunk = chunk.map_err(|e| DownloadError::Http {
                 source: e,
                 path: path_str.clone().into(),
@@ -402,10 +424,17 @@ async fn attempt_download<C: DownloadClient>(
     .await;
     drop(file);
     if let Err(e) = stream_result {
-        if !e.is_retryable() {
+        if !e.is_retryable() && !e.is_interrupted() {
             crate::fs_util::log_remove_async(part_path).await;
         }
         return Err(e);
+    }
+
+    if shutdown_token.is_some_and(CancellationToken::is_cancelled) {
+        return Err(DownloadError::Interrupted {
+            path: path_str.into(),
+            bytes_written,
+        });
     }
 
     // Verify the server sent the number of bytes it promised.
@@ -1649,6 +1678,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1673,6 +1703,7 @@ mod tests {
             &download_path,
             &part_path,
             true,
+            None,
             None,
             None,
         )
@@ -1704,6 +1735,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1731,6 +1763,7 @@ mod tests {
             false,
             Some(1024),
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1755,6 +1788,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
             None,
         )
@@ -1783,6 +1817,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
             None,
         )
@@ -1820,6 +1855,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1855,6 +1891,7 @@ mod tests {
             &part_path,
             false,
             Some(150), // expected_size signals version A
+            None,
             None,
         )
         .await
@@ -1895,6 +1932,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1919,6 +1957,7 @@ mod tests {
             &part_path,
             false,
             Some(body.len() as u64),
+            None,
             None,
         )
         .await
@@ -1975,6 +2014,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1984,6 +2024,180 @@ mod tests {
             100,
             "client should receive the .part file size as resume offset"
         );
+    }
+
+    #[derive(Debug)]
+    struct InterruptingResumeClient {
+        body: Vec<u8>,
+        first_chunk_len: usize,
+        calls: std::sync::atomic::AtomicUsize,
+        resume_requests: std::sync::Mutex<Vec<Option<u64>>>,
+    }
+
+    impl InterruptingResumeClient {
+        fn new(body: Vec<u8>, first_chunk_len: usize) -> Self {
+            Self {
+                body,
+                first_chunk_len,
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                resume_requests: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn pending_after_first_chunk(&self) -> DownloadResponse {
+            let first_chunk = self.body[..self.first_chunk_len].to_vec();
+            let stream = futures_util::stream::unfold(Some(first_chunk), |next| async move {
+                match next {
+                    Some(chunk) => Some((Ok(Bytes::from(chunk)), None)),
+                    None => std::future::pending().await,
+                }
+            });
+            DownloadResponse {
+                status: 200,
+                content_length: Some(self.body.len() as u64),
+                content_type: Some("image/jpeg".to_string()),
+                stream: Box::pin(stream),
+            }
+        }
+
+        fn remaining_from(&self, resume_from: u64) -> DownloadResponse {
+            let offset = usize::try_from(resume_from).expect("resume offset fits usize");
+            let chunks: Vec<Result<Bytes, BoxError>> =
+                vec![Ok(Bytes::from(self.body[offset..].to_vec()))];
+            DownloadResponse {
+                status: 206,
+                content_length: Some((self.body.len() - offset) as u64),
+                content_type: Some("image/jpeg".to_string()),
+                stream: Box::pin(futures_util::stream::iter(chunks)),
+            }
+        }
+
+        fn resume_requests(&self) -> Vec<Option<u64>> {
+            self.resume_requests.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DownloadClient for InterruptingResumeClient {
+        async fn fetch(
+            &self,
+            _url: &str,
+            resume_from: Option<u64>,
+        ) -> Result<DownloadResponse, BoxError> {
+            self.resume_requests.lock().unwrap().push(resume_from);
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(if call == 0 {
+                self.pending_after_first_chunk()
+            } else {
+                self.remaining_from(resume_from.expect("second request must resume"))
+            })
+        }
+    }
+
+    async fn wait_for_part_len(part_path: &Path, expected_len: u64) {
+        for _ in 0..100 {
+            if std::fs::metadata(part_path).is_ok_and(|meta| meta.len() == expected_len) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        panic!(
+            "part file {} did not reach {expected_len} bytes",
+            part_path.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn download_file_interrupted_mid_body_keeps_part_and_resumes() {
+        let mut body = vec![0xFF, 0xD8, 0xFF, 0xE0];
+        body.extend((4..128u8).map(|n| n.wrapping_mul(3)));
+        let client = InterruptingResumeClient::new(body.clone(), 4);
+        let dir = TempDir::new().unwrap();
+        let download_path = dir.path().join("interrupted.jpg");
+        let checksum = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+        let part_path = temp_download_path(&download_path, &checksum, ".kei-tmp").unwrap();
+        let config = RetryConfig {
+            max_retries: 0,
+            base_delay_secs: 0,
+            max_delay_secs: 0,
+        };
+        let shutdown_token = CancellationToken::new();
+
+        let first_result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let download = download_file(
+                &client,
+                "http://stub/interrupted.jpg",
+                &download_path,
+                &checksum,
+                &config,
+                ".kei-tmp",
+                DownloadOpts {
+                    skip_rename: false,
+                    expected_size: Some(body.len() as u64),
+                },
+                DownloadLimits {
+                    shutdown_token: Some(&shutdown_token),
+                    ..Default::default()
+                },
+            );
+            let cancel_after_partial = async {
+                wait_for_part_len(&part_path, 4).await;
+                shutdown_token.cancel();
+            };
+            let (result, ()) = tokio::join!(download, cancel_after_partial);
+            result
+        })
+        .await
+        .expect("interrupted download should not hang");
+
+        let err = first_result.expect_err("mid-body shutdown must interrupt the download");
+        assert!(
+            matches!(
+                err,
+                DownloadError::Interrupted {
+                    bytes_written: 4,
+                    ..
+                }
+            ),
+            "expected interrupted error after first chunk, got {err:?}"
+        );
+        assert!(
+            !download_path.exists(),
+            "interrupted download must not publish the final path"
+        );
+        assert_eq!(
+            std::fs::metadata(&part_path).unwrap().len(),
+            4,
+            "interrupted download must leave the resumable .part bytes"
+        );
+
+        download_file(
+            &client,
+            "http://stub/interrupted.jpg",
+            &download_path,
+            &checksum,
+            &config,
+            ".kei-tmp",
+            DownloadOpts {
+                skip_rename: false,
+                expected_size: Some(body.len() as u64),
+            },
+            DownloadLimits::default(),
+        )
+        .await
+        .expect("second run should resume and publish");
+
+        assert_eq!(
+            client.resume_requests(),
+            vec![None, Some(4)],
+            "second request must use the partial-file offset"
+        );
+        assert_eq!(std::fs::read(&download_path).unwrap(), body);
+        assert!(!part_path.exists(), "published resume must remove .part");
+
+        use sha2::{Digest, Sha256};
+        let expected_hash = format!("{:x}", Sha256::digest(&body));
+        assert_eq!(compute_sha256(&download_path).await.unwrap(), expected_hash);
     }
 
     // --- download_file retry integration tests ---
@@ -2131,6 +2345,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -2163,6 +2378,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2184,6 +2400,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2203,6 +2420,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
             None,
         )
@@ -2887,6 +3105,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -2920,6 +3139,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
             None,
         )
@@ -2965,6 +3185,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2995,6 +3216,7 @@ mod tests {
             &part_path,
             false,
             Some(1024), // API says 1024 but download is 8
+            None,
             None,
         )
         .await
@@ -3077,12 +3299,32 @@ mod tests {
             let dp_a = download_path.clone();
             let pp_a = part_path.clone();
             let task_a = tokio::spawn(async move {
-                attempt_download(&client_a, "http://stub", &dp_a, &pp_a, false, None, None).await
+                attempt_download(
+                    &client_a,
+                    "http://stub",
+                    &dp_a,
+                    &pp_a,
+                    false,
+                    None,
+                    None,
+                    None,
+                )
+                .await
             });
             let dp_b = download_path.clone();
             let pp_b = part_path.clone();
             let task_b = tokio::spawn(async move {
-                attempt_download(&client_b, "http://stub", &dp_b, &pp_b, false, None, None).await
+                attempt_download(
+                    &client_b,
+                    "http://stub",
+                    &dp_b,
+                    &pp_b,
+                    false,
+                    None,
+                    None,
+                    None,
+                )
+                .await
             });
 
             let a = task_a.await.unwrap();
@@ -3113,6 +3355,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
             None,
         )

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2045,6 +2045,7 @@ async fn download_photos_incremental(
     if downloadable_assets.is_empty() {
         let stats = SyncStats {
             elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: shutdown_token.is_cancelled(),
             ..SyncStats::default()
         };
         tracing::info!("No new photos to download from incremental sync");
@@ -2186,6 +2187,7 @@ async fn download_photos_incremental(
         let stats = SyncStats {
             skipped: skip_breakdown,
             elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: shutdown_token.is_cancelled(),
             ..SyncStats::default()
         };
         tracing::info!("All incremental assets already downloaded or filtered");
@@ -2227,6 +2229,7 @@ async fn download_photos_incremental(
     );
 
     // Run the download pass on the collected tasks
+    let pass_shutdown_token = shutdown_token.clone();
     let pass_config = PassConfig {
         client: download_client,
         retry_config: &config.retry,
@@ -2234,7 +2237,7 @@ async fn download_photos_incremental(
         concurrency: config.concurrent_downloads,
         reporting: controls.reporting,
         temp_suffix: Arc::clone(&config.temp_suffix),
-        shutdown_token,
+        shutdown_token: pass_shutdown_token,
         state_db: config.state_db.clone(),
         rate_limit_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         bandwidth_limiter: config.bandwidth_limiter.clone(),
@@ -2263,7 +2266,8 @@ async fn download_photos_incremental(
         state_write_failures: pass_result.state_write_failures,
         enumeration_errors: 0,
         elapsed_secs: started.elapsed().as_secs_f64(),
-        interrupted: pass_result.auth_errors >= AUTH_ERROR_THRESHOLD,
+        interrupted: shutdown_token.is_cancelled()
+            || pass_result.auth_errors >= AUTH_ERROR_THRESHOLD,
         rate_limited: pass_result.rate_limit_observations,
         photos_downloaded: pass_result.photos_downloaded,
         videos_downloaded: pass_result.videos_downloaded,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2229,7 +2229,6 @@ async fn download_photos_incremental(
     );
 
     // Run the download pass on the collected tasks
-    let pass_shutdown_token = shutdown_token.clone();
     let pass_config = PassConfig {
         client: download_client,
         retry_config: &config.retry,
@@ -2237,7 +2236,7 @@ async fn download_photos_incremental(
         concurrency: config.concurrent_downloads,
         reporting: controls.reporting,
         temp_suffix: Arc::clone(&config.temp_suffix),
-        shutdown_token: pass_shutdown_token,
+        shutdown_token: shutdown_token.clone(),
         state_db: config.state_db.clone(),
         rate_limit_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         bandwidth_limiter: config.bandwidth_limiter.clone(),

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1754,16 +1754,20 @@ where
             let temp_suffix = Arc::clone(&temp_suffix);
             let rate_limit_counter = Arc::clone(&rate_limit_counter);
             let bandwidth_limiter = bandwidth_limiter.clone();
+            let shutdown_token = shutdown_token.clone();
             async move {
                 let result = Box::pin(download_single_task(
                     &client,
                     &task,
                     &retry_config,
                     metadata_flags,
-                    &temp_suffix,
-                    Some(rate_limit_counter.as_ref()),
-                    bandwidth_limiter.as_ref(),
-                    mode,
+                    DownloadSingleContext {
+                        temp_suffix: &temp_suffix,
+                        rate_limit_counter: Some(rate_limit_counter.as_ref()),
+                        bandwidth_limiter: bandwidth_limiter.as_ref(),
+                        shutdown_token: &shutdown_token,
+                        mode,
+                    },
                 ))
                 .await;
                 (task, result)
@@ -1870,7 +1874,10 @@ where
                 }
             }
             Err(e) => {
-                if let Some(download_err) = e.downcast_ref::<DownloadError>() {
+                if is_interrupted_download(&e) {
+                    log_interrupted_download(&pb, &task, &e);
+                    continue;
+                } else if let Some(download_err) = e.downcast_ref::<DownloadError>() {
                     if download_err.is_session_expired() {
                         auth_errors += 1;
                         pb.suspend(|| {
@@ -2345,16 +2352,20 @@ pub(super) async fn run_download_pass(
             let temp_suffix = Arc::clone(&temp_suffix);
             let rate_limit_counter = Arc::clone(&rate_limit_counter);
             let bandwidth_limiter = bandwidth_limiter.clone();
+            let shutdown_token = shutdown_token.clone();
             async move {
                 let result = Box::pin(download_single_task(
                     &client,
                     &task,
                     retry_config,
                     metadata_flags,
-                    &temp_suffix,
-                    Some(rate_limit_counter.as_ref()),
-                    bandwidth_limiter.as_ref(),
-                    mode,
+                    DownloadSingleContext {
+                        temp_suffix: &temp_suffix,
+                        rate_limit_counter: Some(rate_limit_counter.as_ref()),
+                        bandwidth_limiter: bandwidth_limiter.as_ref(),
+                        shutdown_token: &shutdown_token,
+                        mode,
+                    },
                 ))
                 .await;
                 (task, result)
@@ -2444,6 +2455,11 @@ pub(super) async fn run_download_pass(
                 }
             }
             Err(e) => {
+                if is_interrupted_download(e) {
+                    log_interrupted_download(&pb, &task, e);
+                    pb.inc(1);
+                    continue;
+                }
                 let is_auth = e
                     .downcast_ref::<DownloadError>()
                     .is_some_and(DownloadError::is_session_expired);
@@ -2613,15 +2629,38 @@ fn plan_metadata_write(
 ///
 /// Returns `Ok(true)` on full success, `Ok(false)` if the download succeeded
 /// but EXIF stamping failed (the file is usable but lacks EXIF metadata).
+#[derive(Debug, Clone, Copy)]
+struct DownloadSingleContext<'a> {
+    temp_suffix: &'a str,
+    rate_limit_counter: Option<&'a std::sync::atomic::AtomicUsize>,
+    bandwidth_limiter: Option<&'a super::BandwidthLimiter>,
+    shutdown_token: &'a CancellationToken,
+    mode: crate::personality::Mode,
+}
+
+fn is_interrupted_download(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<DownloadError>()
+        .is_some_and(DownloadError::is_interrupted)
+}
+
+fn log_interrupted_download(pb: &ProgressBar, task: &DownloadTask, error: &anyhow::Error) {
+    pb.suspend(|| {
+        tracing::info!(
+            asset_id = %task.asset_id,
+            path = %task.download_path.display(),
+            error = %error,
+            "Download interrupted before final publish"
+        );
+    });
+}
+
 async fn download_single_task(
     client: &Client,
     task: &DownloadTask,
     retry_config: &RetryConfig,
     metadata_flags: MetadataFlags,
-    temp_suffix: &str,
-    rate_limit_counter: Option<&std::sync::atomic::AtomicUsize>,
-    bandwidth_limiter: Option<&super::BandwidthLimiter>,
-    mode: crate::personality::Mode,
+    context: DownloadSingleContext<'_>,
 ) -> Result<(bool, String, Option<String>, u64, u64)> {
     if let Some(parent) = task.download_path.parent() {
         tokio::fs::create_dir_all(parent)
@@ -2648,16 +2687,17 @@ async fn download_single_task(
         &task.download_path,
         &task.checksum,
         retry_config,
-        temp_suffix,
+        context.temp_suffix,
         super::file::DownloadOpts {
             skip_rename: needs_exif,
             expected_size: if task.size > 0 { Some(task.size) } else { None },
         },
         super::file::DownloadLimits {
-            rate_limit_counter,
-            bandwidth_limiter,
+            rate_limit_counter: context.rate_limit_counter,
+            bandwidth_limiter: context.bandwidth_limiter,
+            shutdown_token: Some(context.shutdown_token),
         },
-        mode,
+        context.mode,
     ))
     .await?;
 
@@ -2665,8 +2705,12 @@ async fn download_single_task(
     // the atomic rename, preventing silent corruption on power loss / SIGKILL.
     let part_path = if needs_exif {
         Some(
-            super::file::temp_download_path(&task.download_path, &task.checksum, temp_suffix)
-                .context("failed to compute part path")?,
+            super::file::temp_download_path(
+                &task.download_path,
+                &task.checksum,
+                context.temp_suffix,
+            )
+            .context("failed to compute part path")?,
         )
     } else {
         None
@@ -2685,7 +2729,7 @@ async fn download_single_task(
         let exif_path = part.clone();
         let payload = task.metadata.clone();
         let created_local = task.created_local;
-        let metadata_temp_suffix = temp_suffix.to_string();
+        let metadata_temp_suffix = context.temp_suffix.to_string();
         // Probe + plan + apply all run on the blocking pool so no file I/O
         // happens on the async runtime's poll thread.
         let exif_result = tokio::task::spawn_blocking(move || {
@@ -2744,7 +2788,7 @@ async fn download_single_task(
         let sidecar_path = task.download_path.clone();
         let payload = task.metadata.clone();
         let created_local = task.created_local;
-        let sidecar_temp_suffix = temp_suffix.to_string();
+        let sidecar_temp_suffix = context.temp_suffix.to_string();
         let sidecar_result = tokio::task::spawn_blocking(move || {
             let write = plan_sidecar_write(&payload, &created_local);
             if write.is_empty() {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2725,26 +2725,16 @@ mod tests {
             .expect("full album page records")
             .clone();
 
-        crate::icloud::photos::PhotoAlbum::new(
-            crate::icloud::photos::PhotoAlbumConfig {
-                params: Arc::new(std::collections::HashMap::new()),
-                service_endpoint: Arc::from("https://example.com"),
-                name: Arc::from("TestAlbum"),
-                list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
-                obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
-                query_filter: None,
-                page_size: 100,
-                zone_id: Arc::new(json!({"zoneName": zone})),
-                retry_config: retry::RetryConfig::default(),
-            },
-            Box::new(crate::test_helpers::MockPhotosSession::new().ok(json!({
+        make_full_album_with_session(
+            zone,
+            crate::test_helpers::MockPhotosSession::new().ok(json!({
                 "zones": [{
                     "zoneID": {"zoneName": zone, "ownerRecordName": "_defaultOwner"},
                     "syncToken": zone_sync_token,
                     "moreComing": false,
                     "records": records
                 }]
-            }))),
+            })),
         )
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1725,7 +1725,8 @@ async fn run_cycle(
             &sync_result.outcome,
             config.runtime.dry_run,
             cycle_has_stale_plan,
-        );
+        ) && !sync_result.stats.interrupted
+            && !shutdown_token.is_cancelled();
         if should_store_token {
             match (&sync_result.sync_token, state_db) {
                 (Some(token), Some(db)) => {
@@ -2713,6 +2714,40 @@ mod tests {
         )
     }
 
+    fn make_one_photo_incremental_album_for_zone(
+        zone: &str,
+        zone_sync_token: &str,
+    ) -> crate::icloud::photos::PhotoAlbum {
+        use serde_json::json;
+        let page = full_album_page(zone, &format!("master-{zone}"), zone_sync_token);
+        let records = page
+            .get("records")
+            .expect("full album page records")
+            .clone();
+
+        crate::icloud::photos::PhotoAlbum::new(
+            crate::icloud::photos::PhotoAlbumConfig {
+                params: Arc::new(std::collections::HashMap::new()),
+                service_endpoint: Arc::from("https://example.com"),
+                name: Arc::from("TestAlbum"),
+                list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
+                obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
+                query_filter: None,
+                page_size: 100,
+                zone_id: Arc::new(json!({"zoneName": zone})),
+                retry_config: retry::RetryConfig::default(),
+            },
+            Box::new(crate::test_helpers::MockPhotosSession::new().ok(json!({
+                "zones": [{
+                    "zoneID": {"zoneName": zone, "ownerRecordName": "_defaultOwner"},
+                    "syncToken": zone_sync_token,
+                    "moreComing": false,
+                    "records": records
+                }]
+            }))),
+        )
+    }
+
     fn album_count_response(count: u64) -> serde_json::Value {
         serde_json::json!({
             "batch": [{"records": [{"fields": {"itemCount": {"value": count}}}]}]
@@ -3084,6 +3119,7 @@ mod tests {
         inner: Arc<dyn state::StateDb>,
         failure: MetadataSetFailure,
         message: &'static str,
+        cancel_on_upsert: Option<CancellationToken>,
     }
 
     impl std::fmt::Debug for FailingMetadataSetDb {
@@ -3115,7 +3151,13 @@ mod tests {
             &self,
             record: &state::types::AssetRecord,
         ) -> Result<(), state::error::StateError> {
-            self.inner.upsert_seen(record).await
+            let result = self.inner.upsert_seen(record).await;
+            if result.is_ok() {
+                if let Some(token) = &self.cancel_on_upsert {
+                    token.cancel();
+                }
+            }
+            result
         }
 
         async fn mark_downloaded(
@@ -4097,6 +4139,7 @@ mod tests {
             inner,
             failure: MetadataSetFailure::Exact(DB_SYNC_TOKEN_KEY),
             message: "simulated db_sync_token write failure",
+            cancel_on_upsert: None,
         });
 
         let session = crate::test_helpers::MockPhotosSession::new().ok(json!({
@@ -4581,6 +4624,7 @@ mod tests {
             inner: Arc::clone(&inner),
             failure: MetadataSetFailure::Prefix(SYNC_TOKEN_PREFIX),
             message: "simulated sync-token write failure",
+            cancel_on_upsert: None,
         });
         let download_dir = tempfile::tempdir().expect("download tempdir");
         let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
@@ -4617,6 +4661,70 @@ mod tests {
                 .as_deref(),
             Some("zone-tok-prev"),
             "failed zone-token write must leave old token in place for replay"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_interrupted_incremental_download_blocks_sync_token_advance() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let shutdown_token = CancellationToken::new();
+        let db: Arc<dyn state::StateDb> = Arc::new(FailingMetadataSetDb {
+            inner: Arc::clone(&inner),
+            failure: MetadataSetFailure::Exact("__unused_metadata_key__"),
+            message: "unused",
+            cancel_on_upsert: Some(shutdown_token.clone()),
+        });
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_one_photo_incremental_album_for_zone("PrimarySync", "zone-tok-new"),
+        );
+        let states = vec![&lib_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &shutdown_token,
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert!(
+            result.stats.interrupted,
+            "cancellation before the download pass must be visible in cycle stats"
+        );
+        assert!(
+            !result.db_sync_token_advance_safe,
+            "database precheck token must not advance after an interrupted download cycle"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "interrupted cycle must leave the old zone token in place for replay"
+        );
+        assert!(
+            !download_dir.path().join("2023/11/14/photo.jpg").exists(),
+            "test must not pass by completing the download before cancellation"
         );
     }
 


### PR DESCRIPTION
## Summary
- Added a typed interrupted-download error so shutdown during a response body leaves the `.part` file in place.
- Passed the shutdown token into single-file downloads and skipped failed/downloaded state updates for interrupted in-flight assets.
- Added regression coverage for no final publish, resumable partial bytes, `Range` resume, final byte equality, and SHA-256 verification.

## Context
Closes #284.

`harden_process` coverage is left out here; this PR covers the download-layer shutdown path from the issue.

## Tests
- `cargo check`
- `cargo test download::error:: --lib`
- `cargo test download::file:: --lib`
- `cargo test download::pipeline:: --lib`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
