### PR TITLE
Split state DB into role traits

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -18,7 +18,7 @@ use crate::download::paths::{normalize_ampm, DirCache};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
-use crate::state::StateDb;
+use crate::state::ImportStateStore;
 use crate::types::FileMatchPolicy;
 
 use super::service::{init_photos_service, resolve_libraries, resolve_passes};
@@ -402,10 +402,10 @@ async fn resolve_match_path(
 /// `photo_stream` -- after the stream is drained, we check it and bail
 /// loudly if any fetcher task panicked, since a panicked fetcher closes
 /// the stream early and would otherwise read as a clean enumeration.
-pub(crate) async fn import_assets<S>(
+pub(crate) async fn import_assets<S, D>(
     stream: S,
     panic_rx: tokio::sync::oneshot::Receiver<bool>,
-    db: &dyn StateDb,
+    db: &D,
     download_config: &download::DownloadConfig,
     library_label: &str,
     dir_cache: &mut DirCache,
@@ -413,6 +413,7 @@ pub(crate) async fn import_assets<S>(
 ) -> anyhow::Result<ImportStats>
 where
     S: futures_util::Stream<Item = anyhow::Result<PhotoAsset>>,
+    D: ImportStateStore + ?Sized,
 {
     use futures_util::StreamExt;
     use std::sync::atomic::Ordering;

--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use crate::cli;
 use crate::config;
 use crate::state;
-use crate::state::{StateDb, VersionSizeKey};
+use crate::state::{ReportStateStore, VersionSizeKey};
 
 use super::{print_truncation_tail, LISTING_CAP};
 
@@ -54,11 +54,14 @@ pub(crate) struct ScanCounts {
 
 /// Reads every page before any mutation so later `mark_failed` calls can't
 /// shift OFFSET pagination and skip rows.
-pub(crate) async fn scan_missing(
-    db: &dyn StateDb,
+pub(crate) async fn scan_missing<D>(
+    db: &D,
     mut report_missing: impl FnMut(&MissingAsset),
     mut report_no_path: impl FnMut(&str),
-) -> anyhow::Result<(ScanCounts, Vec<MissingAsset>)> {
+) -> anyhow::Result<(ScanCounts, Vec<MissingAsset>)>
+where
+    D: ReportStateStore + ?Sized,
+{
     let mut counts = ScanCounts::default();
     let mut missing = Vec::new();
 

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -5,7 +5,6 @@
 
 use crate::config;
 use crate::state;
-use crate::state::StateDb;
 
 /// Run the reset-state command.
 pub(crate) async fn run_reset_state(

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,7 +7,7 @@ use crate::cli;
 use crate::config;
 use crate::service::status::{render_oneline, service_state};
 use crate::state;
-use crate::state::{AssetRecord, StateDb};
+use crate::state::AssetRecord;
 
 use super::{print_truncation_tail, LISTING_CAP};
 

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -9,7 +9,6 @@ use crate::cli;
 use crate::config;
 use crate::download;
 use crate::state;
-use crate::state::StateDb;
 
 use super::{print_truncation_tail, LISTING_CAP};
 

--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -14,22 +14,25 @@ use crate::metrics::MetricsHandle;
 use crate::notifications::{self, Notifier};
 use crate::personality::Mode;
 use crate::report::{self, RunOptions};
-use crate::state::{self, StateDb};
+use crate::state::{self, ReportStateStore};
 
 /// Stable dependencies and resolved options used by the post-cycle reporter.
-pub(crate) struct CycleReporter<'a> {
+pub(crate) struct CycleReporter<'a, D: ReportStateStore + ?Sized> {
     username: &'a str,
     watch_mode: bool,
     report_path: Option<&'a Path>,
     run_options: RunOptions,
     health_dir: &'a Path,
     personality_mode: Mode,
-    state_db: Option<&'a dyn StateDb>,
+    state_db: Option<&'a D>,
     metrics_handle: Option<&'a MetricsHandle>,
     notifier: &'a Notifier,
 }
 
-impl std::fmt::Debug for CycleReporter<'_> {
+impl<D> std::fmt::Debug for CycleReporter<'_, D>
+where
+    D: ReportStateStore + ?Sized,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CycleReporter")
             .field("username", &self.username)
@@ -46,19 +49,22 @@ impl std::fmt::Debug for CycleReporter<'_> {
 }
 
 /// Constructor input for [`CycleReporter`].
-pub(crate) struct CycleReporterConfig<'a> {
+pub(crate) struct CycleReporterConfig<'a, D: ReportStateStore + ?Sized> {
     pub(crate) username: &'a str,
     pub(crate) watch_mode: bool,
     pub(crate) report_path: Option<&'a Path>,
     pub(crate) run_options: RunOptions,
     pub(crate) health_dir: &'a Path,
     pub(crate) personality_mode: Mode,
-    pub(crate) state_db: Option<&'a dyn StateDb>,
+    pub(crate) state_db: Option<&'a D>,
     pub(crate) metrics_handle: Option<&'a MetricsHandle>,
     pub(crate) notifier: &'a Notifier,
 }
 
-impl std::fmt::Debug for CycleReporterConfig<'_> {
+impl<D> std::fmt::Debug for CycleReporterConfig<'_, D>
+where
+    D: ReportStateStore + ?Sized,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CycleReporterConfig")
             .field("username", &self.username)
@@ -83,8 +89,11 @@ pub(crate) struct CycleReportInput<'a> {
     pub(crate) elapsed: Duration,
 }
 
-impl<'a> CycleReporter<'a> {
-    pub(crate) fn new(config: CycleReporterConfig<'a>) -> Self {
+impl<'a, D> CycleReporter<'a, D>
+where
+    D: ReportStateStore + ?Sized,
+{
+    pub(crate) fn new(config: CycleReporterConfig<'a, D>) -> Self {
         Self {
             username: config.username,
             watch_mode: config.watch_mode,
@@ -357,7 +366,7 @@ mod tests {
         dir: &'a Path,
         report_path: Option<&'a Path>,
         notifier: &'a Notifier,
-    ) -> CycleReporter<'a> {
+    ) -> CycleReporter<'a, state::SqliteStateDb> {
         CycleReporter::new(CycleReporterConfig {
             username: "reporter@example.com",
             watch_mode: false,
@@ -377,7 +386,7 @@ mod tests {
     }
 
     async fn report_cycle(
-        reporter: &CycleReporter<'_>,
+        reporter: &CycleReporter<'_, state::SqliteStateDb>,
         health: &mut HealthStatus,
         stats: &SyncStats,
         failed_count: usize,

--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -4,9 +4,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::state::{StateDb, VersionSizeKey};
+use crate::state::{DownloadStateStore, MetadataRewriteStore, VersionSizeKey};
 
 use super::filter::DownloadTask;
+
+pub(super) trait DownloadFinalizationStore:
+    DownloadStateStore + MetadataRewriteStore
+{
+}
+
+impl<T> DownloadFinalizationStore for T where T: DownloadStateStore + MetadataRewriteStore + ?Sized {}
 
 /// A successful download whose state write to SQLite failed on first attempt.
 /// Accumulated during download loops and retried in a final flush.
@@ -46,14 +53,17 @@ pub(super) enum DownloadedFinalization {
 /// Persist success state for a task that has already landed safely on disk.
 /// On success, metadata retry markers are updated immediately. On failure,
 /// the caller receives a deferred write record for bounded retry.
-pub(super) async fn finalize_downloaded(
-    db: &dyn StateDb,
+pub(super) async fn finalize_downloaded<D>(
+    db: &D,
     library: &Arc<str>,
     task: &DownloadTask,
     local_checksum: String,
     download_checksum: Option<String>,
     exif_ok: bool,
-) -> DownloadedFinalization {
+) -> DownloadedFinalization
+where
+    D: DownloadFinalizationStore + ?Sized,
+{
     match db
         .mark_downloaded(
             library,
@@ -91,25 +101,30 @@ pub(super) async fn finalize_downloaded(
 }
 
 /// Persist failure state for a task that could not be downloaded.
-pub(super) async fn finalize_failed(
-    db: &dyn StateDb,
+pub(super) async fn finalize_failed<D>(
+    db: &D,
     library: &Arc<str>,
     task: &DownloadTask,
     error: &str,
-) -> Result<(), crate::state::error::StateError> {
+) -> Result<(), crate::state::error::StateError>
+where
+    D: DownloadStateStore + ?Sized,
+{
     db.mark_failed(library, &task.asset_id, task.version_size.as_str(), error)
         .await
 }
 
 /// Set or clear the metadata-rewrite marker for an asset-version pair based
 /// on whether the EXIF/XMP writer succeeded.
-async fn update_metadata_marker(
-    db: &dyn StateDb,
+async fn update_metadata_marker<D>(
+    db: &D,
     library: &str,
     asset_id: &str,
     version_size: &str,
     exif_ok: bool,
-) {
+) where
+    D: MetadataRewriteStore + ?Sized,
+{
     if exif_ok {
         if let Err(e) = db
             .clear_metadata_write_failure(library, asset_id, version_size)
@@ -138,11 +153,14 @@ async fn update_metadata_marker(
     }
 }
 
-async fn retry_pending_state_write(
-    db: &dyn StateDb,
+async fn retry_pending_state_write<D>(
+    db: &D,
     write: &PendingStateWrite,
     pending_count: usize,
-) -> bool {
+) -> bool
+where
+    D: DownloadStateStore + ?Sized,
+{
     use rand::RngExt;
 
     for attempt in 1..=STATE_WRITE_MAX_RETRIES {
@@ -196,10 +214,13 @@ async fn retry_pending_state_write(
     false
 }
 
-pub(super) async fn flush_pending_state_writes_retaining_failures(
-    db: &dyn StateDb,
+pub(super) async fn flush_pending_state_writes_retaining_failures<D>(
+    db: &D,
     pending: &mut Vec<PendingStateWrite>,
-) -> StateWriteFlush {
+) -> StateWriteFlush
+where
+    D: DownloadStateStore + ?Sized,
+{
     if pending.is_empty() {
         return StateWriteFlush::default();
     }
@@ -237,10 +258,10 @@ pub(super) async fn flush_pending_state_writes_retaining_failures(
 /// Retry all pending state writes that failed during a download pass.
 ///
 /// Returns the number of writes that still failed after all retries.
-pub(super) async fn flush_pending_state_writes(
-    db: &dyn StateDb,
-    pending: &[PendingStateWrite],
-) -> usize {
+pub(super) async fn flush_pending_state_writes<D>(db: &D, pending: &[PendingStateWrite]) -> usize
+where
+    D: DownloadStateStore + ?Sized,
+{
     if pending.is_empty() {
         return 0;
     }
@@ -278,10 +299,13 @@ pub(super) fn state_db_unwritable_error(pending_total: usize) -> anyhow::Error {
     )
 }
 
-pub(super) async fn check_state_write_circuit_breaker(
-    db: &dyn StateDb,
+pub(super) async fn check_state_write_circuit_breaker<D>(
+    db: &D,
     pending: &mut Vec<PendingStateWrite>,
-) -> Option<anyhow::Error> {
+) -> Option<anyhow::Error>
+where
+    D: DownloadStateStore + ?Sized,
+{
     if pending.len() < STATE_DB_UNWRITABLE_THRESHOLD {
         return None;
     }
@@ -294,13 +318,15 @@ pub(super) async fn check_state_write_circuit_breaker(
 }
 
 #[cfg(test)]
-pub(super) async fn update_metadata_marker_for_test(
-    db: &dyn StateDb,
+pub(super) async fn update_metadata_marker_for_test<D>(
+    db: &D,
     library: &str,
     asset_id: &str,
     version_size: &str,
     exif_ok: bool,
-) {
+) where
+    D: MetadataRewriteStore + ?Sized,
+{
     update_metadata_marker(db, library, asset_id, version_size, exif_ok).await;
 }
 
@@ -312,7 +338,7 @@ mod tests {
     use chrono::Local;
     use tempfile::TempDir;
 
-    use crate::state::{MediaType, SqliteStateDb, StateDb, VersionSizeKey};
+    use crate::state::{MediaType, SqliteStateDb, VersionSizeKey};
     use crate::test_helpers::TestAssetRecord;
 
     use super::super::filter::{DownloadTask, MetadataPayload};

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -42,7 +42,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::{PhotoAsset, SyncTokenError};
 use crate::retry::RetryConfig;
-use crate::state::{StateDb, VersionSizeKey};
+use crate::state::{DownloadStateStore, MetadataRewriteStore, StateDb, VersionSizeKey};
 use crate::types::{
     AssetVersionSize, ChangeReason, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
     RawPolicy,
@@ -984,7 +984,10 @@ impl DownloadContext {
     /// Load the download context from the state database. All six queries
     /// are independent and run concurrently so sync start doesn't serialize
     /// on round-trip latency across them.
-    async fn load(db: &dyn StateDb, retry_only: bool) -> Self {
+    async fn load<D>(db: &D, retry_only: bool) -> Self
+    where
+        D: DownloadStateStore + MetadataRewriteStore + ?Sized,
+    {
         let known_ids_fut = async {
             if retry_only {
                 db.get_all_known_ids().await.unwrap_or_else(|e| {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::PhotoAsset;
 use crate::retry::RetryConfig;
-use crate::state::{StateDb, SyncRunStats, VersionSizeKey};
+use crate::state::{MetadataRewriteStore, StateDb, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
 #[cfg_attr(not(feature = "xmp"), allow(unused_imports))]
@@ -239,13 +239,15 @@ pub(super) const AUTH_ERROR_THRESHOLD: usize = 3;
 /// metadata drifted from the stored hash (or that already carries a marker
 /// from a prior sync). No-op when metadata writing is off or the state DB
 /// is absent. Shared by the trust-state and on-disk-skip producer branches.
-async fn tag_metadata_rewrites(
-    state_db: Option<&dyn StateDb>,
+async fn tag_metadata_rewrites<D>(
+    state_db: Option<&D>,
     config: &DownloadConfig,
     asset: &PhotoAsset,
     candidates: &[(VersionSizeKey, &str)],
     ctx: &DownloadContext,
-) {
+) where
+    D: MetadataRewriteStore + ?Sized,
+{
     if MetadataFlags::from(config).is_empty() {
         return;
     }
@@ -284,12 +286,14 @@ const METADATA_REWRITE_BATCH: usize = 500;
 /// re-apply EXIF/XMP using the stored metadata. On success clears
 /// the marker and refreshes `metadata_hash`; on failure leaves the marker so
 /// the next sync retries.
-async fn run_metadata_rewrites(
-    db: &dyn StateDb,
+async fn run_metadata_rewrites<D>(
+    db: &D,
     metadata_flags: MetadataFlags,
     temp_suffix: Arc<str>,
     shutdown_token: &CancellationToken,
-) {
+) where
+    D: MetadataRewriteStore + ?Sized,
+{
     let pending = match db
         .get_pending_metadata_rewrites(METADATA_REWRITE_BATCH)
         .await
@@ -2790,7 +2794,10 @@ mod tests {
     use super::*;
     use crate::state::error::StateError;
     use crate::state::types::SyncSummary;
-    use crate::state::{AssetRecord, SyncRunStats, VersionSizeKey};
+    use crate::state::{
+        AssetRecord, DownloadStateStore, ImportStateStore, MembershipStore, MetadataRewriteStore,
+        ReportStateStore, SyncRunStats, SyncTokenStore, VersionSizeKey,
+    };
     use crate::test_helpers::TestPhotoAsset;
     use std::collections::{HashMap, HashSet};
     use std::fs;
@@ -2940,7 +2947,7 @@ mod tests {
 
     // ── add_asset_album retry tests ─────────────────────────────────
 
-    /// StateDb stub whose `add_asset_album` returns `LockPoisoned` for the
+    /// Membership store stub whose `add_asset_album` returns `LockPoisoned` for the
     /// first `fail_first` calls, then succeeds. Tracks total call count so
     /// tests can pin the retry-attempt accounting. Other methods panic
     /// because the test path never reaches them.
@@ -2961,102 +2968,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl StateDb for AlbumRetryStubDb {
-        #[cfg(test)]
-        async fn should_download(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &Path,
-        ) -> Result<bool, StateError> {
-            unimplemented!()
-        }
-        async fn upsert_seen(&self, _: &AssetRecord) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn mark_downloaded(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &Path,
-            _: &str,
-            _: Option<&str>,
-        ) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn import_adopt(
-            &self,
-            _: &AssetRecord,
-            _: &Path,
-            _: &str,
-            _: u64,
-            _: Option<i64>,
-        ) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
-        }
-        async fn get_failed_sample(&self, _: u32) -> Result<(Vec<AssetRecord>, u64), StateError> {
-            unimplemented!()
-        }
-        async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
-        }
-        async fn get_summary(&self) -> Result<SyncSummary, StateError> {
-            unimplemented!()
-        }
-        async fn get_downloaded_page(
-            &self,
-            _: u64,
-            _: u32,
-        ) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
-        }
-        async fn start_sync_run(&self) -> Result<i64, StateError> {
-            unimplemented!()
-        }
-        async fn complete_sync_run(&self, _: i64, _: &SyncRunStats) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
-            unimplemented!()
-        }
-        async fn begin_enum_progress(&self, _: &str) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn end_enum_progress(&self, _: &str) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
-            unimplemented!()
-        }
-        async fn reset_failed(&self) -> Result<u64, StateError> {
-            unimplemented!()
-        }
-        async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
-            unimplemented!()
-        }
-        async fn promote_pending_to_failed(&self, _: i64) -> Result<u64, StateError> {
-            unimplemented!()
-        }
-        async fn get_downloaded_ids(
-            &self,
-        ) -> Result<HashSet<(String, String, String)>, StateError> {
-            unimplemented!()
-        }
-        async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
-            unimplemented!()
-        }
-        async fn touch_last_seen_many(&self, _: &str, _: &[&str]) -> Result<(), StateError> {
-            unimplemented!()
-        }
+    impl MembershipStore for AlbumRetryStubDb {
         async fn add_asset_album(
             &self,
             _library: &str,
@@ -3078,82 +2990,12 @@ mod tests {
                 Ok(())
             }
         }
+
         async fn get_all_asset_albums(&self, _: &str) -> Result<Vec<(String, String)>, StateError> {
             unimplemented!()
         }
+
         async fn get_all_asset_people(&self, _: &str) -> Result<Vec<(String, String)>, StateError> {
-            unimplemented!()
-        }
-        async fn mark_soft_deleted(
-            &self,
-            _: &str,
-            _: &str,
-            _: Option<chrono::DateTime<chrono::Utc>>,
-        ) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn mark_hidden_at_source(&self, _: &str, _: &str) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn record_metadata_write_failure(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-        ) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn clear_metadata_write_failure(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-        ) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
-            unimplemented!()
-        }
-        async fn get_downloaded_checksums(
-            &self,
-        ) -> Result<HashMap<(String, String, String), String>, StateError> {
-            unimplemented!()
-        }
-        async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
-            unimplemented!()
-        }
-        async fn get_metadata(&self, _: &str) -> Result<Option<String>, StateError> {
-            unimplemented!()
-        }
-        async fn set_metadata(&self, _: &str, _: &str) -> Result<(), StateError> {
-            unimplemented!()
-        }
-        async fn delete_metadata_by_prefix(&self, _: &str) -> Result<u64, StateError> {
-            unimplemented!()
-        }
-        async fn get_downloaded_metadata_hashes(
-            &self,
-        ) -> Result<HashMap<(String, String, String), String>, StateError> {
-            unimplemented!()
-        }
-        async fn get_metadata_retry_markers(
-            &self,
-        ) -> Result<HashSet<(String, String, String)>, StateError> {
-            unimplemented!()
-        }
-        async fn get_pending_metadata_rewrites(
-            &self,
-            _: usize,
-        ) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
-        }
-        async fn update_metadata_hash(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &str,
-        ) -> Result<(), StateError> {
             unimplemented!()
         }
     }
@@ -3783,7 +3625,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl StateDb for FailingStateDb {
+    impl DownloadStateStore for FailingStateDb {
         #[cfg(test)]
         async fn should_download(
             &self,
@@ -3795,9 +3637,11 @@ mod tests {
         ) -> Result<bool, StateError> {
             unimplemented!()
         }
+
         async fn upsert_seen(&self, _: &AssetRecord) -> Result<(), StateError> {
             unimplemented!()
         }
+
         async fn mark_downloaded(
             &self,
             _: &str,
@@ -3817,6 +3661,68 @@ mod tests {
                 Ok(())
             }
         }
+
+        async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {
+            unimplemented!()
+        }
+
+        #[cfg(test)]
+        async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+            unimplemented!()
+        }
+
+        async fn reset_failed(&self) -> Result<u64, StateError> {
+            unimplemented!()
+        }
+
+        async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+            Ok((0, 0, 0))
+        }
+
+        async fn promote_pending_to_failed(&self, _seen_since: i64) -> Result<u64, StateError> {
+            Ok(0)
+        }
+
+        async fn get_downloaded_ids(
+            &self,
+        ) -> Result<HashSet<(String, String, String)>, StateError> {
+            Ok(HashSet::new())
+        }
+
+        async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+            Ok(HashSet::new())
+        }
+
+        async fn get_downloaded_checksums(
+            &self,
+        ) -> Result<HashMap<(String, String, String), String>, StateError> {
+            Ok(HashMap::new())
+        }
+
+        async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+            Ok(HashMap::new())
+        }
+
+        async fn touch_last_seen_many(&self, _: &str, _: &[&str]) -> Result<(), StateError> {
+            Ok(())
+        }
+
+        async fn mark_soft_deleted(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<(), StateError> {
+            Ok(())
+        }
+
+        async fn mark_hidden_at_source(&self, _: &str, _: &str) -> Result<(), StateError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ImportStateStore for FailingStateDb {
         async fn import_adopt(
             &self,
             _: &AssetRecord,
@@ -3827,24 +3733,49 @@ mod tests {
         ) -> Result<(), StateError> {
             unimplemented!()
         }
-        async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {
-            unimplemented!()
+
+        async fn get_all_imported_records(
+            &self,
+            _: &str,
+        ) -> Result<HashMap<(String, String), crate::state::ImportedRecord>, StateError> {
+            Ok(HashMap::new())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl ReportStateStore for FailingStateDb {
+        #[cfg(test)]
         async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
             unimplemented!()
         }
+
         async fn get_failed_sample(
             &self,
             _limit: u32,
         ) -> Result<(Vec<AssetRecord>, u64), StateError> {
             Ok((Vec::new(), 0))
         }
-        async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+
+        async fn get_failed_page(
+            &self,
+            _offset: u64,
+            _limit: u32,
+        ) -> Result<Vec<AssetRecord>, StateError> {
             unimplemented!()
         }
+
+        async fn get_pending_page(
+            &self,
+            _offset: u64,
+            _limit: u32,
+        ) -> Result<Vec<AssetRecord>, StateError> {
+            unimplemented!()
+        }
+
         async fn get_summary(&self) -> Result<SyncSummary, StateError> {
             unimplemented!()
         }
+
         async fn get_downloaded_page(
             &self,
             _offset: u64,
@@ -3852,9 +3783,11 @@ mod tests {
         ) -> Result<Vec<AssetRecord>, StateError> {
             unimplemented!()
         }
+
         async fn start_sync_run(&self) -> Result<i64, StateError> {
             Ok(1)
         }
+
         async fn complete_sync_run(&self, _: i64, _: &SyncRunStats) -> Result<(), StateError> {
             if self.fail_complete_sync_run {
                 Err(StateError::LockPoisoned(
@@ -3864,57 +3797,41 @@ mod tests {
                 Ok(())
             }
         }
+
         async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
             Ok(0)
         }
-        async fn begin_enum_progress(&self, _zone: &str) -> Result<(), StateError> {
-            Ok(())
-        }
-        async fn end_enum_progress(&self, _zone: &str) -> Result<(), StateError> {
-            Ok(())
-        }
-        async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
-            Ok(Vec::new())
-        }
-        async fn reset_failed(&self) -> Result<u64, StateError> {
-            unimplemented!()
-        }
-        async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
-            Ok((0, 0, 0))
-        }
-        async fn promote_pending_to_failed(&self, _seen_since: i64) -> Result<u64, StateError> {
-            Ok(0)
-        }
-        async fn get_downloaded_ids(
-            &self,
-        ) -> Result<HashSet<(String, String, String)>, StateError> {
-            Ok(HashSet::new())
-        }
-        async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
-            Ok(HashSet::new())
-        }
-        async fn get_downloaded_checksums(
-            &self,
-        ) -> Result<HashMap<(String, String, String), String>, StateError> {
-            Ok(HashMap::new())
-        }
-        async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
-            Ok(HashMap::new())
-        }
+    }
+
+    #[async_trait::async_trait]
+    impl SyncTokenStore for FailingStateDb {
         async fn get_metadata(&self, _: &str) -> Result<Option<String>, StateError> {
             Ok(None)
         }
+
         async fn set_metadata(&self, _: &str, _: &str) -> Result<(), StateError> {
             Ok(())
         }
+
         async fn delete_metadata_by_prefix(&self, _: &str) -> Result<u64, StateError> {
             Ok(0)
         }
-        async fn touch_last_seen_many(&self, _: &str, _: &[&str]) -> Result<(), StateError> {
-            // Unused in these tests; default no-op so they don't bump the
-            // pipeline's batch-flush path.
+
+        async fn begin_enum_progress(&self, _zone: &str) -> Result<(), StateError> {
             Ok(())
         }
+
+        async fn end_enum_progress(&self, _zone: &str) -> Result<(), StateError> {
+            Ok(())
+        }
+
+        async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MembershipStore for FailingStateDb {
         async fn add_asset_album(
             &self,
             _: &str,
@@ -3924,23 +3841,18 @@ mod tests {
         ) -> Result<(), StateError> {
             Ok(())
         }
+
         async fn get_all_asset_albums(&self, _: &str) -> Result<Vec<(String, String)>, StateError> {
             Ok(Vec::new())
         }
+
         async fn get_all_asset_people(&self, _: &str) -> Result<Vec<(String, String)>, StateError> {
             Ok(Vec::new())
         }
-        async fn mark_soft_deleted(
-            &self,
-            _: &str,
-            _: &str,
-            _: Option<chrono::DateTime<chrono::Utc>>,
-        ) -> Result<(), StateError> {
-            Ok(())
-        }
-        async fn mark_hidden_at_source(&self, _: &str, _: &str) -> Result<(), StateError> {
-            Ok(())
-        }
+    }
+
+    #[async_trait::async_trait]
+    impl MetadataRewriteStore for FailingStateDb {
         async fn record_metadata_write_failure(
             &self,
             _: &str,
@@ -3949,6 +3861,7 @@ mod tests {
         ) -> Result<(), StateError> {
             Ok(())
         }
+
         async fn clear_metadata_write_failure(
             &self,
             _: &str,
@@ -3961,22 +3874,26 @@ mod tests {
                 Ok(())
             }
         }
+
         async fn get_downloaded_metadata_hashes(
             &self,
         ) -> Result<HashMap<(String, String, String), String>, StateError> {
             Ok(HashMap::new())
         }
+
         async fn get_metadata_retry_markers(
             &self,
         ) -> Result<HashSet<(String, String, String)>, StateError> {
             Ok(HashSet::new())
         }
+
         async fn get_pending_metadata_rewrites(
             &self,
             _: usize,
         ) -> Result<Vec<AssetRecord>, StateError> {
             Ok(Vec::new())
         }
+
         async fn update_metadata_hash(
             &self,
             _: &str,
@@ -3986,6 +3903,7 @@ mod tests {
         ) -> Result<(), StateError> {
             Ok(())
         }
+
         async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
             Ok(false)
         }
@@ -4685,7 +4603,7 @@ mod tests {
     async fn ghost_loop_regression_filtered_pending_asset_survives_sync() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
-        use crate::state::{MediaType, SqliteStateDb, StateDb};
+        use crate::state::{MediaType, SqliteStateDb};
         use chrono::TimeZone;
         use futures_util::stream;
         use std::sync::Arc;
@@ -4793,7 +4711,7 @@ mod tests {
     async fn producer_flushes_touched_ids_so_pending_on_disk_skip_promotes() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
-        use crate::state::{SqliteStateDb, StateDb};
+        use crate::state::SqliteStateDb;
         use crate::test_helpers::TestAssetRecord;
         use futures_util::stream;
         use std::sync::Arc;
@@ -4885,7 +4803,7 @@ mod tests {
     async fn deleted_downloaded_file_is_forwarded_not_state_skipped() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
-        use crate::state::{SqliteStateDb, StateDb};
+        use crate::state::SqliteStateDb;
         use futures_util::stream;
         use std::sync::Arc;
 

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use crate::icloud::photos::PhotoAsset;
-use crate::state::{AssetRecord, StateDb};
+use crate::state::{AssetRecord, DownloadStateStore, MembershipStore};
 
 use super::filter::{
     determine_media_type, filter_asset_to_tasks, is_asset_filtered, pre_ensure_asset_dir,
@@ -84,12 +84,15 @@ pub(super) enum ExistingPathMatch {
 
 /// Persist the pending state row that a later `mark_downloaded` /
 /// `mark_failed` call will finalize.
-pub(super) async fn upsert_seen_for_task(
-    db: &dyn StateDb,
+pub(super) async fn upsert_seen_for_task<D>(
+    db: &D,
     config: &DownloadConfig,
     asset: &PhotoAsset,
     task: &DownloadTask,
-) -> Result<(), crate::state::error::StateError> {
+) -> Result<(), crate::state::error::StateError>
+where
+    D: DownloadStateStore + ?Sized,
+{
     let media_type = determine_media_type(task.version_size, asset);
     let record = AssetRecord::new_pending(
         Arc::clone(&config.library),
@@ -113,11 +116,14 @@ pub(super) async fn upsert_seen_for_task(
 /// Record an asset's membership in the current concrete album/smart-folder
 /// pass. Returns `Ok(())` without touching the DB when the pass is not
 /// album-scoped.
-pub(super) async fn record_album_membership_if_named(
-    db: &dyn StateDb,
+pub(super) async fn record_album_membership_if_named<D>(
+    db: &D,
     config: &DownloadConfig,
     asset: &PhotoAsset,
-) -> Result<(), crate::state::error::StateError> {
+) -> Result<(), crate::state::error::StateError>
+where
+    D: MembershipStore + ?Sized,
+{
     let Some(album_name) = config.album_name.as_deref().filter(|name| !name.is_empty()) else {
         return Ok(());
     };
@@ -134,13 +140,16 @@ pub(super) const ADD_ASSET_ALBUM_MAX_RETRIES: u32 = 3;
 /// Insert an asset/album row with a bounded inline retry loop. The
 /// underlying call is `INSERT OR IGNORE` so retries are idempotent. Returns
 /// the final result so the caller can log on persistent failure.
-pub(super) async fn add_asset_album_with_retry(
-    db: &dyn StateDb,
+pub(super) async fn add_asset_album_with_retry<D>(
+    db: &D,
     library: &str,
     asset_id: &str,
     album_name: &str,
     source: &str,
-) -> Result<(), crate::state::error::StateError> {
+) -> Result<(), crate::state::error::StateError>
+where
+    D: MembershipStore + ?Sized,
+{
     use rand::RngExt;
     let mut last_err: Option<crate::state::error::StateError> = None;
     for attempt in 1..=ADD_ASSET_ALBUM_MAX_RETRIES {
@@ -192,7 +201,7 @@ mod tests {
 
     use crate::commands::{AlbumPass, PassKind};
     use crate::icloud::photos::PhotoAlbum;
-    use crate::state::{SqliteStateDb, StateDb};
+    use crate::state::SqliteStateDb;
     use crate::test_helpers::TestPhotoAsset;
 
     use super::*;

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -24,7 +24,7 @@ use super::types::{
 const DEFAULT_SOURCE: &str = "icloud";
 
 /// Snapshot of an already-imported asset, returned by
-/// [`StateDb::get_imported_record`].
+/// [`ImportStateStore::get_all_imported_records`].
 ///
 /// `import-existing` consults this on every match candidate to decide whether
 /// the on-disk file can be trusted as unchanged since the last adopt. If
@@ -40,10 +40,194 @@ pub struct ImportedRecord {
     pub imported_mtime: Option<i64>,
 }
 
+/// State operations used by the download producer and finalizer.
+#[allow(
+    dead_code,
+    reason = "role traits expose test and command slices that are not all used in the main binary"
+)]
+#[async_trait]
+pub trait DownloadStateStore: Send + Sync {
+    #[cfg(test)]
+    async fn should_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        checksum: &str,
+        local_path: &Path,
+    ) -> Result<bool, StateError>;
+
+    async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError>;
+    async fn mark_downloaded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+    ) -> Result<(), StateError>;
+    async fn mark_failed(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        error: &str,
+    ) -> Result<(), StateError>;
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError>;
+    async fn reset_failed(&self) -> Result<u64, StateError>;
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
+    async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError>;
+    async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError>;
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError>;
+    async fn get_downloaded_checksums(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError>;
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError>;
+    async fn touch_last_seen_many(
+        &self,
+        library: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), StateError>;
+    async fn mark_soft_deleted(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<(), StateError>;
+    async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError>;
+}
+
+/// Import-time adoption and imported-file snapshot reads.
+#[async_trait]
+pub trait ImportStateStore: Send + Sync {
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
+    ) -> Result<(), StateError>;
+
+    async fn get_all_imported_records(
+        &self,
+        library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError>;
+}
+
+/// Summary, status-page, failed-sample, and sync-run ledger reads/writes.
+#[allow(
+    dead_code,
+    reason = "status and test-only readers are part of the report role even when the main binary does not call every method"
+)]
+#[async_trait]
+pub trait ReportStateStore: Send + Sync {
+    async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError>;
+    async fn get_failed_sample(&self, limit: u32) -> Result<(Vec<AssetRecord>, u64), StateError>;
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError>;
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError>;
+    async fn get_summary(&self) -> Result<SyncSummary, StateError>;
+    async fn get_downloaded_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError>;
+    async fn start_sync_run(&self) -> Result<i64, StateError>;
+    async fn complete_sync_run(&self, run_id: i64, stats: &SyncRunStats) -> Result<(), StateError>;
+    async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError>;
+}
+
+/// Metadata key-value operations used for sync tokens and state markers.
+#[allow(
+    dead_code,
+    reason = "startup diagnostics and tests use only part of the sync-token role in some build targets"
+)]
+#[async_trait]
+pub trait SyncTokenStore: Send + Sync {
+    async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError>;
+    async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError>;
+    async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError>;
+    async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError>;
+    async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError>;
+    async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError>;
+}
+
+/// Album and people membership reads/writes.
+#[async_trait]
+pub trait MembershipStore: Send + Sync {
+    async fn add_asset_album(
+        &self,
+        library: &str,
+        asset_id: &str,
+        album_name: &str,
+        source: &str,
+    ) -> Result<(), StateError>;
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    async fn get_all_asset_albums(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError>;
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    async fn get_all_asset_people(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError>;
+}
+
+/// Metadata rewrite markers and hashes.
+#[async_trait]
+pub trait MetadataRewriteStore: Send + Sync {
+    async fn record_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError>;
+    async fn get_downloaded_metadata_hashes(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError>;
+    async fn get_metadata_retry_markers(
+        &self,
+    ) -> Result<HashSet<(String, String, String)>, StateError>;
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    async fn get_pending_metadata_rewrites(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<AssetRecord>, StateError>;
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    async fn update_metadata_hash(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        metadata_hash: &str,
+    ) -> Result<(), StateError>;
+    async fn clear_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError>;
+    async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError>;
+}
+
 /// Trait for state database operations.
 ///
 /// This trait is object-safe and can be used with `Arc<dyn StateDb>` for
 /// shared access across async tasks.
+#[allow(
+    dead_code,
+    reason = "transitional composite trait remains for outer wiring and legacy tests while callers migrate to role traits"
+)]
 #[async_trait]
 pub trait StateDb: Send + Sync {
     /// Check if an asset should be downloaded.
@@ -102,9 +286,10 @@ pub trait StateDb: Send + Sync {
     ///
     /// `imported_size` and `imported_mtime` snapshot the on-disk file's size
     /// (bytes) and modification time (epoch seconds) at adopt time. Subsequent
-    /// `import-existing` runs read these via `get_imported_record` and skip
-    /// the SHA-256 re-read when the file is unchanged. `imported_mtime` is
-    /// `None` only when the host filesystem doesn't expose a usable mtime.
+    /// `import-existing` runs bulk-read these via
+    /// `get_all_imported_records` and skip the SHA-256 re-read when the file
+    /// is unchanged. `imported_mtime` is `None` only when the host filesystem
+    /// doesn't expose a usable mtime.
     async fn import_adopt(
         &self,
         record: &AssetRecord,
@@ -250,7 +435,7 @@ pub trait StateDb: Send + Sync {
 
     // ── Bulk read operations ──
 
-    /// Get all downloaded asset IDs as (id, `version_size`) pairs.
+    /// Get all downloaded asset IDs as (`library`, id, `version_size`) triples.
     ///
     /// Used at sync start to pre-load downloaded state for O(1) skip decisions.
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError>;
@@ -420,6 +605,611 @@ pub trait StateDb: Send + Sync {
     async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError>;
 }
 
+#[async_trait]
+impl<T> StateDb for T
+where
+    T: DownloadStateStore
+        + ImportStateStore
+        + ReportStateStore
+        + SyncTokenStore
+        + MembershipStore
+        + MetadataRewriteStore,
+{
+    #[cfg(test)]
+    async fn should_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        checksum: &str,
+        local_path: &Path,
+    ) -> Result<bool, StateError> {
+        DownloadStateStore::should_download(self, library, id, version_size, checksum, local_path)
+            .await
+    }
+
+    async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
+        DownloadStateStore::upsert_seen(self, record).await
+    }
+
+    async fn mark_downloaded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+    ) -> Result<(), StateError> {
+        DownloadStateStore::mark_downloaded(
+            self,
+            library,
+            id,
+            version_size,
+            local_path,
+            local_checksum,
+            download_checksum,
+        )
+        .await
+    }
+
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
+    ) -> Result<(), StateError> {
+        ImportStateStore::import_adopt(
+            self,
+            record,
+            local_path,
+            local_checksum,
+            imported_size,
+            imported_mtime,
+        )
+        .await
+    }
+
+    async fn get_all_imported_records(
+        &self,
+        library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
+        ImportStateStore::get_all_imported_records(self, library).await
+    }
+
+    async fn mark_failed(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        error: &str,
+    ) -> Result<(), StateError> {
+        DownloadStateStore::mark_failed(self, library, id, version_size, error).await
+    }
+
+    async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
+        <T as ReportStateStore>::get_failed(self).await
+    }
+
+    async fn get_failed_sample(&self, limit: u32) -> Result<(Vec<AssetRecord>, u64), StateError> {
+        ReportStateStore::get_failed_sample(self, limit).await
+    }
+
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+        <T as DownloadStateStore>::get_pending(self).await
+    }
+
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        ReportStateStore::get_failed_page(self, offset, limit).await
+    }
+
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        ReportStateStore::get_pending_page(self, offset, limit).await
+    }
+
+    async fn get_summary(&self) -> Result<SyncSummary, StateError> {
+        ReportStateStore::get_summary(self).await
+    }
+
+    async fn get_downloaded_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        ReportStateStore::get_downloaded_page(self, offset, limit).await
+    }
+
+    async fn start_sync_run(&self) -> Result<i64, StateError> {
+        ReportStateStore::start_sync_run(self).await
+    }
+
+    async fn complete_sync_run(&self, run_id: i64, stats: &SyncRunStats) -> Result<(), StateError> {
+        ReportStateStore::complete_sync_run(self, run_id, stats).await
+    }
+
+    async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
+        ReportStateStore::promote_orphaned_sync_runs(self).await
+    }
+
+    async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        SyncTokenStore::begin_enum_progress(self, zone).await
+    }
+
+    async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        SyncTokenStore::end_enum_progress(self, zone).await
+    }
+
+    async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
+        SyncTokenStore::list_interrupted_enumerations(self).await
+    }
+
+    async fn reset_failed(&self) -> Result<u64, StateError> {
+        DownloadStateStore::reset_failed(self).await
+    }
+
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+        DownloadStateStore::prepare_for_retry(self).await
+    }
+
+    async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
+        DownloadStateStore::promote_pending_to_failed(self, seen_since).await
+    }
+
+    async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
+        DownloadStateStore::get_downloaded_ids(self).await
+    }
+
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+        DownloadStateStore::get_all_known_ids(self).await
+    }
+
+    async fn get_downloaded_checksums(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        DownloadStateStore::get_downloaded_checksums(self).await
+    }
+
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+        DownloadStateStore::get_attempt_counts(self).await
+    }
+
+    async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
+        SyncTokenStore::get_metadata(self, key).await
+    }
+
+    async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
+        SyncTokenStore::set_metadata(self, key, value).await
+    }
+
+    async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
+        SyncTokenStore::delete_metadata_by_prefix(self, prefix).await
+    }
+
+    async fn touch_last_seen_many(
+        &self,
+        library: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), StateError> {
+        DownloadStateStore::touch_last_seen_many(self, library, asset_ids).await
+    }
+
+    async fn add_asset_album(
+        &self,
+        library: &str,
+        asset_id: &str,
+        album_name: &str,
+        source: &str,
+    ) -> Result<(), StateError> {
+        MembershipStore::add_asset_album(self, library, asset_id, album_name, source).await
+    }
+
+    async fn get_all_asset_albums(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        MembershipStore::get_all_asset_albums(self, library).await
+    }
+
+    async fn get_all_asset_people(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        MembershipStore::get_all_asset_people(self, library).await
+    }
+
+    async fn mark_soft_deleted(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<(), StateError> {
+        DownloadStateStore::mark_soft_deleted(self, library, asset_id, deleted_at).await
+    }
+
+    async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError> {
+        DownloadStateStore::mark_hidden_at_source(self, library, asset_id).await
+    }
+
+    async fn record_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        MetadataRewriteStore::record_metadata_write_failure(self, library, asset_id, version_size)
+            .await
+    }
+
+    async fn get_downloaded_metadata_hashes(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        MetadataRewriteStore::get_downloaded_metadata_hashes(self).await
+    }
+
+    async fn get_metadata_retry_markers(
+        &self,
+    ) -> Result<HashSet<(String, String, String)>, StateError> {
+        MetadataRewriteStore::get_metadata_retry_markers(self).await
+    }
+
+    async fn get_pending_metadata_rewrites(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        MetadataRewriteStore::get_pending_metadata_rewrites(self, limit).await
+    }
+
+    async fn update_metadata_hash(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        metadata_hash: &str,
+    ) -> Result<(), StateError> {
+        MetadataRewriteStore::update_metadata_hash(
+            self,
+            library,
+            asset_id,
+            version_size,
+            metadata_hash,
+        )
+        .await
+    }
+
+    async fn clear_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        MetadataRewriteStore::clear_metadata_write_failure(self, library, asset_id, version_size)
+            .await
+    }
+
+    async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
+        MetadataRewriteStore::has_downloaded_without_metadata_hash(self).await
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "default StateDb pagination methods use this for non-SQLite test stubs"
+)]
+fn page_from_full(
+    full: Vec<AssetRecord>,
+    offset: u64,
+    limit: u32,
+) -> Result<Vec<AssetRecord>, StateError> {
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(full.len());
+    let take = usize::try_from(limit).unwrap_or(usize::MAX);
+    Ok(full.into_iter().skip(start).take(take).collect())
+}
+
+#[async_trait]
+impl DownloadStateStore for dyn StateDb + '_ {
+    #[cfg(test)]
+    async fn should_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        checksum: &str,
+        local_path: &Path,
+    ) -> Result<bool, StateError> {
+        StateDb::should_download(self, library, id, version_size, checksum, local_path).await
+    }
+
+    async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
+        StateDb::upsert_seen(self, record).await
+    }
+
+    async fn mark_downloaded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+    ) -> Result<(), StateError> {
+        StateDb::mark_downloaded(
+            self,
+            library,
+            id,
+            version_size,
+            local_path,
+            local_checksum,
+            download_checksum,
+        )
+        .await
+    }
+
+    async fn mark_failed(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        error: &str,
+    ) -> Result<(), StateError> {
+        StateDb::mark_failed(self, library, id, version_size, error).await
+    }
+
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_pending(self).await
+    }
+
+    async fn reset_failed(&self) -> Result<u64, StateError> {
+        StateDb::reset_failed(self).await
+    }
+
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+        StateDb::prepare_for_retry(self).await
+    }
+
+    async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
+        StateDb::promote_pending_to_failed(self, seen_since).await
+    }
+
+    async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
+        StateDb::get_downloaded_ids(self).await
+    }
+
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+        StateDb::get_all_known_ids(self).await
+    }
+
+    async fn get_downloaded_checksums(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        StateDb::get_downloaded_checksums(self).await
+    }
+
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+        StateDb::get_attempt_counts(self).await
+    }
+
+    async fn touch_last_seen_many(
+        &self,
+        library: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), StateError> {
+        StateDb::touch_last_seen_many(self, library, asset_ids).await
+    }
+
+    async fn mark_soft_deleted(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<(), StateError> {
+        StateDb::mark_soft_deleted(self, library, asset_id, deleted_at).await
+    }
+
+    async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError> {
+        StateDb::mark_hidden_at_source(self, library, asset_id).await
+    }
+}
+
+#[async_trait]
+impl ImportStateStore for dyn StateDb + '_ {
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
+    ) -> Result<(), StateError> {
+        StateDb::import_adopt(
+            self,
+            record,
+            local_path,
+            local_checksum,
+            imported_size,
+            imported_mtime,
+        )
+        .await
+    }
+
+    async fn get_all_imported_records(
+        &self,
+        library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
+        StateDb::get_all_imported_records(self, library).await
+    }
+}
+
+#[async_trait]
+impl ReportStateStore for dyn StateDb + '_ {
+    async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_failed(self).await
+    }
+
+    async fn get_failed_sample(&self, limit: u32) -> Result<(Vec<AssetRecord>, u64), StateError> {
+        StateDb::get_failed_sample(self, limit).await
+    }
+
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_failed_page(self, offset, limit).await
+    }
+
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_pending_page(self, offset, limit).await
+    }
+
+    async fn get_summary(&self) -> Result<SyncSummary, StateError> {
+        StateDb::get_summary(self).await
+    }
+
+    async fn get_downloaded_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_downloaded_page(self, offset, limit).await
+    }
+
+    async fn start_sync_run(&self) -> Result<i64, StateError> {
+        StateDb::start_sync_run(self).await
+    }
+
+    async fn complete_sync_run(&self, run_id: i64, stats: &SyncRunStats) -> Result<(), StateError> {
+        StateDb::complete_sync_run(self, run_id, stats).await
+    }
+
+    async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
+        StateDb::promote_orphaned_sync_runs(self).await
+    }
+}
+
+#[async_trait]
+impl SyncTokenStore for dyn StateDb + '_ {
+    async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
+        StateDb::get_metadata(self, key).await
+    }
+
+    async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
+        StateDb::set_metadata(self, key, value).await
+    }
+
+    async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
+        StateDb::delete_metadata_by_prefix(self, prefix).await
+    }
+
+    async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        StateDb::begin_enum_progress(self, zone).await
+    }
+
+    async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        StateDb::end_enum_progress(self, zone).await
+    }
+
+    async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
+        StateDb::list_interrupted_enumerations(self).await
+    }
+}
+
+#[async_trait]
+impl MembershipStore for dyn StateDb + '_ {
+    async fn add_asset_album(
+        &self,
+        library: &str,
+        asset_id: &str,
+        album_name: &str,
+        source: &str,
+    ) -> Result<(), StateError> {
+        StateDb::add_asset_album(self, library, asset_id, album_name, source).await
+    }
+
+    async fn get_all_asset_albums(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        StateDb::get_all_asset_albums(self, library).await
+    }
+
+    async fn get_all_asset_people(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        StateDb::get_all_asset_people(self, library).await
+    }
+}
+
+#[async_trait]
+impl MetadataRewriteStore for dyn StateDb + '_ {
+    async fn record_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        StateDb::record_metadata_write_failure(self, library, asset_id, version_size).await
+    }
+
+    async fn get_downloaded_metadata_hashes(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        StateDb::get_downloaded_metadata_hashes(self).await
+    }
+
+    async fn get_metadata_retry_markers(
+        &self,
+    ) -> Result<HashSet<(String, String, String)>, StateError> {
+        StateDb::get_metadata_retry_markers(self).await
+    }
+
+    async fn get_pending_metadata_rewrites(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        StateDb::get_pending_metadata_rewrites(self, limit).await
+    }
+
+    async fn update_metadata_hash(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        metadata_hash: &str,
+    ) -> Result<(), StateError> {
+        StateDb::update_metadata_hash(self, library, asset_id, version_size, metadata_hash).await
+    }
+
+    async fn clear_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        StateDb::clear_metadata_write_failure(self, library, asset_id, version_size).await
+    }
+
+    async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
+        StateDb::has_downloaded_without_metadata_hash(self).await
+    }
+}
+
 /// `SQLite` implementation of the state database.
 pub struct SqliteStateDb {
     /// Wrapped in `Arc<Mutex<...>>` because `rusqlite::Connection` is
@@ -563,24 +1353,6 @@ impl SqliteStateDb {
         })
         .await?
     }
-}
-
-/// Slice a `Vec<AssetRecord>` into a page using the same `(offset, limit)`
-/// semantics as `SqliteStateDb::get_downloaded_page`. Used as the default
-/// `get_failed_page` / `get_pending_page` body so trait mocks that only
-/// implement the unbounded `get_failed` / `get_pending` keep compiling. The
-/// production `SqliteStateDb` impl overrides with a real LIMIT/OFFSET query
-/// and never materializes the full vector.
-fn page_from_full(
-    full: Vec<AssetRecord>,
-    offset: u64,
-    limit: u32,
-) -> Result<Vec<AssetRecord>, StateError> {
-    let start = usize::try_from(offset)
-        .unwrap_or(usize::MAX)
-        .min(full.len());
-    let take = usize::try_from(limit).unwrap_or(usize::MAX);
-    Ok(full.into_iter().skip(start).take(take).collect())
 }
 
 /// Execute the asset UPSERT on `conn` (works against either a `Connection`
@@ -748,10 +1520,9 @@ where
     out
 }
 
-#[async_trait]
-impl StateDb for SqliteStateDb {
+impl SqliteStateDb {
     #[cfg(test)]
-    async fn should_download(
+    pub(crate) async fn should_download(
         &self,
         library: &str,
         id: &str,
@@ -825,7 +1596,7 @@ impl StateDb for SqliteStateDb {
         }
     }
 
-    async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
+    pub(crate) async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
         let record = record.clone();
         self.with_conn("upsert_seen", move |conn| {
             upsert_asset_row(conn, &record, Utc::now().timestamp())
@@ -833,7 +1604,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn mark_downloaded(
+    pub(crate) async fn mark_downloaded(
         &self,
         library: &str,
         id: &str,
@@ -875,7 +1646,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn import_adopt(
+    pub(crate) async fn import_adopt(
         &self,
         record: &AssetRecord,
         local_path: &Path,
@@ -934,7 +1705,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_all_imported_records(
+    pub(crate) async fn get_all_imported_records(
         &self,
         library: &str,
     ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
@@ -979,7 +1750,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn mark_failed(
+    pub(crate) async fn mark_failed(
         &self,
         library: &str,
         id: &str,
@@ -1022,7 +1793,8 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
+    #[cfg(test)]
+    pub(crate) async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_failed", move |conn| {
             let sql = format!(
                 "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
@@ -1043,7 +1815,10 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_failed_sample(&self, limit: u32) -> Result<(Vec<AssetRecord>, u64), StateError> {
+    pub(crate) async fn get_failed_sample(
+        &self,
+        limit: u32,
+    ) -> Result<(Vec<AssetRecord>, u64), StateError> {
         self.with_conn("get_failed_sample", move |conn| {
             let total: i64 = conn
                 .query_row(
@@ -1077,7 +1852,8 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+    #[cfg(test)]
+    pub(crate) async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_pending", move |conn| {
             let sql = format!(
                 "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' \
@@ -1098,7 +1874,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_failed_page(
+    pub(crate) async fn get_failed_page(
         &self,
         offset: u64,
         limit: u32,
@@ -1131,7 +1907,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_pending_page(
+    pub(crate) async fn get_pending_page(
         &self,
         offset: u64,
         limit: u32,
@@ -1164,7 +1940,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_summary(&self) -> Result<SyncSummary, StateError> {
+    pub(crate) async fn get_summary(&self) -> Result<SyncSummary, StateError> {
         self.with_conn("get_summary", move |conn| {
             let (total_assets, downloaded, pending, failed, downloaded_bytes) = conn
                 .query_row(
@@ -1227,7 +2003,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_downloaded_page(
+    pub(crate) async fn get_downloaded_page(
         &self,
         offset: u64,
         limit: u32,
@@ -1255,7 +2031,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn start_sync_run(&self) -> Result<i64, StateError> {
+    pub(crate) async fn start_sync_run(&self) -> Result<i64, StateError> {
         let started_at = Utc::now().timestamp();
         self.with_conn("start_sync_run", move |conn| {
             conn.execute(
@@ -1269,7 +2045,11 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn complete_sync_run(&self, run_id: i64, stats: &SyncRunStats) -> Result<(), StateError> {
+    pub(crate) async fn complete_sync_run(
+        &self,
+        run_id: i64,
+        stats: &SyncRunStats,
+    ) -> Result<(), StateError> {
         let completed_at = Utc::now().timestamp();
         let assets_seen = i64::try_from(stats.assets_seen).unwrap_or(i64::MAX);
         let assets_downloaded = i64::try_from(stats.assets_downloaded).unwrap_or(i64::MAX);
@@ -1305,7 +2085,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
+    pub(crate) async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
         self.with_conn("promote_orphaned_sync_runs", move |conn| {
             let rows = conn
                 .execute(
@@ -1319,7 +2099,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+    pub(crate) async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError> {
         let key = format!("enum_in_progress:{zone}");
         let now = Utc::now().timestamp().to_string();
         self.with_conn("begin_enum_progress", move |conn| {
@@ -1335,7 +2115,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+    pub(crate) async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError> {
         let key = format!("enum_in_progress:{zone}");
         self.with_conn("end_enum_progress", move |conn| {
             conn.execute("DELETE FROM metadata WHERE key = ?1", [key])
@@ -1345,7 +2125,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
+    pub(crate) async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
         self.with_conn("list_interrupted_enumerations", move |conn| {
             let mut stmt = conn
                 .prepare("SELECT key FROM metadata WHERE key LIKE 'enum_in_progress:%'")
@@ -1365,12 +2145,12 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn reset_failed(&self) -> Result<u64, StateError> {
+    pub(crate) async fn reset_failed(&self) -> Result<u64, StateError> {
         let (failed, _, _) = self.prepare_for_retry().await?;
         Ok(failed)
     }
 
-    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+    pub(crate) async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
         self.with_conn("prepare_for_retry", move |conn| {
             let failed = conn
                 .execute(
@@ -1403,7 +2183,10 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
+    pub(crate) async fn promote_pending_to_failed(
+        &self,
+        seen_since: i64,
+    ) -> Result<u64, StateError> {
         self.with_conn("promote_pending_to_failed", move |conn| {
             // Only promote assets the producer dispatched this sync (last_seen_at
             // was bumped by upsert_seen at or after sync_started_at) that never
@@ -1423,7 +2206,9 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
+    pub(crate) async fn get_downloaded_ids(
+        &self,
+    ) -> Result<HashSet<(String, String, String)>, StateError> {
         self.with_conn("get_downloaded_ids", move |conn| {
             let count: i64 = conn
                 .query_row(
@@ -1459,7 +2244,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+    pub(crate) async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
         self.with_conn("get_all_known_ids", move |conn| {
             let mut stmt = conn
                 .prepare_cached("SELECT DISTINCT id FROM assets")
@@ -1476,7 +2261,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_downloaded_checksums(
+    pub(crate) async fn get_downloaded_checksums(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
         self.with_conn("get_downloaded_checksums", move |conn| {
@@ -1520,7 +2305,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+    pub(crate) async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
         self.with_conn("get_attempt_counts", move |conn| {
             let mut stmt = conn
                 .prepare_cached(
@@ -1544,7 +2329,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
+    pub(crate) async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
         let key = key.to_owned();
         self.with_conn("get_metadata", move |conn| {
             let value = conn
@@ -1559,7 +2344,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
+    pub(crate) async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
         let key = key.to_owned();
         let value = value.to_owned();
         self.with_conn("set_metadata", move |conn| {
@@ -1574,7 +2359,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
+    pub(crate) async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
         let prefix = prefix.to_owned();
         self.with_conn("delete_metadata_by_prefix", move |conn| {
             let mut stmt = conn
@@ -1589,7 +2374,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn touch_last_seen_many(
+    pub(crate) async fn touch_last_seen_many(
         &self,
         library: &str,
         asset_ids: &[&str],
@@ -1622,7 +2407,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn add_asset_album(
+    pub(crate) async fn add_asset_album(
         &self,
         library: &str,
         asset_id: &str,
@@ -1645,7 +2430,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_all_asset_albums(
+    pub(crate) async fn get_all_asset_albums(
         &self,
         library: &str,
     ) -> Result<Vec<(String, String)>, StateError> {
@@ -1664,7 +2449,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_all_asset_people(
+    pub(crate) async fn get_all_asset_people(
         &self,
         library: &str,
     ) -> Result<Vec<(String, String)>, StateError> {
@@ -1683,7 +2468,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn mark_soft_deleted(
+    pub(crate) async fn mark_soft_deleted(
         &self,
         library: &str,
         asset_id: &str,
@@ -1703,7 +2488,11 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError> {
+    pub(crate) async fn mark_hidden_at_source(
+        &self,
+        library: &str,
+        asset_id: &str,
+    ) -> Result<(), StateError> {
         let library = library.to_owned();
         let asset_id = asset_id.to_owned();
         self.with_conn("mark_hidden_at_source", move |conn| {
@@ -1717,7 +2506,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn record_metadata_write_failure(
+    pub(crate) async fn record_metadata_write_failure(
         &self,
         library: &str,
         asset_id: &str,
@@ -1739,7 +2528,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn clear_metadata_write_failure(
+    pub(crate) async fn clear_metadata_write_failure(
         &self,
         library: &str,
         asset_id: &str,
@@ -1760,7 +2549,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_downloaded_metadata_hashes(
+    pub(crate) async fn get_downloaded_metadata_hashes(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
         self.with_conn("get_downloaded_metadata_hashes", move |conn| {
@@ -1793,7 +2582,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_pending_metadata_rewrites(
+    pub(crate) async fn get_pending_metadata_rewrites(
         &self,
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError> {
@@ -1821,7 +2610,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn get_metadata_retry_markers(
+    pub(crate) async fn get_metadata_retry_markers(
         &self,
     ) -> Result<HashSet<(String, String, String)>, StateError> {
         self.with_conn("get_metadata_retry_markers", move |conn| {
@@ -1850,7 +2639,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn update_metadata_hash(
+    pub(crate) async fn update_metadata_hash(
         &self,
         library: &str,
         asset_id: &str,
@@ -1873,7 +2662,7 @@ impl StateDb for SqliteStateDb {
         .await
     }
 
-    async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
+    pub(crate) async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
         self.with_conn("has_downloaded_without_metadata_hash", move |conn| {
             let exists: i64 = conn
                 .query_row(
@@ -1886,6 +2675,300 @@ impl StateDb for SqliteStateDb {
             Ok(exists != 0)
         })
         .await
+    }
+}
+
+#[async_trait]
+impl DownloadStateStore for SqliteStateDb {
+    #[cfg(test)]
+    async fn should_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        checksum: &str,
+        local_path: &Path,
+    ) -> Result<bool, StateError> {
+        SqliteStateDb::should_download(self, library, id, version_size, checksum, local_path).await
+    }
+
+    async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
+        SqliteStateDb::upsert_seen(self, record).await
+    }
+
+    async fn mark_downloaded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::mark_downloaded(
+            self,
+            library,
+            id,
+            version_size,
+            local_path,
+            local_checksum,
+            download_checksum,
+        )
+        .await
+    }
+
+    async fn mark_failed(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        error: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::mark_failed(self, library, id, version_size, error).await
+    }
+
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+        <SqliteStateDb as ReportStateStore>::get_pending_page(self, 0, u32::MAX).await
+    }
+
+    async fn reset_failed(&self) -> Result<u64, StateError> {
+        SqliteStateDb::reset_failed(self).await
+    }
+
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+        SqliteStateDb::prepare_for_retry(self).await
+    }
+
+    async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
+        SqliteStateDb::promote_pending_to_failed(self, seen_since).await
+    }
+
+    async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
+        SqliteStateDb::get_downloaded_ids(self).await
+    }
+
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+        SqliteStateDb::get_all_known_ids(self).await
+    }
+
+    async fn get_downloaded_checksums(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        SqliteStateDb::get_downloaded_checksums(self).await
+    }
+
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+        SqliteStateDb::get_attempt_counts(self).await
+    }
+
+    async fn touch_last_seen_many(
+        &self,
+        library: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), StateError> {
+        SqliteStateDb::touch_last_seen_many(self, library, asset_ids).await
+    }
+
+    async fn mark_soft_deleted(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::mark_soft_deleted(self, library, asset_id, deleted_at).await
+    }
+
+    async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError> {
+        SqliteStateDb::mark_hidden_at_source(self, library, asset_id).await
+    }
+}
+
+#[async_trait]
+impl ImportStateStore for SqliteStateDb {
+    async fn import_adopt(
+        &self,
+        record: &AssetRecord,
+        local_path: &Path,
+        local_checksum: &str,
+        imported_size: u64,
+        imported_mtime: Option<i64>,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::import_adopt(
+            self,
+            record,
+            local_path,
+            local_checksum,
+            imported_size,
+            imported_mtime,
+        )
+        .await
+    }
+
+    async fn get_all_imported_records(
+        &self,
+        library: &str,
+    ) -> Result<HashMap<(String, String), ImportedRecord>, StateError> {
+        SqliteStateDb::get_all_imported_records(self, library).await
+    }
+}
+
+#[async_trait]
+impl ReportStateStore for SqliteStateDb {
+    async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
+        <SqliteStateDb as ReportStateStore>::get_failed_page(self, 0, u32::MAX).await
+    }
+
+    async fn get_failed_sample(&self, limit: u32) -> Result<(Vec<AssetRecord>, u64), StateError> {
+        SqliteStateDb::get_failed_sample(self, limit).await
+    }
+
+    async fn get_failed_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        SqliteStateDb::get_failed_page(self, offset, limit).await
+    }
+
+    async fn get_pending_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        SqliteStateDb::get_pending_page(self, offset, limit).await
+    }
+
+    async fn get_summary(&self) -> Result<SyncSummary, StateError> {
+        SqliteStateDb::get_summary(self).await
+    }
+
+    async fn get_downloaded_page(
+        &self,
+        offset: u64,
+        limit: u32,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        SqliteStateDb::get_downloaded_page(self, offset, limit).await
+    }
+
+    async fn start_sync_run(&self) -> Result<i64, StateError> {
+        SqliteStateDb::start_sync_run(self).await
+    }
+
+    async fn complete_sync_run(&self, run_id: i64, stats: &SyncRunStats) -> Result<(), StateError> {
+        SqliteStateDb::complete_sync_run(self, run_id, stats).await
+    }
+
+    async fn promote_orphaned_sync_runs(&self) -> Result<u64, StateError> {
+        SqliteStateDb::promote_orphaned_sync_runs(self).await
+    }
+}
+
+#[async_trait]
+impl SyncTokenStore for SqliteStateDb {
+    async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
+        SqliteStateDb::get_metadata(self, key).await
+    }
+
+    async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
+        SqliteStateDb::set_metadata(self, key, value).await
+    }
+
+    async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
+        SqliteStateDb::delete_metadata_by_prefix(self, prefix).await
+    }
+
+    async fn begin_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        SqliteStateDb::begin_enum_progress(self, zone).await
+    }
+
+    async fn end_enum_progress(&self, zone: &str) -> Result<(), StateError> {
+        SqliteStateDb::end_enum_progress(self, zone).await
+    }
+
+    async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
+        SqliteStateDb::list_interrupted_enumerations(self).await
+    }
+}
+
+#[async_trait]
+impl MembershipStore for SqliteStateDb {
+    async fn add_asset_album(
+        &self,
+        library: &str,
+        asset_id: &str,
+        album_name: &str,
+        source: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::add_asset_album(self, library, asset_id, album_name, source).await
+    }
+
+    async fn get_all_asset_albums(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        SqliteStateDb::get_all_asset_albums(self, library).await
+    }
+
+    async fn get_all_asset_people(
+        &self,
+        library: &str,
+    ) -> Result<Vec<(String, String)>, StateError> {
+        SqliteStateDb::get_all_asset_people(self, library).await
+    }
+}
+
+#[async_trait]
+impl MetadataRewriteStore for SqliteStateDb {
+    async fn record_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::record_metadata_write_failure(self, library, asset_id, version_size).await
+    }
+
+    async fn get_downloaded_metadata_hashes(
+        &self,
+    ) -> Result<HashMap<(String, String, String), String>, StateError> {
+        SqliteStateDb::get_downloaded_metadata_hashes(self).await
+    }
+
+    async fn get_metadata_retry_markers(
+        &self,
+    ) -> Result<HashSet<(String, String, String)>, StateError> {
+        SqliteStateDb::get_metadata_retry_markers(self).await
+    }
+
+    async fn get_pending_metadata_rewrites(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        SqliteStateDb::get_pending_metadata_rewrites(self, limit).await
+    }
+
+    async fn update_metadata_hash(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        metadata_hash: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::update_metadata_hash(self, library, asset_id, version_size, metadata_hash)
+            .await
+    }
+
+    async fn clear_metadata_write_failure(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::clear_metadata_write_failure(self, library, asset_id, version_size).await
+    }
+
+    async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
+        SqliteStateDb::has_downloaded_without_metadata_hash(self).await
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,5 +12,10 @@ pub mod error;
 pub mod schema;
 pub mod types;
 
-pub use db::{SqliteStateDb, StateDb};
+#[cfg(test)]
+pub use db::ImportedRecord;
+pub use db::{
+    DownloadStateStore, ImportStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore,
+    SqliteStateDb, StateDb, SyncTokenStore,
+};
 pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -145,10 +145,13 @@ impl EnumConfigHashOutcome {
 /// and swallowed, but the new hash is never persisted unless stale sync
 /// tokens were cleared first. Otherwise a failed purge could leave old
 /// tokens behind while the updated hash makes later cycles trust them.
-pub(crate) async fn check_and_persist_enum_config_hash(
-    db: &dyn state::StateDb,
+pub(crate) async fn check_and_persist_enum_config_hash<D>(
+    db: &D,
     current_hash: &str,
-) -> EnumConfigHashOutcome {
+) -> EnumConfigHashOutcome
+where
+    D: state::SyncTokenStore + ?Sized,
+{
     let stored_hash = match db.get_metadata(ENUM_CONFIG_HASH_KEY).await {
         Ok(hash) => hash,
         Err(e) => {
@@ -401,10 +404,13 @@ pub(crate) async fn run_cycle(
 /// person memberships across zones (the v9 schema scopes both join tables
 /// per library; this reader honours that scope).
 #[cfg(feature = "xmp")]
-pub(crate) async fn preload_asset_groupings(
-    state_db: Option<&dyn state::StateDb>,
+pub(crate) async fn preload_asset_groupings<D>(
+    state_db: Option<&D>,
     library: &str,
-) -> Arc<download::AssetGroupings> {
+) -> Arc<download::AssetGroupings>
+where
+    D: state::MembershipStore + ?Sized,
+{
     let Some(db) = state_db else {
         return Arc::new(download::AssetGroupings::default());
     };
@@ -431,13 +437,16 @@ pub(crate) async fn preload_asset_groupings(
 }
 
 /// Determine the sync mode for a library: full enumeration or incremental.
-pub(crate) async fn determine_sync_mode(
+pub(crate) async fn determine_sync_mode<D>(
     is_retry_failed: bool,
     library_count: usize,
-    state_db: Option<&dyn state::StateDb>,
+    state_db: Option<&D>,
     sync_token_key: &str,
     zone_name: &str,
-) -> download::SyncMode {
+) -> download::SyncMode
+where
+    D: state::SyncTokenStore + ?Sized,
+{
     if is_retry_failed {
         if library_count == 1 {
             tracing::debug!(

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -22,7 +22,7 @@ use crate::notifications::{self, Notifier};
 use crate::password::{self, ExposeSecret, SecretString};
 use crate::retry;
 use crate::shutdown;
-use crate::state::{self, StateDb};
+use crate::state;
 use crate::sync_cycle::{run_cycle, sync_token_key as make_sync_token_key, LibraryState};
 
 #[cfg(test)]
@@ -3055,270 +3055,55 @@ mod tests {
     /// propagating. The watch loop must keep going even if sqlite hiccups —
     /// silently biasing toward Incremental on errors would mask data loss.
     ///
-    /// We reach the failure surface by closing the underlying connection
-    /// out from under a real `SqliteStateDb`. Doing this against a plain
-    /// fail-everything stub would require implementing every method in the
-    /// (large) `StateDb` trait; instead we use the test-only failing impl
-    /// the pipeline tests already maintain. See the inline `FailingDb`.
+    /// The inline `FailingDb` implements only `SyncTokenStore`, so any future
+    /// reroute inside `determine_sync_mode` has to either stay inside the
+    /// token role or fail to compile.
     #[tokio::test]
     async fn determine_sync_mode_state_db_error_falls_back_to_full() {
-        use std::collections::{HashMap, HashSet};
-
         // Minimal failing impl: only `get_metadata` is reachable from
-        // `determine_sync_mode`; every other method is unimplemented so
-        // any silent reroute lights up immediately.
+        // `determine_sync_mode`; the narrow role trait keeps any silent
+        // reroute from compiling against this stub.
         struct FailingDb;
 
         #[async_trait::async_trait]
-        impl state::StateDb for FailingDb {
-            #[cfg(test)]
-            async fn should_download(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-            ) -> Result<bool, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn upsert_seen(
-                &self,
-                _: &state::types::AssetRecord,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_downloaded(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-                _: &str,
-                _: Option<&str>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn import_adopt(
-                &self,
-                _: &state::types::AssetRecord,
-                _: &std::path::Path,
-                _: &str,
-                _: u64,
-                _: Option<i64>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_failed(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed_sample(
-                &self,
-                _: u32,
-            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_pending(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_summary(
-                &self,
-            ) -> Result<state::types::SyncSummary, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_page(
-                &self,
-                _: u64,
-                _: u32,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn complete_sync_run(
-                &self,
-                _: i64,
-                _: &state::types::SyncRunStats,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn list_interrupted_enumerations(
-                &self,
-            ) -> Result<Vec<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_pending_to_failed(
-                &self,
-                _: i64,
-            ) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_ids(
-                &self,
-            ) -> Result<HashSet<(String, String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_all_known_ids(&self) -> Result<HashSet<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_checksums(
-                &self,
-            ) -> Result<HashMap<(String, String, String), String>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_attempt_counts(
-                &self,
-            ) -> Result<HashMap<String, u32>, state::error::StateError> {
-                unimplemented!()
-            }
+        impl state::SyncTokenStore for FailingDb {
             async fn get_metadata(
                 &self,
                 _: &str,
             ) -> Result<Option<String>, state::error::StateError> {
                 Err(state::error::StateError::LockPoisoned("simulated".into()))
             }
+
             async fn set_metadata(&self, _: &str, _: &str) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
+
             async fn delete_metadata_by_prefix(
                 &self,
                 _: &str,
             ) -> Result<u64, state::error::StateError> {
                 unimplemented!()
             }
-            async fn touch_last_seen_many(
-                &self,
-                _: &str,
-                _: &[&str],
-            ) -> Result<(), state::error::StateError> {
+
+            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
-            async fn add_asset_album(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
+
+            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
                 unimplemented!()
             }
-            async fn get_all_asset_albums(
+
+            async fn list_interrupted_enumerations(
                 &self,
-                _: &str,
-            ) -> Result<Vec<(String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_all_asset_people(
-                &self,
-                _: &str,
-            ) -> Result<Vec<(String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_soft_deleted(
-                &self,
-                _: &str,
-                _: &str,
-                _: Option<chrono::DateTime<chrono::Utc>>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_hidden_at_source(
-                &self,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn record_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_metadata_hashes(
-                &self,
-            ) -> Result<HashMap<(String, String, String), String>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_metadata_retry_markers(
-                &self,
-            ) -> Result<HashSet<(String, String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_pending_metadata_rewrites(
-                &self,
-                _: usize,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn update_metadata_hash(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn clear_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn has_downloaded_without_metadata_hash(
-                &self,
-            ) -> Result<bool, state::error::StateError> {
+            ) -> Result<Vec<String>, state::error::StateError> {
                 unimplemented!()
             }
         }
 
-        let db: Arc<dyn state::StateDb> = Arc::new(FailingDb);
+        let db = FailingDb;
 
-        let mode = determine_sync_mode(
-            false,
-            1,
-            Some(db.as_ref()),
-            "sync_token:PrimarySync",
-            "PrimarySync",
-        )
-        .await;
+        let mode =
+            determine_sync_mode(false, 1, Some(&db), "sync_token:PrimarySync", "PrimarySync").await;
 
         assert!(
             matches!(mode, download::SyncMode::Full),
@@ -3331,8 +3116,14 @@ mod tests {
     /// it so a future refactor that drops the `else` branch tells us.
     #[tokio::test]
     async fn determine_sync_mode_no_state_db_returns_full() {
-        let mode =
-            determine_sync_mode(false, 1, None, "sync_token:PrimarySync", "PrimarySync").await;
+        let mode = determine_sync_mode::<state::SqliteStateDb>(
+            false,
+            1,
+            None,
+            "sync_token:PrimarySync",
+            "PrimarySync",
+        )
+        .await;
 
         assert!(
             matches!(mode, download::SyncMode::Full),
@@ -3767,167 +3558,12 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn preload_asset_groupings_partial_people_failure_keeps_albums() {
-        use std::collections::{HashMap, HashSet};
-
         struct PartialDb {
             inner: Arc<dyn state::StateDb>,
         }
 
         #[async_trait::async_trait]
-        impl state::StateDb for PartialDb {
-            #[cfg(test)]
-            async fn should_download(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-            ) -> Result<bool, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn upsert_seen(
-                &self,
-                _: &state::types::AssetRecord,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_downloaded(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &std::path::Path,
-                _: &str,
-                _: Option<&str>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn import_adopt(
-                &self,
-                _: &state::types::AssetRecord,
-                _: &std::path::Path,
-                _: &str,
-                _: u64,
-                _: Option<i64>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_failed(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_failed_sample(
-                &self,
-                _: u32,
-            ) -> Result<(Vec<state::types::AssetRecord>, u64), state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_pending(
-                &self,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_summary(
-                &self,
-            ) -> Result<state::types::SyncSummary, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_page(
-                &self,
-                _: u64,
-                _: u32,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn start_sync_run(&self) -> Result<i64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn complete_sync_run(
-                &self,
-                _: i64,
-                _: &state::types::SyncRunStats,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_orphaned_sync_runs(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn begin_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn end_enum_progress(&self, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn list_interrupted_enumerations(
-                &self,
-            ) -> Result<Vec<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn reset_failed(&self) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn promote_pending_to_failed(
-                &self,
-                _: i64,
-            ) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_ids(
-                &self,
-            ) -> Result<HashSet<(String, String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_all_known_ids(&self) -> Result<HashSet<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_checksums(
-                &self,
-            ) -> Result<HashMap<(String, String, String), String>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_attempt_counts(
-                &self,
-            ) -> Result<HashMap<String, u32>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_metadata(
-                &self,
-                _: &str,
-            ) -> Result<Option<String>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn set_metadata(&self, _: &str, _: &str) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn delete_metadata_by_prefix(
-                &self,
-                _: &str,
-            ) -> Result<u64, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn touch_last_seen_many(
-                &self,
-                _: &str,
-                _: &[&str],
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
+        impl state::MembershipStore for PartialDb {
             async fn add_asset_album(
                 &self,
                 library: &str,
@@ -3939,12 +3575,14 @@ mod tests {
                     .add_asset_album(library, asset_id, album_name, source)
                     .await
             }
+
             async fn get_all_asset_albums(
                 &self,
                 library: &str,
             ) -> Result<Vec<(String, String)>, state::error::StateError> {
                 self.inner.get_all_asset_albums(library).await
             }
+
             async fn get_all_asset_people(
                 &self,
                 _: &str,
@@ -3952,68 +3590,6 @@ mod tests {
                 Err(state::error::StateError::LockPoisoned(
                     "simulated people-table read failure".into(),
                 ))
-            }
-            async fn mark_soft_deleted(
-                &self,
-                _: &str,
-                _: &str,
-                _: Option<chrono::DateTime<chrono::Utc>>,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn mark_hidden_at_source(
-                &self,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn record_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_downloaded_metadata_hashes(
-                &self,
-            ) -> Result<HashMap<(String, String, String), String>, state::error::StateError>
-            {
-                unimplemented!()
-            }
-            async fn get_metadata_retry_markers(
-                &self,
-            ) -> Result<HashSet<(String, String, String)>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn get_pending_metadata_rewrites(
-                &self,
-                _: usize,
-            ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-                unimplemented!()
-            }
-            async fn update_metadata_hash(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn clear_metadata_write_failure(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> Result<(), state::error::StateError> {
-                unimplemented!()
-            }
-            async fn has_downloaded_without_metadata_hash(
-                &self,
-            ) -> Result<bool, state::error::StateError> {
-                unimplemented!()
             }
         }
 
@@ -4029,9 +3605,9 @@ mod tests {
             .await
             .expect("add album B");
 
-        let db: Option<Arc<dyn state::StateDb>> = Some(Arc::new(PartialDb { inner }));
+        let db = PartialDb { inner };
 
-        let groupings = preload_asset_groupings(db.as_deref(), "PrimarySync").await;
+        let groupings = preload_asset_groupings(Some(&db), "PrimarySync").await;
         // Albums must survive intact.
         assert_eq!(
             groupings.albums.len(),
@@ -4054,7 +3630,7 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn preload_asset_groupings_no_db_returns_empty() {
-        let groupings = preload_asset_groupings(None, "PrimarySync").await;
+        let groupings = preload_asset_groupings::<state::SqliteStateDb>(None, "PrimarySync").await;
         assert!(groupings.albums.is_empty());
         assert!(groupings.people.is_empty());
     }


### PR DESCRIPTION
## Summary
- Split the state DB surface into smaller role traits for download state, imports, reporting, sync tokens, memberships, and metadata rewrites.
- Kept `SqliteStateDb` as the single production implementation while narrowing cycle, download, report, import, and reconcile call sites to the roles they use.
- Shrunk targeted test stubs so token and membership failure tests no longer implement the full DB surface.

## Review notes
Start with `src/state/db.rs` for the trait split and forwarding impls. The rest is call-site follow-through.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test sync_loop -- --test-threads=1`
- `cargo test download` - passed outside the sandbox after the sandbox run hit localhost bind denial in wiremock tests
- `cargo test state` - passed outside the sandbox after the sandbox run hit localhost bind denial in one wiremock test
