### PR TITLE
Simplify selection config shape

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -295,16 +295,6 @@ pub struct DownloadSettings {
 
 #[derive(Debug)]
 pub struct FilterConfig {
-    #[allow(
-        dead_code,
-        reason = "legacy album shape stays during v0.20 migration while runtime uses Selection"
-    )]
-    pub albums: AlbumSelection,
-    #[allow(
-        dead_code,
-        reason = "legacy album exclude shape stays during v0.20 migration while runtime uses Selection"
-    )]
-    pub exclude_albums: Vec<String>,
     pub selection: crate::selection::Selection,
     pub media: MediaSelection,
     pub skip_created_before: Option<DateTime<Local>>,
@@ -496,50 +486,6 @@ const fn media_kind_name(kind: MediaKind) -> &'static str {
     }
 }
 
-/// Which albums to sync.
-///
-/// v0.13 default is `All`. `-a all` (explicit), no `-a` flag, and the
-/// auto-promotion from `{album}` in `--folder-structure` (deprecated) all
-/// resolve here. The unfiled pass is independent of `AlbumSelection`: by
-/// default it always runs, and `--unfiled false` is the only way to disable
-/// it (see `unfiled_default`).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AlbumSelection {
-    /// `-a none`: no album passes. Useful when paired with `--smart-folder`
-    /// or when the user wants only the unfiled pass.
-    LibraryOnly,
-    /// Explicit list of album names to sync.
-    Named(Vec<String>),
-    /// `-a all` (explicit), no `-a` flag (v0.13 default), or the legacy
-    /// `{album}`-in-template auto-promotion: every discovered album.
-    All,
-}
-
-impl AlbumSelection {
-    /// Serialize to a `Vec<String>` for TOML persistence and JSON reports.
-    #[allow(
-        dead_code,
-        reason = "legacy report/test helper kept while runtime selection uses Selection::to_raw"
-    )]
-    pub fn to_vec(&self) -> Vec<String> {
-        match self {
-            Self::LibraryOnly => Vec::new(),
-            Self::All => vec!["all".to_string()],
-            Self::Named(v) => v.clone(),
-        }
-    }
-}
-
-impl std::fmt::Display for AlbumSelection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::LibraryOnly => f.write_str("<library-only>"),
-            Self::All => f.write_str("all"),
-            Self::Named(names) => f.write_str(&names.join(", ")),
-        }
-    }
-}
-
 /// Default template for album passes: a flat per-album folder. Users opt
 /// into a date hierarchy by passing `--folder-structure-albums "{album}/%Y..."`.
 pub(crate) const DEFAULT_FOLDER_STRUCTURE_ALBUMS: &str = "{album}";
@@ -683,96 +629,6 @@ fn warn_implicit_unfiled_pass() {
          `[filters] unfiled = false` to restrict to just the album pass(es); pass \
          `[filters] unfiled = true` to silence this warning."
     );
-}
-
-/// Translate the internal `(AlbumSelection, exclude_albums)` tuple plus the
-/// parsed library/smart-folder selectors into the
-/// [`crate::selection::Selection`]. Pure function so the truth table is
-/// testable without `Config::build`.
-///
-/// Lowering for album fields:
-/// - `AlbumSelection::LibraryOnly` maps to `AlbumSelector::None`. Set when
-///   the user passed `--album none`; produces no album passes (unfiled
-///   alone covers the library).
-/// - `AlbumSelection::Named(v)` maps to `AlbumSelector::Named { v, exclude }`.
-/// - `AlbumSelection::All` (the no-flag default and the `-a all` case) maps
-///   to `AlbumSelector::All { exclude }`.
-///
-/// Library and smart-folder selectors are passed through directly — their
-/// new-grammar parsing already happened in `Config::build`.
-///
-/// `unfiled_override` is `Some(b)` when the user passed `--unfiled` (or set
-/// `[filters].unfiled` in TOML) and `None` otherwise. When `None`, unfiled
-/// defaults to `true` regardless of `--album` (v0.13 semantics).
-#[allow(
-    dead_code,
-    reason = "kept as a pure adapter for selection truth-table tests and future config refactors"
-)]
-pub(crate) fn derive_selection(
-    albums: &AlbumSelection,
-    exclude_albums: &[String],
-    library: &crate::selection::LibrarySelector,
-    raw_smart_folders: &[String],
-    unfiled_override: Option<bool>,
-) -> anyhow::Result<crate::selection::Selection> {
-    // Build the raw album list as if the user had written it on the CLI.
-    // Feeds through `parse_album_selector` so the production path exercises
-    // every sentinel/exclusion code path the tests cover.
-    //
-    // Edge case: legacy `LibraryOnly + exclude_albums` has no clean mapping
-    // in the new grammar (Selector::None doesn't take excludes; the new
-    // model expects `--album all '!Family'` for that intent). The legacy
-    // resolver still handles excludes for `LibraryOnly` correctly, so we
-    // drop them here from the Selection-side preview without changing
-    // observable behaviour.
-    let raw_albums: Vec<String> = match albums {
-        AlbumSelection::LibraryOnly => vec!["none".to_string()],
-        AlbumSelection::Named(names) => names
-            .iter()
-            .cloned()
-            .chain(exclude_albums.iter().map(|n| format!("!{n}")))
-            .collect(),
-        AlbumSelection::All => std::iter::once("all".to_string())
-            .chain(exclude_albums.iter().map(|n| format!("!{n}")))
-            .collect(),
-    };
-
-    let unfiled = unfiled_override.unwrap_or_else(unfiled_default);
-
-    Ok(crate::selection::Selection {
-        albums: crate::selection::parse_album_selector(&raw_albums, true)?,
-        smart_folders: crate::selection::parse_smart_folder_selector(raw_smart_folders)?,
-        libraries: library.clone(),
-        unfiled,
-    })
-}
-
-/// Convert a raw `Vec<String>` (from CLI or TOML, with optional `!name`
-/// exclusions and `all`/`none` sentinels) into the legacy
-/// `(AlbumSelection, exclude_albums)` pair. Validates the new v0.13 grammar
-/// (contradictions, sentinel rules) by routing through
-/// [`crate::selection::parse_album_selector`], then lowers back into the
-/// legacy shape that `compute_config_hash` and `report.rs` still consume.
-/// Pass execution itself runs off `Selection.albums` via `resolve_passes`.
-fn resolve_album_selection(raw: &[String]) -> anyhow::Result<(AlbumSelection, Vec<String>)> {
-    if raw.is_empty() {
-        // v0.13+ default: `--album all`. No-flag `kei sync` enumerates every
-        // user album and (with `unfiled = true`) runs an unfiled pass for
-        // photos in no album.
-        return Ok((AlbumSelection::All, Vec::new()));
-    }
-
-    let selector = crate::selection::parse_album_selector(raw, true)?;
-    Ok(match selector {
-        crate::selection::AlbumSelector::None => (AlbumSelection::LibraryOnly, Vec::new()),
-        crate::selection::AlbumSelector::All { excluded } => {
-            (AlbumSelection::All, excluded.into_iter().collect())
-        }
-        crate::selection::AlbumSelector::Named { included, excluded } => (
-            AlbumSelection::Named(included.into_iter().collect()),
-            excluded.into_iter().collect(),
-        ),
-    })
 }
 
 /// Application configuration.
@@ -1390,7 +1246,6 @@ impl Config {
         let library_selector = resolve_library_selector(overrides.libraries, toml_filters)?;
         let toml_albums = toml_filters.and_then(|f| f.albums.clone());
         let raw_albums = resolve_vec(overrides.albums, toml_albums);
-        let (albums, exclude_albums) = resolve_album_selection(&raw_albums)?;
 
         // The base template is for unfiled/library-only paths. Album-specific
         // paths must use `folder_structure_albums`.
@@ -1411,11 +1266,6 @@ impl Config {
             .unfiled
             .or_else(|| toml_filters.and_then(|f| f.unfiled));
 
-        // Build the [`Selection`] that the pass resolver consumes directly
-        // from raw TOML/override values. Keep the legacy `albums` /
-        // `exclude_albums` fields for report compatibility, but don't route
-        // TOML serialization through them: that would erase escaped literal
-        // sentinel names such as `=all`.
         let selection = crate::selection::Selection {
             albums: crate::selection::parse_album_selector(&raw_albums, true)?,
             smart_folders: crate::selection::parse_smart_folder_selector(&raw_smart_folders)?,
@@ -1590,8 +1440,6 @@ impl Config {
                 no_progress_bar,
             },
             filters: FilterConfig {
-                albums,
-                exclude_albums,
                 selection,
                 media,
                 skip_created_before,
@@ -2450,6 +2298,14 @@ mod tests {
         SyncArgs::default()
     }
 
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    fn assert_album_raw(config: &Config, expected: &[&str]) {
+        assert_eq!(config.filters.selection.albums.to_raw(), strings(expected));
+    }
+
     #[test]
     fn test_build_defaults_no_toml() {
         let cfg = Config::build(
@@ -3155,10 +3011,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(
-            cfg.filters.albums,
-            AlbumSelection::Named(vec!["Favorites".to_string(), "Vacation".to_string()])
-        );
+        assert_album_raw(&cfg, &["Favorites", "Vacation"]);
     }
 
     #[test]
@@ -3172,10 +3025,7 @@ mod tests {
         sync.config_overrides.albums = vec!["Screenshots".to_string()];
         let cfg =
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
-        assert_eq!(
-            cfg.filters.albums,
-            AlbumSelection::Named(vec!["Screenshots".to_string()])
-        );
+        assert_album_raw(&cfg, &["Screenshots"]);
     }
 
     #[test]
@@ -4000,7 +3850,7 @@ mod tests {
             cfg.filters.selection.libraries.to_raw(),
             vec!["primary".to_string()]
         );
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
         assert!(
             cfg.filters.selection.unfiled,
             "v0.13 default: unfiled = true"
@@ -5061,10 +4911,7 @@ mod tests {
             cfg.filters.selection.libraries.to_raw(),
             vec!["SharedSync-FULL".to_string()]
         );
-        assert_eq!(
-            cfg.filters.albums,
-            AlbumSelection::Named(vec!["Album1".to_string()])
-        );
+        assert_album_raw(&cfg, &["Album1"]);
         assert!(cfg.filters.skip_videos);
         assert_eq!(cfg.filters.recent, Some(50));
         assert!(matches!(cfg.photos.resolution, PhotoResolution::Medium));
@@ -5191,7 +5038,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
         assert!(cfg.filters.selection.unfiled);
     }
 
@@ -5205,28 +5052,18 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
         assert!(cfg.filters.selection.unfiled);
     }
 
-    #[test]
-    fn test_album_selection_to_vec_roundtrip() {
-        assert!(AlbumSelection::LibraryOnly.to_vec().is_empty());
-        assert_eq!(AlbumSelection::All.to_vec(), vec!["all".to_string()]);
-        assert_eq!(
-            AlbumSelection::Named(vec!["A".into(), "B".into()]).to_vec(),
-            vec!["A".to_string(), "B".to_string()]
-        );
-    }
-
-    // ── AlbumSelection resolution tests ────────────────────────────
+    // ── Album selector resolution tests ─────────────────────────────
 
     #[test]
     fn test_build_album_all_maps_to_all_variant() {
         let mut sync = default_sync();
         sync.config_overrides.albums = vec!["all".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
     }
 
     #[test]
@@ -5236,9 +5073,9 @@ mod tests {
             sync.config_overrides.albums = vec![raw.to_string()];
             let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
             assert_eq!(
-                cfg.filters.albums,
-                AlbumSelection::All,
-                "'{raw}' should resolve to AlbumSelection::All"
+                cfg.filters.selection.albums.to_raw(),
+                strings(&["all"]),
+                "'{raw}' should resolve to AlbumSelector::All"
             );
         }
     }
@@ -5269,7 +5106,7 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
     }
 
     #[test]
@@ -5277,7 +5114,7 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure_albums = Some("{album}/%Y/%m".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
     }
 
     #[test]
@@ -5288,7 +5125,7 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure = Some("%Y/%m/%d".to_string());
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
+        assert_album_raw(&cfg, &["all"]);
         assert!(cfg.filters.selection.unfiled);
     }
 
@@ -5300,10 +5137,7 @@ mod tests {
         // Names are normalised through the v0.13 selector grammar, which uses
         // a BTreeSet for deterministic ordering — alphabetical, regardless of
         // CLI input order.
-        assert_eq!(
-            cfg.filters.albums,
-            AlbumSelection::Named(vec!["Trip".to_string(), "Vacation".to_string()])
-        );
+        assert_album_raw(&cfg, &["Trip", "Vacation"]);
     }
 
     #[test]
@@ -5313,8 +5147,7 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.albums = vec!["!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
-        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
+        assert_album_raw(&cfg, &["all", "!Family"]);
     }
 
     #[test]
@@ -5322,8 +5155,7 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.albums = vec!["all".to_string(), "!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::All);
-        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
+        assert_album_raw(&cfg, &["all", "!Family"]);
     }
 
     #[test]
@@ -5331,11 +5163,7 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.albums = vec!["Vacation".to_string(), "!Family".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(
-            cfg.filters.albums,
-            AlbumSelection::Named(vec!["Vacation".to_string()])
-        );
-        assert_eq!(cfg.filters.exclude_albums, vec!["Family".to_string()]);
+        assert_album_raw(&cfg, &["Vacation", "!Family"]);
     }
 
     #[test]
@@ -5343,7 +5171,10 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.albums = vec!["none".to_string()];
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
-        assert_eq!(cfg.filters.albums, AlbumSelection::LibraryOnly);
+        assert_eq!(
+            cfg.filters.selection.albums,
+            crate::selection::AlbumSelector::None
+        );
     }
 
     #[test]

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -143,7 +143,7 @@ pub(super) struct MetadataPayload {
     pub(super) title: Option<String>,
     /// Image description text (prefers `description`, falls back to `title`).
     pub(super) description: Option<String>,
-    /// `dc:subject` tags — provider keywords plus album memberships merge here.
+    /// `dc:subject` tags - source keywords plus album memberships merge here.
     pub(super) keywords: Vec<String>,
     /// MWG-RS person names for `iptcExt:PersonInImage`.
     pub(super) people: Vec<String>,
@@ -153,7 +153,7 @@ pub(super) struct MetadataPayload {
     pub(super) is_archived: bool,
     /// Media subtype (panorama, screenshot, burst, slo_mo, …).
     pub(super) media_subtype: Option<String>,
-    /// Opaque provider burst grouping id.
+    /// Opaque source burst grouping id.
     pub(super) burst_id: Option<String>,
 }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -943,11 +943,11 @@ struct DownloadContext {
     /// All key levels use borrowed `&str` lookups for zero-allocation probes.
     downloaded_ids: LibraryAssetVersionSet,
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> checksum).
-    /// Used to detect checksum changes (provider asset updated) without DB queries.
+    /// Used to detect checksum changes (CloudKit asset updated) without DB queries.
     downloaded_checksums: LibraryAssetVersionValueMap,
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> metadata_hash).
     /// Used to detect metadata-only changes (favorite toggle, keywords, GPS
-    /// edit, etc.) when file bytes are unchanged but the provider has newer
+    /// edit, etc.) when file bytes are unchanged but CloudKit has newer
     /// metadata.
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     downloaded_metadata_hashes: LibraryAssetVersionValueMap,
@@ -2926,7 +2926,7 @@ mod tests {
     fn needs_metadata_rewrite_refreshes_null_stored_hash() {
         // Pre-v5 downloaded rows have metadata_hash IS NULL; even without a
         // retry marker, a fresh hash should trigger a rewrite so the XMP
-        // gets the provider state this tree has never recorded.
+        // gets the source state this tree has never recorded.
         let ctx = DownloadContext::default();
         assert!(ctx.needs_metadata_rewrite(
             "PrimarySync",

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -551,7 +551,7 @@ const METADATA_REWRITE_BATCH: usize = 500;
 
 /// Drain persisted metadata-rewrite markers: for each asset whose
 /// `metadata_write_failed_at` is set and whose local file is still on disk,
-/// re-apply EXIF/XMP using the stored provider metadata. On success clears
+/// re-apply EXIF/XMP using the stored metadata. On success clears
 /// the marker and refreshes `metadata_hash`; on failure leaves the marker so
 /// the next sync retries.
 async fn run_metadata_rewrites(

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -328,7 +328,7 @@ impl PhotoAsset {
         }
     }
 
-    /// Provider-agnostic metadata extracted at construction time.
+    /// Metadata extracted at construction time.
     pub fn metadata(&self) -> &AssetMetadata {
         &self.asset_metadata
     }

--- a/src/icloud/photos/metadata.rs
+++ b/src/icloud/photos/metadata.rs
@@ -1,7 +1,7 @@
-//! Extract provider-agnostic metadata from iCloud CloudKit records.
+//! Extract metadata from iCloud CloudKit records.
 //!
 //! Maps iCloud-specific fields (e.g. `isFavorite`, `captionEnc`, `locationEnc`,
-//! `assetSubtype`) into the canonical `AssetMetadata` schema. Provider-specific
+//! `assetSubtype`) into the canonical `AssetMetadata` schema. Source-native
 //! fields that don't fit the canonical schema are preserved verbatim in
 //! `provider_data` so that invariant 4 (capture everything available) holds.
 
@@ -12,7 +12,7 @@ use crate::state::AssetMetadata;
 use super::asset::f64_to_millis_datetime;
 use super::enc;
 
-/// Provider identifier stored on every iCloud-sourced asset record.
+/// Source identifier stored on every iCloud-sourced asset record.
 pub const SOURCE: &str = "icloud";
 
 /// Fields whose raw values we preserve in `provider_data` for fidelity to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,9 @@
-//! kei: media sync engine.
+//! kei: iCloud Photos sync engine.
 //!
-//! Moves photos and videos between cloud services and local storage as a
-//! transparent layer: provider-agnostic core with provider-specific adapters.
-//! iCloud is the first source: authentication uses SRP-6a with Apple's custom
-//! variant followed by optional 2FA, and assets are streamed from `CloudKit`
-//! with exponential-backoff retries on transient failures. Additional sources
-//! (Google Takeout, Immich, Nextcloud, ...) plug into the same pipeline.
+//! Moves photos and videos from iCloud Photos to local storage. Authentication
+//! uses SRP-6a with Apple's custom variant followed by optional 2FA, and assets
+//! are streamed from `CloudKit` with exponential-backoff retries on transient
+//! failures.
 //!
 //! Lint configuration lives in `[lints.clippy]` in `Cargo.toml`.
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -14,13 +14,13 @@ use super::types::{
     AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, SyncSummary, VersionSizeKey,
 };
 
-/// Fallback provider identifier when `AssetMetadata::source` is unset.
+/// Fallback source identifier when `AssetMetadata::source` is unset.
 ///
 /// The `assets.source` column is NOT NULL (v5 migration defaults pre-existing
 /// rows to "icloud"). Test fixtures and legacy call sites that don't populate
 /// metadata get the same value written here so that inserts always succeed.
-/// Real provider adapters (iCloud, Takeout, etc.) set `source` explicitly;
-/// this fallback is a safety net, not the intended write path.
+/// CloudKit parsing sets `source` explicitly; this fallback is a safety net,
+/// not the intended write path.
 const DEFAULT_SOURCE: &str = "icloud";
 
 /// Snapshot of an already-imported asset, returned by
@@ -309,8 +309,8 @@ pub trait StateDb: Send + Sync {
     ///
     /// Called during album enumeration when an asset is seen in an album. The
     /// `(library, asset_id, album_name, source)` composite key namespaces
-    /// memberships per library and per provider so multi-library accounts
-    /// don't cross-attribute and multiple providers can coexist.
+    /// memberships per library and source so multi-library accounts don't
+    /// cross-attribute album rows.
     async fn add_asset_album(
         &self,
         library: &str,
@@ -375,8 +375,8 @@ pub trait StateDb: Send + Sync {
 
     /// Pre-load the set of `(library, asset_id, version_size)` triples that
     /// have a non-null `metadata_write_failed_at`. These need a metadata
-    /// rewrite on the next sync regardless of whether the provider reports
-    /// a hash change.
+    /// rewrite on the next sync regardless of whether CloudKit reports a hash
+    /// change.
     async fn get_metadata_retry_markers(
         &self,
     ) -> Result<HashSet<(String, String, String)>, StateError>;
@@ -4774,7 +4774,7 @@ mod tests {
         db.add_asset_album("PrimarySync", "A1", "Favorites", "icloud")
             .await
             .unwrap();
-        db.add_asset_album("PrimarySync", "A1", "Favorites", "takeout")
+        db.add_asset_album("PrimarySync", "A1", "Favorites", "external-import")
             .await
             .unwrap();
         let conn = db.acquire_lock("test").unwrap();
@@ -4831,10 +4831,9 @@ mod tests {
 
     #[tokio::test]
     async fn get_all_asset_people_returns_every_pair() {
-        // asset_people has no production writer yet (reserved for future
-        // provider adapters); insert test rows via raw SQL so this covers
-        // the read path without adding a trait method that would sit unused
-        // in production builds.
+        // asset_people has no production writer yet; insert test rows via raw
+        // SQL so this covers the read path without adding a trait method that
+        // would sit unused in production builds.
         let db = SqliteStateDb::open_in_memory().unwrap();
         {
             let conn = db.acquire_lock("seed").unwrap();

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -106,7 +106,7 @@ const SCHEMA_V4: &str = "ALTER TABLE assets ADD COLUMN download_checksum TEXT;";
 
 /// V5 metadata columns added to the `assets` table.
 ///
-/// `source` records which provider ingested the asset. `DEFAULT 'icloud'` is
+/// `source` records where the asset came from. `DEFAULT 'icloud'` is
 /// correct for migration because every pre-v5 row came from iCloud sync; new
 /// inserts always set `source` explicitly.
 const V5_ASSET_COLUMNS: &[(&str, &str)] = &[

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -152,23 +152,22 @@ impl MediaType {
     }
 }
 
-/// Provider-agnostic metadata for an asset.
+/// Metadata captured for an asset.
 ///
-/// Every field is optional or has a safe default: providers populate what they
-/// can, consumers handle missing values. Mapping from provider-specific fields
-/// (iCloud `isFavorite`, Takeout `favorited`, etc.) lives in provider adapters.
+/// Every field is optional or has a safe default: CloudKit parsing populates
+/// what Apple returns, and consumers handle missing values.
 ///
 /// `metadata_hash` is computed from the metadata fields and stored alongside
 /// them so that incremental sync can detect metadata-only changes in O(1).
 #[derive(Debug, Clone, Default)]
 pub struct AssetMetadata {
-    /// Provider that created this record ("icloud", "takeout", etc.).
+    /// Source label for this record. Currently "icloud".
     /// Uses `Arc<str>` so repeated source names share a single allocation
     /// via the global string interner.
     pub source: Option<Arc<str>>,
-    /// Provider-native favorite/heart flag.
+    /// Favorite/heart flag from iCloud Photos.
     pub is_favorite: bool,
-    /// 1-5 star rating (providers with boolean favorites set 5).
+    /// 1-5 star rating. Boolean favorites set 5.
     pub rating: Option<u8>,
     /// Latitude in decimal degrees, WGS84.
     pub latitude: Option<f64>,
@@ -200,13 +199,13 @@ pub struct AssetMetadata {
     pub is_hidden: bool,
     /// Archived (hidden from main timeline but retained).
     pub is_archived: bool,
-    /// When metadata was last edited at source (provider-supplied only).
+    /// When metadata was last edited at source.
     pub modified_at: Option<DateTime<Utc>>,
     /// Soft-deleted at source.
     pub is_deleted: bool,
     /// When the asset was deleted/expunged at source.
     pub deleted_at: Option<DateTime<Utc>>,
-    /// Opaque JSON blob for provider-specific fields that don't fit the
+    /// Opaque JSON blob for source-native fields that don't fit the
     /// canonical schema (invariant 4: capture everything available).
     pub provider_data: Option<String>,
     /// SHA-256 of the metadata fields above, for change detection.
@@ -355,7 +354,7 @@ pub struct AssetRecord {
     /// Current status of the asset.
     pub status: AssetStatus,
 
-    /// Provider-agnostic metadata captured from the source (v5+).
+    /// Metadata captured from the source (v5+).
     ///
     /// Behind `Arc` so `PhotoAsset` → `AssetRecord` (the producer hot
     /// loop) shares the same allocation instead of deep-cloning every
@@ -644,7 +643,7 @@ mod tests {
         }
         .compute_hash();
         let b = AssetMetadata {
-            source: Some("takeout".into()),
+            source: Some("external-import".into()),
             metadata_hash: Some("also_ignored".into()),
             is_favorite: true,
             ..AssetMetadata::default()

--- a/src/string_interner.rs
+++ b/src/string_interner.rs
@@ -1,7 +1,7 @@
 //! Global interner for high-cardinality-but-small short strings.
 //!
 //! Used for values with ~10-20 unique strings across 100k+ allocations per sync cycle:
-//! iCloud UTI asset types (public.jpeg, public.heic, …) and provider source names.
+//! iCloud UTI asset types (public.jpeg, public.heic, ...) and source labels.
 
 use std::sync::{Arc, OnceLock};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 /// Whether an asset is an image or a video.
-///
-/// Provider-agnostic — each provider adapter maps its native classification
-/// (e.g., iCloud UTI strings) into this enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AssetItemType {
     Image,
@@ -13,7 +10,6 @@ pub enum AssetItemType {
 /// Version size key for asset versions.
 ///
 /// Uses `#[repr(u8)]` to guarantee 1-byte size for better struct packing.
-/// Provider-agnostic — maps to every provider's concept of resolution tiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum AssetVersionSize {
@@ -41,16 +37,13 @@ impl From<VersionSize> for AssetVersionSize {
 }
 
 /// Reason for a record change in a delta/incremental sync response.
-///
-/// Provider-agnostic — each provider maps its native change types into
-/// these categories.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChangeReason {
     /// New or modified record (state DB determines which).
     Created,
     /// Soft-deleted (moved to trash / recently deleted).
     SoftDeleted,
-    /// Permanently purged from the provider.
+    /// Permanently purged from the source.
     HardDeleted,
     /// Hidden from the main library view.
     Hidden,

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -513,8 +513,8 @@ directory = {}
 fn config_show_emits_unfiled_false_when_explicit() {
     // The cli.rs help-shadow test for --unfiled only verifies clap parses;
     // it does not pin the resolved value all the way through Config::build
-    // → Selection → to_toml. A clap-default flip (or a derive_selection
-    // regression) that swallowed the explicit `false` would land green
+    // → Selection → to_toml. A clap-default flip or selector regression
+    // that swallowed the explicit `false` would land green
     // there. `to_toml()` only emits `unfiled` when the resolved value
     // differs from the `true` default, so an explicit `false` is the case
     // we can observe directly in `kei config show` output.


### PR DESCRIPTION
## Summary
- Removed the legacy resolved album pair from runtime config so `selection::Selection` is the only album/library/smart-folder selection shape.
- Kept config/report serialization on `Selection::to_raw()` and updated tests to assert that shape directly.
- Trimmed speculative provider-facing wording from runtime docs/comments without changing persisted `source` or `provider_data` fields.

## Tests
- `cargo check`
- `cargo test selection`
- `cargo test config`
- `cargo test report`
- `cargo test source`
- `cargo run --quiet -- --config <temp> config show` for default, `albums = ["all"]`, `albums = ["=all"]`, `albums = ["!Family"]`, `smart_folders = ["Favorites"]`, and `unfiled = false`
- `cargo run --quiet -- sync --album all --help`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
