### PR TITLE
Guard full-enumeration sync token advancement

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1632,6 +1632,29 @@ fn classify_pagination_shortfall(total: u64, seen: u64) -> PaginationShortfall {
     }
 }
 
+/// Resolve the zone sync token from every full-enumeration pass that reported
+/// one. All passes for a zone must agree before the token can advance; picking
+/// the first completed pass would hide snapshot drift between album-scoped
+/// enumerations.
+fn unanimous_pass_sync_token(tokens: &[String]) -> Option<String> {
+    let first = tokens.first()?;
+    if tokens.iter().all(|token| token == first) {
+        return Some(first.clone());
+    }
+
+    let mut unique_tokens = FxHashSet::default();
+    for token in tokens {
+        unique_tokens.insert(token.as_str());
+    }
+    tracing::warn!(
+        token_count = tokens.len(),
+        unique_token_count = unique_tokens.len(),
+        "Full enumeration syncToken mismatch across passes; blocking sync \
+         token advancement"
+    );
+    None
+}
+
 /// Full enumeration with syncToken capture.
 ///
 /// Uses `photo_stream_with_token` to capture the zone-level syncToken
@@ -1873,19 +1896,23 @@ async fn download_photos_full_with_token(
         false
     };
 
-    // Collect the sync token from any album's token receiver.
-    // In practice, all albums share the same zone so any token suffices.
+    // Collect the sync token from every album's token receiver and require
+    // agreement before advancing. In practice, all passes for a zone should
+    // report the same token; disagreement means the full enumeration did not
+    // observe one coherent snapshot.
     // Don't advance the token for read-only operations, or when pagination
     // was incomplete (would permanently skip missed assets).
-    let mut sync_token = None;
-    if !controls.run_mode.only_print_filenames() && !pagination_undercount {
+    let sync_token = if !controls.run_mode.only_print_filenames() && !pagination_undercount {
+        let mut tokens = Vec::new();
         for rx in token_receivers {
             if let Ok(Some(token)) = rx.await {
-                sync_token = Some(token);
-                break;
+                tokens.push(token);
             }
         }
-    }
+        unanimous_pass_sync_token(&tokens)
+    } else {
+        None
+    };
 
     // Capture the enumeration-complete signal before
     // `build_download_outcome` consumes `streaming_result`. The marker
@@ -4203,6 +4230,27 @@ mod tests {
 
         assert_eq!(counts, vec![0, 0]);
         assert_eq!(errors, 2);
+    }
+
+    #[test]
+    fn unanimous_pass_sync_token_returns_token_when_passes_agree() {
+        let tokens = vec!["zone-token".to_string(), "zone-token".to_string()];
+
+        assert_eq!(
+            unanimous_pass_sync_token(&tokens).as_deref(),
+            Some("zone-token")
+        );
+    }
+
+    #[test]
+    fn unanimous_pass_sync_token_suppresses_disagreement() {
+        let tokens = vec!["zone-token-a".to_string(), "zone-token-b".to_string()];
+
+        assert_eq!(
+            unanimous_pass_sync_token(&tokens),
+            None,
+            "mismatched full-enumeration pass tokens must block advancement"
+        );
     }
 
     /// Per-pass mode AND-folds `enumeration_complete` across passes.

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use anyhow::Context;
 use serde_json::{json, Value};
@@ -73,6 +73,30 @@ fn log_fetcher_response(album: &str, response: &Value) {
         response = %response,
         "Fetcher response body",
     );
+}
+
+/// Return a full-enumeration sync token only when every fetcher that reported
+/// one agreed. A single overwritten token is unsafe: if two parallel fetchers
+/// observed different zone tokens, advancing either token could skip records
+/// that were not present in the other fetcher's snapshot.
+fn unanimous_fetcher_sync_token(album: &str, tokens: &[String]) -> Option<String> {
+    let first = tokens.first()?;
+    if tokens.iter().all(|token| token == first) {
+        return Some(first.clone());
+    }
+
+    let mut unique_tokens = FxHashSet::default();
+    for token in tokens {
+        unique_tokens.insert(token.as_str());
+    }
+    tracing::warn!(
+        album,
+        token_count = tokens.len(),
+        unique_token_count = unique_tokens.len(),
+        "Full enumeration syncToken mismatch across parallel fetchers; \
+         blocking sync token advancement"
+    );
+    None
 }
 
 /// Configuration for creating a `PhotoAlbum`, bundling all non-session fields.
@@ -267,15 +291,16 @@ impl PhotoAlbum {
         concurrency: usize,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
         let (token_tx, token_rx) = tokio::sync::oneshot::channel();
-        let shared_sync_token: Arc<tokio::sync::Mutex<Option<String>>> =
-            Arc::new(tokio::sync::Mutex::new(None));
+        let fetcher_sync_tokens: Arc<tokio::sync::Mutex<Vec<String>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
 
         let (stream, handles) = self.photo_stream_inner(
             limit,
             total_count,
             concurrency,
-            Some(shared_sync_token.clone()),
+            Some(fetcher_sync_tokens.clone()),
         );
+        let album_name = Arc::clone(&self.name);
 
         // Spawn a monitor task that waits for all fetcher tasks to complete,
         // then delivers the captured syncToken through the oneshot channel.
@@ -289,7 +314,8 @@ impl PhotoAlbum {
             let final_token = if fetcher_panicked {
                 None
             } else {
-                shared_sync_token.lock().await.clone()
+                let tokens = fetcher_sync_tokens.lock().await;
+                unanimous_fetcher_sync_token(&album_name, &tokens)
             };
             let _ = token_tx.send(final_token);
         });
@@ -429,8 +455,8 @@ impl PhotoAlbum {
 
     /// Shared implementation for `photo_stream` and `photo_stream_with_token`.
     ///
-    /// When `shared_sync_token` is `Some`, each fetcher writes its last
-    /// observed `syncToken` into the shared mutex.
+    /// When `fetcher_sync_tokens` is `Some`, each fetcher appends its last
+    /// observed `syncToken` to the shared token list.
     ///
     /// Returns the stream and all spawned fetcher `JoinHandle`s.
     fn photo_stream_inner(
@@ -438,7 +464,7 @@ impl PhotoAlbum {
         limit: Option<u32>,
         total_count: Option<u64>,
         concurrency: usize,
-        shared_sync_token: Option<Arc<tokio::sync::Mutex<Option<String>>>>,
+        fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
     ) -> (PhotoStream, Vec<JoinHandle<()>>) {
         let page_size = self.page_size;
         let mut handles = Vec::new();
@@ -507,7 +533,7 @@ impl PhotoAlbum {
                     start,
                     end,
                     fetcher_limit,
-                    shared_sync_token.clone(),
+                    fetcher_sync_tokens.clone(),
                 ));
             }
             // Drop our sender so channel closes when all fetchers finish.
@@ -515,7 +541,7 @@ impl PhotoAlbum {
         } else {
             tracing::info!("Fetching photos from iCloud...");
             // Move tx directly — no clone needed for a single fetcher.
-            handles.push(self.spawn_fetcher(tx, 0, u64::MAX, limit, shared_sync_token));
+            handles.push(self.spawn_fetcher(tx, 0, u64::MAX, limit, fetcher_sync_tokens));
         }
 
         (
@@ -532,16 +558,16 @@ impl PhotoAlbum {
     /// - the per-fetcher `limit` is reached
     /// - the receiver is dropped
     ///
-    /// If `shared_sync_token` is provided, the fetcher writes the last non-None
-    /// `syncToken` from each `QueryResponse` page into it. Because the token is
-    /// a zone-level invariant, any fetcher's final value is correct.
+    /// If `fetcher_sync_tokens` is provided, the fetcher appends the last
+    /// non-None `syncToken` it observed. The monitor task compares every
+    /// fetcher's final token before allowing token advancement.
     fn spawn_fetcher(
         &self,
         tx: mpsc::Sender<anyhow::Result<PhotoAsset>>,
         start_offset: u64,
         end_offset: u64,
         limit: Option<u32>,
-        shared_sync_token: Option<Arc<tokio::sync::Mutex<Option<String>>>>,
+        fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
     ) -> JoinHandle<()> {
         let session = self.session.clone_box();
         let service_endpoint = Arc::clone(&self.service_endpoint);
@@ -556,6 +582,7 @@ impl PhotoAlbum {
         tokio::spawn(async move {
             let mut offset = start_offset;
             let mut total_sent: u64 = 0;
+            let mut last_sync_token: Option<String> = None;
             let mut pending_masters: FxHashMap<String, super::cloudkit::Record> =
                 FxHashMap::default();
             let mut consecutive_empty_pages: u32 = 0;
@@ -616,10 +643,8 @@ impl PhotoAlbum {
                 };
 
                 // Capture the zone-level syncToken from each page response.
-                if let Some(shared) = &shared_sync_token {
-                    if let Some(token) = &query.sync_token {
-                        *shared.lock().await = Some(token.clone());
-                    }
+                if let Some(token) = &query.sync_token {
+                    last_sync_token = Some(token.clone());
                 }
 
                 let records = query.records;
@@ -759,6 +784,10 @@ impl PhotoAlbum {
                 for id in pending_masters.keys() {
                     tracing::debug!(master_id = %id, "Unpaired CPLMaster");
                 }
+            }
+
+            if let (Some(shared), Some(token)) = (&fetcher_sync_tokens, last_sync_token) {
+                shared.lock().await.push(token);
             }
         })
     }
@@ -1184,6 +1213,94 @@ mod tests {
 
         let token = token_rx.await.expect("oneshot should not be dropped");
         assert_eq!(token.as_deref(), Some("st-second"));
+    }
+
+    async fn drain_photo_stream_count(stream: PhotoStream) -> u32 {
+        use tokio_stream::StreamExt;
+
+        tokio::pin!(stream);
+        let mut count = 0u32;
+        while let Some(result) = stream.next().await {
+            result.expect("photo asset should be Ok");
+            count += 1;
+        }
+        count
+    }
+
+    #[derive(Clone, Debug)]
+    struct TokenByOffsetSession {
+        tokens_by_offset: Arc<HashMap<u64, &'static str>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for TokenByOffsetSession {
+        async fn post(
+            &self,
+            _url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            let request: Value = serde_json::from_str(&body)?;
+            let offset = request["query"]["filterBy"]
+                .as_array()
+                .and_then(|filters| {
+                    filters.iter().find_map(|filter| {
+                        (filter["fieldName"] == "startRank")
+                            .then(|| filter["fieldValue"]["value"].as_u64())
+                            .flatten()
+                    })
+                })
+                .unwrap_or(0);
+
+            Ok(self.tokens_by_offset.get(&offset).map_or_else(
+                || json!({"records": []}),
+                |token| canned_page(&format!("master-{offset}"), Some(token)),
+            ))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn token_by_offset_session(tokens: &[(u64, &'static str)]) -> TokenByOffsetSession {
+        TokenByOffsetSession {
+            tokens_by_offset: Arc::new(tokens.iter().copied().collect()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_photo_stream_with_token_parallel_fetchers_agree() {
+        let album = make_album_with_session(
+            1,
+            Box::new(token_by_offset_session(&[(0, "st-same"), (1, "st-same")])),
+        );
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, Some(2), 2);
+        assert_eq!(drain_photo_stream_count(stream).await, 2);
+
+        let token = token_rx.await.expect("oneshot should not be dropped");
+        assert_eq!(token.as_deref(), Some("st-same"));
+    }
+
+    #[tokio::test]
+    async fn test_photo_stream_with_token_parallel_fetchers_disagree_suppresses_token() {
+        let album = make_album_with_session(
+            1,
+            Box::new(token_by_offset_session(&[
+                (0, "st-first"),
+                (1, "st-second"),
+            ])),
+        );
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, Some(2), 2);
+        assert_eq!(drain_photo_stream_count(stream).await, 2);
+
+        let token = token_rx.await.expect("oneshot should not be dropped");
+        assert_eq!(
+            token, None,
+            "mismatched parallel fetcher tokens must block advancement"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Require full-enumeration fetchers to agree on the zone sync token before advancing it.
- Require album/pass sync tokens to agree before a full-enumeration cycle returns a token to persist.
- Add regression coverage for matching and mismatched parallel fetcher tokens, plus pass-level token agreement.

## Tests
- `cargo check`
- `cargo test icloud::photos::album::tests::test_photo_stream_with_token_parallel_fetchers -- --test-threads=1`
- `cargo test download::tests::unanimous_pass_sync_token -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
