### PR TITLE
Extract sync cycle runner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod setup;
 mod shutdown;
 mod state;
 mod string_interner;
+mod sync_cycle;
 mod sync_loop;
 mod systemd;
 mod types;

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -1,0 +1,469 @@
+//! Single-cycle sync runner.
+//!
+//! This module owns the per-cycle boundary that sits between the outer
+//! process/watch loop and the download engine: mode choice, enumeration config
+//! hash handling, grouping preload, download dispatch, zone-token writes, and
+//! the aggregate cycle result.
+
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::auth;
+use crate::config;
+use crate::download;
+use crate::state;
+
+/// Per-library state: zone name, sync token key, and resolved album plan.
+pub(crate) struct LibraryState {
+    pub(crate) library: crate::icloud::photos::PhotoLibrary,
+    pub(crate) zone_name: String,
+    pub(crate) sync_token_key: String,
+    /// Ordered list of download passes. Each pass carries its own
+    /// exclude-asset-ids set. See [`crate::commands::AlbumPlan`].
+    pub(crate) plan: crate::commands::AlbumPlan,
+    /// True when `resolve_passes` failed at the end of the prior cycle and
+    /// the plan above is the previous cycle's stale snapshot. Album
+    /// membership data captured under a stale plan can route assets to the
+    /// wrong pass (e.g. an asset added to a newly-created album shows up in
+    /// the unfiled pass), so any cycle that consumes a stale plan must not
+    /// advance the sync token for any zone -- doing so would skip the
+    /// change events those assets generated and leave `asset_albums`
+    /// permanently incomplete.
+    pub(crate) plan_is_stale: bool,
+    /// True after an idle watch sleep. Refreshing only when a later
+    /// `changes/database` pre-check finds relevant work avoids burning album
+    /// listing calls on quiet watch cycles.
+    pub(crate) plan_needs_refresh: bool,
+}
+
+/// Metadata key holding the SHA-256 of the enumeration-affecting subset of
+/// the user's download config. Distinct from the path-affecting
+/// `config_hash` consumed by the download pipeline; using a single key for
+/// both would cause each cycle to overwrite the other's value and
+/// permanently invalidate incremental sync.
+pub(crate) const ENUM_CONFIG_HASH_KEY: &str = "enum_config_hash";
+
+/// Prefix for every per-zone CloudKit sync token row in the metadata
+/// table. Cleared en masse when [`ENUM_CONFIG_HASH_KEY`] changes so the
+/// next cycle falls back to full enumeration.
+pub(crate) const SYNC_TOKEN_PREFIX: &str = "sync_token:";
+
+/// Return the metadata key that stores the CloudKit sync token for a zone.
+pub(crate) fn sync_token_key(zone_name: &str) -> String {
+    format!("{SYNC_TOKEN_PREFIX}{zone_name}")
+}
+
+/// Outcome of a single sync cycle across all libraries.
+#[derive(Debug)]
+pub(crate) struct CycleResult {
+    pub(crate) failed_count: usize,
+    pub(crate) session_expired: bool,
+    pub(crate) stats: download::SyncStats,
+    pub(crate) db_sync_token_advance_safe: bool,
+}
+
+/// Decide whether the per-zone `sync_token` should be persisted to the state
+/// DB after a download pass.
+///
+/// The contract is "advance only on full success and not in dry-run":
+/// - On `PartialFailure`, a stored token would skip the failed assets on the
+///   next incremental sync (they'd never appear in the delta again -- silent
+///   data loss).
+/// - On `SessionExpired`, the cycle aborts mid-stream; the token may be
+///   stale or only reflect a subset of the work.
+/// - In `--dry-run`, we promise to make no DB writes that survive the run
+///   (apart from the `sync_runs` ledger). Advancing the token here would
+///   silently break the next real sync.
+///
+/// The returned bool is the gate: callers still check that `sync_token` is
+/// `Some(_)` and that a state DB is configured before persisting.
+pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_run: bool) -> bool {
+    matches!(outcome, download::DownloadOutcome::Success) && !dry_run
+}
+
+/// Cycle-level gate that combines the per-library outcome check with the
+/// cross-library "any plan is stale" override.
+///
+/// If any library entered the cycle with a reused plan (the prior
+/// album refresh failed), suppress sync-token advancement for every library
+/// in the cycle. A stale plan can route assets created or moved between
+/// cycles to the wrong pass; advancing the token would skip the change
+/// events that would surface those assets correctly on the next refresh,
+/// leaving `asset_albums` permanently incomplete.
+pub(crate) fn should_store_sync_token_for_cycle(
+    outcome: &download::DownloadOutcome,
+    dry_run: bool,
+    cycle_has_stale_plan: bool,
+) -> bool {
+    should_store_sync_token(outcome, dry_run) && !cycle_has_stale_plan
+}
+
+/// Closure shape used to derive a per-library `DownloadConfig` from the
+/// shared base config. Boxed dyn so `run_cycle` can accept a single
+/// reference instead of a generic parameter (avoids reuse-by-monomorphization
+/// blow-up in error messages).
+pub(crate) type BuildDownloadConfigFn<'a> = dyn Fn(
+        download::SyncMode,
+        Arc<rustc_hash::FxHashSet<String>>,
+        Arc<download::AssetGroupings>,
+        Arc<str>,
+    ) -> Arc<download::DownloadConfig>
+    + 'a;
+
+/// Outcome of [`check_and_persist_enum_config_hash`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnumConfigHashOutcome {
+    /// No prior hash; current hash persisted. Sync tokens left alone:
+    /// a first-run DB must not invalidate tokens another process may
+    /// have written.
+    Initial,
+    Unchanged,
+    /// Hash drifted; sync tokens cleared and new hash persisted so this
+    /// cycle falls back to full enumeration.
+    Changed,
+    /// Hash drift was detected, but the stale sync-token rows could not be
+    /// cleared. The new hash was not persisted, and the current cycle must
+    /// force full enumeration rather than trusting any surviving tokens.
+    ChangedTokenPurgeFailed,
+    /// The stored hash could not be read, so the cycle cannot prove whether
+    /// existing sync tokens still match the current config.
+    ReadFailed,
+}
+
+impl EnumConfigHashOutcome {
+    fn must_force_full_sync(self) -> bool {
+        matches!(
+            self,
+            Self::Changed | Self::ChangedTokenPurgeFailed | Self::ReadFailed
+        )
+    }
+}
+
+/// Compare the current download-config hash against the one stored in
+/// the state DB and react to drift. Storage failures are logged at warn
+/// and swallowed, but the new hash is never persisted unless stale sync
+/// tokens were cleared first. Otherwise a failed purge could leave old
+/// tokens behind while the updated hash makes later cycles trust them.
+pub(crate) async fn check_and_persist_enum_config_hash(
+    db: &dyn state::StateDb,
+    current_hash: &str,
+) -> EnumConfigHashOutcome {
+    let stored_hash = match db.get_metadata(ENUM_CONFIG_HASH_KEY).await {
+        Ok(hash) => hash,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to read enum_config_hash");
+            return EnumConfigHashOutcome::ReadFailed;
+        }
+    };
+    let outcome = match stored_hash.as_deref() {
+        Some(h) if h == current_hash => return EnumConfigHashOutcome::Unchanged,
+        Some(_) => EnumConfigHashOutcome::Changed,
+        None => EnumConfigHashOutcome::Initial,
+    };
+
+    if matches!(outcome, EnumConfigHashOutcome::Changed) {
+        tracing::info!("Download config changed since last sync, clearing sync tokens");
+        match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
+            Ok(n) if n > 0 => {
+                tracing::debug!(cleared = n, "Cleared stale sync tokens");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to clear sync tokens; enum_config_hash will not advance"
+                );
+                return EnumConfigHashOutcome::ChangedTokenPurgeFailed;
+            }
+            _ => {}
+        }
+    }
+    if let Err(e) = db.set_metadata(ENUM_CONFIG_HASH_KEY, current_hash).await {
+        tracing::warn!(error = %e, "Failed to persist enum_config_hash");
+    }
+    outcome
+}
+
+/// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
+pub(crate) async fn run_cycle(
+    library_states: &[&LibraryState],
+    config: &config::Config,
+    state_db: Option<&dyn state::StateDb>,
+    is_retry_failed: bool,
+    build_download_config: &BuildDownloadConfigFn<'_>,
+    download_controls: download::DownloadControls,
+    shared_session: &auth::SharedSession,
+    shutdown_token: &CancellationToken,
+) -> anyhow::Result<CycleResult> {
+    let mut cycle_failed_count = 0usize;
+    let mut cycle_session_expired = false;
+    let mut cycle_stats = download::SyncStats::default();
+
+    // If ANY library entered the cycle with a stale plan (the prior
+    // album refresh failed and the previous plan is being reused), suppress
+    // sync-token advancement for every library in this cycle. A reused plan
+    // can route assets created or moved between cycles to the wrong pass and
+    // produce silently incomplete `asset_albums` data; without this gate the
+    // change events for those assets sit behind the advanced token and
+    // never replay.
+    let cycle_has_stale_plan = library_states.iter().any(|s| s.plan_is_stale);
+    if cycle_has_stale_plan {
+        tracing::warn!(
+            "One or more libraries are running on a stale album plan; sync \
+             token will not advance this cycle"
+        );
+    }
+    let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
+    let mut force_full_for_config_hash = false;
+
+    // Check if the download config changed since last sync. If so, clear
+    // sync tokens and force full enumeration for this cycle
+    // -- the stored incremental token would miss assets that are newly
+    // eligible under the changed config (e.g. a user switching
+    // [photos].resolution or changing [filters].media). The hash is
+    // cycle-invariant across libraries,
+    // so this runs once per cycle, not once per library.
+    //
+    // The metadata key `enum_config_hash` is distinct from the download
+    // pipeline's `config_hash` (which tracks path-affecting fields only).
+    // Using a single key for both would cause the two hashes to overwrite
+    // each other every cycle, permanently preventing incremental sync.
+    if !config.runtime.dry_run {
+        if let Some(db) = state_db {
+            let config_hash = download::compute_config_hash(config);
+            let config_hash_outcome = check_and_persist_enum_config_hash(db, &config_hash).await;
+            force_full_for_config_hash = config_hash_outcome.must_force_full_sync();
+            if matches!(
+                config_hash_outcome,
+                EnumConfigHashOutcome::ChangedTokenPurgeFailed | EnumConfigHashOutcome::ReadFailed
+            ) {
+                db_sync_token_advance_safe = false;
+            }
+        }
+    }
+
+    for lib_state in library_states {
+        if shutdown_token.is_cancelled() {
+            break;
+        }
+
+        // Determine sync mode per-library
+        // retry-failed must always use full enumeration: incremental
+        // sync only returns NEW iCloud changes, missing previously-
+        // failed assets that were already enumerated but not downloaded.
+        let sync_mode = if force_full_for_config_hash {
+            tracing::debug!(
+                zone = %lib_state.zone_name,
+                "Forcing full sync because config-hash validation invalidated stored sync tokens"
+            );
+            download::SyncMode::Full
+        } else {
+            determine_sync_mode(
+                is_retry_failed,
+                library_states.len(),
+                state_db,
+                &lib_state.sync_token_key,
+                &lib_state.zone_name,
+            )
+            .await
+        };
+
+        let sync_mode_label = match &sync_mode {
+            download::SyncMode::Full => "full",
+            download::SyncMode::Incremental { .. } => "incremental",
+        };
+        tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
+
+        // Skip the DB scan entirely when nothing downstream will read it.
+        #[cfg(feature = "xmp")]
+        let asset_groupings = if config.metadata.embed_xmp || config.metadata.xmp_sidecar {
+            preload_asset_groupings(state_db, &lib_state.zone_name).await
+        } else {
+            Arc::new(download::AssetGroupings::default())
+        };
+        #[cfg(not(feature = "xmp"))]
+        let asset_groupings = Arc::new(download::AssetGroupings::default());
+        // Each pass carries its own exclude-asset-ids, so the config built
+        // here starts with an empty set; download_photos_with_sync derives
+        // per-pass configs internally via `with_exclude_ids`.
+        let download_config = build_download_config(
+            sync_mode,
+            Arc::new(rustc_hash::FxHashSet::default()),
+            asset_groupings,
+            Arc::from(lib_state.zone_name.as_str()),
+        );
+        let download_client = shared_session.read().await.download_client().clone();
+        let sync_result = download::download_photos_with_sync(
+            &download_client,
+            &lib_state.plan.passes,
+            download_config,
+            download_controls,
+            shutdown_token.clone(),
+        )
+        .await?;
+
+        let library_completed_without_errors =
+            matches!(&sync_result.outcome, download::DownloadOutcome::Success)
+                && !sync_result.stats.interrupted
+                && sync_result.stats.enumeration_errors == 0
+                && !shutdown_token.is_cancelled();
+        if sync_result.full_enumeration_ran
+            && library_completed_without_errors
+            && download_controls.run_mode.downloads_files()
+            && !is_retry_failed
+            && sync_result.stats.assets_seen == 0
+        {
+            tracing::warn!(
+                library = %lib_state.zone_name,
+                library_count = library_states.len(),
+                assets_seen = sync_result.stats.assets_seen,
+                "Sync completed after enumerating zero assets; check iCloud library \
+                 access and filters if this was unexpected"
+            );
+        }
+
+        // Store sync token only when all downloads succeeded.
+        // For full sync this is safe (state DB tracks individual failures for retry).
+        // For incremental sync, advancing the token on partial failure would lose
+        // change events for failed assets -- they'd never appear in the next delta.
+        // Note: the token is stored after download_photos_with_sync returns, which
+        // means all batch flushes are complete. A crash here means the token is
+        // NOT advanced, so assets will replay on next sync (safe, not data loss).
+        let should_store_token = should_store_sync_token_for_cycle(
+            &sync_result.outcome,
+            config.runtime.dry_run,
+            cycle_has_stale_plan,
+        ) && !sync_result.stats.interrupted
+            && !shutdown_token.is_cancelled();
+        if should_store_token {
+            match (&sync_result.sync_token, state_db) {
+                (Some(token), Some(db)) => {
+                    if let Err(e) = db.set_metadata(&lib_state.sync_token_key, token).await {
+                        db_sync_token_advance_safe = false;
+                        tracing::warn!(error = %e, "Failed to store sync token");
+                    } else {
+                        tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
+                    }
+                }
+                (Some(_), None) => {
+                    db_sync_token_advance_safe = false;
+                    tracing::debug!(
+                        zone = %lib_state.zone_name,
+                        "Sync token available but no state DB is configured"
+                    );
+                }
+                (None, _) => {
+                    db_sync_token_advance_safe = false;
+                    tracing::debug!(
+                        zone = %lib_state.zone_name,
+                        "Sync token unavailable after successful sync"
+                    );
+                }
+            }
+        } else if sync_result.sync_token.is_some() {
+            db_sync_token_advance_safe = false;
+            tracing::info!(
+                zone = %lib_state.zone_name,
+                "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
+            );
+        }
+
+        // Accumulate stats across libraries.
+        cycle_stats.accumulate(&sync_result.stats);
+
+        match sync_result.outcome {
+            download::DownloadOutcome::Success => {}
+            download::DownloadOutcome::SessionExpired { auth_error_count } => {
+                tracing::warn!(
+                    auth_error_count,
+                    zone = %lib_state.zone_name,
+                    "Session expired during library sync"
+                );
+                cycle_session_expired = true;
+                break; // Stop iterating libraries -- need re-auth
+            }
+            download::DownloadOutcome::PartialFailure { failed_count } => {
+                cycle_failed_count += failed_count;
+            }
+        }
+    }
+
+    Ok(CycleResult {
+        failed_count: cycle_failed_count,
+        session_expired: cycle_session_expired,
+        stats: cycle_stats,
+        db_sync_token_advance_safe,
+    })
+}
+
+/// Bulk-load `asset_albums` + `asset_people` into an in-memory index so the
+/// filter phase can enrich payloads without per-asset DB hits. Scoped to a
+/// single library so multi-library accounts don't cross-attribute album /
+/// person memberships across zones (the v9 schema scopes both join tables
+/// per library; this reader honours that scope).
+#[cfg(feature = "xmp")]
+pub(crate) async fn preload_asset_groupings(
+    state_db: Option<&dyn state::StateDb>,
+    library: &str,
+) -> Arc<download::AssetGroupings> {
+    let Some(db) = state_db else {
+        return Arc::new(download::AssetGroupings::default());
+    };
+    let albums = db.get_all_asset_albums(library).await;
+    let people = db.get_all_asset_people(library).await;
+    let mut groupings = download::AssetGroupings::default();
+    match albums {
+        Ok(rows) => {
+            for (asset_id, album) in rows {
+                groupings.albums.entry(asset_id).or_default().push(album);
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, library, "Failed to preload asset_albums"),
+    }
+    match people {
+        Ok(rows) => {
+            for (asset_id, person) in rows {
+                groupings.people.entry(asset_id).or_default().push(person);
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, library, "Failed to preload asset_people"),
+    }
+    Arc::new(groupings)
+}
+
+/// Determine the sync mode for a library: full enumeration or incremental.
+pub(crate) async fn determine_sync_mode(
+    is_retry_failed: bool,
+    library_count: usize,
+    state_db: Option<&dyn state::StateDb>,
+    sync_token_key: &str,
+    zone_name: &str,
+) -> download::SyncMode {
+    if is_retry_failed {
+        if library_count == 1 {
+            tracing::debug!(
+                "Retry-failed requires full enumeration to find previously-failed assets"
+            );
+        }
+        download::SyncMode::Full
+    } else if let Some(db) = state_db {
+        match db.get_metadata(sync_token_key).await {
+            Ok(Some(ref token)) if !token.is_empty() => {
+                tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
+                download::SyncMode::Incremental {
+                    zone_sync_token: token.clone(),
+                }
+            }
+            Ok(_) => {
+                tracing::debug!(zone = %zone_name, "No sync token found, performing full enumeration");
+                download::SyncMode::Full
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load sync token, falling back to full enumeration");
+                download::SyncMode::Full
+            }
+        }
+    } else {
+        download::SyncMode::Full
+    }
+}

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -7,7 +7,6 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use tokio_util::sync::CancellationToken;
 
 use crate::auth;
 use crate::cli;
@@ -24,34 +23,25 @@ use crate::password::{self, ExposeSecret, SecretString};
 use crate::retry;
 use crate::shutdown;
 use crate::state::{self, StateDb};
+use crate::sync_cycle::{run_cycle, sync_token_key as make_sync_token_key, LibraryState};
+
+#[cfg(test)]
+use crate::sync_cycle::{
+    check_and_persist_enum_config_hash, determine_sync_mode, should_store_sync_token,
+    should_store_sync_token_for_cycle, CycleResult, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY,
+    SYNC_TOKEN_PREFIX,
+};
+
+#[cfg(all(test, feature = "xmp"))]
+use crate::sync_cycle::preload_asset_groupings;
+
 use crate::systemd::SystemdNotifier;
 use crate::{
     available_disk_space, check_min_disk_space, make_password_provider, PartialSyncError,
     PidFileGuard,
 };
-
-/// Per-library state: zone name, sync token key, and resolved album plan.
-struct LibraryState {
-    library: crate::icloud::photos::PhotoLibrary,
-    zone_name: String,
-    sync_token_key: String,
-    /// Ordered list of download passes. Each pass carries its own
-    /// exclude-asset-ids set. See [`crate::commands::AlbumPlan`].
-    plan: crate::commands::AlbumPlan,
-    /// True when `resolve_passes` failed at the end of the prior cycle and
-    /// the plan above is the previous cycle's stale snapshot. Album
-    /// membership data captured under a stale plan can route assets to the
-    /// wrong pass (e.g. an asset added to a newly-created album shows up in
-    /// the unfiled pass), so any cycle that consumes a stale plan must not
-    /// advance the sync token for any zone -- doing so would skip the
-    /// change events those assets generated and leave `asset_albums`
-    /// permanently incomplete.
-    plan_is_stale: bool,
-    /// True after an idle watch sleep. Refreshing only when a later
-    /// `changes/database` pre-check finds relevant work avoids burning album
-    /// listing calls on quiet watch cycles.
-    plan_needs_refresh: bool,
-}
+#[cfg(test)]
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, PartialEq, Eq)]
 enum WatchPrecheck {
@@ -106,18 +96,6 @@ impl WatchPrecheck {
 /// the version suffix (e.g. `_v2`) re-fires the notice for every existing
 /// data dir the next time it's used.
 const SHARED_LIBRARY_NOTICE_KEY: &str = "shared_library_notice_shown_v1";
-
-/// Metadata key holding the SHA-256 of the enumeration-affecting subset of
-/// the user's download config. Distinct from the path-affecting
-/// `config_hash` consumed by the download pipeline; using a single key for
-/// both would cause each cycle to overwrite the other's value and
-/// permanently invalidate incremental sync.
-const ENUM_CONFIG_HASH_KEY: &str = "enum_config_hash";
-
-/// Prefix for every per-zone CloudKit sync token row in the metadata
-/// table. Cleared en masse when [`ENUM_CONFIG_HASH_KEY`] changes so the
-/// next cycle falls back to full enumeration.
-const SYNC_TOKEN_PREFIX: &str = "sync_token:";
 
 /// Metadata key for the database-level token used by `/changes/database`.
 const DB_SYNC_TOKEN_KEY: &str = "db_sync_token";
@@ -793,7 +771,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     let mut library_states: Vec<LibraryState> = Vec::with_capacity(libraries.len());
     for library in &libraries {
         let zone_name = library.zone_name().to_string();
-        let sync_token_key = format!("sync_token:{zone_name}");
+        let sync_token_key = make_sync_token_key(&zone_name);
         let plan = resolve_passes(library, &config.filters.selection).await?;
         let (album_passes, smart_folder_passes, unfiled) = count_passes(&plan);
         tracing::info!(
@@ -1150,15 +1128,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
 }
 
-/// Outcome of a single sync cycle across all libraries.
-#[derive(Debug)]
-struct CycleResult {
-    failed_count: usize,
-    session_expired: bool,
-    stats: download::SyncStats,
-    db_sync_token_advance_safe: bool,
-}
-
 /// Re-authenticate via SRP after a session-error signature from CloudKit.
 ///
 /// Drops any live session + service (releasing the file lock), strips routing
@@ -1224,42 +1193,6 @@ async fn reauth_with_srp(
         }
         Err(e) => Err(e),
     }
-}
-
-/// Decide whether the per-zone `sync_token` should be persisted to the state
-/// DB after a download pass.
-///
-/// The contract is "advance only on full success and not in dry-run":
-/// - On `PartialFailure`, a stored token would skip the failed assets on the
-///   next incremental sync (they'd never appear in the delta again -- silent
-///   data loss).
-/// - On `SessionExpired`, the cycle aborts mid-stream; the token may be
-///   stale or only reflect a subset of the work.
-/// - In `--dry-run`, we promise to make no DB writes that survive the run
-///   (apart from the `sync_runs` ledger). Advancing the token here would
-///   silently break the next real sync.
-///
-/// The returned bool is the gate: callers still check that `sync_token` is
-/// `Some(_)` and that a state DB is configured before persisting.
-pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_run: bool) -> bool {
-    matches!(outcome, download::DownloadOutcome::Success) && !dry_run
-}
-
-/// Cycle-level gate that combines the per-library outcome check with the
-/// cross-library "any plan is stale" override.
-///
-/// If any library entered the cycle with a reused plan (the prior
-/// album refresh failed), suppress sync-token advancement for every library
-/// in the cycle. A stale plan can route assets created or moved between
-/// cycles to the wrong pass; advancing the token would skip the change
-/// events that would surface those assets correctly on the next refresh,
-/// leaving `asset_albums` permanently incomplete.
-pub(crate) fn should_store_sync_token_for_cycle(
-    outcome: &download::DownloadOutcome,
-    dry_run: bool,
-    cycle_has_stale_plan: bool,
-) -> bool {
-    should_store_sync_token(outcome, dry_run) && !cycle_has_stale_plan
 }
 
 /// Walk every `downloaded` row in the state DB and warn when the
@@ -1362,341 +1295,6 @@ pub(crate) fn should_wait_for_2fa(is_watch_mode: bool, err: &anyhow::Error) -> b
             .is_some_and(auth::error::AuthError::is_two_factor_required)
 }
 
-/// Closure shape used to derive a per-library `DownloadConfig` from the
-/// shared base config. Boxed dyn so `run_cycle` can accept a single
-/// reference instead of a generic parameter (avoids reuse-by-monomorphization
-/// blow-up in error messages).
-type BuildDownloadConfigFn<'a> = dyn Fn(
-        download::SyncMode,
-        Arc<rustc_hash::FxHashSet<String>>,
-        Arc<download::AssetGroupings>,
-        Arc<str>,
-    ) -> Arc<download::DownloadConfig>
-    + 'a;
-
-/// Outcome of [`check_and_persist_enum_config_hash`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum EnumConfigHashOutcome {
-    /// No prior hash; current hash persisted. Sync tokens left alone:
-    /// a first-run DB must not invalidate tokens another process may
-    /// have written.
-    Initial,
-    Unchanged,
-    /// Hash drifted; sync tokens cleared and new hash persisted so this
-    /// cycle falls back to full enumeration.
-    Changed,
-    /// Hash drift was detected, but the stale sync-token rows could not be
-    /// cleared. The new hash was not persisted, and the current cycle must
-    /// force full enumeration rather than trusting any surviving tokens.
-    ChangedTokenPurgeFailed,
-    /// The stored hash could not be read, so the cycle cannot prove whether
-    /// existing sync tokens still match the current config.
-    ReadFailed,
-}
-
-impl EnumConfigHashOutcome {
-    fn must_force_full_sync(self) -> bool {
-        matches!(
-            self,
-            Self::Changed | Self::ChangedTokenPurgeFailed | Self::ReadFailed
-        )
-    }
-}
-
-/// Compare the current download-config hash against the one stored in
-/// the state DB and react to drift. Storage failures are logged at warn
-/// and swallowed, but the new hash is never persisted unless stale sync
-/// tokens were cleared first. Otherwise a failed purge could leave old
-/// tokens behind while the updated hash makes later cycles trust them.
-pub(crate) async fn check_and_persist_enum_config_hash(
-    db: &dyn state::StateDb,
-    current_hash: &str,
-) -> EnumConfigHashOutcome {
-    let stored_hash = match db.get_metadata(ENUM_CONFIG_HASH_KEY).await {
-        Ok(hash) => hash,
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to read enum_config_hash");
-            return EnumConfigHashOutcome::ReadFailed;
-        }
-    };
-    let outcome = match stored_hash.as_deref() {
-        Some(h) if h == current_hash => return EnumConfigHashOutcome::Unchanged,
-        Some(_) => EnumConfigHashOutcome::Changed,
-        None => EnumConfigHashOutcome::Initial,
-    };
-
-    if matches!(outcome, EnumConfigHashOutcome::Changed) {
-        tracing::info!("Download config changed since last sync, clearing sync tokens");
-        match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
-            Ok(n) if n > 0 => {
-                tracing::debug!(cleared = n, "Cleared stale sync tokens");
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to clear sync tokens; enum_config_hash will not advance"
-                );
-                return EnumConfigHashOutcome::ChangedTokenPurgeFailed;
-            }
-            _ => {}
-        }
-    }
-    if let Err(e) = db.set_metadata(ENUM_CONFIG_HASH_KEY, current_hash).await {
-        tracing::warn!(error = %e, "Failed to persist enum_config_hash");
-    }
-    outcome
-}
-
-/// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
-async fn run_cycle(
-    library_states: &[&LibraryState],
-    config: &config::Config,
-    state_db: Option<&dyn state::StateDb>,
-    is_retry_failed: bool,
-    build_download_config: &BuildDownloadConfigFn<'_>,
-    download_controls: download::DownloadControls,
-    shared_session: &auth::SharedSession,
-    shutdown_token: &CancellationToken,
-) -> anyhow::Result<CycleResult> {
-    let mut cycle_failed_count = 0usize;
-    let mut cycle_session_expired = false;
-    let mut cycle_stats = download::SyncStats::default();
-
-    // If ANY library entered the cycle with a stale plan (the prior
-    // album refresh failed and the previous plan is being reused), suppress
-    // sync-token advancement for every library in this cycle. A reused plan
-    // can route assets created or moved between cycles to the wrong pass and
-    // produce silently incomplete `asset_albums` data; without this gate the
-    // change events for those assets sit behind the advanced token and
-    // never replay.
-    let cycle_has_stale_plan = library_states.iter().any(|s| s.plan_is_stale);
-    if cycle_has_stale_plan {
-        tracing::warn!(
-            "One or more libraries are running on a stale album plan; sync \
-             token will not advance this cycle"
-        );
-    }
-    let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
-    let mut force_full_for_config_hash = false;
-
-    // Check if the download config changed since last sync. If so, clear
-    // sync tokens and force full enumeration for this cycle
-    // -- the stored incremental token would miss assets that are newly
-    // eligible under the changed config (e.g. a user switching
-    // [photos].resolution or changing [filters].media). The hash is
-    // cycle-invariant across libraries,
-    // so this runs once per cycle, not once per library.
-    //
-    // The metadata key `enum_config_hash` is distinct from the download
-    // pipeline's `config_hash` (which tracks path-affecting fields only).
-    // Using a single key for both would cause the two hashes to overwrite
-    // each other every cycle, permanently preventing incremental sync.
-    if !config.runtime.dry_run {
-        if let Some(db) = state_db {
-            let config_hash = download::compute_config_hash(config);
-            let config_hash_outcome = check_and_persist_enum_config_hash(db, &config_hash).await;
-            force_full_for_config_hash = config_hash_outcome.must_force_full_sync();
-            if matches!(
-                config_hash_outcome,
-                EnumConfigHashOutcome::ChangedTokenPurgeFailed | EnumConfigHashOutcome::ReadFailed
-            ) {
-                db_sync_token_advance_safe = false;
-            }
-        }
-    }
-
-    for lib_state in library_states {
-        if shutdown_token.is_cancelled() {
-            break;
-        }
-
-        // Determine sync mode per-library
-        // retry-failed must always use full enumeration: incremental
-        // sync only returns NEW iCloud changes, missing previously-
-        // failed assets that were already enumerated but not downloaded.
-        let sync_mode = if force_full_for_config_hash {
-            tracing::debug!(
-                zone = %lib_state.zone_name,
-                "Forcing full sync because config-hash validation invalidated stored sync tokens"
-            );
-            download::SyncMode::Full
-        } else {
-            determine_sync_mode(
-                is_retry_failed,
-                library_states.len(),
-                state_db,
-                &lib_state.sync_token_key,
-                &lib_state.zone_name,
-            )
-            .await
-        };
-
-        let sync_mode_label = match &sync_mode {
-            download::SyncMode::Full => "full",
-            download::SyncMode::Incremental { .. } => "incremental",
-        };
-        tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
-
-        // Skip the DB scan entirely when nothing downstream will read it.
-        #[cfg(feature = "xmp")]
-        let asset_groupings = if config.metadata.embed_xmp || config.metadata.xmp_sidecar {
-            preload_asset_groupings(state_db, &lib_state.zone_name).await
-        } else {
-            Arc::new(download::AssetGroupings::default())
-        };
-        #[cfg(not(feature = "xmp"))]
-        let asset_groupings = Arc::new(download::AssetGroupings::default());
-        // Each pass carries its own exclude-asset-ids, so the config built
-        // here starts with an empty set; download_photos_with_sync derives
-        // per-pass configs internally via `with_exclude_ids`.
-        let download_config = build_download_config(
-            sync_mode,
-            Arc::new(rustc_hash::FxHashSet::default()),
-            asset_groupings,
-            Arc::from(lib_state.zone_name.as_str()),
-        );
-        let download_client = shared_session.read().await.download_client().clone();
-        let sync_result = download::download_photos_with_sync(
-            &download_client,
-            &lib_state.plan.passes,
-            download_config,
-            download_controls,
-            shutdown_token.clone(),
-        )
-        .await?;
-
-        let library_completed_without_errors =
-            matches!(&sync_result.outcome, download::DownloadOutcome::Success)
-                && !sync_result.stats.interrupted
-                && sync_result.stats.enumeration_errors == 0
-                && !shutdown_token.is_cancelled();
-        if sync_result.full_enumeration_ran
-            && library_completed_without_errors
-            && download_controls.run_mode.downloads_files()
-            && !is_retry_failed
-            && sync_result.stats.assets_seen == 0
-        {
-            tracing::warn!(
-                library = %lib_state.zone_name,
-                library_count = library_states.len(),
-                assets_seen = sync_result.stats.assets_seen,
-                "Sync completed after enumerating zero assets; check iCloud library \
-                 access and filters if this was unexpected"
-            );
-        }
-
-        // Store sync token only when all downloads succeeded.
-        // For full sync this is safe (state DB tracks individual failures for retry).
-        // For incremental sync, advancing the token on partial failure would lose
-        // change events for failed assets -- they'd never appear in the next delta.
-        // Note: the token is stored after download_photos_with_sync returns, which
-        // means all batch flushes are complete. A crash here means the token is
-        // NOT advanced, so assets will replay on next sync (safe, not data loss).
-        let should_store_token = should_store_sync_token_for_cycle(
-            &sync_result.outcome,
-            config.runtime.dry_run,
-            cycle_has_stale_plan,
-        ) && !sync_result.stats.interrupted
-            && !shutdown_token.is_cancelled();
-        if should_store_token {
-            match (&sync_result.sync_token, state_db) {
-                (Some(token), Some(db)) => {
-                    if let Err(e) = db.set_metadata(&lib_state.sync_token_key, token).await {
-                        db_sync_token_advance_safe = false;
-                        tracing::warn!(error = %e, "Failed to store sync token");
-                    } else {
-                        tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
-                    }
-                }
-                (Some(_), None) => {
-                    db_sync_token_advance_safe = false;
-                    tracing::debug!(
-                        zone = %lib_state.zone_name,
-                        "Sync token available but no state DB is configured"
-                    );
-                }
-                (None, _) => {
-                    db_sync_token_advance_safe = false;
-                    tracing::debug!(
-                        zone = %lib_state.zone_name,
-                        "Sync token unavailable after successful sync"
-                    );
-                }
-            }
-        } else if sync_result.sync_token.is_some() {
-            db_sync_token_advance_safe = false;
-            tracing::info!(
-                zone = %lib_state.zone_name,
-                "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
-            );
-        }
-
-        // Accumulate stats across libraries.
-        cycle_stats.accumulate(&sync_result.stats);
-
-        match sync_result.outcome {
-            download::DownloadOutcome::Success => {}
-            download::DownloadOutcome::SessionExpired { auth_error_count } => {
-                tracing::warn!(
-                    auth_error_count,
-                    zone = %lib_state.zone_name,
-                    "Session expired during library sync"
-                );
-                cycle_session_expired = true;
-                break; // Stop iterating libraries -- need re-auth
-            }
-            download::DownloadOutcome::PartialFailure { failed_count } => {
-                cycle_failed_count += failed_count;
-            }
-        }
-    }
-
-    Ok(CycleResult {
-        failed_count: cycle_failed_count,
-        session_expired: cycle_session_expired,
-        stats: cycle_stats,
-        db_sync_token_advance_safe,
-    })
-}
-
-/// Check `changes/database` to determine if this watch cycle can be skipped.
-///
-/// Returns `true` when no zones report changes and `moreComing` is false.
-/// Bulk-load `asset_albums` + `asset_people` into an in-memory index so the
-/// filter phase can enrich payloads without per-asset DB hits. Scoped to a
-/// single library so multi-library accounts don't cross-attribute album /
-/// person memberships across zones (the v9 schema scopes both join tables
-/// per library; this reader honours that scope).
-#[cfg(feature = "xmp")]
-async fn preload_asset_groupings(
-    state_db: Option<&dyn state::StateDb>,
-    library: &str,
-) -> Arc<download::AssetGroupings> {
-    let Some(db) = state_db else {
-        return Arc::new(download::AssetGroupings::default());
-    };
-    let albums = db.get_all_asset_albums(library).await;
-    let people = db.get_all_asset_people(library).await;
-    let mut groupings = download::AssetGroupings::default();
-    match albums {
-        Ok(rows) => {
-            for (asset_id, album) in rows {
-                groupings.albums.entry(asset_id).or_default().push(album);
-            }
-        }
-        Err(e) => tracing::warn!(error = %e, library, "Failed to preload asset_albums"),
-    }
-    match people {
-        Ok(rows) => {
-            for (asset_id, person) in rows {
-                groupings.people.entry(asset_id).or_default().push(person);
-            }
-        }
-        Err(e) => tracing::warn!(error = %e, library, "Failed to preload asset_people"),
-    }
-    Arc::new(groupings)
-}
-
 async fn refresh_needed_library_plans(
     library_states: &mut [LibraryState],
     selection: &crate::selection::Selection,
@@ -1751,6 +1349,9 @@ async fn store_db_sync_token(db: &dyn state::StateDb, token: &str) {
     }
 }
 
+/// Check `changes/database` to determine if this watch cycle can be skipped.
+///
+/// Returns `SkipAll` when no selected zones report changes and `moreComing` is false.
 async fn check_changes_database(
     state_db: Option<&dyn state::StateDb>,
     library_states: &[LibraryState],
@@ -1924,43 +1525,6 @@ fn warn_if_multi_library_paths_commingle(
          `-N` suffix), but cross-library files end up interleaved. Add \
          `{{library}}` to each listed template for zone-disjoint trees."
     );
-}
-
-/// Determine the sync mode for a library: full enumeration or incremental.
-async fn determine_sync_mode(
-    is_retry_failed: bool,
-    library_count: usize,
-    state_db: Option<&dyn state::StateDb>,
-    sync_token_key: &str,
-    zone_name: &str,
-) -> download::SyncMode {
-    if is_retry_failed {
-        if library_count == 1 {
-            tracing::debug!(
-                "Retry-failed requires full enumeration to find previously-failed assets"
-            );
-        }
-        download::SyncMode::Full
-    } else if let Some(db) = state_db {
-        match db.get_metadata(sync_token_key).await {
-            Ok(Some(ref token)) if !token.is_empty() => {
-                tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
-                download::SyncMode::Incremental {
-                    zone_sync_token: token.clone(),
-                }
-            }
-            Ok(_) => {
-                tracing::debug!(zone = %zone_name, "No sync token found, performing full enumeration");
-                download::SyncMode::Full
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to load sync token, falling back to full enumeration");
-                download::SyncMode::Full
-            }
-        }
-    } else {
-        download::SyncMode::Full
-    }
 }
 
 /// Re-validate the session after an idle sleep and re-acquire the lock.


### PR DESCRIPTION
## Summary
- Extracted the per-cycle sync runner from `sync_loop.rs` into `src/sync_cycle.rs`.
- Kept watch/process orchestration in `sync_loop.rs` while moving sync mode selection, enum config hash handling, grouping preload, download dispatch, and zone-token gates to the cycle module.

## Tests
- `cargo check`
- `cargo test sync_loop -- --test-threads=1`
- `cargo run -- --help`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
