### PR TITLE
Extract download planner and finalizer

### DIFF
--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -1,0 +1,451 @@
+//! State finalization for completed or failed download tasks.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::state::{StateDb, VersionSizeKey};
+
+use super::filter::DownloadTask;
+
+/// A successful download whose state write to SQLite failed on first attempt.
+/// Accumulated during download loops and retried in a final flush.
+#[derive(Debug)]
+pub(super) struct PendingStateWrite {
+    pub(super) library: Arc<str>,
+    pub(super) asset_id: Arc<str>,
+    pub(super) version_size: VersionSizeKey,
+    pub(super) download_path: PathBuf,
+    pub(super) local_checksum: String,
+    pub(super) download_checksum: Option<String>,
+}
+
+/// Maximum retry attempts for deferred state writes.
+pub(super) const STATE_WRITE_MAX_RETRIES: u32 = 6;
+const _: () = assert!(STATE_WRITE_MAX_RETRIES <= 32, "shift overflow in backoff");
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct StateWriteFlush {
+    pub(super) attempted: usize,
+    pub(super) failures: usize,
+}
+
+/// Minimum pending-queue size at which a 100% flush failure rate is treated
+/// as "state DB unwritable" rather than a transient lock race.
+pub(super) const STATE_DB_UNWRITABLE_THRESHOLD: usize = 5;
+
+#[derive(Debug)]
+pub(super) enum DownloadedFinalization {
+    Persisted,
+    Deferred {
+        write: PendingStateWrite,
+        error: crate::state::error::StateError,
+    },
+}
+
+/// Persist success state for a task that has already landed safely on disk.
+/// On success, metadata retry markers are updated immediately. On failure,
+/// the caller receives a deferred write record for bounded retry.
+pub(super) async fn finalize_downloaded(
+    db: &dyn StateDb,
+    library: &Arc<str>,
+    task: &DownloadTask,
+    local_checksum: String,
+    download_checksum: Option<String>,
+    exif_ok: bool,
+) -> DownloadedFinalization {
+    match db
+        .mark_downloaded(
+            library,
+            &task.asset_id,
+            task.version_size.as_str(),
+            &task.download_path,
+            &local_checksum,
+            download_checksum.as_deref(),
+        )
+        .await
+    {
+        Ok(()) => {
+            update_metadata_marker(
+                db,
+                library,
+                &task.asset_id,
+                task.version_size.as_str(),
+                exif_ok,
+            )
+            .await;
+            DownloadedFinalization::Persisted
+        }
+        Err(error) => DownloadedFinalization::Deferred {
+            write: PendingStateWrite {
+                library: Arc::clone(library),
+                asset_id: task.asset_id.clone(),
+                version_size: task.version_size,
+                download_path: task.download_path.clone(),
+                local_checksum,
+                download_checksum,
+            },
+            error,
+        },
+    }
+}
+
+/// Persist failure state for a task that could not be downloaded.
+pub(super) async fn finalize_failed(
+    db: &dyn StateDb,
+    library: &Arc<str>,
+    task: &DownloadTask,
+    error: &str,
+) -> Result<(), crate::state::error::StateError> {
+    db.mark_failed(library, &task.asset_id, task.version_size.as_str(), error)
+        .await
+}
+
+/// Set or clear the metadata-rewrite marker for an asset-version pair based
+/// on whether the EXIF/XMP writer succeeded.
+async fn update_metadata_marker(
+    db: &dyn StateDb,
+    library: &str,
+    asset_id: &str,
+    version_size: &str,
+    exif_ok: bool,
+) {
+    if exif_ok {
+        if let Err(e) = db
+            .clear_metadata_write_failure(library, asset_id, version_size)
+            .await
+        {
+            tracing::warn!(
+                library,
+                asset_id,
+                version_size,
+                error = %e,
+                "Could not clear metadata-write-failed marker; asset will be \
+                 re-rewritten on next sync"
+            );
+        }
+        return;
+    }
+    if let Err(e) = db
+        .record_metadata_write_failure(library, asset_id, version_size)
+        .await
+    {
+        tracing::warn!(
+            asset_id,
+            error = %e,
+            "Could not set metadata-write-failed marker"
+        );
+    }
+}
+
+async fn retry_pending_state_write(
+    db: &dyn StateDb,
+    write: &PendingStateWrite,
+    pending_count: usize,
+) -> bool {
+    use rand::RngExt;
+
+    for attempt in 1..=STATE_WRITE_MAX_RETRIES {
+        match db
+            .mark_downloaded(
+                &write.library,
+                &write.asset_id,
+                write.version_size.as_str(),
+                &write.download_path,
+                &write.local_checksum,
+                write.download_checksum.as_deref(),
+            )
+            .await
+        {
+            Ok(()) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        asset_id = %write.asset_id,
+                        pending_count,
+                        attempt,
+                        "Recovered deferred state write"
+                    );
+                }
+                return true;
+            }
+            Err(e) => {
+                if attempt < STATE_WRITE_MAX_RETRIES {
+                    tracing::info!(
+                        asset_id = %write.asset_id,
+                        pending_count,
+                        attempt,
+                        error = %e,
+                        "State write retry failed, will retry"
+                    );
+                    let base_ms = 200 * u64::from(1u32 << (attempt - 1));
+                    let jitter_ms = rand::rng().random_range(0..base_ms.max(1) / 4);
+                    tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
+                } else {
+                    tracing::error!(
+                        asset_id = %write.asset_id,
+                        path = %write.download_path.display(),
+                        error = %e,
+                        "State write failed after {STATE_WRITE_MAX_RETRIES} attempts - \
+                         file on disk but untracked; next sync will detect it via \
+                         filesystem check and skip re-download"
+                    );
+                }
+            }
+        }
+    }
+    false
+}
+
+pub(super) async fn flush_pending_state_writes_retaining_failures(
+    db: &dyn StateDb,
+    pending: &mut Vec<PendingStateWrite>,
+) -> StateWriteFlush {
+    if pending.is_empty() {
+        return StateWriteFlush::default();
+    }
+    let pending_count = pending.len();
+    tracing::info!(pending_count, "Retrying deferred state writes");
+
+    let mut failed = Vec::new();
+    for write in pending.drain(..) {
+        if !retry_pending_state_write(db, &write, pending_count).await {
+            failed.push(write);
+        }
+    }
+
+    let flush = StateWriteFlush {
+        attempted: pending_count,
+        failures: failed.len(),
+    };
+    *pending = failed;
+
+    if flush.failures > 0 {
+        tracing::warn!(
+            failures = flush.failures,
+            total = flush.attempted,
+            "Some state writes could not be saved"
+        );
+    } else {
+        tracing::debug!(
+            count = flush.attempted,
+            "All deferred state writes recovered"
+        );
+    }
+    flush
+}
+
+/// Retry all pending state writes that failed during a download pass.
+///
+/// Returns the number of writes that still failed after all retries.
+pub(super) async fn flush_pending_state_writes(
+    db: &dyn StateDb,
+    pending: &[PendingStateWrite],
+) -> usize {
+    if pending.is_empty() {
+        return 0;
+    }
+    let pending_count = pending.len();
+    tracing::info!(pending_count, "Retrying deferred state writes");
+
+    let mut failures = 0;
+    for write in pending {
+        if !retry_pending_state_write(db, write, pending_count).await {
+            failures += 1;
+        }
+    }
+
+    if failures > 0 {
+        tracing::warn!(
+            failures,
+            total = pending.len(),
+            "Some state writes could not be saved"
+        );
+    } else {
+        tracing::debug!(count = pending.len(), "All deferred state writes recovered");
+    }
+    failures
+}
+
+pub(super) fn state_write_circuit_breaker_tripped(flush: &StateWriteFlush) -> bool {
+    flush.attempted >= STATE_DB_UNWRITABLE_THRESHOLD && flush.failures == flush.attempted
+}
+
+pub(super) fn state_db_unwritable_error(pending_total: usize) -> anyhow::Error {
+    anyhow::anyhow!(
+        "State DB appears unwritable: all {pending_total} deferred state writes failed after \
+         {STATE_WRITE_MAX_RETRIES} retries each. Check disk space and permissions on the state \
+         DB file; halting sync to avoid re-downloading into an untracked tree."
+    )
+}
+
+pub(super) async fn check_state_write_circuit_breaker(
+    db: &dyn StateDb,
+    pending: &mut Vec<PendingStateWrite>,
+) -> Option<anyhow::Error> {
+    if pending.len() < STATE_DB_UNWRITABLE_THRESHOLD {
+        return None;
+    }
+
+    let flush = flush_pending_state_writes_retaining_failures(db, pending).await;
+    if state_write_circuit_breaker_tripped(&flush) {
+        return Some(state_db_unwritable_error(flush.attempted));
+    }
+    None
+}
+
+#[cfg(test)]
+pub(super) async fn update_metadata_marker_for_test(
+    db: &dyn StateDb,
+    library: &str,
+    asset_id: &str,
+    version_size: &str,
+    exif_ok: bool,
+) {
+    update_metadata_marker(db, library, asset_id, version_size, exif_ok).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use chrono::Local;
+    use tempfile::TempDir;
+
+    use crate::state::{MediaType, SqliteStateDb, StateDb, VersionSizeKey};
+    use crate::test_helpers::TestAssetRecord;
+
+    use super::super::filter::{DownloadTask, MetadataPayload};
+    use super::*;
+
+    const LIBRARY: &str = "PrimarySync";
+
+    fn task(asset_id: &'static str, path: PathBuf) -> DownloadTask {
+        DownloadTask {
+            url: "https://example.test/photo.jpg".into(),
+            download_path: path,
+            checksum: "remote_checksum".into(),
+            asset_id: Arc::from(asset_id),
+            metadata: Arc::new(MetadataPayload::default()),
+            size: 12,
+            created_local: Local::now(),
+            version_size: VersionSizeKey::Original,
+            media_type: MediaType::Photo,
+        }
+    }
+
+    async fn seed_pending(db: &SqliteStateDb, asset_id: &str, filename: &str) {
+        let record = TestAssetRecord::new(asset_id)
+            .library(LIBRARY)
+            .filename(filename)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+    }
+
+    async fn write_file(path: &Path) {
+        tokio::fs::write(path, b"finalized").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn finalize_downloaded_marks_persisted_and_clears_metadata_marker() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("persisted.jpg");
+        write_file(&path).await;
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        seed_pending(&db, "FINAL_OK", "persisted.jpg").await;
+        db.record_metadata_write_failure(LIBRARY, "FINAL_OK", "original")
+            .await
+            .unwrap();
+
+        let result = finalize_downloaded(
+            &db,
+            &Arc::from(LIBRARY),
+            &task("FINAL_OK", path.clone()),
+            "local_checksum".to_string(),
+            Some("download_checksum".to_string()),
+            true,
+        )
+        .await;
+
+        assert!(matches!(result, DownloadedFinalization::Persisted));
+        assert!(
+            !db.should_download(LIBRARY, "FINAL_OK", "original", "checksum123", &path)
+                .await
+                .unwrap(),
+            "downloaded row with existing file should not be queued again"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(32)
+                .await
+                .unwrap()
+                .is_empty(),
+            "successful metadata write must clear the retry marker"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_downloaded_failure_defers_write() {
+        let path = TempDir::new().unwrap().path().join("missing-row.jpg");
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let result = finalize_downloaded(
+            &db,
+            &Arc::from(LIBRARY),
+            &task("FINAL_DEFER", path.clone()),
+            "local_checksum".to_string(),
+            None,
+            true,
+        )
+        .await;
+
+        let DownloadedFinalization::Deferred { write, error: _ } = result else {
+            panic!("missing state row should defer the state write");
+        };
+        assert_eq!(write.library.as_ref(), LIBRARY);
+        assert_eq!(write.asset_id.as_ref(), "FINAL_DEFER");
+        assert_eq!(write.version_size, VersionSizeKey::Original);
+        assert_eq!(write.download_path, path);
+        assert_eq!(write.local_checksum, "local_checksum");
+        assert_eq!(write.download_checksum, None);
+    }
+
+    #[tokio::test]
+    async fn finalize_downloaded_metadata_failure_sets_retry_marker() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("rewrite-needed.jpg");
+        write_file(&path).await;
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        seed_pending(&db, "FINAL_REWRITE", "rewrite-needed.jpg").await;
+
+        let result = finalize_downloaded(
+            &db,
+            &Arc::from(LIBRARY),
+            &task("FINAL_REWRITE", path),
+            "local_checksum".to_string(),
+            None,
+            false,
+        )
+        .await;
+
+        assert!(matches!(result, DownloadedFinalization::Persisted));
+        let pending = db.get_pending_metadata_rewrites(32).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id.as_ref(), "FINAL_REWRITE");
+    }
+
+    #[tokio::test]
+    async fn finalize_failed_records_failure_status() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        seed_pending(&db, "FINAL_FAILED", "failed.jpg").await;
+        let task = task("FINAL_FAILED", PathBuf::from("failed.jpg"));
+
+        finalize_failed(&db, &Arc::from(LIBRARY), &task, "cdn expired")
+            .await
+            .unwrap();
+
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id.as_ref(), "FINAL_FAILED");
+        assert_eq!(failed[0].last_error.as_deref(), Some("cdn expired"));
+    }
+}

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -6,12 +6,14 @@
 pub mod error;
 pub mod file;
 pub(crate) mod filter;
+pub(crate) mod finalize;
 #[cfg(feature = "xmp")]
 pub(crate) mod heif;
 pub(crate) mod limiter;
 pub mod metadata;
 pub mod paths;
 pub(crate) mod pipeline;
+pub(crate) mod planner;
 pub(crate) mod recap;
 
 pub(crate) use limiter::BandwidthLimiter;
@@ -24,7 +26,7 @@ use pipeline::{
 
 pub(crate) use filter::determine_media_type;
 pub(crate) use filter::AssetGroupings;
-use filter::{filter_asset_to_tasks, pre_ensure_asset_dir, DownloadTask, NormalizedPath};
+use filter::DownloadTask;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -40,7 +42,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::{PhotoAsset, SyncTokenError};
 use crate::retry::RetryConfig;
-use crate::state::{AssetRecord, StateDb, VersionSizeKey};
+use crate::state::{StateDb, VersionSizeKey};
 use crate::types::{
     AssetVersionSize, ChangeReason, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
     RawPolicy,
@@ -275,6 +277,16 @@ impl SkipBreakdown {
         self.duplicates += other.duplicates;
         self.retry_exhausted += other.retry_exhausted;
         self.retry_only += other.retry_only;
+    }
+
+    pub(crate) fn record_filter_reason(&mut self, reason: filter::FilterReason) {
+        match reason {
+            filter::FilterReason::ExcludedAlbum => self.by_excluded_album += 1,
+            filter::FilterReason::MediaType => self.by_media_type += 1,
+            filter::FilterReason::LivePhoto => self.by_live_photo += 1,
+            filter::FilterReason::DateRange => self.by_date_range += 1,
+            filter::FilterReason::Filename => self.by_filename += 1,
+        }
     }
 }
 
@@ -1238,8 +1250,7 @@ async fn build_download_tasks(
         .await;
 
     let mut tasks: Vec<DownloadTask> = Vec::new();
-    let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
-    let mut dir_cache = paths::DirCache::new();
+    let mut task_planner = planner::TaskPlanner::new();
     for pass_result in pass_results {
         let (pass_index, assets) = pass_result?;
         #[allow(
@@ -1250,16 +1261,11 @@ async fn build_download_tasks(
         let pass_config = &pass_configs[pass_index];
 
         for asset in &assets {
-            if filter::is_asset_filtered(asset, pass_config).is_some() {
+            let plan = task_planner.plan_asset(asset, pass_config).await;
+            if plan.filter_reason.is_some() {
                 continue;
             }
-            pre_ensure_asset_dir(&mut dir_cache, asset, pass_config).await;
-            tasks.extend(filter_asset_to_tasks(
-                asset,
-                pass_config,
-                &mut claimed_paths,
-                &mut dir_cache,
-            ));
+            tasks.extend(plan.tasks);
         }
     }
 
@@ -2109,8 +2115,7 @@ async fn download_photos_incremental(
     // applied. Configs are cached per pass index to avoid redundant
     // allocations when many assets flow through the same pass.
     let mut tasks: Vec<DownloadTask> = Vec::new();
-    let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
-    let mut dir_cache = paths::DirCache::new();
+    let mut task_planner = planner::TaskPlanner::new();
     let mut skip_breakdown = SkipBreakdown::default();
     let pass_configs = build_pass_configs(passes, config);
 
@@ -2122,46 +2127,20 @@ async fn download_photos_incremental(
         )]
         let effective_config = &pass_configs[*pass_index];
 
-        if let Some(reason) = filter::is_asset_filtered(asset, effective_config) {
-            match reason {
-                filter::FilterReason::ExcludedAlbum => skip_breakdown.by_excluded_album += 1,
-                filter::FilterReason::MediaType => skip_breakdown.by_media_type += 1,
-                filter::FilterReason::LivePhoto => skip_breakdown.by_live_photo += 1,
-                filter::FilterReason::DateRange => skip_breakdown.by_date_range += 1,
-                filter::FilterReason::Filename => skip_breakdown.by_filename += 1,
-            }
+        let plan = task_planner.plan_asset(asset, effective_config).await;
+        if let Some(reason) = plan.filter_reason {
+            skip_breakdown.record_filter_reason(reason);
             continue;
         }
-
-        // Path-aware on-disk verification only; a DB-only fast-skip would
-        // miss user-deleted files on the incremental path.
-        pre_ensure_asset_dir(&mut dir_cache, asset, effective_config).await;
-        let asset_tasks =
-            filter_asset_to_tasks(asset, effective_config, &mut claimed_paths, &mut dir_cache);
 
         // Upsert state records so mark_downloaded/mark_failed can find them.
         // Without this, the UPDATE in mark_downloaded matches 0 rows and the
         // file ends up on disk but untracked in the state DB.
         if let Some(db) = &config.state_db {
-            for task in &asset_tasks {
-                let media_type = determine_media_type(task.version_size, asset);
-                let record = AssetRecord::new_pending(
-                    Arc::clone(&config.library),
-                    task.asset_id.to_string(),
-                    task.version_size,
-                    task.checksum.to_string(),
-                    task.download_path
-                        .file_name()
-                        .and_then(|f| f.to_str())
-                        .unwrap_or("")
-                        .to_string(),
-                    asset.created(),
-                    Some(asset.added_date()),
-                    task.size,
-                    media_type,
-                )
-                .with_metadata_arc(asset.metadata_arc());
-                if let Err(e) = db.upsert_seen(&record).await {
+            for task in &plan.tasks {
+                if let Err(e) =
+                    planner::upsert_seen_for_task(db.as_ref(), effective_config, asset, task).await
+                {
                     tracing::warn!(
                         asset_id = %task.asset_id,
                         error = %e,
@@ -2172,20 +2151,11 @@ async fn download_photos_incremental(
             // Record this asset's membership in the current album so
             // consumers (EXIF keywords, XMP sidecars, Immich albums) can
             // reconstruct the logical album graph from the state DB.
-            if let Some(album_name) = effective_config
-                .album_name
-                .as_deref()
-                .filter(|n| !n.is_empty())
+            if let Err(e) =
+                planner::record_album_membership_if_named(db.as_ref(), effective_config, asset)
+                    .await
             {
-                if let Err(e) = pipeline::add_asset_album_with_retry(
-                    db.as_ref(),
-                    &effective_config.library,
-                    asset.id(),
-                    album_name,
-                    "icloud",
-                )
-                .await
-                {
+                if let Some(album_name) = effective_config.album_name.as_deref() {
                     tracing::warn!(
                         asset_id = %asset.id(),
                         album = %album_name,
@@ -2197,10 +2167,10 @@ async fn download_photos_incremental(
             }
         }
 
-        if asset_tasks.is_empty() {
+        if plan.tasks.is_empty() {
             skip_breakdown.on_disk += 1;
         }
-        tasks.extend(asset_tasks);
+        tasks.extend(plan.tasks);
     }
 
     if skip_breakdown.by_state > 0 {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -12,24 +12,36 @@ use anyhow::{Context, Result};
 use futures_util::stream::{self, StreamExt};
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::PhotoAsset;
 use crate::retry::RetryConfig;
-use crate::state::{AssetRecord, StateDb, SyncRunStats, VersionSizeKey};
+use crate::state::{StateDb, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
 #[cfg_attr(not(feature = "xmp"), allow(unused_imports))]
 use super::filter::MetadataPayload;
-use super::filter::{
-    determine_media_type, extract_skip_candidates, filter_asset_to_tasks, is_asset_filtered,
-    pre_ensure_asset_dir, DownloadTask, FilterReason, NormalizedPath,
+use super::filter::{extract_skip_candidates, is_asset_filtered, DownloadTask};
+#[cfg(test)]
+use super::finalize::update_metadata_marker_for_test as update_metadata_marker;
+use super::finalize::{
+    check_state_write_circuit_breaker, finalize_downloaded, finalize_failed,
+    flush_pending_state_writes, flush_pending_state_writes_retaining_failures,
+    state_db_unwritable_error, state_write_circuit_breaker_tripped, DownloadedFinalization,
+    PendingStateWrite, StateWriteFlush,
 };
+#[cfg(test)]
+use super::finalize::{STATE_DB_UNWRITABLE_THRESHOLD, STATE_WRITE_MAX_RETRIES};
+#[cfg(test)]
+use super::planner::add_asset_album_with_retry;
+#[cfg(test)]
+use super::planner::ADD_ASSET_ALBUM_MAX_RETRIES;
+use super::planner::{self, ExistingPathMatch, TaskPlanner};
 use super::{
-    paths, DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome, DownloadReporting,
+    DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome, DownloadReporting,
 };
 
 /// Outcome of `batch_forecast_decision` — either keep queueing, emit a
@@ -141,6 +153,16 @@ impl ProducerSkipSummary {
             + self.retry_exhausted
             + self.retry_only
     }
+
+    fn record_filter_reason(&mut self, reason: super::filter::FilterReason) {
+        match reason {
+            super::filter::FilterReason::ExcludedAlbum => self.by_excluded_album += 1,
+            super::filter::FilterReason::MediaType => self.by_media_type += 1,
+            super::filter::FilterReason::LivePhoto => self.by_live_photo += 1,
+            super::filter::FilterReason::DateRange => self.by_date_range += 1,
+            super::filter::FilterReason::Filename => self.by_filename += 1,
+        }
+    }
 }
 
 impl std::ops::AddAssign for ProducerSkipSummary {
@@ -213,139 +235,6 @@ pub(super) struct StreamingResult {
 /// Counted cumulatively across both phases (streaming + cleanup).
 pub(super) const AUTH_ERROR_THRESHOLD: usize = 3;
 
-/// A successful download whose state write to SQLite failed on first attempt.
-/// Accumulated during the download loop and retried in a final flush.
-#[derive(Debug)]
-struct PendingStateWrite {
-    library: Arc<str>,
-    asset_id: Arc<str>,
-    version_size: crate::state::VersionSizeKey,
-    download_path: PathBuf,
-    local_checksum: String,
-    download_checksum: Option<String>,
-}
-
-/// Maximum retry attempts for deferred state writes.
-const STATE_WRITE_MAX_RETRIES: u32 = 6;
-const _: () = assert!(STATE_WRITE_MAX_RETRIES <= 32, "shift overflow in backoff");
-
-#[derive(Debug, Default, PartialEq, Eq)]
-struct StateWriteFlush {
-    attempted: usize,
-    failures: usize,
-}
-
-/// Bounded retry attempts for `add_asset_album`. SQLite-busy under WAL
-/// contention is the dominant transient failure; three attempts at
-/// 200ms / 400ms / 800ms cover the common case while staying short enough
-/// that a wedged DB doesn't stall the producer indefinitely. After the
-/// retries are exhausted the call falls through to a `warn!` (preserving
-/// existing behaviour) and album membership self-heals on the next
-/// enumeration.
-const ADD_ASSET_ALBUM_MAX_RETRIES: u32 = 3;
-
-/// Insert an asset/album row with a bounded inline retry loop. The
-/// underlying call is `INSERT OR IGNORE` so retries are idempotent. Returns
-/// the final result so the caller can log on persistent failure.
-///
-/// The retry shape mirrors `flush_pending_state_writes` (200ms × 2^attempt
-/// plus 0..base/4 jitter) rather than introducing a new primitive. The
-/// jitter spreads simultaneous retries from concurrent producers so they
-/// don't re-collide on the same SQLite lock.
-pub(super) async fn add_asset_album_with_retry(
-    db: &dyn StateDb,
-    library: &str,
-    asset_id: &str,
-    album_name: &str,
-    source: &str,
-) -> Result<(), crate::state::error::StateError> {
-    use rand::RngExt;
-    let mut last_err: Option<crate::state::error::StateError> = None;
-    for attempt in 1..=ADD_ASSET_ALBUM_MAX_RETRIES {
-        match db
-            .add_asset_album(library, asset_id, album_name, source)
-            .await
-        {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                if attempt < ADD_ASSET_ALBUM_MAX_RETRIES {
-                    tracing::debug!(
-                        asset_id,
-                        album = album_name,
-                        library,
-                        attempt,
-                        error = %e,
-                        "add_asset_album retry"
-                    );
-                    let base_ms = 200u64 * u64::from(1u32 << (attempt - 1));
-                    let jitter_ms = rand::rng().random_range(0..base_ms.max(1) / 4);
-                    tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
-                }
-                last_err = Some(e);
-            }
-        }
-    }
-    // ADD_ASSET_ALBUM_MAX_RETRIES is `>= 1` (compile-time-checked below) so
-    // `last_err` is always populated when the loop exits. The fallback to
-    // `LockPoisoned` is a defensive landing the type system can't otherwise
-    // statically rule out.
-    Err(last_err.unwrap_or_else(|| {
-        crate::state::error::StateError::LockPoisoned(
-            "add_asset_album_with_retry: no attempts ran".into(),
-        )
-    }))
-}
-
-const _: () = assert!(
-    ADD_ASSET_ALBUM_MAX_RETRIES >= 1,
-    "ADD_ASSET_ALBUM_MAX_RETRIES must be at least 1; otherwise the retry helper never calls the DB"
-);
-
-/// Minimum pending-queue size at which a 100% flush failure rate is treated
-/// as "state DB unwritable" rather than a transient lock race. Five is large
-/// enough that a short flurry of lock contention won't trigger a bail, but
-/// small enough that a genuinely-wedged DB is caught before many more cycles
-/// of wasted downloads.
-const STATE_DB_UNWRITABLE_THRESHOLD: usize = 5;
-
-/// Set or clear the metadata-rewrite marker for an asset-version pair
-/// based on whether the EXIF/XMP writer succeeded. Shared by both
-/// mark_downloaded call sites (streaming loop and cleanup pass).
-async fn update_metadata_marker(
-    db: &dyn StateDb,
-    library: &str,
-    asset_id: &str,
-    version_size: &str,
-    exif_ok: bool,
-) {
-    if exif_ok {
-        if let Err(e) = db
-            .clear_metadata_write_failure(library, asset_id, version_size)
-            .await
-        {
-            tracing::warn!(
-                library,
-                asset_id,
-                version_size,
-                error = %e,
-                "Could not clear metadata-write-failed marker; asset will be \
-                 re-rewritten on next sync"
-            );
-        }
-        return;
-    }
-    if let Err(e) = db
-        .record_metadata_write_failure(library, asset_id, version_size)
-        .await
-    {
-        tracing::warn!(
-            asset_id,
-            error = %e,
-            "Could not set metadata-write-failed marker"
-        );
-    }
-}
-
 /// Persist a metadata-rewrite marker for each candidate version whose
 /// metadata drifted from the stored hash (or that already carries a marker
 /// from a prior sync). No-op when metadata writing is off or the state DB
@@ -384,165 +273,6 @@ async fn tag_metadata_rewrites(
             );
         }
     }
-}
-
-async fn retry_pending_state_write(
-    db: &dyn StateDb,
-    write: &PendingStateWrite,
-    pending_count: usize,
-) -> bool {
-    use rand::RngExt;
-
-    for attempt in 1..=STATE_WRITE_MAX_RETRIES {
-        match db
-            .mark_downloaded(
-                &write.library,
-                &write.asset_id,
-                write.version_size.as_str(),
-                &write.download_path,
-                &write.local_checksum,
-                write.download_checksum.as_deref(),
-            )
-            .await
-        {
-            Ok(()) => {
-                if attempt > 1 {
-                    tracing::info!(
-                        asset_id = %write.asset_id,
-                        pending_count,
-                        attempt,
-                        "Recovered deferred state write"
-                    );
-                }
-                return true;
-            }
-            Err(e) => {
-                if attempt < STATE_WRITE_MAX_RETRIES {
-                    tracing::info!(
-                        asset_id = %write.asset_id,
-                        pending_count,
-                        attempt,
-                        error = %e,
-                        "State write retry failed, will retry"
-                    );
-                    let base_ms = 200 * u64::from(1u32 << (attempt - 1));
-                    let jitter_ms = rand::rng().random_range(0..base_ms.max(1) / 4);
-                    tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
-                } else {
-                    tracing::error!(
-                        asset_id = %write.asset_id,
-                        path = %write.download_path.display(),
-                        error = %e,
-                        "State write failed after {STATE_WRITE_MAX_RETRIES} attempts - \
-                         file on disk but untracked; next sync will detect it via \
-                         filesystem check and skip re-download"
-                    );
-                }
-            }
-        }
-    }
-    false
-}
-
-async fn flush_pending_state_writes_retaining_failures(
-    db: &dyn StateDb,
-    pending: &mut Vec<PendingStateWrite>,
-) -> StateWriteFlush {
-    if pending.is_empty() {
-        return StateWriteFlush::default();
-    }
-    let pending_count = pending.len();
-    tracing::info!(pending_count, "Retrying deferred state writes");
-
-    let mut failed = Vec::new();
-    for write in pending.drain(..) {
-        if !retry_pending_state_write(db, &write, pending_count).await {
-            failed.push(write);
-        }
-    }
-
-    let flush = StateWriteFlush {
-        attempted: pending_count,
-        failures: failed.len(),
-    };
-    *pending = failed;
-
-    if flush.failures > 0 {
-        tracing::warn!(
-            failures = flush.failures,
-            total = flush.attempted,
-            "Some state writes could not be saved"
-        );
-    } else {
-        tracing::debug!(
-            count = flush.attempted,
-            "All deferred state writes recovered"
-        );
-    }
-    flush
-}
-
-/// Retry all pending state writes that failed during the download loop.
-///
-/// Each write is attempted up to [`STATE_WRITE_MAX_RETRIES`] times with
-/// exponential backoff in the millisecond range (200ms × 2^attempt plus
-/// small jitter to avoid thundering-herd when multiple writes contend
-/// on the same `SQLite` WAL). `RetryConfig::delay_for_retry` is built
-/// for seconds-scale HTTP retries; the state-write grain is finer so
-/// this loop keeps its own scaling.
-///
-/// Returns the number of writes that still failed after all retries.
-async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWrite]) -> usize {
-    if pending.is_empty() {
-        return 0;
-    }
-    let pending_count = pending.len();
-    tracing::info!(pending_count, "Retrying deferred state writes");
-
-    let mut failures = 0;
-    for write in pending {
-        if !retry_pending_state_write(db, write, pending_count).await {
-            failures += 1;
-        }
-    }
-
-    if failures > 0 {
-        tracing::warn!(
-            failures,
-            total = pending.len(),
-            "Some state writes could not be saved"
-        );
-    } else {
-        tracing::debug!(count = pending.len(), "All deferred state writes recovered");
-    }
-    failures
-}
-
-fn state_write_circuit_breaker_tripped(flush: &StateWriteFlush) -> bool {
-    flush.attempted >= STATE_DB_UNWRITABLE_THRESHOLD && flush.failures == flush.attempted
-}
-
-fn state_db_unwritable_error(pending_total: usize) -> anyhow::Error {
-    anyhow::anyhow!(
-        "State DB appears unwritable: all {pending_total} deferred state writes failed after \
-         {STATE_WRITE_MAX_RETRIES} retries each. Check disk space and permissions on the state \
-         DB file; halting sync to avoid re-downloading into an untracked tree."
-    )
-}
-
-async fn check_state_write_circuit_breaker(
-    db: &dyn StateDb,
-    pending: &mut Vec<PendingStateWrite>,
-) -> Option<anyhow::Error> {
-    if pending.len() < STATE_DB_UNWRITABLE_THRESHOLD {
-        return None;
-    }
-
-    let flush = flush_pending_state_writes_retaining_failures(db, pending).await;
-    if state_write_circuit_breaker_tripped(&flush) {
-        return Some(state_db_unwritable_error(flush.attempted));
-    }
-    None
 }
 
 /// Maximum assets processed per metadata-rewrite invocation. Bounds worst-case
@@ -1133,8 +863,7 @@ where
 
         tokio::pin!(combined);
         let mut enum_errors = 0usize;
-        let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
-        let mut dir_cache = paths::DirCache::new();
+        let mut task_planner = TaskPlanner::new();
         let mut shutdown_break = false;
         while let Some(result) = combined.next().await {
             if shutdown_token.is_cancelled() {
@@ -1172,14 +901,12 @@ where
                         }
                     }
 
-                    pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
-                    let tasks =
-                        filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
+                    let plan = task_planner.plan_asset(&asset, config).await;
                     #[allow(
                         clippy::print_stdout,
                         reason = "--only-print-filenames writes target paths to stdout so callers can pipe to xargs/etc"
                     )]
-                    for task in &tasks {
+                    for task in &plan.tasks {
                         println!("{}", task.download_path.display());
                     }
                 }
@@ -1202,8 +929,7 @@ where
         tokio::pin!(combined);
         let mut count = 0usize;
         let mut enum_errors = 0usize;
-        let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
-        let mut dir_cache = paths::DirCache::new();
+        let mut task_planner = TaskPlanner::new();
         let mut shutdown_break = false;
         while let Some(result) = combined.next().await {
             if shutdown_token.is_cancelled() {
@@ -1213,16 +939,14 @@ where
             }
             match result {
                 Ok(asset) => {
-                    if is_asset_filtered(&asset, config).is_some() {
+                    let plan = task_planner.plan_asset(&asset, config).await;
+                    if plan.filter_reason.is_some() {
                         continue;
                     }
-                    pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
-                    let tasks =
-                        filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
-                    for task in &tasks {
+                    for task in &plan.tasks {
                         tracing::info!(path = %task.download_path.display(), "[DRY RUN] Would download");
                     }
-                    count += tasks.len();
+                    count += plan.tasks.len();
                 }
                 Err(e) => {
                     enum_errors += 1;
@@ -1382,8 +1106,7 @@ where
     let producer_pb = pb.clone();
     let producer = tokio::spawn(async move {
         let config = &producer_config;
-        let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
-        let mut dir_cache = paths::DirCache::new();
+        let mut task_planner = TaskPlanner::new();
         let mut seen_ids: FxHashSet<Arc<str>> = FxHashSet::default();
         // Skipped-asset IDs accumulated across the producer run and
         // flushed to the DB in a single transaction at the end. This
@@ -1495,26 +1218,14 @@ where
 
                     assets_seen_producer.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-                    if let Some(reason) = is_asset_filtered(&asset, config) {
-                        match reason {
-                            FilterReason::ExcludedAlbum => skips.by_excluded_album += 1,
-                            FilterReason::MediaType => skips.by_media_type += 1,
-                            FilterReason::LivePhoto => skips.by_live_photo += 1,
-                            FilterReason::DateRange => skips.by_date_range += 1,
-                            FilterReason::Filename => skips.by_filename += 1,
-                        }
+                    let plan = task_planner.plan_asset(&asset, config).await;
+                    if let Some(reason) = plan.filter_reason {
+                        skips.record_filter_reason(reason);
                         producer_pb.inc(1);
                         continue;
                     }
 
-                    // Path-aware on-disk verification only; a DB-only fast-skip
-                    // missed user deletions when the startup sample-check
-                    // rolled wrong.
-                    pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
-
-                    let tasks =
-                        filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
-                    if tasks.is_empty() {
+                    if plan.tasks.is_empty() {
                         // No-op for status='downloaded' rows (the common
                         // case). A row left status='pending' by a prior
                         // interrupted sync will be promoted to failed at
@@ -1536,7 +1247,7 @@ where
                     } else {
                         let mut disposition = AssetDisposition::Unresolved;
 
-                        for task in tasks {
+                        for task in plan.tasks {
                             // Mark assets that have exceeded the retry limit as failed.
                             if let Some(&attempts) =
                                 download_ctx.attempt_counts.get(task.asset_id.as_ref())
@@ -1555,14 +1266,13 @@ where
                                             "Exceeded max download attempts ({attempts}/{})",
                                             config.max_download_attempts
                                         );
-                                        if let Err(e) = db
-                                            .mark_failed(
-                                                &config.library,
-                                                &task.asset_id,
-                                                task.version_size.as_str(),
-                                                &error,
-                                            )
-                                            .await
+                                        if let Err(e) = finalize_failed(
+                                            db.as_ref(),
+                                            &config.library,
+                                            &task,
+                                            &error,
+                                        )
+                                        .await
                                         {
                                             tracing::warn!(
                                                 asset_id = %task.asset_id,
@@ -1588,24 +1298,14 @@ where
                             }
 
                             if let Some(db) = &producer_state_db {
-                                let media_type = determine_media_type(task.version_size, &asset);
-                                let record = AssetRecord::new_pending(
-                                    Arc::clone(&config.library),
-                                    task.asset_id.to_string(),
-                                    task.version_size,
-                                    task.checksum.to_string(),
-                                    task.download_path
-                                        .file_name()
-                                        .and_then(|f| f.to_str())
-                                        .unwrap_or("")
-                                        .to_string(),
-                                    asset.created(),
-                                    Some(asset.added_date()),
-                                    task.size,
-                                    media_type,
+                                if let Err(e) = planner::upsert_seen_for_task(
+                                    db.as_ref(),
+                                    config,
+                                    &asset,
+                                    &task,
                                 )
-                                .with_metadata_arc(asset.metadata_arc());
-                                if let Err(e) = db.upsert_seen(&record).await {
+                                .await
+                                {
                                     tracing::warn!(
                                         asset_id = %task.asset_id,
                                         error = %e,
@@ -1616,24 +1316,20 @@ where
                                 // carries the album name so we can record membership.
                                 // In merged-stream mode album is unknown at this point;
                                 // the next incremental sync fills it in.
-                                if let Some(album) = config.album_name.as_deref() {
-                                    if !album.is_empty() {
-                                        if let Err(e) = add_asset_album_with_retry(
-                                            db.as_ref(),
-                                            &config.library,
-                                            asset.id(),
-                                            album,
-                                            "icloud",
-                                        )
-                                        .await
-                                        {
-                                            tracing::warn!(
-                                                asset_id = %asset.id(),
-                                                album = %album,
-                                                error = %e,
-                                                "Failed to record album membership after retries"
-                                            );
-                                        }
+                                if let Err(e) = planner::record_album_membership_if_named(
+                                    db.as_ref(),
+                                    config,
+                                    &asset,
+                                )
+                                .await
+                                {
+                                    if let Some(album) = config.album_name.as_deref() {
+                                        tracing::warn!(
+                                            asset_id = %asset.id(),
+                                            album = %album,
+                                            error = %e,
+                                            "Failed to record album membership after retries"
+                                        );
                                     }
                                 }
 
@@ -1661,20 +1357,18 @@ where
                                             "Skipping (state confirms no download needed)"
                                         );
                                     }
-                                    None => {
-                                        // Directory was pre-populated above, so these
-                                        // are cache-hits -- no blocking I/O.
-                                        if dir_cache.exists(&task.download_path) {
+                                    None => match task_planner
+                                        .existing_path_match(&task.download_path)
+                                    {
+                                        ExistingPathMatch::Exact => {
                                             disposition = disposition.max(AssetDisposition::OnDisk);
                                             tracing::debug!(
                                                 asset_id = %task.asset_id,
                                                 path = %task.download_path.display(),
                                                 "Skipping (already downloaded)"
                                             );
-                                        } else if dir_cache
-                                            .find_ampm_variant(&task.download_path)
-                                            .is_some()
-                                        {
+                                        }
+                                        ExistingPathMatch::AmpmVariant => {
                                             disposition =
                                                 disposition.max(AssetDisposition::AmpmVariant);
                                             tracing::debug!(
@@ -1682,7 +1376,8 @@ where
                                                 path = %task.download_path.display(),
                                                 "Skipping (AM/PM variant exists on disk)"
                                             );
-                                        } else {
+                                        }
+                                        ExistingPathMatch::Missing => {
                                             tracing::debug!(
                                                 asset_id = %task.asset_id,
                                                 path = %task.download_path.display(),
@@ -1698,7 +1393,7 @@ where
                                                 return skips;
                                             }
                                         }
-                                    }
+                                    },
                                 }
                             } else {
                                 disposition = disposition.max(AssetDisposition::Forwarded);
@@ -1914,61 +1609,44 @@ where
                     });
                 }
                 if let Some(db) = &state_db {
-                    if let Err(e) = db
-                        .mark_downloaded(
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            &task.download_path,
-                            &local_checksum,
-                            download_checksum.as_deref(),
-                        )
-                        .await
+                    match finalize_downloaded(
+                        db.as_ref(),
+                        &library,
+                        &task,
+                        local_checksum,
+                        download_checksum,
+                        exif_ok,
+                    )
+                    .await
                     {
-                        pb.suspend(|| {
-                            tracing::warn!(
-                                asset_id = %task.asset_id,
-                                error = %e,
-                                "State write failed, deferring for retry"
-                            );
-                        });
-                        pending_state_writes.push(PendingStateWrite {
-                            library: Arc::clone(&library),
-                            asset_id: task.asset_id.clone(),
-                            version_size: task.version_size,
-                            download_path: task.download_path.clone(),
-                            local_checksum,
-                            download_checksum,
-                        });
-                        if state_write_circuit_error.is_none() {
-                            if let Some(err) = check_state_write_circuit_breaker(
-                                db.as_ref(),
-                                &mut pending_state_writes,
-                            )
-                            .await
-                            {
-                                pb.suspend(|| {
-                                    tracing::error!(
-                                        error = %err,
-                                        "State write circuit breaker opened; halting downloads"
-                                    );
-                                });
-                                state_write_circuit_error = Some(err);
-                                pipeline_shutdown.cancel();
+                        DownloadedFinalization::Persisted => {}
+                        DownloadedFinalization::Deferred { write, error } => {
+                            pb.suspend(|| {
+                                tracing::warn!(
+                                    asset_id = %task.asset_id,
+                                    error = %error,
+                                    "State write failed, deferring for retry"
+                                );
+                            });
+                            pending_state_writes.push(write);
+                            if state_write_circuit_error.is_none() {
+                                if let Some(err) = check_state_write_circuit_breaker(
+                                    db.as_ref(),
+                                    &mut pending_state_writes,
+                                )
+                                .await
+                                {
+                                    pb.suspend(|| {
+                                        tracing::error!(
+                                            error = %err,
+                                            "State write circuit breaker opened; halting downloads"
+                                        );
+                                    });
+                                    state_write_circuit_error = Some(err);
+                                    pipeline_shutdown.cancel();
+                                }
                             }
                         }
-                    } else {
-                        // Bytes landed and the state row reflects it. Keep
-                        // or drop the rewrite marker based on whether the
-                        // EXIF/XMP writer succeeded.
-                        update_metadata_marker(
-                            db.as_ref(),
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            exif_ok,
-                        )
-                        .await;
                     }
                 }
             }
@@ -2007,14 +1685,8 @@ where
                     });
                 }
                 if let Some(db) = &state_db {
-                    if let Err(e) = db
-                        .mark_failed(
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            &e.to_string(),
-                        )
-                        .await
+                    if let Err(e) =
+                        finalize_failed(db.as_ref(), &library, &task, &e.to_string()).await
                     {
                         tracing::warn!(
                             asset_id = %task.asset_id,
@@ -2517,58 +2189,44 @@ pub(super) async fn run_download_pass(
                     });
                 }
                 if let Some(db) = &state_db {
-                    if let Err(e) = db
-                        .mark_downloaded(
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            &task.download_path,
-                            local_checksum,
-                            download_checksum.as_deref(),
-                        )
-                        .await
+                    match finalize_downloaded(
+                        db.as_ref(),
+                        &library,
+                        &task,
+                        local_checksum.clone(),
+                        download_checksum.clone(),
+                        *exif_ok,
+                    )
+                    .await
                     {
-                        pb.suspend(|| {
-                            tracing::warn!(
-                                asset_id = %task.asset_id,
-                                error = %e,
-                                "State write failed, deferring for retry"
-                            );
-                        });
-                        pending_state_writes.push(PendingStateWrite {
-                            library: Arc::clone(&library),
-                            asset_id: task.asset_id.clone(),
-                            version_size: task.version_size,
-                            download_path: task.download_path.clone(),
-                            local_checksum: local_checksum.clone(),
-                            download_checksum: download_checksum.clone(),
-                        });
-                        if !state_write_circuit_open {
-                            if let Some(err) = check_state_write_circuit_breaker(
-                                db.as_ref(),
-                                &mut pending_state_writes,
-                            )
-                            .await
-                            {
-                                pb.suspend(|| {
-                                    tracing::error!(
-                                        error = %err,
-                                        "State write circuit breaker opened; halting cleanup downloads"
-                                    );
-                                });
-                                state_write_circuit_open = true;
-                                pass_shutdown.cancel();
+                        DownloadedFinalization::Persisted => {}
+                        DownloadedFinalization::Deferred { write, error } => {
+                            pb.suspend(|| {
+                                tracing::warn!(
+                                    asset_id = %task.asset_id,
+                                    error = %error,
+                                    "State write failed, deferring for retry"
+                                );
+                            });
+                            pending_state_writes.push(write);
+                            if !state_write_circuit_open {
+                                if let Some(err) = check_state_write_circuit_breaker(
+                                    db.as_ref(),
+                                    &mut pending_state_writes,
+                                )
+                                .await
+                                {
+                                    pb.suspend(|| {
+                                        tracing::error!(
+                                            error = %err,
+                                            "State write circuit breaker opened; halting cleanup downloads"
+                                        );
+                                    });
+                                    state_write_circuit_open = true;
+                                    pass_shutdown.cancel();
+                                }
                             }
                         }
-                    } else {
-                        update_metadata_marker(
-                            db.as_ref(),
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            *exif_ok,
-                        )
-                        .await;
                     }
                 }
             }
@@ -2592,14 +2250,8 @@ pub(super) async fn run_download_pass(
                     });
                 }
                 if let Some(db) = &state_db {
-                    if let Err(e) = db
-                        .mark_failed(
-                            &library,
-                            &task.asset_id,
-                            task.version_size.as_str(),
-                            &e.to_string(),
-                        )
-                        .await
+                    if let Err(e) =
+                        finalize_failed(db.as_ref(), &library, &task, &e.to_string()).await
                     {
                         tracing::warn!(
                             asset_id = %task.asset_id,

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -1,0 +1,316 @@
+//! Asset-to-task planning shared by full, incremental, dry-run, and cleanup
+//! paths.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+
+use crate::icloud::photos::PhotoAsset;
+use crate::state::{AssetRecord, StateDb};
+
+use super::filter::{
+    determine_media_type, filter_asset_to_tasks, is_asset_filtered, pre_ensure_asset_dir,
+    DownloadTask, FilterReason, NormalizedPath,
+};
+use super::paths;
+use super::DownloadConfig;
+
+/// Mutable path-planning state carried across assets in one pass.
+#[derive(Debug)]
+pub(super) struct TaskPlanner {
+    claimed_paths: FxHashMap<NormalizedPath, u64>,
+    dir_cache: paths::DirCache,
+}
+
+impl TaskPlanner {
+    pub(super) fn new() -> Self {
+        Self {
+            claimed_paths: FxHashMap::default(),
+            dir_cache: paths::DirCache::new(),
+        }
+    }
+
+    /// Convert one asset into download tasks after applying the shared
+    /// asset-level filters and path-aware on-disk checks.
+    pub(super) async fn plan_asset(
+        &mut self,
+        asset: &PhotoAsset,
+        config: &DownloadConfig,
+    ) -> AssetTaskPlan {
+        if let Some(filter_reason) = is_asset_filtered(asset, config) {
+            return AssetTaskPlan {
+                tasks: SmallVec::new(),
+                filter_reason: Some(filter_reason),
+            };
+        }
+
+        pre_ensure_asset_dir(&mut self.dir_cache, asset, config).await;
+        let tasks =
+            filter_asset_to_tasks(asset, config, &mut self.claimed_paths, &mut self.dir_cache);
+        AssetTaskPlan {
+            tasks,
+            filter_reason: None,
+        }
+    }
+
+    pub(super) fn existing_path_match(&mut self, path: &Path) -> ExistingPathMatch {
+        if self.dir_cache.exists(path) {
+            ExistingPathMatch::Exact
+        } else if self.dir_cache.find_ampm_variant(path).is_some() {
+            ExistingPathMatch::AmpmVariant
+        } else {
+            ExistingPathMatch::Missing
+        }
+    }
+}
+
+/// Result of planning a single asset.
+#[derive(Debug)]
+pub(super) struct AssetTaskPlan {
+    pub(super) tasks: SmallVec<[DownloadTask; 5]>,
+    pub(super) filter_reason: Option<FilterReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExistingPathMatch {
+    Exact,
+    AmpmVariant,
+    Missing,
+}
+
+/// Persist the pending state row that a later `mark_downloaded` /
+/// `mark_failed` call will finalize.
+pub(super) async fn upsert_seen_for_task(
+    db: &dyn StateDb,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    task: &DownloadTask,
+) -> Result<(), crate::state::error::StateError> {
+    let media_type = determine_media_type(task.version_size, asset);
+    let record = AssetRecord::new_pending(
+        Arc::clone(&config.library),
+        task.asset_id.to_string(),
+        task.version_size,
+        task.checksum.to_string(),
+        task.download_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("")
+            .to_string(),
+        asset.created(),
+        Some(asset.added_date()),
+        task.size,
+        media_type,
+    )
+    .with_metadata_arc(asset.metadata_arc());
+    db.upsert_seen(&record).await
+}
+
+/// Record an asset's membership in the current concrete album/smart-folder
+/// pass. Returns `Ok(false)` when the pass is not album-scoped.
+pub(super) async fn record_album_membership_if_named(
+    db: &dyn StateDb,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+) -> Result<(), crate::state::error::StateError> {
+    let Some(album_name) = config.album_name.as_deref().filter(|name| !name.is_empty()) else {
+        return Ok(());
+    };
+    add_asset_album_with_retry(db, &config.library, asset.id(), album_name, "icloud").await
+}
+
+/// Bounded retry attempts for `add_asset_album`. SQLite-busy under WAL
+/// contention is the dominant transient failure; three attempts at
+/// 200ms / 400ms / 800ms cover the common case while staying short enough
+/// that a wedged DB doesn't stall the producer indefinitely. After retries
+/// are exhausted the caller logs the persistent failure.
+pub(super) const ADD_ASSET_ALBUM_MAX_RETRIES: u32 = 3;
+
+/// Insert an asset/album row with a bounded inline retry loop. The
+/// underlying call is `INSERT OR IGNORE` so retries are idempotent. Returns
+/// the final result so the caller can log on persistent failure.
+pub(super) async fn add_asset_album_with_retry(
+    db: &dyn StateDb,
+    library: &str,
+    asset_id: &str,
+    album_name: &str,
+    source: &str,
+) -> Result<(), crate::state::error::StateError> {
+    use rand::RngExt;
+    let mut last_err: Option<crate::state::error::StateError> = None;
+    for attempt in 1..=ADD_ASSET_ALBUM_MAX_RETRIES {
+        match db
+            .add_asset_album(library, asset_id, album_name, source)
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if attempt < ADD_ASSET_ALBUM_MAX_RETRIES {
+                    tracing::debug!(
+                        asset_id,
+                        album = album_name,
+                        library,
+                        attempt,
+                        error = %e,
+                        "add_asset_album retry"
+                    );
+                    let base_ms = 200u64 * u64::from(1u32 << (attempt - 1));
+                    let jitter_ms = rand::rng().random_range(0..base_ms.max(1) / 4);
+                    tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
+                }
+                last_err = Some(e);
+            }
+        }
+    }
+    // ADD_ASSET_ALBUM_MAX_RETRIES is `>= 1` (compile-time-checked below) so
+    // `last_err` is always populated when the loop exits. The fallback to
+    // `LockPoisoned` is a defensive landing the type system cannot otherwise
+    // statically rule out.
+    Err(last_err.unwrap_or_else(|| {
+        crate::state::error::StateError::LockPoisoned(
+            "add_asset_album_with_retry: no attempts ran".into(),
+        )
+    }))
+}
+
+const _: () = assert!(
+    ADD_ASSET_ALBUM_MAX_RETRIES >= 1,
+    "ADD_ASSET_ALBUM_MAX_RETRIES must be at least 1; otherwise the retry helper never calls the DB"
+);
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rustc_hash::FxHashSet;
+    use tempfile::TempDir;
+
+    use crate::commands::{AlbumPass, PassKind};
+    use crate::icloud::photos::PhotoAlbum;
+    use crate::state::{SqliteStateDb, StateDb};
+    use crate::test_helpers::TestPhotoAsset;
+
+    use super::*;
+
+    fn test_config(root: &std::path::Path) -> DownloadConfig {
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(root);
+        config.folder_structure = "%Y/%m/%d".to_string();
+        config.folder_structure_albums = Arc::from("{album}/%Y/%m/%d");
+        config
+    }
+
+    fn make_pass(kind: PassKind, name: &str) -> AlbumPass {
+        AlbumPass {
+            kind,
+            album: PhotoAlbum::stub_for_test(Arc::from(name)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn planner_uses_per_pass_album_path() {
+        let tmp = TempDir::new().unwrap();
+        let base = test_config(tmp.path());
+        let pass_config = base.with_pass(&make_pass(PassKind::Album, "Vacation"));
+        let asset = TestPhotoAsset::new("ALBUM_PATH")
+            .filename("IMG_0001.JPG")
+            .build();
+
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &pass_config).await;
+
+        assert_eq!(plan.filter_reason, None);
+        assert_eq!(plan.tasks.len(), 1);
+        assert!(
+            plan.tasks[0]
+                .download_path
+                .strip_prefix(tmp.path())
+                .unwrap()
+                .starts_with("Vacation"),
+            "album pass must route through the expanded album folder"
+        );
+    }
+
+    #[tokio::test]
+    async fn planner_applies_filename_date_media_and_unfiled_exclusions() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.filename_exclude = Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
+        let asset = TestPhotoAsset::new("FILTERED_NAME")
+            .filename("IMG_0001.AAE")
+            .build();
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &config).await;
+        assert_eq!(plan.filter_reason, Some(FilterReason::Filename));
+
+        let mut config = test_config(tmp.path());
+        config.media.photos = false;
+        let asset = TestPhotoAsset::new("FILTERED_MEDIA").build();
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &config).await;
+        assert_eq!(plan.filter_reason, Some(FilterReason::MediaType));
+
+        let mut config = test_config(tmp.path());
+        config.exclude_asset_ids = Arc::new(FxHashSet::from_iter(["EXCLUDED".to_string()]));
+        let asset = TestPhotoAsset::new("EXCLUDED").build();
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &config).await;
+        assert_eq!(plan.filter_reason, Some(FilterReason::ExcludedAlbum));
+    }
+
+    #[tokio::test]
+    async fn planner_skips_existing_same_size_file_on_disk() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let asset = TestPhotoAsset::new("ON_DISK")
+            .filename("IMG_0002.JPG")
+            .orig_size(1000)
+            .build();
+
+        let mut first = TaskPlanner::new();
+        let plan = first.plan_asset(&asset, &config).await;
+        assert_eq!(plan.tasks.len(), 1);
+        let path = plan.tasks[0].download_path.clone();
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&path, vec![0u8; 1000]).await.unwrap();
+
+        let mut second = TaskPlanner::new();
+        let plan = second.plan_asset(&asset, &config).await;
+        assert_eq!(plan.filter_reason, None);
+        assert!(plan.tasks.is_empty(), "existing same-size file should skip");
+    }
+
+    #[tokio::test]
+    async fn planner_upserts_seen_and_records_album_membership() {
+        let tmp = TempDir::new().unwrap();
+        let base = test_config(tmp.path());
+        let pass_config = base.with_pass(&make_pass(PassKind::Album, "Family"));
+        let asset = TestPhotoAsset::new("STATEFUL")
+            .filename("IMG_0003.JPG")
+            .build();
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &pass_config).await;
+        assert_eq!(plan.tasks.len(), 1);
+        upsert_seen_for_task(&db, &pass_config, &asset, &plan.tasks[0])
+            .await
+            .unwrap();
+        record_album_membership_if_named(&db, &pass_config, &asset)
+            .await
+            .unwrap();
+
+        let pending = db.get_pending().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id.as_ref(), "STATEFUL");
+        let albums = db.get_all_asset_albums(&pass_config.library).await.unwrap();
+        assert_eq!(albums, vec![("STATEFUL".to_string(), "Family".to_string())]);
+    }
+}

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -111,7 +111,8 @@ pub(super) async fn upsert_seen_for_task(
 }
 
 /// Record an asset's membership in the current concrete album/smart-folder
-/// pass. Returns `Ok(false)` when the pass is not album-scoped.
+/// pass. Returns `Ok(())` without touching the DB when the pass is not
+/// album-scoped.
 pub(super) async fn record_album_membership_if_named(
     db: &dyn StateDb,
     config: &DownloadConfig,


### PR DESCRIPTION
## Summary
- Extracted shared asset-to-task planning into `download::planner`, then reused it from full sync, incremental sync, dry-run, print-only, and cleanup paths.
- Moved download state finalization into `download::finalize`, including downloaded/failed state writes, deferred state write retries, and metadata retry marker updates.
- Added planner and finalizer tests around per-pass paths, filtering, on-disk skips, state upserts, album membership, deferred writes, and metadata markers.

## Review notes
- `download/file.rs` is untouched. `.part` promotion, checksum verification, and byte-level file safety stay in the existing single-file download code.
- The main behavior risk is state finalization parity. The new finalizer coverage pins success, failure, deferred state writes, and metadata marker behavior.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test download::planner -- --test-threads=1`
- `cargo test download::finalize -- --test-threads=1`
- `cargo test download:: -- --test-threads=1`
- `cargo test -- --test-threads=1`
