### PR TITLE
Keep full-test tempdirs in repo scratch

### DIFF
--- a/scripts/full-test/run_all.sh
+++ b/scripts/full-test/run_all.sh
@@ -78,6 +78,16 @@ export ICLOUD_TEST_COOKIE_DIR="$repo_root/.test-cookies"
 export KEI_TEST_ALBUM="${KEI_TEST_ALBUM:-kei-test}"
 export KEI_DOCKER_IMAGE="${KEI_DOCKER_IMAGE:-kei:dev}"
 
+# Keep child tempdirs on the repo filesystem. The top-level failure log stays
+# in /tmp through the just recipe, but cargo/live/shell phases can create large
+# download roots and should not trip the production 1 GiB free-space guard just
+# because tmpfs is nearly full.
+full_tmp_dir="${KEI_FULL_TEST_TMPDIR:-$repo_root/.scratch/full-test-tmp}"
+mkdir -p "$full_tmp_dir"
+export TMPDIR="$full_tmp_dir"
+export TEMP="$full_tmp_dir"
+export TMP="$full_tmp_dir"
+
 tp() { "$script_dir/time_phase.sh" "$@"; }
 run_phase() {
   current_phase="$1"

--- a/scripts/full-test/run_live_smokes.sh
+++ b/scripts/full-test/run_live_smokes.sh
@@ -9,7 +9,7 @@
 # Optional env:
 #   KEI_TEST_DATA_DIR  cookie / db dir (default .test-cookies under repo)
 #   KEI_TEST_ALBUM     album name for sync dry-run (default kei-test)
-#   KEI_TEST_DOWNLOAD_DIR  scratch dir for sync/import dry-run (default /tmp/codex/photos-test)
+#   KEI_TEST_DOWNLOAD_DIR  scratch dir for sync/import dry-run (default under TMPDIR)
 #
 # Adding a new CLI subcommand: add a smoke line below. Don't add destructive
 # (reset) or interactive (login) commands -- they're covered elsewhere.
@@ -31,7 +31,7 @@ fi
 
 USR="${ICLOUD_USERNAME:-missing@example.invalid}"
 DD="${KEI_TEST_DATA_DIR:-$repo_root/.test-cookies}"
-DOWNLOAD_DIR="${KEI_TEST_DOWNLOAD_DIR:-/tmp/codex/photos-test}"
+DOWNLOAD_DIR="${KEI_TEST_DOWNLOAD_DIR:-${TMPDIR:-$repo_root/.scratch/full-test-tmp}/photos-test}"
 mkdir -p "$DOWNLOAD_DIR"
 
 sync_config="$(kei_write_sync_config "$DD" "$DOWNLOAD_DIR")"
@@ -62,4 +62,4 @@ run live_config_show       env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binar
 run live_verify            bash -c verify_wrapper
 run live_reconcile_dryrun  env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" reconcile --dry-run
 run live_password_backend  env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" password backend
-run live_import_dryrun     env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" import-existing --dry-run --recent 5 --download-dir "$DOWNLOAD_DIR"
+run live_import_dryrun     env ICLOUD_USERNAME="$USR" KEI_DATA_DIR="$DD" "$binary" import-existing --dry-run --recent 5 --config "$sync_config"

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -121,3 +121,21 @@ fn full_test_routes_child_tempdirs_to_repo_scratch() {
         "TMPDIR must be set before live cargo and shell phases allocate tempdirs"
     );
 }
+
+#[test]
+fn live_import_smoke_uses_toml_directory() {
+    let smokes = repo_file("scripts/full-test/run_live_smokes.sh");
+
+    assert!(
+        smokes.contains("import-existing --dry-run --recent 5 --config \"$sync_config\""),
+        "import-existing live smoke must pass the generated TOML config"
+    );
+    assert!(
+        !smokes.contains("import-existing --dry-run --recent 5 --download-dir"),
+        "import-existing live smoke must not use the removed --download-dir flag"
+    );
+    assert!(
+        smokes.contains(r#"${TMPDIR:-$repo_root/.scratch/full-test-tmp}/photos-test"#),
+        "live smoke download scratch should follow full-test's repo-local TMPDIR"
+    );
+}

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -83,3 +83,41 @@ fn migration_guide_uses_toml_for_durable_sync_settings() {
         );
     }
 }
+
+#[test]
+fn full_test_routes_child_tempdirs_to_repo_scratch() {
+    let run_all = repo_file("scripts/full-test/run_all.sh");
+    let tmp_assignment =
+        "full_tmp_dir=\"${KEI_FULL_TEST_TMPDIR:-$repo_root/.scratch/full-test-tmp}\"";
+    let tmp_export = "export TMPDIR=\"$full_tmp_dir\"";
+    let temp_export = "export TEMP=\"$full_tmp_dir\"";
+    let tmp_windows_export = "export TMP=\"$full_tmp_dir\"";
+
+    for expected in [
+        tmp_assignment,
+        "mkdir -p \"$full_tmp_dir\"",
+        tmp_export,
+        temp_export,
+        tmp_windows_export,
+    ] {
+        assert!(
+            run_all.contains(expected),
+            "full-test orchestrator missing repo-local tempdir setup: {expected}"
+        );
+    }
+
+    let export_pos = run_all
+        .find(tmp_export)
+        .expect("full-test must export TMPDIR before live tests");
+    let live_pos = run_all
+        .find("run_live_phase test_live")
+        .expect("full-test live phase must still exist");
+    let shell_pos = run_all
+        .find("run_shell_suites.sh")
+        .expect("full-test shell phase must still exist");
+
+    assert!(
+        export_pos < live_pos && export_pos < shell_pos,
+        "TMPDIR must be set before live cargo and shell phases allocate tempdirs"
+    );
+}


### PR DESCRIPTION
## Summary
- Route `just full-test` child tempdirs through repo-local `.scratch/full-test-tmp` by default, with `KEI_FULL_TEST_TMPDIR` as an override.
- Move the live smoke download scratch path under `TMPDIR`.
- Update the `import-existing` live smoke to use the generated TOML config instead of the removed `--download-dir` flag.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test branch_static`
- `bash -n scripts/full-test/run_all.sh scripts/full-test/run_live_smokes.sh`
