### PR TITLE
Replace CloudKit and Windows service panic paths

### DIFF
--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -476,22 +476,22 @@ impl PhotoAlbum {
 
         // Use 2x concurrency for enumeration fetchers — Apple's CloudKit
         // doesn't throttle at these levels and it halves enumeration time.
-        let num_fetchers = match effective_total {
+        let (num_fetchers, parallel_total) = match effective_total {
             Some(total) if concurrency > 1 => {
-                determine_fetcher_count(total, page_size, concurrency * 2)
+                let num_fetchers = determine_fetcher_count(total, page_size, concurrency * 2);
+                if num_fetchers > 1 {
+                    (num_fetchers, Some(total))
+                } else {
+                    (1, None)
+                }
             }
-            _ => 1,
+            _ => (1, None),
         };
 
         let (tx, rx) =
             mpsc::channel::<anyhow::Result<PhotoAsset>>((page_size * num_fetchers).min(500));
 
-        if num_fetchers > 1 {
-            #[allow(
-                clippy::expect_used,
-                reason = "effective_total is unconditionally set when num_fetchers > 1 (see compute above)"
-            )]
-            let total = effective_total.expect("effective_total set when num_fetchers > 1");
+        if let Some(total) = parallel_total {
             // Partition offset range into non-overlapping chunks aligned to
             // page_size boundaries so each fetcher starts on a clean page.
             let chunk_size_items = {

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -150,15 +150,9 @@ impl PhotosService {
             let libs = self.fetch_libraries("private").await?;
             self.private_libraries = Some(libs);
         }
-        // Safe: we just ensured private_libraries is Some above
-        #[allow(
-            clippy::unreachable,
-            reason = "private_libraries was set to Some on the line above; None is impossible here"
-        )]
-        Ok(self
-            .private_libraries
+        self.private_libraries
             .as_ref()
-            .unwrap_or_else(|| unreachable!("private_libraries was just set to Some")))
+            .context("internal error: private libraries were not cached")
     }
 
     /// Fetch shared libraries (lazily, first call triggers the HTTP request).
@@ -169,15 +163,9 @@ impl PhotosService {
             let libs = self.fetch_libraries("shared").await?;
             self.shared_libraries = Some(libs);
         }
-        // Safe: we just ensured shared_libraries is Some above
-        #[allow(
-            clippy::unreachable,
-            reason = "shared_libraries was set to Some on the line above; None is impossible here"
-        )]
-        Ok(self
-            .shared_libraries
+        self.shared_libraries
             .as_ref()
-            .unwrap_or_else(|| unreachable!("shared_libraries was just set to Some")))
+            .context("internal error: shared libraries were not cached")
     }
 
     async fn fetch_libraries(

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -321,15 +321,13 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                 records.retain(|r| r.get("serverErrorCode").and_then(Value::as_str).is_none());
                 let valid_count = records.len();
                 if valid_count == 0 {
-                    // Control only reaches here because the loop above walked
-                    // at least one record with `serverErrorCode` set, which
-                    // always assigns `last_ck_err`. The expect encodes that
-                    // invariant — it cannot fire at runtime.
-                    #[allow(
-                        clippy::expect_used,
-                        reason = "invariant: valid_count==0 implies the errored loop ran and assigned last_ck_err"
-                    )]
-                    return Err(last_ck_err.expect("errored is non-empty").into());
+                    let Some(last_ck_err) = last_ck_err else {
+                        anyhow::bail!(
+                            "CloudKit response contained no valid records, \
+                             but no per-record server error was available"
+                        );
+                    };
+                    return Err(last_ck_err.into());
                 }
                 tracing::warn!(
                     errored = total - valid_count,

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -325,7 +325,7 @@ fn prompt_windows_password(user: &str) -> Result<String> {
 #[cfg(target_os = "windows")]
 mod scm_impl {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard};
     use windows_service::{
         define_windows_service,
         service::{
@@ -358,6 +358,19 @@ mod scm_impl {
     struct ScmPayload {
         globals: crate::config::GlobalArgs,
         sync: crate::sync_loop::SyncArgs,
+    }
+
+    fn lock_scm_payload() -> Result<MutexGuard<'static, Option<ScmPayload>>> {
+        SCM_PAYLOAD
+            .lock()
+            .map_err(|_| anyhow!("internal: SCM payload mutex poisoned"))
+    }
+
+    fn lock_scm_shutdown_tx(
+    ) -> Result<MutexGuard<'static, Option<tokio::sync::oneshot::Sender<()>>>> {
+        SCM_SHUTDOWN_TX
+            .lock()
+            .map_err(|_| anyhow!("internal: SCM shutdown mutex poisoned"))
     }
 
     /// Owned form of [`ServiceInfoInputs`] -- crosses the spawn_blocking
@@ -535,7 +548,7 @@ mod scm_impl {
     ) -> Result<()> {
         // Stash payload before the dispatcher attempt so the SCM-spawned
         // service-main thread cannot observe an empty slot.
-        *SCM_PAYLOAD.lock().unwrap() = Some(ScmPayload { globals, sync });
+        *lock_scm_payload()? = Some(ScmPayload { globals, sync });
 
         let dispatcher_result = tokio::task::spawn_blocking(|| {
             service_dispatcher::start(SERVICE_NAME, ffi_service_main)
@@ -553,10 +566,9 @@ mod scm_impl {
                     service = SERVICE_NAME,
                     "kei service run invoked outside SCM; running in foreground"
                 );
-                let payload =
-                    SCM_PAYLOAD.lock().unwrap().take().ok_or_else(|| {
-                        anyhow!("internal: SCM payload missing on foreground path")
-                    })?;
+                let payload = lock_scm_payload()?
+                    .take()
+                    .ok_or_else(|| anyhow!("internal: SCM payload missing on foreground path"))?;
                 crate::sync_loop::run_sync(&payload.globals, payload.sync).await
             }
             Err(e) => Err(anyhow!("StartServiceCtrlDispatcher failed: {e}")),
@@ -571,13 +583,21 @@ mod scm_impl {
 
     fn service_main_inner() -> Result<()> {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-        *SCM_SHUTDOWN_TX.lock().unwrap() = Some(shutdown_tx);
+        *lock_scm_shutdown_tx()? = Some(shutdown_tx);
 
         let event_handler = move |control_event| -> ServiceControlHandlerResult {
             match control_event {
                 ServiceControl::Stop | ServiceControl::Shutdown => {
-                    if let Some(tx) = SCM_SHUTDOWN_TX.lock().unwrap().take() {
-                        let _ = tx.send(());
+                    match lock_scm_shutdown_tx() {
+                        Ok(mut guard) => {
+                            if let Some(tx) = guard.take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "failed to signal SCM shutdown");
+                            return ServiceControlHandlerResult::Other(1);
+                        }
                     }
                     ServiceControlHandlerResult::NoError
                 }
@@ -609,9 +629,7 @@ mod scm_impl {
     }
 
     fn run_payload_under_scm(mut shutdown_rx: tokio::sync::oneshot::Receiver<()>) -> Result<()> {
-        let payload = SCM_PAYLOAD
-            .lock()
-            .unwrap()
+        let payload = lock_scm_payload()?
             .take()
             .ok_or_else(|| anyhow!("kei service main started without a stashed payload"))?;
 


### PR DESCRIPTION
## Summary
- Replaced narrow CloudKit enumeration/cache panic paths with explicit errors.
- Replaced Windows SCM mutex unwraps with poisoned-mutex errors and a logged SCM control-handler failure path.
- Published the supervisor exit-code contract to the wiki Service page.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo test -- --test-threads=1`
- `cargo test test_photo_stream_with_token_setup_does_not_panic --lib`
- `cargo test test_fetch_private_libraries_parses_zone_list --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes
- `cargo check --target x86_64-pc-windows-gnu` was attempted, but this host is missing `x86_64-w64-mingw32-gcc`, so native C dependencies cannot cross-compile here.
- Wiki update: `rhoopr/kei.wiki@5ea4274`.
