### PR TITLE
Improve test coverage for sync safety gaps

### DIFF
--- a/justfile
+++ b/justfile
@@ -105,7 +105,7 @@ test MODE="":
             ;;
     esac
 
-# Coverage: (none) | html | live | patch [BASE]. `live` merges sync + state_auth into the offline baseline.
+# Coverage: (none) | html | check | live | patch [BASE]. `live` merges sync + state_auth into the offline baseline.
 cov MODE="" BASE="main":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -119,6 +119,9 @@ cov MODE="" BASE="main":
         html)
             cargo llvm-cov --all-features --html
             echo "Report: target/llvm-cov/html/index.html"
+            ;;
+        check)
+            cargo llvm-cov --all-features --summary-only --fail-under-lines 90
             ;;
         live)
             _live_env
@@ -151,7 +154,7 @@ cov MODE="" BASE="main":
             ;;
         *)
             echo "Unknown mode: {{MODE}}" >&2
-            echo "Modes: (none) | html | live | patch [BASE]" >&2
+            echo "Modes: (none) | html | check | live | patch [BASE]" >&2
             exit 1
             ;;
     esac

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -600,6 +600,11 @@ fn check_requires_2fa(data: &AccountLoginResponse) -> bool {
 mod tests {
     use super::*;
     use crate::auth::responses::{AccountLoginResponse, DsInfo};
+    use secrecy::SecretString;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     fn make_response(
         hsa_version: i64,
@@ -700,5 +705,84 @@ mod tests {
         let dir = Path::new("/var/cookies");
         let path = session_file_path(dir, "");
         assert_eq!(path, Path::new("/var/cookies/.session"));
+    }
+
+    #[tokio::test]
+    async fn authenticate_rejects_unsupported_domain_before_password_lookup() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let called = Arc::new(AtomicBool::new(false));
+        let called_for_provider = Arc::clone(&called);
+        let provider: crate::password::PasswordProvider = Arc::new(move || {
+            called_for_provider.store(true, Ordering::SeqCst);
+            Some(SecretString::from("should-not-be-read"))
+        });
+
+        let err = authenticate(
+            cookies.path(),
+            "user@example.com",
+            &provider,
+            "unsupported",
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("unsupported domain should fail before session auth");
+
+        assert!(
+            err.to_string().contains("not supported"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "password provider must not run when endpoint resolution fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_2fa_push_rejects_unsupported_domain_before_password_lookup() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let called = Arc::new(AtomicBool::new(false));
+        let called_for_provider = Arc::clone(&called);
+        let provider: crate::password::PasswordProvider = Arc::new(move || {
+            called_for_provider.store(true, Ordering::SeqCst);
+            Some(SecretString::from("should-not-be-read"))
+        });
+
+        let err = send_2fa_push(cookies.path(), "user@example.com", &provider, "unsupported")
+            .await
+            .expect_err("unsupported domain should fail before SRP");
+
+        assert!(
+            err.to_string().contains("not supported"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "password provider must not run when endpoint resolution fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_result_debug_redacts_session_and_data() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(
+            cookies.path(),
+            "debug@example.com",
+            "https://setup.icloud.com",
+            None,
+        )
+        .await
+        .expect("session");
+        let result = AuthResult {
+            session,
+            data: make_response(2, false, true, true),
+            requires_2fa: false,
+        };
+
+        let rendered = format!("{result:?}");
+        assert!(rendered.contains("session: \"<redacted>\""));
+        assert!(rendered.contains("data: \"<...>\""));
+        assert!(!rendered.contains("debug@example.com"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5287,21 +5287,24 @@ mod tests {
     fn test_folder_structure_valid_tokens_accepted() {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure = Some("%Y/%m/%d".to_string());
-        assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        assert_eq!(cfg.download.folder_structure, "%Y/%m/%d");
     }
 
     #[test]
     fn test_folder_structure_all_tokens_accepted() {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure = Some("%Y/%m/%d/%H/%M/%S".to_string());
-        assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        assert_eq!(cfg.download.folder_structure, "%Y/%m/%d/%H/%M/%S");
     }
 
     #[test]
     fn test_folder_structure_none_bypasses_validation() {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure = Some("none".to_string());
-        assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        assert_eq!(cfg.download.folder_structure, "none");
     }
 
     #[test]
@@ -5317,7 +5320,8 @@ mod tests {
     fn test_folder_structure_wrapped_format_accepted() {
         let mut sync = default_sync();
         sync.config_overrides.folder_structure = Some("{:%Y/%m/%d}".to_string());
-        assert!(Config::build(&default_globals(), &default_password(), sync, None).is_ok());
+        let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();
+        assert_eq!(cfg.download.folder_structure, "{:%Y/%m/%d}");
     }
 
     // ── to_toml() tests ─────────────────────────────────────────────

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -79,6 +79,9 @@ pub(super) fn temp_download_path(
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(checksum)
         .context("Failed to decode base64 checksum")?;
+    if decoded.is_empty() {
+        anyhow::bail!("Decoded checksum is empty");
+    }
     let encoded = data_encoding::BASE32_NOPAD.encode(&decoded);
     let download_dir = download_path.parent().unwrap_or_else(|| Path::new("."));
     Ok(download_dir.join(format!("{encoded}{temp_suffix}")))
@@ -1036,17 +1039,15 @@ mod tests {
 
     #[test]
     fn temp_download_path_empty_checksum_fails() {
-        // Empty string is technically valid base64 (decodes to empty bytes),
-        // but produces an empty base32 filename — verify it at least doesn't panic.
-        // An empty checksum decodes to zero bytes, so base32 is also empty.
-        let path = PathBuf::from("/photos/test.jpg");
+        // Empty base64 decodes successfully to zero bytes. That must still
+        // be rejected because accepting it would make every malformed
+        // checksum share the same suffix-only temp path.
+        let path = PathBuf::from("/photos/IMG_0001.JPG");
         let result = temp_download_path(&path, "", ".kei-tmp");
-        // Empty base64 decodes successfully to empty bytes; the path is valid
-        // but the stem is empty — just the suffix. Ensure no error.
-        assert!(result.is_ok());
-        let temp = result.unwrap();
-        // The filename should be just the suffix since the encoded part is empty
-        assert_eq!(temp.file_name().unwrap().to_str().unwrap(), ".kei-tmp");
+        assert!(
+            result.is_err(),
+            "empty checksum must not produce a shared .kei-tmp path"
+        );
     }
 
     /// Robustness regression for downloaded-byte verification. Apple does

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -24,6 +24,7 @@ use super::DownloadConfig;
 /// Reason an asset was filtered out during content/metadata filtering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FilterReason {
+    MalformedAsset,
     ExcludedAlbum,
     MediaType,
     LivePhoto,
@@ -387,6 +388,10 @@ pub(crate) fn is_asset_filtered(
     asset: &crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> Option<FilterReason> {
+    if !asset.has_valid_id() {
+        tracing::warn!("Skipping malformed asset with empty CloudKit recordName");
+        return Some(FilterReason::MalformedAsset);
+    }
     if config.exclude_asset_ids.contains(asset.id()) {
         tracing::debug!(asset_id = %asset.id(), "Skipping (excluded album asset)");
         return Some(FilterReason::ExcludedAlbum);
@@ -450,6 +455,10 @@ pub(super) fn extract_skip_candidates<'a>(
     asset: &'a crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> SmallVec<[(VersionSizeKey, &'a str); 5]> {
+    if !asset.has_valid_id() {
+        return SmallVec::new();
+    }
+
     let ctx = DerivationContext::build(asset, config);
     let mut result = SmallVec::new();
     let mut seen_urls = SmallVec::<[&str; 4]>::new();
@@ -873,6 +882,10 @@ pub(super) fn derive_expected_paths(
     asset: &crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> SmallVec<[DerivedPath; 5]> {
+    if !asset.has_valid_id() {
+        return SmallVec::new();
+    }
+
     let ctx = DerivationContext::build(asset, config);
     let mut out = SmallVec::<[DerivedPath; 5]>::new();
     let mut seen_urls = SmallVec::<[Box<str>; 4]>::new();
@@ -1134,6 +1147,10 @@ pub(super) fn filter_asset_to_tasks(
     claimed_paths: &mut FxHashMap<NormalizedPath, u64>,
     dir_cache: &mut paths::DirCache,
 ) -> SmallVec<[DownloadTask; 5]> {
+    if !asset.has_valid_id() {
+        return SmallVec::new();
+    }
+
     // Sync-only fingerprint-fallback exclusion: when `asset.filename()` is
     // None, log the synthesized name and apply `filename_exclude` patterns
     // to it (`is_asset_filtered` only sees real filenames). Import never
@@ -1369,6 +1386,41 @@ mod tests {
         assert_eq!(&*tasks[0].url, "https://p01.icloud-content.com/orig");
         assert_eq!(&*tasks[0].checksum, "abc123");
         assert_eq!(tasks[0].size, 1000);
+    }
+
+    #[test]
+    fn empty_record_name_is_filtered_before_path_planning() {
+        let asset = PhotoAsset::new(
+            json!({"recordName": "", "fields": {
+                "filenameEnc": {"value": "photo.jpg", "type": "STRING"},
+                "itemType": {"value": "public.jpeg"},
+                "resOriginalRes": {"value": {
+                    "size": 1000,
+                    "downloadURL": "https://p01.icloud-content.com/orig",
+                    "fileChecksum": "abc123"
+                }},
+                "resOriginalFileType": {"value": "public.jpeg"}
+            }}),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+        let config = test_config();
+
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::MalformedAsset)
+        );
+        assert!(
+            extract_skip_candidates(&asset, &config).is_empty(),
+            "invalid id must not enter state-skip decisions"
+        );
+        assert!(
+            expected_paths_for(&asset, &config).is_empty(),
+            "invalid id must not derive import/sync paths"
+        );
+        assert!(
+            filter_asset_fresh(&asset, &config).is_empty(),
+            "invalid id must not produce download tasks"
+        );
     }
 
     // ── expected_paths_for tests ────────────────────────────────────────

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -281,6 +281,7 @@ impl SkipBreakdown {
 
     pub(crate) fn record_filter_reason(&mut self, reason: filter::FilterReason) {
         match reason {
+            filter::FilterReason::MalformedAsset => self.by_filename += 1,
             filter::FilterReason::ExcludedAlbum => self.by_excluded_album += 1,
             filter::FilterReason::MediaType => self.by_media_type += 1,
             filter::FilterReason::LivePhoto => self.by_live_photo += 1,
@@ -1174,6 +1175,15 @@ impl DownloadContext {
         checksum: &str,
         trust_state: bool,
     ) -> Option<bool> {
+        if checksum.is_empty() {
+            tracing::warn!(
+                asset_id,
+                version_size = %version_size.as_str(),
+                "Empty remote checksum cannot be trusted for skip decisions"
+            );
+            return Some(true);
+        }
+
         let version_size_str = version_size.as_str();
 
         // Borrowed `&str` keys at every level — no allocation per probe.
@@ -3102,12 +3112,12 @@ mod tests {
 
     // ── Gap coverage: empty versions, path traversal, empty filename ───
 
-    // ── Gap coverage: should_download_fast with empty checksum ──────────
-
     #[test]
-    fn should_download_fast_empty_checksum_string() {
-        // When the stored checksum is empty and the incoming checksum is also
-        // empty, they match — should behave like a normal matching checksum.
+    fn should_download_fast_empty_checksum_never_hard_skips() {
+        // Empty remote checksum is malformed provider input. Even if a stale
+        // DB row also has an empty checksum, this must not turn into a hard
+        // skip: the provider parser rejects new empty checksums, and this
+        // fast path stays defensive for legacy/corrupt state.
         let mut ctx = DownloadContext::default();
         ctx.downloaded_ids
             .entry("PrimarySync".into())
@@ -3122,7 +3132,6 @@ mod tests {
             .or_default()
             .insert("original".into(), "".into());
 
-        // Empty matches empty → trust_state=true gives hard skip
         assert_eq!(
             ctx.should_download_fast(
                 "PrimarySync",
@@ -3131,9 +3140,8 @@ mod tests {
                 "",
                 true
             ),
-            Some(false)
+            Some(true)
         );
-        // Empty matches empty → trust_state=false gives None (needs fs check)
         assert_eq!(
             ctx.should_download_fast(
                 "PrimarySync",
@@ -3142,9 +3150,8 @@ mod tests {
                 "",
                 false
             ),
-            None
+            Some(true)
         );
-        // Non-empty vs empty stored → checksum changed, needs download
         assert_eq!(
             ctx.should_download_fast(
                 "PrimarySync",

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -156,6 +156,7 @@ impl ProducerSkipSummary {
 
     fn record_filter_reason(&mut self, reason: super::filter::FilterReason) {
         match reason {
+            super::filter::FilterReason::MalformedAsset => self.by_filename += 1,
             super::filter::FilterReason::ExcludedAlbum => self.by_excluded_album += 1,
             super::filter::FilterReason::MediaType => self.by_media_type += 1,
             super::filter::FilterReason::LivePhoto => self.by_live_photo += 1,
@@ -3246,6 +3247,33 @@ mod tests {
     }
 
     #[test]
+    fn pass_config_debug_keeps_runtime_handles_out_of_output() {
+        let client = reqwest::Client::new();
+        let retry_config = RetryConfig::default();
+        let config = PassConfig {
+            client: &client,
+            retry_config: &retry_config,
+            metadata: MetadataFlags::DATETIME | MetadataFlags::DESCRIPTION,
+            concurrency: 3,
+            reporting: DownloadReporting::hidden(),
+            temp_suffix: Arc::from(".part"),
+            shutdown_token: CancellationToken::new(),
+            state_db: None,
+            rate_limit_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            bandwidth_limiter: None,
+            library: Arc::from("PrimarySync"),
+        };
+
+        let rendered = format!("{config:?}");
+        assert!(rendered.contains("metadata"));
+        assert!(rendered.contains("concurrency: 3"));
+        assert!(rendered.contains("temp_suffix: \".part\""));
+        assert!(!rendered.contains("client"));
+        assert!(!rendered.contains("retry_config"));
+        assert!(!rendered.contains("shutdown_token"));
+    }
+
+    #[test]
     fn test_set_file_mtime_positive_timestamp() {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("pos.txt");
@@ -3531,6 +3559,55 @@ mod tests {
         assert_eq!(a.retry_exhausted, 10);
         assert_eq!(a.retry_only, 7);
         assert_eq!(a.total(), 53);
+    }
+
+    #[test]
+    fn producer_skip_summary_records_every_filter_reason() {
+        let mut skips = ProducerSkipSummary::default();
+
+        skips.record_filter_reason(super::super::filter::FilterReason::MalformedAsset);
+        skips.record_filter_reason(super::super::filter::FilterReason::ExcludedAlbum);
+        skips.record_filter_reason(super::super::filter::FilterReason::MediaType);
+        skips.record_filter_reason(super::super::filter::FilterReason::LivePhoto);
+        skips.record_filter_reason(super::super::filter::FilterReason::DateRange);
+        skips.record_filter_reason(super::super::filter::FilterReason::Filename);
+
+        assert_eq!(skips.by_filename, 2);
+        assert_eq!(skips.by_excluded_album, 1);
+        assert_eq!(skips.by_media_type, 1);
+        assert_eq!(skips.by_live_photo, 1);
+        assert_eq!(skips.by_date_range, 1);
+        assert_eq!(skips.total(), 6);
+    }
+
+    #[test]
+    fn producer_skip_summary_converts_to_public_skip_breakdown() {
+        let skips = ProducerSkipSummary {
+            by_state: 1,
+            on_disk: 2,
+            ampm_variant: 3,
+            by_media_type: 4,
+            by_date_range: 5,
+            by_live_photo: 6,
+            by_filename: 7,
+            by_excluded_album: 8,
+            duplicates: 9,
+            retry_exhausted: 10,
+            retry_only: 11,
+        };
+
+        let breakdown = super::super::SkipBreakdown::from(skips);
+        assert_eq!(breakdown.by_state, 1);
+        assert_eq!(breakdown.on_disk, 2);
+        assert_eq!(breakdown.ampm_variant, 3);
+        assert_eq!(breakdown.by_media_type, 4);
+        assert_eq!(breakdown.by_date_range, 5);
+        assert_eq!(breakdown.by_live_photo, 6);
+        assert_eq!(breakdown.by_filename, 7);
+        assert_eq!(breakdown.by_excluded_album, 8);
+        assert_eq!(breakdown.duplicates, 9);
+        assert_eq!(breakdown.retry_exhausted, 10);
+        assert_eq!(breakdown.retry_only, 11);
     }
 
     #[test]

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -198,17 +198,25 @@ fn extract_versions(
             }
         };
 
-        let checksum: Box<str> =
-            if let Some(c) = res_entry.get("fileChecksum").and_then(Value::as_str) {
-                c.into()
-            } else {
+        let checksum: Box<str> = match res_entry.get("fileChecksum").and_then(Value::as_str) {
+            Some(c) if !c.is_empty() => c.into(),
+            Some(_) => {
+                tracing::warn!(
+                    asset = %record_name,
+                    field = format_args!("{res_field}.fileChecksum"),
+                    "Empty fileChecksum, skipping version"
+                );
+                continue;
+            }
+            None => {
                 tracing::warn!(
                     asset = %record_name,
                     field = format_args!("{res_field}.fileChecksum"),
                     "Missing fileChecksum, skipping version"
                 );
                 continue;
-            };
+            }
+        };
 
         let asset_type: std::sync::Arc<str> = match fields
             .get(type_field)
@@ -343,6 +351,15 @@ impl PhotoAsset {
 
     pub fn id(&self) -> &str {
         &self.record_name
+    }
+
+    /// True when the CloudKit record carried a usable recordName.
+    ///
+    /// An empty ID cannot safely key state rows, path fingerprints, retry
+    /// accounting, or metadata rewrite markers, so production planners must
+    /// filter it before deriving any download tasks.
+    pub(crate) fn has_valid_id(&self) -> bool {
+        !self.record_name.is_empty()
     }
 
     /// Shared handle on the record ID. Consumers that want to store the ID
@@ -833,6 +850,26 @@ mod tests {
         );
         // Missing checksum now results in empty versions map (logged at construction)
         assert!(asset.versions().is_empty());
+    }
+
+    #[test]
+    fn test_versions_empty_checksum() {
+        let asset = make_asset(
+            json!({"fields": {
+                "itemType": {"value": "public.jpeg"},
+                "resOriginalRes": {"value": {
+                    "size": 1000,
+                    "downloadURL": "https://p01.icloud-content.com/orig",
+                    "fileChecksum": ""
+                }},
+                "resOriginalFileType": {"value": "public.jpeg"}
+            }}),
+            json!({"fields": {}}),
+        );
+        assert!(
+            asset.versions().is_empty(),
+            "empty checksum must not create a downloadable version"
+        );
     }
 
     #[test]
@@ -1598,10 +1635,14 @@ mod tests {
     // --- Gap tests: API response handling robustness ---
 
     #[test]
-    fn photo_asset_null_record_name_returns_empty_id() {
+    fn photo_asset_null_record_name_is_not_valid_id() {
         // recordName is JSON null rather than missing entirely
         let asset = make_asset(json!({"recordName": null}), json!({}));
         assert_eq!(asset.id(), "");
+        assert!(
+            !asset.has_valid_id(),
+            "null recordName must not be considered downloadable"
+        );
     }
 
     #[test]
@@ -1691,13 +1732,16 @@ mod tests {
     }
 
     #[test]
-    fn asset_empty_record_name_still_exposes_empty_id() {
+    fn asset_empty_record_name_is_not_valid_id() {
         let asset = make_asset(json!({"recordName": ""}), json!({}));
         assert_eq!(
             asset.id(),
             "",
-            "empty recordName must be reflected as empty id so upstream producers \
-             can detect and reject; no silent defaulting to a placeholder"
+            "empty recordName must be reflected as empty id for diagnostics"
+        );
+        assert!(
+            !asset.has_valid_id(),
+            "empty recordName must be filtered before path planning"
         );
     }
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -156,6 +156,119 @@ fn migrate_directory_contents(src_dir: &Path, dst_dir: &Path) -> anyhow::Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    fn set_home_for_test(home: &Path) -> HomeGuard {
+        static HOME_LOCK: Mutex<()> = Mutex::new(());
+        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_home = std::env::var_os("HOME");
+        // SAFETY: this module serializes every test that mutates HOME through
+        // HOME_LOCK, and these tests do not read HOME from other threads.
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        HomeGuard {
+            _lock: lock,
+            prev_home,
+        }
+    }
+
+    struct HomeGuard {
+        _lock: MutexGuard<'static, ()>,
+        prev_home: Option<OsString>,
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            if let Some(home) = self.prev_home.take() {
+                // SAFETY: still holding HOME_LOCK, so restoration is serialized
+                // with every test in this module that mutates HOME.
+                unsafe {
+                    std::env::set_var("HOME", home);
+                }
+            } else {
+                // SAFETY: still holding HOME_LOCK, so restoration is serialized
+                // with every test in this module that mutates HOME.
+                unsafe {
+                    std::env::remove_var("HOME");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn migrate_legacy_paths_migrates_config_and_cookie_files_from_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_home_for_test(tmp.path());
+        let old_config = tmp.path().join(".config/icloudpd-rs/config.toml");
+        let old_cookie_dir = tmp.path().join(".icloudpd-rs");
+        std::fs::create_dir_all(old_config.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&old_cookie_dir).unwrap();
+        std::fs::write(&old_config, "username = \"old@example.com\"").unwrap();
+        std::fs::write(old_cookie_dir.join("old.session"), "session").unwrap();
+        std::fs::write(old_cookie_dir.join("old.db"), "db").unwrap();
+
+        let report = migrate_legacy_paths().expect("legacy paths should migrate");
+
+        assert!(report.config_migrated);
+        assert!(report.cookies_migrated);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(".config/kei/config.toml")).unwrap(),
+            "username = \"old@example.com\""
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(".config/kei/cookies/old.session")).unwrap(),
+            "session"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(".config/kei/cookies/old.db")).unwrap(),
+            "db"
+        );
+        assert!(old_config.exists(), "legacy config must be left in place");
+        assert!(
+            old_cookie_dir.exists(),
+            "legacy cookie dir must be left in place"
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|line| line.contains("deprecated")),
+            "migration report should tell users to move off old paths: {report:?}"
+        );
+    }
+
+    #[test]
+    fn migrate_legacy_paths_skips_when_new_config_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_home_for_test(tmp.path());
+        let new_config = tmp.path().join(".config/kei/config.toml");
+        let old_config = tmp.path().join(".config/icloudpd-rs/config.toml");
+        std::fs::create_dir_all(new_config.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(old_config.parent().unwrap()).unwrap();
+        std::fs::write(&new_config, "username = \"new@example.com\"").unwrap();
+        std::fs::write(&old_config, "username = \"old@example.com\"").unwrap();
+
+        assert!(migrate_legacy_paths().is_none());
+        assert_eq!(
+            std::fs::read_to_string(&new_config).unwrap(),
+            "username = \"new@example.com\""
+        );
+    }
+
+    #[test]
+    fn migrate_legacy_paths_returns_none_without_legacy_inputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_home_for_test(tmp.path());
+
+        assert!(migrate_legacy_paths().is_none());
+        assert!(
+            !tmp.path().join(".config/kei").exists(),
+            "no legacy inputs should not create new directories"
+        );
+    }
+
     #[test]
     fn migrate_file_copies_to_new_location() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -31,14 +31,22 @@ pub(crate) struct MigrationReport {
 pub fn migrate_legacy_paths() -> Option<MigrationReport> {
     let new_config = expand_tilde(NEW_CONFIG_PATH);
     let new_cookie_dir = expand_tilde(NEW_COOKIE_DIR);
+    let old_config = expand_tilde(OLD_CONFIG_PATH);
+    let old_cookie_dir = expand_tilde(OLD_COOKIE_DIR);
 
+    migrate_legacy_paths_from_paths(&new_config, &new_cookie_dir, &old_config, &old_cookie_dir)
+}
+
+fn migrate_legacy_paths_from_paths(
+    new_config: &Path,
+    new_cookie_dir: &Path,
+    old_config: &Path,
+    old_cookie_dir: &Path,
+) -> Option<MigrationReport> {
     // If new config already exists, no migration needed.
     if new_config.exists() {
         return None;
     }
-
-    let old_config = expand_tilde(OLD_CONFIG_PATH);
-    let old_cookie_dir = expand_tilde(OLD_COOKIE_DIR);
 
     let has_old_config = old_config.is_file();
     let has_old_cookies = old_cookie_dir.is_dir();
@@ -51,7 +59,7 @@ pub fn migrate_legacy_paths() -> Option<MigrationReport> {
 
     // Migrate config file
     if has_old_config {
-        match migrate_file(&old_config, &new_config) {
+        match migrate_file(old_config, new_config) {
             Ok(true) => {
                 report.config_migrated = true;
                 report.warnings.push(format!(
@@ -72,7 +80,7 @@ pub fn migrate_legacy_paths() -> Option<MigrationReport> {
 
     // Migrate cookie/session/state files
     if has_old_cookies {
-        match migrate_directory_contents(&old_cookie_dir, &new_cookie_dir) {
+        match migrate_directory_contents(old_cookie_dir, new_cookie_dir) {
             Ok(count) if count > 0 => {
                 report.cookies_migrated = true;
                 report.warnings.push(format!(
@@ -156,51 +164,19 @@ fn migrate_directory_contents(src_dir: &Path, dst_dir: &Path) -> anyhow::Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
 
-    fn set_home_for_test(home: &Path) -> HomeGuard {
-        static HOME_LOCK: Mutex<()> = Mutex::new(());
-        let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev_home = std::env::var_os("HOME");
-        // SAFETY: this module serializes every test that mutates HOME through
-        // HOME_LOCK, and these tests do not read HOME from other threads.
-        unsafe {
-            std::env::set_var("HOME", home);
-        }
-        HomeGuard {
-            _lock: lock,
-            prev_home,
-        }
-    }
-
-    struct HomeGuard {
-        _lock: MutexGuard<'static, ()>,
-        prev_home: Option<OsString>,
-    }
-
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            if let Some(home) = self.prev_home.take() {
-                // SAFETY: still holding HOME_LOCK, so restoration is serialized
-                // with every test in this module that mutates HOME.
-                unsafe {
-                    std::env::set_var("HOME", home);
-                }
-            } else {
-                // SAFETY: still holding HOME_LOCK, so restoration is serialized
-                // with every test in this module that mutates HOME.
-                unsafe {
-                    std::env::remove_var("HOME");
-                }
-            }
-        }
+    fn migrate_legacy_paths_for_test(home: &Path) -> Option<MigrationReport> {
+        migrate_legacy_paths_from_paths(
+            &home.join(".config/kei/config.toml"),
+            &home.join(".config/kei/cookies"),
+            &home.join(".config/icloudpd-rs/config.toml"),
+            &home.join(".icloudpd-rs"),
+        )
     }
 
     #[test]
     fn migrate_legacy_paths_migrates_config_and_cookie_files_from_home() {
         let tmp = tempfile::tempdir().unwrap();
-        let _home = set_home_for_test(tmp.path());
         let old_config = tmp.path().join(".config/icloudpd-rs/config.toml");
         let old_cookie_dir = tmp.path().join(".icloudpd-rs");
         std::fs::create_dir_all(old_config.parent().unwrap()).unwrap();
@@ -209,7 +185,8 @@ mod tests {
         std::fs::write(old_cookie_dir.join("old.session"), "session").unwrap();
         std::fs::write(old_cookie_dir.join("old.db"), "db").unwrap();
 
-        let report = migrate_legacy_paths().expect("legacy paths should migrate");
+        let report =
+            migrate_legacy_paths_for_test(tmp.path()).expect("legacy paths should migrate");
 
         assert!(report.config_migrated);
         assert!(report.cookies_migrated);
@@ -242,7 +219,6 @@ mod tests {
     #[test]
     fn migrate_legacy_paths_skips_when_new_config_exists() {
         let tmp = tempfile::tempdir().unwrap();
-        let _home = set_home_for_test(tmp.path());
         let new_config = tmp.path().join(".config/kei/config.toml");
         let old_config = tmp.path().join(".config/icloudpd-rs/config.toml");
         std::fs::create_dir_all(new_config.parent().unwrap()).unwrap();
@@ -250,7 +226,7 @@ mod tests {
         std::fs::write(&new_config, "username = \"new@example.com\"").unwrap();
         std::fs::write(&old_config, "username = \"old@example.com\"").unwrap();
 
-        assert!(migrate_legacy_paths().is_none());
+        assert!(migrate_legacy_paths_for_test(tmp.path()).is_none());
         assert_eq!(
             std::fs::read_to_string(&new_config).unwrap(),
             "username = \"new@example.com\""
@@ -260,9 +236,8 @@ mod tests {
     #[test]
     fn migrate_legacy_paths_returns_none_without_legacy_inputs() {
         let tmp = tempfile::tempdir().unwrap();
-        let _home = set_home_for_test(tmp.path());
 
-        assert!(migrate_legacy_paths().is_none());
+        assert!(migrate_legacy_paths_for_test(tmp.path()).is_none());
         assert!(
             !tmp.path().join(".config/kei").exists(),
             "no legacy inputs should not create new directories"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1624,6 +1624,30 @@ mod tests {
     use crate::types::LivePhotoMode;
 
     #[test]
+    fn dim_comments_preserves_toml_text_while_styling_comments_and_sections() {
+        let rendered = dim_comments("# comment\n[auth]\nusername = \"u\"");
+
+        assert!(rendered.contains("# comment"));
+        assert!(rendered.contains("[auth]"));
+        assert!(rendered.contains("username = \"u\""));
+        assert_eq!(rendered.lines().count(), 3);
+    }
+
+    #[test]
+    fn setup_secret_source_password_prompt_policy_is_explicit() {
+        assert!(SetupSecretSource::CredentialStore.needs_password_prompt());
+        assert!(SetupSecretSource::EnvFile.needs_password_prompt());
+        assert!(
+            !SetupSecretSource::PasswordFile("/run/secrets/icloud".to_string())
+                .needs_password_prompt()
+        );
+        assert!(
+            !SetupSecretSource::PasswordCommand("op read item kei".to_string())
+                .needs_password_prompt()
+        );
+    }
+
+    #[test]
     fn test_generate_toml_defaults_only() {
         let answers = SetupAnswers {
             username: "user@example.com".to_string(),
@@ -2503,6 +2527,120 @@ mod tests {
         let content = std::fs::read_to_string(&env_path).unwrap();
         assert!(content.contains("ICLOUD_USERNAME='test@example.com'"));
         assert!(content.contains("ICLOUD_PASSWORD='secret'"));
+    }
+
+    #[test]
+    fn secret_summary_lines_covers_every_secret_source() {
+        let env_dir = tempfile::tempdir().unwrap();
+        let env_path = env_dir.path().join(".env");
+
+        for (secret_source, write_result, expected) in [
+            (
+                SetupSecretSource::CredentialStore,
+                SetupWriteResult {
+                    credential_backend: None,
+                    env_path: None,
+                },
+                vec![
+                    "  Secrets →  credential-store backend".to_string(),
+                    "             Use `kei password backend` to check it or `kei password set` to change it."
+                        .to_string(),
+                ],
+            ),
+            (
+                SetupSecretSource::PasswordFile("/run/secrets/icloud".to_string()),
+                SetupWriteResult {
+                    credential_backend: None,
+                    env_path: None,
+                },
+                vec!["  Secrets →  password file: /run/secrets/icloud".to_string()],
+            ),
+            (
+                SetupSecretSource::PasswordCommand("op read item kei".to_string()),
+                SetupWriteResult {
+                    credential_backend: None,
+                    env_path: None,
+                },
+                vec!["  Secrets →  password command from config".to_string()],
+            ),
+            (
+                SetupSecretSource::EnvFile,
+                SetupWriteResult {
+                    credential_backend: None,
+                    env_path: Some(env_path.clone()),
+                },
+                vec![format!("  Secrets →  {}", env_path.display())],
+            ),
+        ] {
+            let answers = SetupAnswers {
+                username: "user@example.com".to_string(),
+                password: secrecy::SecretString::from("secret"),
+                secret_source,
+                directory: "/photos".to_string(),
+                ..Default::default()
+            };
+
+            assert_eq!(
+                secret_summary_lines(&answers, &write_result),
+                expected,
+                "unexpected secret summary for {:?}",
+                answers.secret_source
+            );
+        }
+    }
+
+    #[test]
+    fn shell_single_quote_escape_handles_embedded_quotes() {
+        assert_eq!(shell_single_quote_escape("plain"), "plain");
+        assert_eq!(shell_single_quote_escape("don't"), "don'\\''t");
+        assert_eq!(shell_single_quote_escape("a'b'c"), "a'\\''b'\\''c");
+    }
+
+    #[test]
+    fn credential_store_dir_uses_data_dir_or_cookie_default() {
+        let custom = SetupAnswers {
+            data_dir: Some("/var/lib/kei".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(credential_store_dir(&custom), PathBuf::from("/var/lib/kei"));
+
+        let default = SetupAnswers::default();
+        assert_eq!(
+            credential_store_dir(&default),
+            crate::config::expand_tilde("~/.config/kei/cookies")
+        );
+    }
+
+    #[test]
+    fn write_setup_files_with_external_secret_source_writes_only_config() {
+        for secret_source in [
+            SetupSecretSource::PasswordFile("/run/secrets/icloud".to_string()),
+            SetupSecretSource::PasswordCommand("op read item kei".to_string()),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let config_path = dir.path().join("config.toml");
+            let answers = SetupAnswers {
+                username: "user@example.com".to_string(),
+                password: secrecy::SecretString::from("secret"),
+                secret_source,
+                ..Default::default()
+            };
+
+            let result = write_setup_files_with_store(
+                &config_path,
+                "[auth]\nusername = \"user@example.com\"\n",
+                &answers,
+                |_username, _dir, _pw| {
+                    panic!("external secret sources must not write to credential store")
+                },
+            )
+            .expect("setup files");
+
+            assert_eq!(result.credential_backend, None);
+            assert_eq!(result.env_path, None);
+            assert!(config_path.exists());
+            assert!(!dir.path().join(".env").exists());
+        }
     }
 
     // ── Numeric / date wizard-input validators ──────────────────────

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -1530,6 +1530,15 @@ impl SqliteStateDb {
         checksum: &str,
         local_path: &Path,
     ) -> Result<bool, StateError> {
+        if checksum.is_empty() {
+            tracing::warn!(
+                id,
+                version_size,
+                "Empty remote checksum cannot be trusted for state skip decisions"
+            );
+            return Ok(true);
+        }
+
         let library_owned = library.to_owned();
         let id_owned = id.to_owned();
         let version_size_owned = version_size.to_owned();
@@ -2063,7 +2072,7 @@ impl SqliteStateDb {
         };
 
         self.with_conn("complete_sync_run", move |conn| {
-            conn.execute(
+            let rows = conn.execute(
                 "UPDATE sync_runs SET completed_at = ?1, assets_seen = ?2, assets_downloaded = ?3, \
                  assets_failed = ?4, interrupted = ?5, status = ?6, enumeration_errors = ?7 \
                  WHERE id = ?8",
@@ -2079,6 +2088,12 @@ impl SqliteStateDb {
                 ],
             )
             .map_err(|e| StateError::query("complete_sync_run", e))?;
+            if rows == 0 {
+                return Err(StateError::Invariant {
+                    operation: "complete_sync_run",
+                    detail: format!("no sync_runs row for id {run_id}"),
+                });
+            }
 
             Ok(())
         })
@@ -3344,6 +3359,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_download_empty_remote_checksum_does_not_skip_existing_file() {
+        let dir = test_dir();
+        let file_path = dir.path().join("photo.jpg");
+        fs::write(&file_path, b"test content").unwrap();
+
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("ABC123").checksum("").build();
+
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "ABC123",
+            "original",
+            &file_path,
+            "oldhash",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let result = db
+            .should_download("PrimarySync", "ABC123", "original", "", &file_path)
+            .await
+            .unwrap();
+        assert!(
+            result,
+            "empty remote checksum must not hard-skip a downloaded row"
+        );
+    }
+
+    #[tokio::test]
     async fn test_mark_failed_and_get_failed() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
@@ -3612,6 +3658,39 @@ mod tests {
             stored, 17,
             "enumeration_errors must round-trip from SyncRunStats to sync_runs row"
         );
+    }
+
+    #[tokio::test]
+    async fn complete_sync_run_unknown_id_returns_error() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let stats = SyncRunStats {
+            assets_seen: 3,
+            assets_downloaded: 2,
+            assets_failed: 1,
+            enumeration_errors: 0,
+            interrupted: false,
+        };
+
+        let err = db
+            .complete_sync_run(999_999, &stats)
+            .await
+            .expect_err("unknown sync_run id must fail loudly");
+        match err {
+            StateError::Invariant { operation, detail } => {
+                assert_eq!(operation, "complete_sync_run");
+                assert!(
+                    detail.contains("999999") || detail.contains("999_999"),
+                    "error detail should name the missing run id, got: {detail}"
+                );
+            }
+            other => panic!("expected StateError::Invariant, got {other:?}"),
+        }
+
+        let conn = db.acquire_lock("unknown_sync_run").unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_runs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "unknown completion must not create a row");
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1612,6 +1612,50 @@ mod tests {
         assert_eq!(service_mode_default_interval(None, false), None);
     }
 
+    #[test]
+    fn watch_precheck_skip_all_blocks_every_zone_and_token() {
+        let precheck = WatchPrecheck::SkipAll;
+
+        assert!(precheck.changed_zones().is_none());
+        assert!(precheck.db_sync_token_after_success().is_none());
+        assert!(!precheck.should_sync_zone("PrimarySync"));
+        assert!(!precheck.should_sync_zone("SharedSync-123"));
+    }
+
+    #[test]
+    fn watch_precheck_proceed_all_allows_every_zone_without_db_token() {
+        let precheck = WatchPrecheck::proceed_all();
+
+        assert!(precheck.changed_zones().is_none());
+        assert!(precheck.db_sync_token_after_success().is_none());
+        assert!(precheck.should_sync_zone("PrimarySync"));
+        assert!(precheck.should_sync_zone("SharedSync-123"));
+    }
+
+    #[test]
+    fn watch_precheck_changed_zones_scopes_sync_and_carries_db_token() {
+        let mut zones = rustc_hash::FxHashSet::default();
+        zones.insert("PrimarySync".to_string());
+        let precheck = WatchPrecheck::Proceed {
+            changed_zones: Some(zones),
+            db_sync_token_after_success: Some("db-token-after-cycle".to_string()),
+        };
+
+        assert_eq!(
+            precheck.db_sync_token_after_success(),
+            Some("db-token-after-cycle")
+        );
+        assert_eq!(
+            precheck
+                .changed_zones()
+                .expect("changed zone filter should be present")
+                .len(),
+            1
+        );
+        assert!(precheck.should_sync_zone("PrimarySync"));
+        assert!(!precheck.should_sync_zone("SharedSync-123"));
+    }
+
     fn primary() -> crate::selection::LibrarySelector {
         crate::selection::LibrarySelector::default()
     }
@@ -3500,6 +3544,37 @@ mod tests {
         assert!(
             states[1].plan_needs_refresh,
             "unchanged zone must not refresh albums on this cycle"
+        );
+        assert_eq!(failures, 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_needed_library_plans_without_zone_filter_refreshes_every_stale_plan() {
+        let mut states = vec![
+            make_library_state("PrimarySync", "sync_token:PrimarySync"),
+            make_library_state("SharedSync-ABCD", "sync_token:SharedSync-ABCD"),
+        ];
+        for state in &mut states {
+            state.plan_needs_refresh = true;
+            state.plan_is_stale = true;
+        }
+        let selection = crate::selection::Selection {
+            albums: crate::selection::AlbumSelector::None,
+            smart_folders: crate::selection::SmartFolderSelector::None,
+            libraries: all_libraries(),
+            unfiled: false,
+        };
+        let mut failures = 2;
+
+        refresh_needed_library_plans(&mut states, &selection, None, &mut failures).await;
+
+        assert!(
+            states.iter().all(|state| !state.plan_needs_refresh),
+            "every stale plan should refresh when no changed-zone precheck filtered the cycle"
+        );
+        assert!(
+            states.iter().all(|state| !state.plan_is_stale),
+            "successful refresh should clear stale-plan token gates"
         );
         assert_eq!(failures, 0);
     }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -669,6 +669,30 @@ fn sync_requires_username() {
         .code(1)
         .stderr(predicate::str::contains("username is required"));
 }
+
+#[test]
+fn service_run_uses_sync_worker_path_and_requires_username() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    write_sync_config(&config_path, "/photos");
+    clean_cmd()
+        .env_remove("ICLOUD_USERNAME")
+        .args([
+            "service",
+            "run",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--no-progress-bar",
+        ])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("starting kei service worker"))
+        .stderr(predicate::str::contains(
+            "service mode: applied default watch interval",
+        ))
+        .stderr(predicate::str::contains("username is required"));
+}
+
 #[test]
 fn sync_requires_directory() {
     let dir = tempfile::tempdir().unwrap();
@@ -1945,6 +1969,51 @@ fn exit_1_for_missing_directory_on_sync() {
         .code(1)
         .stderr(predicate::str::contains("[download] directory is required"));
 }
+
+#[cfg(unix)]
+#[test]
+fn sync_unwritable_download_directory_errors_before_auth() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Root can write through 0o555 directories, so this probe is not
+    // meaningful under root-owned CI containers.
+    // SAFETY: libc::geteuid() is a stateless POSIX call with no
+    // preconditions and no memory-safety implications.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let data_dir = dir.path().join("data");
+    let download_dir = dir.path().join("photos");
+    let config_path = dir.path().join("config.toml");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    std::fs::create_dir_all(&download_dir).unwrap();
+    std::fs::set_permissions(&download_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    write_sync_config(&config_path, download_dir.to_str().unwrap());
+
+    clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", &data_dir)
+        .args([
+            "sync",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--password",
+            "not-used-before-auth",
+            "--no-progress-bar",
+        ])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("is not writable"));
+
+    std::fs::set_permissions(&download_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        std::fs::read_dir(&data_dir).unwrap().next().is_none(),
+        "unwritable download dir must fail before auth/session state is written"
+    );
+}
+
 #[test]
 fn exit_1_for_missing_username_on_sync() {
     let dir = tempfile::tempdir().unwrap();
@@ -2070,6 +2139,17 @@ fn config_show_help_exits_zero() {
         .args(["config", "show", "--help"])
         .assert()
         .success();
+}
+
+#[test]
+fn config_setup_requires_interactive_terminal() {
+    clean_cmd()
+        .args(["config", "setup"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "The setup wizard requires an interactive terminal",
+        ));
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Fixed production gaps found by the test review around empty checksums, empty CloudKit record names, unknown sync-run completion IDs, and malformed-asset skip accounting.
- Added focused tests for setup, migration, auth redaction/domain rejection, sync-loop stale plan refresh, service-run routing, and download/state edge cases.
- Added `just cov check`; current offline line coverage is 90.40%.

## Tests
- `cargo check` - passed
- `cargo fmt --check` - passed
- `cargo clippy --all-targets --all-features -- -D warnings` - passed
- `cargo test` - passed
- `cargo test -- --test-threads=1` - passed
- `just cov check` - passed, TOTAL line coverage 90.40%
- `git diff --check` - passed
