### PR TITLE
Extract post-cycle reporter

### DIFF
--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -1,0 +1,511 @@
+//! Post-cycle reporting boundary for sync/watch cycles.
+//!
+//! The sync loop owns CloudKit/auth/download orchestration. This module owns
+//! the side effects that happen after a cycle has produced facts: friendly
+//! narration, health state, Prometheus metrics, JSON reports, and completion
+//! notifications.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::download::SyncStats;
+use crate::health::HealthStatus;
+use crate::metrics::MetricsHandle;
+use crate::notifications::{self, Notifier};
+use crate::personality::Mode;
+use crate::report::{self, RunOptions};
+use crate::state::{self, StateDb};
+
+/// Stable dependencies and resolved options used by the post-cycle reporter.
+pub(crate) struct CycleReporter<'a> {
+    username: &'a str,
+    watch_mode: bool,
+    report_path: Option<&'a Path>,
+    run_options: RunOptions,
+    health_dir: &'a Path,
+    personality_mode: Mode,
+    state_db: Option<&'a dyn StateDb>,
+    metrics_handle: Option<&'a MetricsHandle>,
+    notifier: &'a Notifier,
+}
+
+impl std::fmt::Debug for CycleReporter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CycleReporter")
+            .field("username", &self.username)
+            .field("watch_mode", &self.watch_mode)
+            .field("report_path", &self.report_path)
+            .field("run_options", &self.run_options)
+            .field("health_dir", &self.health_dir)
+            .field("personality_mode", &self.personality_mode)
+            .field("has_state_db", &self.state_db.is_some())
+            .field("has_metrics_handle", &self.metrics_handle.is_some())
+            .field("notifier", &self.notifier)
+            .finish()
+    }
+}
+
+/// Constructor input for [`CycleReporter`].
+pub(crate) struct CycleReporterConfig<'a> {
+    pub(crate) username: &'a str,
+    pub(crate) watch_mode: bool,
+    pub(crate) report_path: Option<&'a Path>,
+    pub(crate) run_options: RunOptions,
+    pub(crate) health_dir: &'a Path,
+    pub(crate) personality_mode: Mode,
+    pub(crate) state_db: Option<&'a dyn StateDb>,
+    pub(crate) metrics_handle: Option<&'a MetricsHandle>,
+    pub(crate) notifier: &'a Notifier,
+}
+
+impl std::fmt::Debug for CycleReporterConfig<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CycleReporterConfig")
+            .field("username", &self.username)
+            .field("watch_mode", &self.watch_mode)
+            .field("report_path", &self.report_path)
+            .field("run_options", &self.run_options)
+            .field("health_dir", &self.health_dir)
+            .field("personality_mode", &self.personality_mode)
+            .field("has_state_db", &self.state_db.is_some())
+            .field("has_metrics_handle", &self.metrics_handle.is_some())
+            .field("notifier", &self.notifier)
+            .finish()
+    }
+}
+
+/// Facts produced by one sync cycle that reporters may render or persist.
+#[derive(Debug)]
+pub(crate) struct CycleReportInput<'a> {
+    pub(crate) stats: &'a SyncStats,
+    pub(crate) failed_count: usize,
+    pub(crate) session_expired: bool,
+    pub(crate) elapsed: Duration,
+}
+
+impl<'a> CycleReporter<'a> {
+    pub(crate) fn new(config: CycleReporterConfig<'a>) -> Self {
+        Self {
+            username: config.username,
+            watch_mode: config.watch_mode,
+            report_path: config.report_path,
+            run_options: config.run_options,
+            health_dir: config.health_dir,
+            personality_mode: config.personality_mode,
+            state_db: config.state_db,
+            metrics_handle: config.metrics_handle,
+            notifier: config.notifier,
+        }
+    }
+
+    /// Report a skipped watch cycle where `changes/database` found no selected
+    /// library changes. This is intentionally health-only: Prometheus health
+    /// gauges and `health.json` need fresh timestamps, but cycle counters,
+    /// duration, reports, and completion notifications must not change.
+    pub(crate) async fn report_skipped_watch_cycle(&self, health: &mut HealthStatus) {
+        health.record_success();
+        health.write(self.health_dir);
+        if let Some(handle) = self.metrics_handle {
+            handle.update_health_only(health).await;
+        }
+    }
+
+    /// Run all post-cycle reporting side effects for a completed sync cycle.
+    pub(crate) async fn report_completed_cycle(
+        &self,
+        health: &mut HealthStatus,
+        input: CycleReportInput<'_>,
+    ) {
+        let friendly_summary = self.friendly_summary().await;
+        self.report_friendly_output(&input, friendly_summary.as_ref());
+        self.update_health(health, &input);
+        self.update_metrics(health, &input, friendly_summary.as_ref())
+            .await;
+        self.write_json_report(&input).await;
+        self.notify_cycle_outcome(&input);
+    }
+
+    async fn friendly_summary(&self) -> Option<state::types::SyncSummary> {
+        if !self.personality_mode.is_friendly() {
+            return None;
+        }
+        let db = self.state_db?;
+        match db.get_summary().await {
+            Ok(summary) => Some(summary),
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "post-cycle summary unavailable; rendering card without library totals"
+                );
+                None
+            }
+        }
+    }
+
+    fn report_friendly_output(
+        &self,
+        input: &CycleReportInput<'_>,
+        library_after_summary: Option<&state::types::SyncSummary>,
+    ) {
+        let downloaded_u64 = u64::try_from(input.stats.downloaded).unwrap_or(u64::MAX);
+        if let Some(library_after) = library_after_summary {
+            let after = library_after.downloaded_bytes;
+            let before = after.saturating_sub(input.stats.bytes_downloaded);
+            crate::personality::narration::downloaded_phase_to_stderr(
+                self.personality_mode,
+                downloaded_u64,
+                before,
+                after,
+            );
+        }
+        crate::personality::narration::verified_phase_to_stderr(
+            self.personality_mode,
+            downloaded_u64,
+        );
+        if let Some(library_after) = library_after_summary {
+            let stats = input.stats;
+            let card = crate::personality::summary::SummaryCard {
+                photos_new: u64::try_from(stats.photos_downloaded).unwrap_or(u64::MAX),
+                videos_new: u64::try_from(stats.videos_downloaded).unwrap_or(u64::MAX),
+                skipped_total: u64::try_from(stats.skipped.total() - stats.skipped.duplicates)
+                    .unwrap_or(u64::MAX),
+                skipped_already_present: u64::try_from(
+                    stats.skipped.by_state + stats.skipped.on_disk,
+                )
+                .unwrap_or(u64::MAX),
+                failed: u64::try_from(stats.failed).unwrap_or(u64::MAX),
+                elapsed: input.elapsed,
+                bytes_downloaded: stats.bytes_downloaded,
+                library_total_assets: library_after.total_assets,
+                library_total_bytes: library_after.downloaded_bytes,
+            };
+            card.print_to_stderr(self.personality_mode);
+            crate::personality::summary::print_recap_to_stderr(
+                self.personality_mode,
+                &input.stats.recap,
+            );
+        }
+
+        crate::personality::narration::signoff_to_stderr(
+            self.personality_mode,
+            &crate::personality::narration::CycleSummary {
+                downloaded: downloaded_u64,
+                failed: u64::try_from(input.failed_count).unwrap_or(u64::MAX),
+                elapsed: input.elapsed,
+                watch_mode: self.watch_mode,
+            },
+        );
+    }
+
+    fn update_health(&self, health: &mut HealthStatus, input: &CycleReportInput<'_>) {
+        if input.session_expired {
+            health.record_failure("session expired");
+        } else if input.failed_count > 0 {
+            health.record_failure(&format!("{} downloads failed", input.failed_count));
+        } else {
+            health.record_success();
+        }
+        health.write(self.health_dir);
+    }
+
+    async fn update_metrics(
+        &self,
+        health: &HealthStatus,
+        input: &CycleReportInput<'_>,
+        friendly_summary: Option<&state::types::SyncSummary>,
+    ) {
+        let Some(handle) = self.metrics_handle else {
+            return;
+        };
+        if input.session_expired {
+            handle.record_session_expiration();
+        }
+        handle.update(input.stats, health).await;
+
+        if let Some(summary) = friendly_summary {
+            handle.update_db_stats(summary, input.stats.assets_seen);
+        } else if let Some(db) = self.state_db {
+            match db.get_summary().await {
+                Ok(summary) => {
+                    handle.update_db_stats(&summary, input.stats.assets_seen);
+                }
+                Err(e) => {
+                    handle.record_db_summary_failure();
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to fetch DB summary for metrics; skipping DB gauge update"
+                    );
+                }
+            }
+        }
+    }
+
+    async fn write_json_report(&self, input: &CycleReportInput<'_>) {
+        let Some(report_path) = self.report_path else {
+            return;
+        };
+        let status = report::sync_status_str(
+            input.session_expired,
+            input.stats.interrupted,
+            input.failed_count,
+        );
+        let (failed_assets, failed_assets_truncated) = self.failed_asset_sample().await;
+        let report = report::SyncReport {
+            version: "2",
+            kei_version: env!("CARGO_PKG_VERSION"),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            status: status.to_string(),
+            options: self.run_options.clone(),
+            stats: input.stats.clone(),
+            failed_assets,
+            failed_assets_truncated,
+        };
+        if let Err(e) = report::write_report(report_path, &report).await {
+            tracing::warn!(
+                error = %e,
+                path = %report_path.display(),
+                "Failed to write JSON report"
+            );
+        }
+    }
+
+    async fn failed_asset_sample(&self) -> (Vec<report::FailedAssetEntry>, usize) {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "FAILED_ASSETS_CAP is a small compile-time constant well under u32::MAX"
+        )]
+        let cap_u32 = report::FAILED_ASSETS_CAP as u32;
+        match self.state_db {
+            Some(db) => match db.get_failed_sample(cap_u32).await {
+                Ok((records, total)) => {
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        reason = "failed-asset totals are persisted counts of per-sync failures, comfortably below usize::MAX on 64-bit"
+                    )]
+                    let total_usize = total as usize;
+                    let truncated = total_usize.saturating_sub(report::FAILED_ASSETS_CAP);
+                    let entries = records
+                        .iter()
+                        .map(report::FailedAssetEntry::from_record)
+                        .collect();
+                    (entries, truncated)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to load failed_assets for sync_report.json"
+                    );
+                    (Vec::new(), 0)
+                }
+            },
+            None => (Vec::new(), 0),
+        }
+    }
+
+    fn notify_cycle_outcome(&self, input: &CycleReportInput<'_>) {
+        if input.session_expired {
+            return;
+        }
+        let data = notifications::SyncNotificationData::from(input.stats);
+        if input.failed_count > 0 {
+            self.notifier.notify(
+                notifications::Event::SyncFailed,
+                &format!("{} downloads failed", input.failed_count),
+                self.username,
+                Some(&data),
+            );
+        } else {
+            self.notifier.notify(
+                notifications::Event::SyncComplete,
+                "Sync completed successfully",
+                self.username,
+                Some(&data),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_options() -> RunOptions {
+        let download_dir = tempfile::tempdir().unwrap();
+        let globals = crate::config::GlobalArgs {
+            username: Some("reporter@example.com".to_string()),
+            domain: None,
+            data_dir: None,
+        };
+        let sync = crate::cli::SyncArgs {
+            config_overrides: crate::config::SyncConfigOverrides {
+                download_dir: Some(download_dir.path().display().to_string()),
+                ..Default::default()
+            },
+            ..crate::cli::SyncArgs::default()
+        };
+        let config = crate::config::Config::build(
+            &globals,
+            &crate::cli::PasswordArgs::default(),
+            sync,
+            None,
+        )
+        .unwrap();
+        RunOptions::from_config(&config)
+    }
+
+    fn reporter<'a>(
+        dir: &'a Path,
+        report_path: Option<&'a Path>,
+        notifier: &'a Notifier,
+    ) -> CycleReporter<'a> {
+        CycleReporter::new(CycleReporterConfig {
+            username: "reporter@example.com",
+            watch_mode: false,
+            report_path,
+            run_options: run_options(),
+            health_dir: dir,
+            personality_mode: Mode::Off,
+            state_db: None,
+            metrics_handle: None,
+            notifier,
+        })
+    }
+
+    fn parse_json(path: &Path) -> serde_json::Value {
+        let contents = std::fs::read_to_string(path).unwrap();
+        serde_json::from_str(&contents).unwrap()
+    }
+
+    async fn report_cycle(
+        reporter: &CycleReporter<'_>,
+        health: &mut HealthStatus,
+        stats: &SyncStats,
+        failed_count: usize,
+        session_expired: bool,
+    ) {
+        reporter
+            .report_completed_cycle(
+                health,
+                CycleReportInput {
+                    stats,
+                    failed_count,
+                    session_expired,
+                    elapsed: Duration::from_secs(7),
+                },
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn success_updates_health_and_writes_success_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            downloaded: 2,
+            bytes_downloaded: 1024,
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 0, false).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 0);
+        assert!(health_json["last_error"].is_null());
+        let report_json = parse_json(&report_path);
+        assert_eq!(report_json["status"], "success");
+        assert_eq!(report_json["stats"]["downloaded"], 2);
+    }
+
+    #[tokio::test]
+    async fn partial_failure_updates_health_and_writes_partial_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            failed: 3,
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 3, false).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 1);
+        assert_eq!(health_json["last_error"], "3 downloads failed");
+        let report_json = parse_json(&report_path);
+        assert_eq!(report_json["status"], "partial_failure");
+        assert_eq!(report_json["stats"]["failed"], 3);
+    }
+
+    #[tokio::test]
+    async fn session_expiry_updates_health_and_writes_session_expired_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+
+        report_cycle(&reporter, &mut health, &SyncStats::default(), 0, true).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 1);
+        assert_eq!(health_json["last_error"], "session expired");
+        let report_json = parse_json(&report_path);
+        assert_eq!(report_json["status"], "session_expired");
+    }
+
+    #[tokio::test]
+    async fn interrupted_cycle_writes_interrupted_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            interrupted: true,
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 0, false).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 0);
+        let report_json = parse_json(&report_path);
+        assert_eq!(report_json["status"], "interrupted");
+    }
+
+    #[tokio::test]
+    async fn skipped_watch_cycle_is_health_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+
+        reporter.report_skipped_watch_cycle(&mut health).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 0);
+        assert!(
+            !report_path.exists(),
+            "skipped cycles should not overwrite sync_report.json"
+        );
+    }
+
+    #[tokio::test]
+    async fn report_write_failure_does_not_block_health_update() {
+        let dir = tempfile::tempdir().unwrap();
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(dir.path()), &notifier);
+        let mut health = HealthStatus::new();
+
+        report_cycle(&reporter, &mut health, &SyncStats::default(), 0, false).await;
+
+        let health_json = parse_json(&dir.path().join("health.json"));
+        assert_eq!(health_json["consecutive_failures"], 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod cli;
 mod commands;
 mod config;
 mod credential;
+mod cycle_reporter;
 mod download;
 mod fs_util;
 mod health;

--- a/src/report.rs
+++ b/src/report.rs
@@ -80,7 +80,7 @@ const fn is_zero_usize(n: &usize) -> bool {
 /// variant will silently change the emitted JSON. When a variant rename
 /// is needed, either keep the old lowercase string here explicitly or
 /// bump the report schema version.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct RunOptions {
     pub username: String,
     pub download_dir: PathBuf,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -847,6 +847,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     };
 
     let mut health = health::HealthStatus::new();
+    let cycle_reporter =
+        crate::cycle_reporter::CycleReporter::new(crate::cycle_reporter::CycleReporterConfig {
+            username: &config.auth.username,
+            watch_mode: is_watch_mode,
+            report_path: config.report.json.as_deref(),
+            run_options: crate::report::RunOptions::from_config(&config),
+            health_dir: &config.auth.cookie_directory,
+            personality_mode: config.ui.personality_mode,
+            state_db: state_db.as_deref(),
+            metrics_handle: metrics_handle.as_ref(),
+            notifier: &notifier,
+        });
     let mut consecutive_album_refresh_failures = 0u32;
     // 1-based cycle counter for periodic-reconcile cadence. Logged at
     // cycle start so an operator chasing missed reconciliation runs has a
@@ -884,15 +896,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         };
 
         if matches!(watch_precheck, WatchPrecheck::SkipAll) {
-            // Skipped cycle (no changes detected) -- still update health so
-            // Docker HEALTHCHECK doesn't mark the container unhealthy after
-            // the 2-hour staleness window when no new photos are uploaded.
-            health.record_success();
-            health.write(&config.auth.cookie_directory);
-            // Refresh health gauges only -- do not reset cycle_duration_seconds.
-            if let Some(ref handle) = metrics_handle {
-                handle.update_health_only(&health).await;
-            }
+            cycle_reporter.report_skipped_watch_cycle(&mut health).await;
         } else {
             refresh_needed_library_plans(
                 &mut library_states,
@@ -945,176 +949,17 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 }
             }
 
-            // One state-DB summary per cycle (friendly mode only). Powers
-            // the `Downloaded N new (X → Y)` phase line, the summary
-            // card's library totals, and the metrics gauges below; all
-            // three reuse the same fetch. Off mode skips it entirely so
-            // the v0.13 cycle path stays free of friendly-only DB calls.
-            let library_after_summary = if config.ui.personality_mode.is_friendly() {
-                match state_db.as_deref() {
-                    Some(db) => match db.get_summary().await {
-                        Ok(s) => Some(s),
-                        Err(e) => {
-                            tracing::debug!(error = %e, "post-cycle summary unavailable; rendering card without library totals");
-                            None
-                        }
+            cycle_reporter
+                .report_completed_cycle(
+                    &mut health,
+                    crate::cycle_reporter::CycleReportInput {
+                        stats: &cycle_result.stats,
+                        failed_count: cycle_result.failed_count,
+                        session_expired: cycle_result.session_expired,
+                        elapsed: cycle_started_at.elapsed(),
                     },
-                    None => None,
-                }
-            } else {
-                None
-            };
-
-            // Friendly-mode phase ✓ lines: scrollback-stable narration that
-            // survives after the bar clears. The Downloaded line derives
-            // `before` by subtracting this cycle's bytes from the
-            // post-cycle library total — saves a second SQL aggregate per
-            // cycle and is exact unless a concurrent reconcile rewrote
-            // the table mid-cycle. Off mode is silent; log_sync_summary
-            // still fires its tracing events for journals.
-            let downloaded_u64 = u64::try_from(cycle_result.stats.downloaded).unwrap_or(u64::MAX);
-            if let Some(library_after) = library_after_summary.as_ref() {
-                let after = library_after.downloaded_bytes;
-                let before = after.saturating_sub(cycle_result.stats.bytes_downloaded);
-                crate::personality::narration::downloaded_phase_to_stderr(
-                    config.ui.personality_mode,
-                    downloaded_u64,
-                    before,
-                    after,
-                );
-            }
-            crate::personality::narration::verified_phase_to_stderr(
-                config.ui.personality_mode,
-                downloaded_u64,
-            );
-            if let Some(library_after) = library_after_summary.as_ref() {
-                let cycle_elapsed = cycle_started_at.elapsed();
-                let stats = &cycle_result.stats;
-                let card = crate::personality::summary::SummaryCard {
-                    photos_new: u64::try_from(stats.photos_downloaded).unwrap_or(u64::MAX),
-                    videos_new: u64::try_from(stats.videos_downloaded).unwrap_or(u64::MAX),
-                    skipped_total: u64::try_from(stats.skipped.total() - stats.skipped.duplicates)
-                        .unwrap_or(u64::MAX),
-                    skipped_already_present: u64::try_from(
-                        stats.skipped.by_state + stats.skipped.on_disk,
-                    )
-                    .unwrap_or(u64::MAX),
-                    failed: u64::try_from(stats.failed).unwrap_or(u64::MAX),
-                    elapsed: cycle_elapsed,
-                    bytes_downloaded: stats.bytes_downloaded,
-                    library_total_assets: library_after.total_assets,
-                    library_total_bytes: library_after.downloaded_bytes,
-                };
-                card.print_to_stderr(config.ui.personality_mode);
-                crate::personality::summary::print_recap_to_stderr(
-                    config.ui.personality_mode,
-                    &cycle_result.stats.recap,
-                );
-            }
-
-            // Friendly-mode signoff line. Off-mode keeps relying on
-            // log_sync_summary for journal output.
-            crate::personality::narration::signoff_to_stderr(
-                config.ui.personality_mode,
-                &crate::personality::narration::CycleSummary {
-                    downloaded: downloaded_u64,
-                    failed: u64::try_from(cycle_result.failed_count).unwrap_or(u64::MAX),
-                    elapsed: cycle_started_at.elapsed(),
-                    watch_mode: is_watch_mode,
-                },
-            );
-
-            // Update health status for Docker HEALTHCHECK observability.
-            if cycle_result.session_expired {
-                health.record_failure("session expired");
-            } else if cycle_result.failed_count > 0 {
-                health.record_failure(&format!("{} downloads failed", cycle_result.failed_count));
-            } else {
-                health.record_success();
-            }
-            health.write(&config.auth.cookie_directory);
-
-            // Update Prometheus metrics if the server is running.
-            if let Some(ref handle) = metrics_handle {
-                if cycle_result.session_expired {
-                    handle.record_session_expiration();
-                }
-                handle.update(&cycle_result.stats, &health).await;
-
-                // Update DB-backed gauges from the state database. Reuse
-                // the post-cycle summary fetched for the friendly card
-                // when it's available, otherwise issue the call here.
-                if let Some(summary) = library_after_summary.as_ref() {
-                    handle.update_db_stats(summary, cycle_result.stats.assets_seen);
-                } else if let Some(ref db) = state_db {
-                    match db.get_summary().await {
-                        Ok(summary) => {
-                            handle.update_db_stats(&summary, cycle_result.stats.assets_seen);
-                        }
-                        Err(e) => {
-                            handle.record_db_summary_failure();
-                            tracing::warn!(error = %e, "Failed to fetch DB summary for metrics; skipping DB gauge update");
-                        }
-                    }
-                }
-            }
-
-            // Write JSON report if configured
-            if let Some(report_path) = &config.report.json {
-                let status = crate::report::sync_status_str(
-                    cycle_result.session_expired,
-                    cycle_result.stats.interrupted,
-                    cycle_result.failed_count,
-                );
-                // Populate failed_assets from the state DB so the report
-                // reflects the final committed set, not mid-sync churn.
-                // get_failed_sample pushes the LIMIT into SQL so an account
-                // with thousands of failures doesn't load every row here.
-                #[allow(
-                    clippy::cast_possible_truncation,
-                    reason = "FAILED_ASSETS_CAP is a small compile-time constant well under u32::MAX"
-                )]
-                let cap_u32 = crate::report::FAILED_ASSETS_CAP as u32;
-                let (failed_assets, failed_assets_truncated) = match state_db.as_ref() {
-                    Some(db) => match db.get_failed_sample(cap_u32).await {
-                        Ok((records, total)) => {
-                            #[allow(
-                                clippy::cast_possible_truncation,
-                                reason = "failed-asset totals are persisted counts of per-sync failures, comfortably below usize::MAX on 64-bit"
-                            )]
-                            let total_usize = total as usize;
-                            let truncated =
-                                total_usize.saturating_sub(crate::report::FAILED_ASSETS_CAP);
-                            let entries: Vec<_> = records
-                                .iter()
-                                .map(crate::report::FailedAssetEntry::from_record)
-                                .collect();
-                            (entries, truncated)
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "Failed to load failed_assets for sync_report.json"
-                            );
-                            (Vec::new(), 0)
-                        }
-                    },
-                    None => (Vec::new(), 0),
-                };
-                let report = crate::report::SyncReport {
-                    version: "2",
-                    kei_version: env!("CARGO_PKG_VERSION"),
-                    timestamp: chrono::Utc::now().to_rfc3339(),
-                    status: status.to_string(),
-                    options: crate::report::RunOptions::from_config(&config),
-                    stats: cycle_result.stats.clone(),
-                    failed_assets,
-                    failed_assets_truncated,
-                };
-                if let Err(e) = crate::report::write_report(report_path, &report).await {
-                    tracing::warn!(error = %e, path = %report_path.display(), "Failed to write JSON report");
-                }
-            }
+                )
+                .await;
 
             // Handle aggregate outcome across all libraries
             if cycle_result.session_expired {
@@ -1193,13 +1038,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     }
                 }
             } else if cycle_result.failed_count > 0 {
-                let data = notifications::SyncNotificationData::from(&cycle_result.stats);
-                notifier.notify(
-                    notifications::Event::SyncFailed,
-                    &format!("{} downloads failed", cycle_result.failed_count),
-                    &config.auth.username,
-                    Some(&data),
-                );
                 cumulative_failed_count =
                     cumulative_failed_count.saturating_add(cycle_result.failed_count);
                 if is_watch_mode {
@@ -1213,13 +1051,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 }
             } else {
                 reauth_attempts = 0;
-                let data = notifications::SyncNotificationData::from(&cycle_result.stats);
-                notifier.notify(
-                    notifications::Event::SyncComplete,
-                    "Sync completed successfully",
-                    &config.auth.username,
-                    Some(&data),
-                );
             }
         }
 


### PR DESCRIPTION
## Summary
- Added `cycle_reporter` as the single post-cycle boundary for friendly output, health files, metrics, JSON reports, and completion notifications.
- Reduced `sync_loop.rs` to passing cycle facts into the reporter while leaving token advance and reauth handling in the loop.
- Added reporter tests for success, partial failure, session expiry, interruption, skipped watch cycles, and report-write failure.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test cycle_reporter -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --help`
- `cargo run -- --config /tmp/kei-reporter-smoke.toml config show`
- `cargo test -- --test-threads=1` (rerun outside the sandbox after localhost-bind failures)
