### PR TITLE
Add shared service install policy

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,7 +428,7 @@ pub struct InstallArgs {
     pub user: bool,
 
     /// Install system-wide (Linux only; requires root). On macOS and
-    /// Windows the per-platform default is used regardless of this flag.
+    /// Windows this is rejected with a pointer to the per-user install.
     #[arg(long, conflicts_with = "user")]
     pub system: bool,
 

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 
 use crate::cli::InstallArgs;
 use crate::service::env::is_in_container;
+use crate::service::plan::{InstallPlan, InstallScope};
 
 pub(crate) async fn run(args: InstallArgs, config_path: &Path) -> Result<()> {
     if is_in_container() {
@@ -25,41 +26,39 @@ pub(crate) async fn run(args: InstallArgs, config_path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    dispatch(args, config_path).await
+    let plan = InstallPlan::from_args(&args);
+    dispatch(plan, config_path).await
 }
 
 #[cfg(target_os = "linux")]
-async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
     use crate::service::linux;
-    if args.system {
-        linux::install_system(&args, config_path).await
-    } else {
-        linux::install_user(&args, config_path).await
+    match plan.scope() {
+        InstallScope::User => linux::install_user(plan, config_path).await,
+        InstallScope::System => linux::install_system(plan, config_path).await,
     }
 }
 
 #[cfg(target_os = "macos")]
-async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
     use crate::service::macos;
-    if args.system {
-        macos::install_system(&args, config_path)
-    } else {
-        macos::install_user(&args, config_path).await
+    match plan.scope() {
+        InstallScope::User => macos::install_user(plan, config_path).await,
+        InstallScope::System => macos::install_system(plan, config_path),
     }
 }
 
 #[cfg(target_os = "windows")]
-async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
     use crate::service::windows;
-    if args.system {
-        windows::install_system(&args, config_path)
-    } else {
-        windows::install_user(&args, config_path).await
+    match plan.scope() {
+        InstallScope::User => windows::install_user(plan, config_path).await,
+        InstallScope::System => windows::install_system(plan, config_path),
     }
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
+async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
     use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
     let exe = current_executable()?;
     tracing::info!(
@@ -67,9 +66,8 @@ async fn dispatch(args: InstallArgs, config_path: &Path) -> Result<()> {
         description = SERVICE_DESCRIPTION,
         executable = %exe.display(),
         config = %config_path.display(),
-        user = args.user,
-        system = args.system,
-        dry_run = args.dry_run,
+        scope = ?plan.scope(),
+        effect = ?plan.effect(),
         "preparing to install kei service",
     );
     Err(anyhow::anyhow!(

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -30,10 +30,11 @@ use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use tokio::process::Command;
 
-use crate::cli::{InstallArgs, UninstallArgs};
+use crate::cli::UninstallArgs;
 use crate::service::env::{
     current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
 };
+use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;
 
 const UNIT_FILE_NAME: &str = "kei.service";
@@ -121,10 +122,10 @@ fn system_unit_path() -> PathBuf {
 
 /// Top-level entry for `kei install --user` (and the bare `kei install`
 /// default on Linux).
-pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
+pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
     let contents = render_user_unit(&exe, config_path);
-    if args.dry_run {
+    if plan.is_preview() {
         print!("{contents}");
         tracing::info!("dry run: rendered per-user systemd unit; no files written");
         return Ok(());
@@ -154,9 +155,9 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
 }
 
 /// Top-level entry for `kei install --system`.
-pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Result<()> {
-    if args.dry_run {
-        let user = system_preview_user()?;
+pub(crate) async fn install_system(plan: InstallPlan, config_path: &Path) -> Result<()> {
+    let user = plan::linux_system_user(plan, config_path)?;
+    if plan.is_preview() {
         let exe = current_executable()?;
         let contents = render_system_unit(&exe, config_path, &user);
         print!("{contents}");
@@ -167,15 +168,6 @@ pub(crate) async fn install_system(args: &InstallArgs, config_path: &Path) -> Re
         return Ok(());
     }
 
-    if !is_root() {
-        bail!(
-            "`kei install --system` must be run as root (EUID=0); \
-             rerun:  sudo kei install --system --config {}  \
-             Or use `kei install --user` for a per-user install.",
-            config_path.display()
-        );
-    }
-    let user = sudo_user_or_bail()?;
     let exe = current_executable()?;
     let unit_path = system_unit_path();
     let contents = render_system_unit(&exe, config_path, &user);
@@ -414,46 +406,6 @@ fn remove_unit_file(path: &Path) -> Result<()> {
 
 fn is_root() -> bool {
     effective_uid() == 0
-}
-
-fn non_root_env_user(key: &str) -> Option<String> {
-    match std::env::var(key) {
-        Ok(user) if !user.is_empty() && user != "root" => Some(user),
-        _ => None,
-    }
-}
-
-fn sudo_user_or_bail() -> Result<String> {
-    if let Some(user) = non_root_env_user("SUDO_USER") {
-        return Ok(user);
-    }
-    bail!(
-        "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
-         can be configured to run as your account rather than root"
-    )
-}
-
-fn system_preview_user() -> Result<String> {
-    if let Some(user) = non_root_env_user("SUDO_USER") {
-        return Ok(user);
-    }
-
-    if is_root() {
-        bail!(
-            "$SUDO_USER not set; rerun via `sudo kei install --system --dry-run` so the service \
-             can be previewed for your account rather than root"
-        );
-    }
-
-    for key in ["USER", "LOGNAME"] {
-        if let Some(user) = non_root_env_user(key) {
-            return Ok(user);
-        }
-    }
-    bail!(
-        "could not determine which user the system unit would run as; \
-         set SUDO_USER or USER before running `kei install --system --dry-run`"
-    )
 }
 
 async fn daemon_reload_user() -> Result<()> {

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -34,10 +34,11 @@ use anyhow::{anyhow, bail, Context, Result};
 use plist::{Dictionary, Value as PlistValue};
 use tokio::process::Command;
 
-use crate::cli::{InstallArgs, UninstallArgs};
+use crate::cli::UninstallArgs;
 use crate::service::env::{
     current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
 };
+use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;
 
 const PLIST_FILE_NAME: &str = "com.rhoopr.kei.plist";
@@ -134,7 +135,7 @@ fn kei_state_dir() -> Option<PathBuf> {
     crate::service::env::kei_state_dir_dotted()
 }
 
-pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
+pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
     let home = dirs::home_dir().ok_or_else(|| {
         anyhow!("could not resolve $HOME; required for plist + LaunchAgents path")
@@ -149,7 +150,7 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
         home: &home,
     });
     let xml = serialize_plist(&dict)?;
-    if args.dry_run {
+    if plan.is_preview() {
         print!("{xml}");
         tracing::info!("dry run: rendered per-user launchd plist; no files written");
         return Ok(());
@@ -182,11 +183,8 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
 /// security review (system-context FDA, keychain access constraints) that
 /// kei does not currently support. Errors with a pointer at the supported
 /// flag rather than silently downgrading.
-pub(crate) fn install_system(_args: &InstallArgs, _config_path: &Path) -> Result<()> {
-    bail!(
-        "macOS only ships a per-user LaunchAgent; \
-         rerun without --system (or with --user) to install."
-    )
+pub(crate) fn install_system(_plan: InstallPlan, _config_path: &Path) -> Result<()> {
+    plan::reject_macos_system_install()
 }
 
 pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,6 +9,7 @@
 
 pub(crate) mod env;
 pub(crate) mod install;
+pub(crate) mod plan;
 pub(crate) mod run;
 pub(crate) mod status;
 pub(crate) mod uninstall;

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -147,10 +147,17 @@ fn non_root_env_user(key: &str) -> Option<String> {
 
 #[cfg(target_os = "linux")]
 fn non_root_user_value(value: Option<String>) -> Option<String> {
-    match value {
-        Some(user) if !user.is_empty() && user != "root" => Some(user),
-        _ => None,
-    }
+    value.filter(|user| is_valid_linux_run_user(user))
+}
+
+#[cfg(target_os = "linux")]
+fn is_valid_linux_run_user(user: &str) -> bool {
+    !user.is_empty()
+        && user != "root"
+        && !user.starts_with('-')
+        && user
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
 }
 
 #[cfg(test)]
@@ -199,9 +206,19 @@ mod tests {
         assert_eq!(non_root_user_value(None), None);
         assert_eq!(non_root_user_value(Some(String::new())), None);
         assert_eq!(non_root_user_value(Some("root".to_string())), None);
+        assert_eq!(non_root_user_value(Some("-alice".to_string())), None);
+        assert_eq!(non_root_user_value(Some("alice bob".to_string())), None);
+        assert_eq!(
+            non_root_user_value(Some("alice\nEnvironment=KEI_INJECTED=1".to_string())),
+            None
+        );
         assert_eq!(
             non_root_user_value(Some("alice".to_string())),
             Some("alice".to_string())
+        );
+        assert_eq!(
+            non_root_user_value(Some("alice.sync-1".to_string())),
+            Some("alice.sync-1".to_string())
         );
     }
 }

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -1,0 +1,207 @@
+//! Shared install policy for `kei install`.
+//!
+//! Platform backends render and apply service-manager artifacts. This module
+//! owns the CLI contract that decides which install shape was requested,
+//! whether it is preview-only, and which system-scope requests are safe to
+//! proceed with.
+
+use anyhow::{bail, Result};
+
+use crate::cli::InstallArgs;
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+
+#[cfg(target_os = "linux")]
+use crate::service::env::effective_uid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InstallScope {
+    User,
+    System,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InstallEffect {
+    Preview,
+    Apply,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InstallPlan {
+    scope: InstallScope,
+    effect: InstallEffect,
+}
+
+impl InstallPlan {
+    pub(crate) fn from_args(args: &InstallArgs) -> Self {
+        let scope = if args.system {
+            InstallScope::System
+        } else {
+            InstallScope::User
+        };
+        let effect = if args.dry_run {
+            InstallEffect::Preview
+        } else {
+            InstallEffect::Apply
+        };
+        Self { scope, effect }
+    }
+
+    pub(crate) fn scope(self) -> InstallScope {
+        self.scope
+    }
+
+    pub(crate) fn effect(self) -> InstallEffect {
+        self.effect
+    }
+
+    pub(crate) fn is_preview(self) -> bool {
+        self.effect == InstallEffect::Preview
+    }
+}
+
+pub(crate) fn reject_macos_system_install() -> Result<()> {
+    bail!(
+        "macOS only ships a per-user LaunchAgent; \
+         rerun without --system (or with --user) to install."
+    )
+}
+
+pub(crate) fn reject_windows_system_install() -> Result<()> {
+    bail!(
+        "`kei install --system` is not supported on Windows; \
+         use `kei install` (per-user) so the service shares your Credential Manager vault \
+         and `~/.config/kei` state directory"
+    )
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn linux_system_user(plan: InstallPlan, config_path: &Path) -> Result<String> {
+    debug_assert_eq!(
+        plan.scope(),
+        InstallScope::System,
+        "linux_system_user is only valid for system installs"
+    );
+    match plan.effect() {
+        InstallEffect::Preview => linux_system_preview_user(),
+        InstallEffect::Apply => {
+            ensure_linux_system_apply_is_root(config_path)?;
+            linux_sudo_user()
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_linux_system_apply_is_root(config_path: &Path) -> Result<()> {
+    if effective_uid() == 0 {
+        return Ok(());
+    }
+    bail!(
+        "`kei install --system` must be run as root (EUID=0); \
+         rerun:  sudo kei install --system --config {}  \
+         Or use `kei install --user` for a per-user install.",
+        config_path.display()
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn linux_sudo_user() -> Result<String> {
+    if let Some(user) = non_root_env_user("SUDO_USER") {
+        return Ok(user);
+    }
+    bail!(
+        "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
+         can be configured to run as your account rather than root"
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn linux_system_preview_user() -> Result<String> {
+    if let Some(user) = non_root_env_user("SUDO_USER") {
+        return Ok(user);
+    }
+
+    if effective_uid() == 0 {
+        bail!(
+            "$SUDO_USER not set; rerun via `sudo kei install --system --dry-run` so the service \
+             can be previewed for your account rather than root"
+        );
+    }
+
+    for key in ["USER", "LOGNAME"] {
+        if let Some(user) = non_root_env_user(key) {
+            return Ok(user);
+        }
+    }
+    bail!(
+        "could not determine which user the system unit would run as; \
+         set SUDO_USER or USER before running `kei install --system --dry-run`"
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn non_root_env_user(key: &str) -> Option<String> {
+    non_root_user_value(std::env::var(key).ok())
+}
+
+#[cfg(target_os = "linux")]
+fn non_root_user_value(value: Option<String>) -> Option<String> {
+    match value {
+        Some(user) if !user.is_empty() && user != "root" => Some(user),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(system: bool, dry_run: bool) -> InstallArgs {
+        InstallArgs {
+            user: !system,
+            system,
+            dry_run,
+        }
+    }
+
+    #[test]
+    fn default_install_is_user_apply() {
+        let plan = InstallPlan::from_args(&args(false, false));
+        assert_eq!(plan.scope(), InstallScope::User);
+        assert_eq!(plan.effect(), InstallEffect::Apply);
+        assert!(!plan.is_preview());
+    }
+
+    #[test]
+    fn dry_run_system_install_is_preview_without_artifact_writes() {
+        let plan = InstallPlan::from_args(&args(true, true));
+        assert_eq!(plan.scope(), InstallScope::System);
+        assert_eq!(plan.effect(), InstallEffect::Preview);
+        assert!(plan.is_preview());
+    }
+
+    #[test]
+    fn unsupported_platform_system_errors_live_in_policy() {
+        assert!(reject_macos_system_install()
+            .expect_err("macOS system install must fail")
+            .to_string()
+            .contains("per-user LaunchAgent"));
+        assert!(reject_windows_system_install()
+            .expect_err("Windows system install must fail")
+            .to_string()
+            .contains("not supported on Windows"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_preview_user_rejects_empty_and_root_values() {
+        assert_eq!(non_root_user_value(None), None);
+        assert_eq!(non_root_user_value(Some(String::new())), None);
+        assert_eq!(non_root_user_value(Some("root".to_string())), None);
+        assert_eq!(
+            non_root_user_value(Some("alice".to_string())),
+            Some("alice".to_string())
+        );
+    }
+}

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -66,6 +66,10 @@ impl InstallPlan {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "platform backend modules are compiled cross-platform; Windows builds do not call the macOS rejection helper"
+)]
 pub(crate) fn reject_macos_system_install() -> Result<()> {
     bail!(
         "macOS only ships a per-user LaunchAgent; \

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -52,6 +52,11 @@ impl InstallPlan {
         self.scope
     }
 
+    #[cfg(any(
+        test,
+        target_os = "linux",
+        not(any(target_os = "linux", target_os = "macos", target_os = "windows"))
+    ))]
     pub(crate) fn effect(self) -> InstallEffect {
         self.effect
     }

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -30,11 +30,12 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 
-use crate::cli::{InstallArgs, UninstallArgs};
+use crate::cli::UninstallArgs;
 use crate::service::env::{
     current_executable, kei_state_dir_dotted, purge_kei_state, SERVICE_DESCRIPTION,
     SERVICE_IDENTIFIER,
 };
+use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;
 
 /// SCM service name (matches `SERVICE_IDENTIFIER` so `sc.exe query
@@ -54,7 +55,7 @@ const FAILURE_RESET_PERIOD: Duration = Duration::from_secs(86_400);
 
 /// Top-level entry for `kei install` (also the bare default; on Windows
 /// `--user` and the default both produce the same per-user SCM entry).
-pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Result<()> {
+pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
     let user = current_user_name()
         .context("could not resolve current Windows user (USERNAME / USERPROFILE unset?)")?;
@@ -65,7 +66,7 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
         account_user: &user,
     };
 
-    if args.dry_run {
+    if plan.is_preview() {
         let preview = render_service_info_preview(&inputs);
         tracing::info!(
             service = SERVICE_NAME,
@@ -99,12 +100,8 @@ pub(crate) async fn install_user(args: &InstallArgs, config_path: &Path) -> Resu
 /// (no user keyring) or a virtual `NT SERVICE\kei` account (no
 /// Credential Manager). Both break the "credentials follow the
 /// operator" contract the per-user form provides.
-pub(crate) fn install_system(_args: &InstallArgs, _config_path: &Path) -> Result<()> {
-    bail!(
-        "`kei install --system` is not supported on Windows; \
-         use `kei install` (per-user) so the service shares your Credential Manager vault \
-         and `~/.config/kei` state directory"
-    )
+pub(crate) fn install_system(_plan: InstallPlan, _config_path: &Path) -> Result<()> {
+    plan::reject_windows_system_install()
 }
 
 /// Top-level entry for `kei uninstall`.

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -28,7 +28,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use crate::cli::UninstallArgs;
 use crate::service::env::{
@@ -676,21 +676,21 @@ mod scm_impl {
     use super::*;
 
     pub(super) async fn install(_inputs: &ServiceInfoInputs<'_>, _password: &str) -> Result<()> {
-        bail!(
+        anyhow::bail!(
             "internal error: Windows install path reached on a non-Windows target; \
              this is a build configuration bug"
         )
     }
 
     pub(super) async fn uninstall_existing() -> Result<bool> {
-        bail!(
+        anyhow::bail!(
             "internal error: Windows uninstall path reached on a non-Windows target; \
              this is a build configuration bug"
         )
     }
 
     pub(super) async fn probe() -> Result<StatusInputs> {
-        bail!(
+        anyhow::bail!(
             "internal error: Windows status path reached on a non-Windows target; \
              this is a build configuration bug"
         )

--- a/tests/README.md
+++ b/tests/README.md
@@ -182,7 +182,7 @@ happens:
   service manager, validates the artifact or no-op contract with
   platform-native checks (`systemd-analyze verify`, `plutil -lint`, or
   `Get-Service`), then runs `kei uninstall` against a clean host.
-  Catches renderer, dry-run, and shared service-policy regressions; doesn't
+  Catches renderer, dry-run, and default install regressions; doesn't
   exercise the actual service-manager handoff.
 
 ## Service testing contract

--- a/tests/README.md
+++ b/tests/README.md
@@ -182,7 +182,7 @@ happens:
   service manager, validates the artifact or no-op contract with
   platform-native checks (`systemd-analyze verify`, `plutil -lint`, or
   `Get-Service`), then runs `kei uninstall` against a clean host.
-  Catches renderer, dry-run, and shared dispatcher regressions; doesn't
+  Catches renderer, dry-run, and shared service-policy regressions; doesn't
   exercise the actual service-manager handoff.
 
 ## Service testing contract

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -177,6 +177,28 @@ fn dry_run_install_system_rejects_root_preview_user() {
 }
 
 #[test]
+fn dry_run_install_system_rejects_control_character_preview_user() {
+    let home = TempDir::new().unwrap();
+    let mut cmd = cmd_with_home(&home);
+    cmd.env("SUDO_USER", "alice\nEnvironment=KEI_INJECTED=1");
+    cmd.env("USER", "root");
+    cmd.env_remove("LOGNAME");
+
+    let assert = cmd
+        .args(["install", "--system", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "could not determine which user the system unit would run as",
+        ));
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        !stdout.contains("Environment=KEI_INJECTED"),
+        "system dry-run must not render injected unit directives:\n{stdout}"
+    );
+}
+
+#[test]
 fn install_system_without_root_fails_clearly() {
     // CI runs as a non-root user, which is exactly the condition this
     // test wants to exercise. Skipping when EUID==0 (rare local-dev


### PR DESCRIPTION
## Summary
- Add a shared service install policy for preview/apply and user/system decisions.
- Move Linux system install user/root checks and macOS/Windows system-install rejections into that policy.
- Keep platform modules focused on rendering and applying service-manager artifacts.

## Tests
- `cargo check`
- `cargo test service`
- `cargo test --test service_linux -- --test-threads=1`
- `cargo run -- install --dry-run`
- `cargo run -- service status`
- `rg -n "dry-run|preview|root|USER=root|service run|ExecStart" src tests Dockerfile docs README.md`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
