### PR TITLE
Enhance sync test coverage

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1353,6 +1353,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use chrono::Utc;
     use rustc_hash::FxHashSet;
 
     use crate::icloud::photos::PhotoAsset;
@@ -1375,6 +1376,133 @@ mod tests {
         let mut claimed_paths = FxHashMap::default();
         let mut dir_cache = paths::DirCache::new();
         filter_asset_to_tasks(asset, config, &mut claimed_paths, &mut dir_cache)
+    }
+
+    fn plain_photo_asset() -> PhotoAsset {
+        TestPhotoAsset::new("TEST_1").build()
+    }
+
+    fn video_asset() -> PhotoAsset {
+        TestPhotoAsset::new("VID_1")
+            .filename("movie.mov")
+            .item_type("com.apple.quicktime-movie")
+            .orig_file_type("com.apple.quicktime-movie")
+            .orig_size(50_000)
+            .orig_url("https://p01.icloud-content.com/vid")
+            .orig_checksum("vid_ck")
+            .build()
+    }
+
+    fn aae_asset() -> PhotoAsset {
+        TestPhotoAsset::new("EXCL_1")
+            .filename("IMG_0001.AAE")
+            .build()
+    }
+
+    fn lowercase_aae_asset() -> PhotoAsset {
+        TestPhotoAsset::new("EXCL_2").filename("Photo.aae").build()
+    }
+
+    fn excluded_asset() -> PhotoAsset {
+        TestPhotoAsset::new("EXCLUDED_1")
+            .filename("IMG_0001.JPG")
+            .build()
+    }
+
+    fn keep_asset() -> PhotoAsset {
+        TestPhotoAsset::new("KEEP_1")
+            .filename("IMG_0002.JPG")
+            .build()
+    }
+
+    fn old_asset() -> PhotoAsset {
+        TestPhotoAsset::new("OLD_1")
+            .asset_date(1_592_179_200_000.0) // 2020-06-15T00:00:00Z
+            .build()
+    }
+
+    fn new_asset() -> PhotoAsset {
+        TestPhotoAsset::new("NEW_1")
+            .asset_date(1_750_003_200_000.0) // 2025-06-15T00:00:00Z
+            .build()
+    }
+
+    fn date_time(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).expect("test date").into()
+    }
+
+    fn no_config_change(_: &mut DownloadConfig) {}
+
+    fn skip_videos(config: &mut DownloadConfig) {
+        config.media.videos = false;
+    }
+
+    fn skip_photos(config: &mut DownloadConfig) {
+        config.media.photos = false;
+    }
+
+    fn skip_before_february_2025(config: &mut DownloadConfig) {
+        config.skip_created_before = Some(date_time("2025-02-01T00:00:00Z"));
+    }
+
+    fn skip_after_january_2025(config: &mut DownloadConfig) {
+        config.skip_created_after = Some(date_time("2025-01-01T00:00:00Z"));
+    }
+
+    fn skip_before_2024(config: &mut DownloadConfig) {
+        config.skip_created_before = Some(date_time("2024-01-01T00:00:00Z"));
+    }
+
+    fn skip_after_2023(config: &mut DownloadConfig) {
+        config.skip_created_after = Some(date_time("2023-01-01T00:00:00Z"));
+    }
+
+    fn skip_live_photos(config: &mut DownloadConfig) {
+        config.live_photo_mode = LivePhotoMode::Skip;
+    }
+
+    fn live_photo_image_only(config: &mut DownloadConfig) {
+        config.live_photo_mode = LivePhotoMode::ImageOnly;
+    }
+
+    fn live_photo_video_only(config: &mut DownloadConfig) {
+        config.live_photo_mode = LivePhotoMode::VideoOnly;
+    }
+
+    fn medium_resolution_with_fallback(config: &mut DownloadConfig) {
+        config.resolution = crate::types::PhotoResolution::Medium;
+        config.force_resolution = false;
+    }
+
+    fn medium_resolution_without_fallback(config: &mut DownloadConfig) {
+        config.resolution = crate::types::PhotoResolution::Medium;
+        config.force_resolution = true;
+    }
+
+    fn live_adjusted_with_fallback(config: &mut DownloadConfig) {
+        config.live_resolution = AssetVersionSize::LiveAdjusted;
+        config.force_resolution = false;
+    }
+
+    fn live_adjusted_without_fallback(config: &mut DownloadConfig) {
+        config.live_resolution = AssetVersionSize::LiveAdjusted;
+        config.force_resolution = true;
+    }
+
+    fn exclude_aae_filenames(config: &mut DownloadConfig) {
+        config.filename_exclude = Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
+    }
+
+    fn exclude_known_asset_id(config: &mut DownloadConfig) {
+        let mut ids = FxHashSet::default();
+        ids.insert("EXCLUDED_1".to_string());
+        config.exclude_asset_ids = Arc::new(ids);
+    }
+
+    fn exclude_other_asset_id(config: &mut DownloadConfig) {
+        let mut ids = FxHashSet::default();
+        ids.insert("OTHER_ID".to_string());
+        config.exclude_asset_ids = Arc::new(ids);
     }
 
     #[test]
@@ -3299,180 +3427,96 @@ mod tests {
 
     // ── extract_skip_candidates tests ──────────────────────────────
 
-    #[test]
-    fn test_extract_skip_candidates_photo() {
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let config = test_config();
-        let candidates = extract_skip_candidates(&asset, &config);
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].0, VersionSizeKey::Original);
-        assert_eq!(candidates[0].1, "abc123");
+    struct SkipCandidateCase {
+        name: &'static str,
+        asset: fn() -> PhotoAsset,
+        configure: fn(&mut DownloadConfig),
+        expected: &'static [(VersionSizeKey, &'static str)],
     }
 
     #[test]
-    fn test_extract_skip_candidates_live_photo() {
-        let asset = test_live_photo_asset();
-        let config = test_config();
-        let candidates = extract_skip_candidates(&asset, &config);
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].0, VersionSizeKey::Original);
-        assert_eq!(candidates[0].1, "heic_ck");
-        assert_eq!(candidates[1].0, VersionSizeKey::LiveOriginal);
-        assert_eq!(candidates[1].1, "mov_ck");
-    }
+    fn extract_skip_candidates_decision_matrix() {
+        let cases = [
+            SkipCandidateCase {
+                name: "plain photo emits original",
+                asset: plain_photo_asset,
+                configure: no_config_change,
+                expected: &[(VersionSizeKey::Original, "abc123")],
+            },
+            SkipCandidateCase {
+                name: "live photo emits primary and mov",
+                asset: test_live_photo_asset,
+                configure: no_config_change,
+                expected: &[
+                    (VersionSizeKey::Original, "heic_ck"),
+                    (VersionSizeKey::LiveOriginal, "mov_ck"),
+                ],
+            },
+            SkipCandidateCase {
+                name: "image-only live photo emits primary only",
+                asset: test_live_photo_asset,
+                configure: live_photo_image_only,
+                expected: &[(VersionSizeKey::Original, "heic_ck")],
+            },
+            SkipCandidateCase {
+                name: "skip mode does not affect non-live photos",
+                asset: plain_photo_asset,
+                configure: skip_live_photos,
+                expected: &[(VersionSizeKey::Original, "abc123")],
+            },
+            SkipCandidateCase {
+                name: "video-only live photo emits mov only",
+                asset: test_live_photo_asset,
+                configure: live_photo_video_only,
+                expected: &[(VersionSizeKey::LiveOriginal, "mov_ck")],
+            },
+            SkipCandidateCase {
+                name: "missing medium resolution falls back to original",
+                asset: plain_photo_asset,
+                configure: medium_resolution_with_fallback,
+                expected: &[(VersionSizeKey::Original, "abc123")],
+            },
+            SkipCandidateCase {
+                name: "force medium resolution prevents fallback",
+                asset: plain_photo_asset,
+                configure: medium_resolution_without_fallback,
+                expected: &[],
+            },
+            SkipCandidateCase {
+                name: "filename exclude no-match still emits original",
+                asset: plain_photo_asset,
+                configure: exclude_aae_filenames,
+                expected: &[(VersionSizeKey::Original, "abc123")],
+            },
+            SkipCandidateCase {
+                name: "missing live adjusted falls back to live original",
+                asset: test_live_photo_asset,
+                configure: live_adjusted_with_fallback,
+                expected: &[
+                    (VersionSizeKey::Original, "heic_ck"),
+                    (VersionSizeKey::LiveOriginal, "mov_ck"),
+                ],
+            },
+            SkipCandidateCase {
+                name: "force live adjusted prevents mov fallback",
+                asset: test_live_photo_asset,
+                configure: live_adjusted_without_fallback,
+                expected: &[(VersionSizeKey::Original, "heic_ck")],
+            },
+        ];
 
-    #[test]
-    fn test_extract_skip_candidates_skip_videos() {
-        let asset = TestPhotoAsset::new("VID_1")
-            .filename("movie.mov")
-            .item_type("com.apple.quicktime-movie")
-            .orig_file_type("com.apple.quicktime-movie")
-            .orig_size(50000)
-            .orig_url("https://p01.icloud-content.com/vid")
-            .orig_checksum("vid_ck")
-            .build();
-        let mut config = test_config();
-        config.media.videos = false;
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::MediaType)
-        );
-    }
+        for case in cases {
+            let asset = (case.asset)();
+            let mut config = test_config();
+            (case.configure)(&mut config);
 
-    #[test]
-    fn test_extract_skip_candidates_skip_photos() {
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let mut config = test_config();
-        config.media.photos = false;
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::MediaType)
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_image_only_mode() {
-        let asset = test_live_photo_asset();
-        let mut config = test_config();
-        config.live_photo_mode = LivePhotoMode::ImageOnly;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // Should still have the primary HEIC version, just not the MOV companion
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].0, VersionSizeKey::Original);
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_skip_mode() {
-        let asset = test_live_photo_asset();
-        let mut config = test_config();
-        config.live_photo_mode = LivePhotoMode::Skip;
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::LivePhoto),
-            "Skip mode should exclude live photos entirely"
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_skip_mode_non_live_passes() {
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let mut config = test_config();
-        config.live_photo_mode = LivePhotoMode::Skip;
-        let candidates = extract_skip_candidates(&asset, &config);
-        assert_eq!(
-            candidates.len(),
-            1,
-            "Skip mode should not affect non-live photos"
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_video_only_mode() {
-        let asset = test_live_photo_asset();
-        let mut config = test_config();
-        config.live_photo_mode = LivePhotoMode::VideoOnly;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // Should have only the MOV companion, no primary image
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].0, VersionSizeKey::LiveOriginal);
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_date_before_filter() {
-        let asset = TestPhotoAsset::new("TEST_1").build(); // assetDate = 1736899200000 = 2025-01-15
-        let mut config = test_config();
-        // Set skip_created_before to a date AFTER the asset's creation
-        config.skip_created_before = Some(
-            DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange)
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_date_after_filter() {
-        let asset = TestPhotoAsset::new("TEST_1").build(); // assetDate = 1736899200000 = 2025-01-15
-        let mut config = test_config();
-        // Set skip_created_after to a date BEFORE the asset's creation
-        config.skip_created_after = Some(
-            DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange)
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_size_fallback_to_original() {
-        let asset = TestPhotoAsset::new("TEST_1").build(); // only has resOriginalRes
-        let mut config = test_config();
-        config.resolution = crate::types::PhotoResolution::Medium; // not available
-        config.force_resolution = false;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // Should fall back to Original
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].0, VersionSizeKey::Original);
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_force_resolution_no_fallback() {
-        let asset = TestPhotoAsset::new("TEST_1").build(); // only has resOriginalRes
-        let mut config = test_config();
-        config.resolution = crate::types::PhotoResolution::Medium; // not available
-        config.force_resolution = true;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // force_resolution prevents fallback — no primary version
-        assert!(candidates.is_empty());
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_live_adjusted_falls_back_to_live_original() {
-        let asset = test_live_photo_asset(); // has LiveOriginal, no LiveAdjusted
-        let mut config = test_config();
-        config.live_resolution = AssetVersionSize::LiveAdjusted;
-        config.force_resolution = false;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // Primary + live companion (fallback to LiveOriginal)
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[1].0, VersionSizeKey::LiveOriginal);
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_live_adjusted_force_resolution_no_fallback() {
-        let asset = test_live_photo_asset(); // has LiveOriginal, no LiveAdjusted
-        let mut config = test_config();
-        config.live_resolution = AssetVersionSize::LiveAdjusted;
-        config.force_resolution = true;
-        let candidates = extract_skip_candidates(&asset, &config);
-        // force_resolution prevents fallback — only primary, no live companion
-        assert_eq!(candidates.len(), 1);
+            let candidates = extract_skip_candidates(&asset, &config);
+            let actual: Vec<_> = candidates
+                .iter()
+                .map(|(version, checksum)| (*version, *checksum))
+                .collect();
+            assert_eq!(actual.as_slice(), case.expected, "{}", case.name);
+        }
     }
 
     #[test]
@@ -4138,73 +4182,56 @@ mod tests {
     // ── Gap coverage: skip_created_before AND skip_created_after ────────
 
     #[test]
-    fn filter_asset_narrowing_date_window_includes_asset_inside() {
-        // Asset date: 2025-01-15 (epoch ms 1736899200000)
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let mut config = test_config();
-        // Window: 2025-01-01 .. 2025-02-01 — asset at Jan 15 is inside
-        config.skip_created_before = Some(
-            DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        config.skip_created_after = Some(
-            DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        let tasks = filter_asset_fresh(&asset, &config);
-        assert_eq!(
-            tasks.len(),
-            1,
-            "Asset inside the date window should produce a task"
-        );
-    }
+    fn filter_asset_narrowing_date_window_matrix() {
+        struct DateWindowCase {
+            name: &'static str,
+            start: &'static str,
+            end: &'static str,
+            expected_filter: Option<FilterReason>,
+        }
 
-    #[test]
-    fn filter_asset_narrowing_date_window_excludes_asset_before() {
-        // Asset date: 2025-01-15
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let mut config = test_config();
-        // Window: 2025-01-20 .. 2025-02-01 — asset at Jan 15 is before the window
-        config.skip_created_before = Some(
-            DateTime::parse_from_rfc3339("2025-01-20T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        config.skip_created_after = Some(
-            DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange),
-            "Asset before the date window should be skipped"
-        );
-    }
+        let cases = [
+            DateWindowCase {
+                name: "inside window",
+                start: "2025-01-01T00:00:00Z",
+                end: "2025-02-01T00:00:00Z",
+                expected_filter: None,
+            },
+            DateWindowCase {
+                name: "before window",
+                start: "2025-01-20T00:00:00Z",
+                end: "2025-02-01T00:00:00Z",
+                expected_filter: Some(FilterReason::DateRange),
+            },
+            DateWindowCase {
+                name: "after window",
+                start: "2024-12-01T00:00:00Z",
+                end: "2025-01-10T00:00:00Z",
+                expected_filter: Some(FilterReason::DateRange),
+            },
+        ];
 
-    #[test]
-    fn filter_asset_narrowing_date_window_excludes_asset_after() {
-        // Asset date: 2025-01-15
-        let asset = TestPhotoAsset::new("TEST_1").build();
-        let mut config = test_config();
-        // Window: 2024-12-01 .. 2025-01-10 — asset at Jan 15 is after the window
-        config.skip_created_before = Some(
-            DateTime::parse_from_rfc3339("2024-12-01T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        config.skip_created_after = Some(
-            DateTime::parse_from_rfc3339("2025-01-10T00:00:00Z")
-                .unwrap()
-                .into(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange),
-            "Asset after the date window should be skipped"
-        );
+        for case in cases {
+            let asset = plain_photo_asset();
+            let mut config = test_config();
+            config.skip_created_before = Some(date_time(case.start));
+            config.skip_created_after = Some(date_time(case.end));
+
+            assert_eq!(
+                is_asset_filtered(&asset, &config),
+                case.expected_filter,
+                "{}",
+                case.name
+            );
+            if case.expected_filter.is_none() {
+                assert_eq!(
+                    filter_asset_fresh(&asset, &config).len(),
+                    1,
+                    "{} should produce a task",
+                    case.name
+                );
+            }
+        }
     }
 
     // ── Gap coverage: NameId7 produces task when file at original path ──
@@ -4362,48 +4389,109 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_filter_skip_created_before_excludes_old_asset() {
-        // Asset created 2020-06-15 (epoch ms)
-        let asset = TestPhotoAsset::new("OLD_1")
-            .asset_date(1592179200000.0) // 2020-06-15T00:00:00Z
-            .build();
-        let mut config = test_config();
-        // skip_created_before = 2024-01-01
-        config.skip_created_before = Some(
-            chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .and_utc(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange),
-            "Asset created in 2020 should be excluded by skip_created_before=2024"
-        );
+    struct FilterDecisionCase {
+        name: &'static str,
+        asset: fn() -> PhotoAsset,
+        configure: fn(&mut DownloadConfig),
+        expected: Option<FilterReason>,
     }
 
     #[test]
-    fn test_filter_skip_created_after_excludes_new_asset() {
-        // Asset created 2025-06-15 (epoch ms)
-        let asset = TestPhotoAsset::new("NEW_1")
-            .asset_date(1750003200000.0) // 2025-06-15T00:00:00Z
-            .build();
-        let mut config = test_config();
-        // skip_created_after = 2023-01-01
-        config.skip_created_after = Some(
-            chrono::NaiveDate::from_ymd_opt(2023, 1, 1)
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .and_utc(),
-        );
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::DateRange),
-            "Asset created in 2025 should be excluded by skip_created_after=2023"
-        );
+    fn is_asset_filtered_decision_matrix() {
+        let cases = [
+            FilterDecisionCase {
+                name: "skip videos rejects movie assets",
+                asset: video_asset,
+                configure: skip_videos,
+                expected: Some(FilterReason::MediaType),
+            },
+            FilterDecisionCase {
+                name: "skip photos rejects still assets",
+                asset: plain_photo_asset,
+                configure: skip_photos,
+                expected: Some(FilterReason::MediaType),
+            },
+            FilterDecisionCase {
+                name: "skip live mode rejects live photos",
+                asset: test_live_photo_asset,
+                configure: skip_live_photos,
+                expected: Some(FilterReason::LivePhoto),
+            },
+            FilterDecisionCase {
+                name: "skip_created_before rejects older asset",
+                asset: plain_photo_asset,
+                configure: skip_before_february_2025,
+                expected: Some(FilterReason::DateRange),
+            },
+            FilterDecisionCase {
+                name: "skip_created_after rejects newer asset",
+                asset: plain_photo_asset,
+                configure: skip_after_january_2025,
+                expected: Some(FilterReason::DateRange),
+            },
+            FilterDecisionCase {
+                name: "skip_created_before rejects old historical asset",
+                asset: old_asset,
+                configure: skip_before_2024,
+                expected: Some(FilterReason::DateRange),
+            },
+            FilterDecisionCase {
+                name: "skip_created_after rejects future asset",
+                asset: new_asset,
+                configure: skip_after_2023,
+                expected: Some(FilterReason::DateRange),
+            },
+            FilterDecisionCase {
+                name: "filename exclude matches uppercase AAE",
+                asset: aae_asset,
+                configure: exclude_aae_filenames,
+                expected: Some(FilterReason::Filename),
+            },
+            FilterDecisionCase {
+                name: "filename exclude is case insensitive",
+                asset: lowercase_aae_asset,
+                configure: exclude_aae_filenames,
+                expected: Some(FilterReason::Filename),
+            },
+            FilterDecisionCase {
+                name: "filename exclude no-match passes",
+                asset: keep_asset,
+                configure: exclude_aae_filenames,
+                expected: None,
+            },
+            FilterDecisionCase {
+                name: "exclude asset ids blocks matching id",
+                asset: excluded_asset,
+                configure: exclude_known_asset_id,
+                expected: Some(FilterReason::ExcludedAlbum),
+            },
+            FilterDecisionCase {
+                name: "exclude asset ids passes non-matching id",
+                asset: keep_asset,
+                configure: exclude_other_asset_id,
+                expected: None,
+            },
+        ];
+
+        for case in cases {
+            let asset = (case.asset)();
+            let mut config = test_config();
+            (case.configure)(&mut config);
+
+            assert_eq!(
+                is_asset_filtered(&asset, &config),
+                case.expected,
+                "{}",
+                case.name
+            );
+            if case.expected.is_none() {
+                assert!(
+                    !filter_asset_fresh(&asset, &config).is_empty(),
+                    "{} should reach task planning",
+                    case.name
+                );
+            }
+        }
     }
 
     #[test]
@@ -4419,19 +4507,7 @@ mod tests {
         );
     }
 
-    // ── LivePhotoMode + filename_exclude filter tests ─────────────
-
-    #[test]
-    fn test_filter_skip_mode_skips_live_photo_entirely() {
-        let asset = test_live_photo_asset();
-        let mut config = test_config();
-        config.live_photo_mode = LivePhotoMode::Skip;
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::LivePhoto),
-            "Skip mode should produce no tasks for live photos"
-        );
-    }
+    // ── LivePhotoMode task shaping ─────────────────────────────────
 
     #[test]
     fn test_filter_video_only_mode_skips_primary_keeps_mov() {
@@ -4442,127 +4518,6 @@ mod tests {
         assert_eq!(tasks.len(), 1);
         // The task should be the MOV companion
         assert!(tasks[0].download_path.to_str().unwrap().contains(".MOV"));
-    }
-
-    #[test]
-    fn test_filter_filename_exclude_matches() {
-        let asset = TestPhotoAsset::new("EXCL_1")
-            .filename("IMG_0001.AAE")
-            .build();
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::Filename),
-            "*.AAE pattern should exclude AAE files"
-        );
-    }
-
-    #[test]
-    fn test_filter_filename_exclude_case_insensitive() {
-        let asset = TestPhotoAsset::new("EXCL_2").filename("Photo.aae").build();
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::Filename),
-            "Pattern matching should be case-insensitive"
-        );
-    }
-
-    #[test]
-    fn test_filter_filename_exclude_no_match_passes() {
-        let asset = TestPhotoAsset::new("EXCL_3")
-            .filename("IMG_0001.JPG")
-            .build();
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        let tasks = filter_asset_fresh(&asset, &config);
-        assert!(!tasks.is_empty(), "Non-matching files should pass through");
-    }
-
-    // ── exclude_asset_ids filter tests ─────────────────────────────
-
-    #[test]
-    fn test_filter_exclude_asset_ids_blocks_matching() {
-        let asset = TestPhotoAsset::new("EXCLUDED_1")
-            .filename("IMG_0001.JPG")
-            .build();
-        let mut config = test_config();
-        let mut ids = FxHashSet::default();
-        ids.insert("EXCLUDED_1".to_string());
-        config.exclude_asset_ids = Arc::new(ids);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::ExcludedAlbum),
-            "Asset in exclude set should be filtered"
-        );
-    }
-
-    #[test]
-    fn test_filter_exclude_asset_ids_passes_non_matching() {
-        let asset = TestPhotoAsset::new("KEEP_1")
-            .filename("IMG_0002.JPG")
-            .build();
-        let mut config = test_config();
-        let mut ids = FxHashSet::default();
-        ids.insert("OTHER_ID".to_string());
-        config.exclude_asset_ids = Arc::new(ids);
-        let tasks = filter_asset_fresh(&asset, &config);
-        assert!(!tasks.is_empty(), "Asset not in exclude set should pass");
-    }
-
-    #[test]
-    fn test_skip_candidates_exclude_asset_ids() {
-        let asset = TestPhotoAsset::new("SKIP_EXCL_1")
-            .filename("IMG_0001.JPG")
-            .build();
-        let mut config = test_config();
-        let mut ids = FxHashSet::default();
-        ids.insert("SKIP_EXCL_1".to_string());
-        config.exclude_asset_ids = Arc::new(ids);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::ExcludedAlbum),
-            "is_asset_filtered should return true for excluded assets"
-        );
-    }
-
-    // ── extract_skip_candidates: filename_exclude ─────────────────
-
-    #[test]
-    fn test_extract_skip_candidates_filename_exclude_matches() {
-        let asset = TestPhotoAsset::new("TEST_1").filename("photo.AAE").build();
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::Filename),
-            "filename_exclude should filter via is_asset_filtered"
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_filename_exclude_no_match_passes() {
-        let asset = TestPhotoAsset::new("TEST_1").build(); // filename = "test_photo.jpg"
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        assert!(
-            !extract_skip_candidates(&asset, &config).is_empty(),
-            "non-matching filename should pass through"
-        );
-    }
-
-    #[test]
-    fn test_extract_skip_candidates_filename_exclude_case_insensitive() {
-        let asset = TestPhotoAsset::new("TEST_1").filename("photo.aae").build();
-        let mut config = test_config();
-        config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
-        assert_eq!(
-            is_asset_filtered(&asset, &config),
-            Some(FilterReason::Filename),
-            "filename_exclude should be case-insensitive"
-        );
     }
 
     // ── Gap: two assets with same filename, same date, same size ──────

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -4597,6 +4597,155 @@ mod tests {
         );
     }
 
+    #[test]
+    fn generated_collision_sets_are_deterministic_and_non_overwriting() {
+        #[derive(Clone, Copy)]
+        struct CollisionAsset {
+            id: &'static str,
+            filename: &'static str,
+            size: u64,
+            checksum: &'static str,
+        }
+
+        fn run_collision_set(root: &Path, assets: &[CollisionAsset]) -> Vec<Vec<PathBuf>> {
+            let mut config = test_config();
+            config.directory = Arc::from(root);
+            let mut claimed_paths = FxHashMap::default();
+            let mut dir_cache = paths::DirCache::new();
+
+            assets
+                .iter()
+                .map(|case| {
+                    let asset = TestPhotoAsset::new(case.id)
+                        .filename(case.filename)
+                        .orig_size(case.size)
+                        .orig_url(&format!("https://p01.icloud-content.com/{}", case.id))
+                        .orig_checksum(case.checksum)
+                        .build();
+                    filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache)
+                        .into_iter()
+                        .map(|task| task.download_path)
+                        .collect()
+                })
+                .collect()
+        }
+
+        let assets = [
+            CollisionAsset {
+                id: "REP_A",
+                filename: "repeat.JPG",
+                size: 1000,
+                checksum: "ck_rep_a",
+            },
+            CollisionAsset {
+                id: "REP_B",
+                filename: "repeat.JPG",
+                size: 1000,
+                checksum: "ck_rep_b",
+            },
+            CollisionAsset {
+                id: "REP_C",
+                filename: "repeat.JPG",
+                size: 2000,
+                checksum: "ck_rep_c",
+            },
+            CollisionAsset {
+                id: "TRAV_A",
+                filename: "../../etc/passwd.jpg",
+                size: 3000,
+                checksum: "ck_trav_a",
+            },
+            CollisionAsset {
+                id: "TRAV_B",
+                filename: "../../etc/passwd.jpg",
+                size: 4000,
+                checksum: "ck_trav_b",
+            },
+            CollisionAsset {
+                id: "CASE_A",
+                filename: "IMG_0001.JPG",
+                size: 5000,
+                checksum: "ck_case_a",
+            },
+            CollisionAsset {
+                id: "CASE_B",
+                filename: "img_0001.jpg",
+                size: 6000,
+                checksum: "ck_case_b",
+            },
+            CollisionAsset {
+                id: "EMPTY_A",
+                filename: "",
+                size: 7000,
+                checksum: "ck_empty_a",
+            },
+            CollisionAsset {
+                id: "UNICODE_A",
+                filename: "日本語.jpg",
+                size: 8000,
+                checksum: "ck_unicode_a",
+            },
+            CollisionAsset {
+                id: "RESERVED_A",
+                filename: "CON",
+                size: 9000,
+                checksum: "ck_reserved_a",
+            },
+        ];
+
+        let dir = TempDir::new().unwrap();
+        let first = run_collision_set(dir.path(), &assets);
+        let second = run_collision_set(dir.path(), &assets);
+        assert_eq!(first, second, "collision resolution must be deterministic");
+        assert!(
+            first[1].is_empty(),
+            "same filename and same size should be treated as the same on-disk file"
+        );
+        assert!(
+            first[2][0]
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("-2000.")),
+            "different-size repeated filename should get a size dedup suffix: {:?}",
+            first[2]
+        );
+
+        let mut exact_paths = FxHashSet::default();
+        let mut normalized_paths = FxHashSet::default();
+        for (asset, paths) in assets.iter().zip(first.iter()) {
+            for path in paths {
+                assert!(
+                    path.starts_with(dir.path()),
+                    "asset {} path escaped root: {}",
+                    asset.id,
+                    path.display()
+                );
+                let relative = path
+                    .strip_prefix(dir.path())
+                    .expect("path starts with root");
+                assert!(
+                    relative
+                        .components()
+                        .all(|component| matches!(component, std::path::Component::Normal(_))),
+                    "asset {} path contains traversal or root components: {}",
+                    asset.id,
+                    path.display()
+                );
+                assert!(
+                    exact_paths.insert(path.clone()),
+                    "generated collision set produced duplicate path: {}",
+                    path.display()
+                );
+                let normalized = NormalizedPath::new(path);
+                assert!(
+                    normalized_paths.insert(normalized),
+                    "generated collision set produced a normalized duplicate path: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
     // ── Gap: zero-size version triggers dedup, never matches ──────────
 
     #[test]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -709,6 +709,7 @@ fn apply_metadata_heif(path: &Path, write: &MetadataWrite, temp_suffix: &str) ->
     // reusing the same fd for the magic-byte probe (below) avoids a
     // second `open()` and the race with whatever interleaves with it.
     // `read(true)` is required because `File::create` opens write-only.
+    let validate_guard = TmpGuard::new(&tmp_path);
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -731,7 +732,6 @@ fn apply_metadata_heif(path: &Path, write: &MetadataWrite, temp_suffix: &str) ->
     // insert_xmp regression that produces non-HEIF output (corrupted
     // ftyp, wrong magic, truncated header) before the corrupt file
     // becomes visible.
-    let validate_guard = TmpGuard::new(&tmp_path);
     validate_heif_post_rewrite(&mut file, &tmp_path)?;
     drop(file);
     std::fs::rename(&tmp_path, path)
@@ -1349,6 +1349,24 @@ mod tests {
         path
     }
 
+    fn heic_with_xmp_packet(xmp: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        heif::insert_xmp(SAMPLE_HEIC, xmp, &mut bytes)
+            .expect("sample HEIC should accept a seed XMP packet");
+        bytes
+    }
+
+    fn heif_ftyp_without_meta() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&24u32.to_be_bytes());
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(&0u32.to_be_bytes());
+        bytes.extend_from_slice(b"heic");
+        bytes.extend_from_slice(b"mif1");
+        bytes
+    }
+
     #[test]
     fn apply_metadata_heic_rating_and_title() {
         let dir = test_tmp_dir("meta_heic_tests");
@@ -1470,6 +1488,99 @@ mod tests {
         assert!(
             s.contains("xmp:Rating"),
             "second-write rating should be present"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn apply_metadata_heic_preserves_fixture_with_seeded_xmp_item() {
+        let seed_xmp = build_xmp_packet(&MetadataWrite {
+            description: Some("Original iOS caption".into()),
+            people: vec!["Casey".into()],
+            media_subtype: Some("portrait".into()),
+            ..MetadataWrite::default()
+        })
+        .expect("seed XMP packet");
+        let source = heic_with_xmp_packet(&seed_xmp);
+
+        let dir = test_tmp_dir("meta_heic_tests");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("seeded_xmp.heic");
+        fs::write(&path, &source).unwrap();
+        apply_metadata_with_default_suffix(
+            &path,
+            &MetadataWrite {
+                rating: Some(5),
+                title: Some("Kei rewrite".into()),
+                keywords: vec!["Favorites".into()],
+                ..MetadataWrite::default()
+            },
+        )
+        .expect("HEIC metadata rewrite should preserve seeded XMP");
+
+        let rewritten = fs::read(&path).unwrap();
+        let xmp = extract_xmp_from_heic(&rewritten).expect("XMP missing after rewrite");
+        let s = std::str::from_utf8(&xmp).unwrap();
+        assert!(
+            s.contains("Original iOS caption"),
+            "seeded description should survive rewrite"
+        );
+        assert!(s.contains("Casey"), "seeded person should survive rewrite");
+        assert!(
+            s.contains("portrait"),
+            "seeded kei media subtype should survive rewrite"
+        );
+        assert!(s.contains("xmp:Rating"), "rewrite rating missing");
+        assert!(s.contains("Kei rewrite"), "rewrite title missing");
+        assert!(s.contains("Favorites"), "rewrite keyword missing");
+        assert_eq!(
+            count_xmp_items_in_heic(&rewritten),
+            1,
+            "rewrite must update the existing XMP item instead of appending duplicates"
+        );
+        assert_eq!(
+            find_mdat_bytes(&source),
+            find_mdat_bytes(&rewritten),
+            "HEIC image data must remain byte-for-byte stable"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn apply_metadata_heic_failure_leaves_media_bytes_intact() {
+        let dir = test_tmp_dir("meta_heic_tests");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("missing_meta.heic");
+        let original = heif_ftyp_without_meta();
+        fs::write(&path, &original).unwrap();
+
+        let err = apply_metadata_with_default_suffix(
+            &path,
+            &MetadataWrite {
+                rating: Some(3),
+                ..MetadataWrite::default()
+            },
+        )
+        .expect_err("HEIC without a meta box should reject XMP rewrite");
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Inserting XMP into HEIC"),
+            "error should name the failed HEIC rewrite step: {message}"
+        );
+        assert!(
+            message.contains("no `meta` box"),
+            "error should include the structural HEIC failure: {message}"
+        );
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            original,
+            "failed HEIC rewrite must leave original media bytes untouched"
+        );
+        let tmp_path = temp_path_for(&path, ".meta-tmp");
+        assert!(
+            !tmp_path.exists(),
+            "failed HEIC rewrite must not leave a metadata temp file behind"
         );
         fs::remove_file(&path).ok();
     }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -1706,6 +1706,73 @@ mod tests {
         );
     }
 
+    #[test]
+    fn generated_path_derivation_inputs_stay_inside_destination() {
+        let root = Path::new("/photos-root");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let folder_structures = [
+            "none",
+            "%Y/%m/%d",
+            "../../%Y/{album}",
+            "{album}/%Y/%m/%d",
+            "{:../%Y/%m/%d}",
+        ];
+        let filenames = [
+            "",
+            "IMG_0001.JPG",
+            "../escape.jpg",
+            "../../etc/passwd",
+            "a/b\\c*d?e\"f<g>h|i.jpg",
+            "日本語.jpg",
+            "CON",
+            "aux.txt",
+            "  ...  ",
+            "photo\nname.jpg",
+            "repeat.JPG",
+            "repeat.JPG",
+        ];
+        let album_names = [
+            None,
+            Some("Vacation"),
+            Some("../etc"),
+            Some("Trip/2024"),
+            Some("日本語"),
+            Some("CON"),
+            Some(""),
+        ];
+
+        for folder_structure in folder_structures {
+            for filename in filenames {
+                for album_name in album_names {
+                    let path =
+                        local_download_path(root, folder_structure, &date, filename, album_name);
+                    assert!(
+                        path.starts_with(root),
+                        "folder={folder_structure:?} filename={filename:?} album={album_name:?}: \
+                         path escaped root: {path:?}"
+                    );
+                    let relative = path
+                        .strip_prefix(root)
+                        .expect("path should start with root");
+                    assert!(
+                        relative.file_name().is_some(),
+                        "folder={folder_structure:?} filename={filename:?} album={album_name:?}: \
+                         path must include a filename: {path:?}"
+                    );
+                    assert!(
+                        relative
+                            .components()
+                            .all(|component| matches!(component, std::path::Component::Normal(_))),
+                        "folder={folder_structure:?} filename={filename:?} album={album_name:?}: \
+                         derived path contains traversal or root components: {path:?}"
+                    );
+                }
+            }
+        }
+    }
+
     /// Unicode normalization: a filename in NFC form (composed) must
     /// match its NFD form (decomposed) after sanitization. macOS and
     /// Linux use different normalization forms; the sanitizer must

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -914,7 +914,7 @@ impl PhotoAlbum {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{MockPhotosFlow, MockPhotosSession};
+    use crate::test_helpers::{mock_photo_query_page, MockPhotosFlow, MockPhotosSession};
     use serde_json::json;
 
     fn make_album(
@@ -1097,61 +1097,12 @@ mod tests {
         )
     }
 
-    /// Build one paired CPLMaster+CPLAsset record set for records/query tests.
-    fn canned_records(record_name: &str) -> Vec<Value> {
-        vec![
-            json!({
-                    "recordName": record_name,
-                    "recordType": "CPLMaster",
-                    "fields": {
-                        "filenameEnc": {"value": "dGVzdC5qcGc=", "type": "STRING"},
-                        "resOriginalRes": {
-                            "value": {
-                                "downloadURL": "https://p01.icloud-content.com/photo.jpg",
-                                "size": 1024,
-                                "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-                            }
-                        },
-                        "resOriginalWidth": {"value": 100, "type": "INT64"},
-                        "resOriginalHeight": {"value": 100, "type": "INT64"},
-                        "resOriginalFileType": {"value": "public.jpeg"},
-                        "itemType": {"value": "public.jpeg"},
-                        "adjustmentRenderType": {"value": 0, "type": "INT64"}
-                    },
-                    "recordChangeTag": "ct1"
-            }),
-            json!({
-                    "recordName": format!("asset-{record_name}"),
-                    "recordType": "CPLAsset",
-                    "fields": {
-                        "masterRef": {
-                            "value": {"recordName": record_name, "zoneID": {"zoneName": "PrimarySync"}},
-                            "type": "REFERENCE"
-                        },
-                        "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
-                        "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
-                    },
-                    "recordChangeTag": "ct2"
-            }),
-        ]
-    }
-
-    /// Build a canned QueryResponse with one paired CPLMaster+CPLAsset
-    /// record and an optional syncToken.
-    fn canned_page(record_name: &str, sync_token: Option<&str>) -> Value {
-        let mut resp = json!({ "records": canned_records(record_name) });
-        if let Some(token) = sync_token {
-            resp["syncToken"] = json!(token);
-        }
-        resp
-    }
-
     #[tokio::test]
     async fn test_photo_stream_with_token_returns_sync_token() {
         use tokio_stream::StreamExt;
 
         let mock = MockPhotosFlow::new()
-            .query_page(canned_records("master-1"), Some("st-zone-abc"))
+            .query_photo_page("master-1", Some("st-zone-abc"))
             // Second call returns empty records to stop the fetcher
             .empty_query_page(Some("st-zone-abc"))
             .build();
@@ -1177,7 +1128,7 @@ mod tests {
 
         // Responses without syncToken field
         let mock = MockPhotosFlow::new()
-            .query_page(canned_records("master-1"), None)
+            .query_photo_page("master-1", None)
             .empty_query_page(None)
             .build();
         let album = make_album_with_session(100, Box::new(mock));
@@ -1201,8 +1152,8 @@ mod tests {
         // page_size=1 so each page yields 1 master record and the fetcher
         // advances offset by 1.
         let mock = MockPhotosFlow::new()
-            .query_page(canned_records("master-1"), Some("st-first"))
-            .query_page(canned_records("master-2"), Some("st-second"))
+            .query_photo_page("master-1", Some("st-first"))
+            .query_photo_page("master-2", Some("st-second"))
             .empty_query_page(None)
             .build();
         let album = make_album_with_session(1, Box::new(mock));
@@ -1369,7 +1320,7 @@ mod tests {
 
             Ok(self.tokens_by_offset.get(&offset).map_or_else(
                 || json!({"records": []}),
-                |token| canned_page(&format!("master-{offset}"), Some(token)),
+                |token| mock_photo_query_page(&format!("master-{offset}"), Some(token)),
             ))
         }
 
@@ -1453,7 +1404,7 @@ mod tests {
         // --recent 0 should produce 0 items. The mock has a valid page
         // available, but limit=0 means the fetcher should never send it.
         let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
+            .ok(mock_photo_query_page("master-1", None))
             .ok(json!({"records": []}));
         let album = make_album_with_session(100, Box::new(mock));
 
@@ -1469,8 +1420,8 @@ mod tests {
         use tokio_stream::StreamExt;
 
         let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
-            .ok(canned_page("master-2", None))
+            .ok(mock_photo_query_page("master-1", None))
+            .ok(mock_photo_query_page("master-2", None))
             .ok(json!({"records": []}));
         let album = make_album_with_session(1, Box::new(mock));
 
@@ -1511,7 +1462,7 @@ mod tests {
         });
 
         // Page 2: Valid paired CPLMaster + CPLAsset.
-        let page2 = canned_page("master-ok", None);
+        let page2 = mock_photo_query_page("master-ok", None);
 
         // Page 3: Empty → terminates.
         let mock = MockPhotosSession::new()
@@ -1543,11 +1494,11 @@ mod tests {
         use tokio_stream::StreamExt;
 
         let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
+            .ok(mock_photo_query_page("master-1", None))
             // Page 2 is empty (simulated gap); must not terminate.
             .ok(json!({"records": []}))
             // Page 3 contains records past the gap.
-            .ok(canned_page("master-2", None));
+            .ok(mock_photo_query_page("master-2", None));
         // MockPhotosSession then returns the default {"records": []} on
         // every subsequent call; the fetcher requires MAX_EMPTY_PAGE_PROBES
         // consecutive empties to commit to EOF.
@@ -1578,14 +1529,14 @@ mod tests {
         use tokio_stream::StreamExt;
 
         let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
+            .ok(mock_photo_query_page("master-1", None))
             // 4 consecutive empty pages (within tolerance).
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             // Records reappear past the empty run.
-            .ok(canned_page("master-2", None));
+            .ok(mock_photo_query_page("master-2", None));
         let album = make_album_with_session(1, Box::new(mock));
 
         let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
@@ -1616,14 +1567,14 @@ mod tests {
         // page with a record would be unreachable; the test asserts it is
         // never observed.
         let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
+            .ok(mock_photo_query_page("master-1", None))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             .ok(json!({"records": []}))
             // Should never be requested — terminator should fire first.
-            .ok(canned_page("master-unreachable", None));
+            .ok(mock_photo_query_page("master-unreachable", None));
         let album = make_album_with_session(1, Box::new(mock));
 
         let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -914,7 +914,7 @@ impl PhotoAlbum {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::MockPhotosSession;
+    use crate::test_helpers::{MockPhotosFlow, MockPhotosSession};
     use serde_json::json;
 
     fn make_album(
@@ -1097,12 +1097,10 @@ mod tests {
         )
     }
 
-    /// Build a canned QueryResponse with one paired CPLMaster+CPLAsset
-    /// record and an optional syncToken.
-    fn canned_page(record_name: &str, sync_token: Option<&str>) -> Value {
-        let mut resp = json!({
-            "records": [
-                {
+    /// Build one paired CPLMaster+CPLAsset record set for records/query tests.
+    fn canned_records(record_name: &str) -> Vec<Value> {
+        vec![
+            json!({
                     "recordName": record_name,
                     "recordType": "CPLMaster",
                     "fields": {
@@ -1121,8 +1119,8 @@ mod tests {
                         "adjustmentRenderType": {"value": 0, "type": "INT64"}
                     },
                     "recordChangeTag": "ct1"
-                },
-                {
+            }),
+            json!({
                     "recordName": format!("asset-{record_name}"),
                     "recordType": "CPLAsset",
                     "fields": {
@@ -1134,9 +1132,14 @@ mod tests {
                         "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
                     },
                     "recordChangeTag": "ct2"
-                }
-            ]
-        });
+            }),
+        ]
+    }
+
+    /// Build a canned QueryResponse with one paired CPLMaster+CPLAsset
+    /// record and an optional syncToken.
+    fn canned_page(record_name: &str, sync_token: Option<&str>) -> Value {
+        let mut resp = json!({ "records": canned_records(record_name) });
         if let Some(token) = sync_token {
             resp["syncToken"] = json!(token);
         }
@@ -1147,10 +1150,11 @@ mod tests {
     async fn test_photo_stream_with_token_returns_sync_token() {
         use tokio_stream::StreamExt;
 
-        let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", Some("st-zone-abc")))
+        let mock = MockPhotosFlow::new()
+            .query_page(canned_records("master-1"), Some("st-zone-abc"))
             // Second call returns empty records to stop the fetcher
-            .ok(json!({"records": [], "syncToken": "st-zone-abc"}));
+            .empty_query_page(Some("st-zone-abc"))
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
@@ -1172,9 +1176,10 @@ mod tests {
         use tokio_stream::StreamExt;
 
         // Responses without syncToken field
-        let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", None))
-            .ok(json!({"records": []}));
+        let mock = MockPhotosFlow::new()
+            .query_page(canned_records("master-1"), None)
+            .empty_query_page(None)
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
@@ -1195,10 +1200,11 @@ mod tests {
         // Two pages with different syncTokens — last one should be captured.
         // page_size=1 so each page yields 1 master record and the fetcher
         // advances offset by 1.
-        let mock = MockPhotosSession::new()
-            .ok(canned_page("master-1", Some("st-first")))
-            .ok(canned_page("master-2", Some("st-second")))
-            .ok(json!({"records": []}));
+        let mock = MockPhotosFlow::new()
+            .query_page(canned_records("master-1"), Some("st-first"))
+            .query_page(canned_records("master-2"), Some("st-second"))
+            .empty_query_page(None)
+            .build();
         let album = make_album_with_session(1, Box::new(mock));
 
         let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
@@ -1590,7 +1596,9 @@ mod tests {
             changes_master("master-1"),
             changes_asset("asset-1", "master-1"),
         ];
-        let mock = MockPhotosSession::new().ok(canned_changes_page(&records, "token-final", false));
+        let mock = MockPhotosFlow::new()
+            .changes_zone_page(records, "token-final", false)
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.changes_stream("token-initial");
@@ -1622,9 +1630,10 @@ mod tests {
             changes_master("master-2"),
             changes_asset("asset-2", "master-2"),
         ];
-        let mock = MockPhotosSession::new()
-            .ok(canned_changes_page(&page1_records, "token-page1", true))
-            .ok(canned_changes_page(&page2_records, "token-page2", false));
+        let mock = MockPhotosFlow::new()
+            .changes_zone_page(page1_records, "token-page1", true)
+            .changes_zone_page(page2_records, "token-page2", false)
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.changes_stream("token-initial");
@@ -1653,9 +1662,10 @@ mod tests {
             changes_master("master-1"),
             changes_asset("asset-1", "master-1"),
         ];
-        let mock = MockPhotosSession::new()
-            .ok(canned_changes_page(&[], "token-empty", true))
-            .ok(canned_changes_page(&page2_records, "token-final", false));
+        let mock = MockPhotosFlow::new()
+            .changes_zone_page(Vec::new(), "token-empty", true)
+            .changes_zone_page(page2_records, "token-final", false)
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.changes_stream("token-initial");
@@ -1677,15 +1687,9 @@ mod tests {
     async fn test_changes_stream_zone_error() {
         use tokio_stream::StreamExt;
 
-        let mock = MockPhotosSession::new().ok(json!({
-            "zones": [{
-                "zoneID": {"zoneName": "PrimarySync"},
-                "syncToken": "",
-                "moreComing": false,
-                "serverErrorCode": "BAD_REQUEST",
-                "reason": "Unknown sync continuation type"
-            }]
-        }));
+        let mock = MockPhotosFlow::new()
+            .changes_zone_error("BAD_REQUEST", "Unknown sync continuation type", "")
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.changes_stream("bad-token");
@@ -1718,15 +1722,9 @@ mod tests {
         // on the very first page must not lose the caller's initial sync_token.
         use tokio_stream::StreamExt;
 
-        let mock = MockPhotosSession::new().ok(json!({
-            "zones": [{
-                "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
-                "syncToken": "",
-                "moreComing": false,
-                "serverErrorCode": "RETRY_LATER",
-                "reason": "temporary backend issue"
-            }]
-        }));
+        let mock = MockPhotosFlow::new()
+            .changes_zone_error("RETRY_LATER", "temporary backend issue", "")
+            .build();
         let album = make_album_with_session(100, Box::new(mock));
 
         let (stream, token_rx) = album.changes_stream("token-T0");

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1233,6 +1233,115 @@ mod tests {
         count
     }
 
+    #[tokio::test]
+    async fn offline_replay_full_pass_fixture() {
+        let mock = MockPhotosFlow::new()
+            .query_photo_page("master-replay-full", Some("token-full"))
+            .empty_query_page(Some("token-full"))
+            .build();
+        let album = make_album_with_session(100, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
+
+        assert_eq!(drain_photo_stream_count(stream).await, 1);
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-full")
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_replay_paginated_full_pass_fixture() {
+        let mock = MockPhotosFlow::new()
+            .query_photo_page("master-replay-page-1", Some("token-page-1"))
+            .query_photo_page("master-replay-page-2", Some("token-page-2"))
+            .empty_query_page(Some("token-page-2"))
+            .build();
+        let album = make_album_with_session(1, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
+
+        assert_eq!(drain_photo_stream_count(stream).await, 2);
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-page-2")
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_replay_empty_page_probe_fixture() {
+        let mock = MockPhotosFlow::new()
+            .query_photo_page("master-before-gap", None)
+            .empty_query_page(None)
+            .query_photo_page("master-after-gap", None)
+            .build();
+        let album = make_album_with_session(1, Box::new(mock));
+
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+
+        assert_eq!(
+            drain_photo_stream_count(stream).await,
+            2,
+            "single empty records/query page must be treated as a gap, not EOF"
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_replay_incremental_changes_fixture() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .changes_photo_page("master-replay-change", "token-incremental", false)
+            .build();
+        let album = make_album_with_session(100, Box::new(mock));
+
+        let (stream, token_rx) = album.changes_stream("token-before");
+        tokio::pin!(stream);
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.expect("change event"));
+        }
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(&*events[0].record_name, "master-replay-change");
+        assert!(events[0].asset.is_some());
+        assert_eq!(
+            token_rx.await.expect("sync token sender"),
+            "token-incremental"
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_replay_retryable_error_page_fixture() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .changes_zone_error("RETRY_LATER", "temporary backend issue", "")
+            .build();
+        let album = make_album_with_session(100, Box::new(mock));
+
+        let (stream, token_rx) = album.changes_stream("token-before");
+        tokio::pin!(stream);
+        let mut errors = Vec::new();
+        while let Some(result) = stream.next().await {
+            if let Err(error) = result {
+                errors.push(error);
+            }
+        }
+
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].to_string().contains("RETRY_LATER"),
+            "retryable fixture should surface the CloudKit retry code: {}",
+            errors[0]
+        );
+        assert_eq!(
+            token_rx.await.expect("sync token sender"),
+            "token-before",
+            "retryable error must preserve the last-good token"
+        );
+    }
+
     #[derive(Clone, Debug)]
     struct TokenByOffsetSession {
         tokens_by_offset: Arc<HashMap<u64, &'static str>>,

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -325,40 +325,54 @@ mod tests {
     /// Write a shell script to a temp dir. No executable permission needed
     /// since `run_script` invokes scripts via `/bin/sh`.
     #[cfg(unix)]
-    fn write_test_script(dir: &std::path::Path, name: &str, body: &[u8]) -> PathBuf {
+    fn write_test_script(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
         let path = dir.join(name);
-        std::fs::write(&path, body).unwrap();
+        std::fs::write(&path, body).unwrap_or_else(|err| {
+            panic!("write notification test script {}: {err}", path.display())
+        });
         path
+    }
+
+    #[cfg(unix)]
+    fn notification_test_dir(context: &str) -> tempfile::TempDir {
+        tempfile::tempdir().unwrap_or_else(|err| panic!("create temp dir for {context}: {err}"))
+    }
+
+    #[cfg(unix)]
+    fn read_script_output(path: &Path) -> String {
+        std::fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("read notification script output {}: {err}", path.display())
+        })
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn run_script_success() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = notification_test_dir("run_script_success");
         let script = write_test_script(dir.path(), "success.sh", b"#!/bin/sh\nexit 0\n");
 
         let status = run_script(&script, "test_event", "msg", "user", None)
             .await
-            .unwrap();
+            .unwrap_or_else(|err| panic!("run notification script {}: {err}", script.display()));
         assert!(status.success());
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn run_script_nonzero_exit() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = notification_test_dir("run_script_nonzero_exit");
         let script = write_test_script(dir.path(), "fail.sh", b"#!/bin/sh\nexit 1\n");
 
         let status = run_script(&script, "test_event", "msg", "user", None)
             .await
-            .unwrap();
+            .unwrap_or_else(|err| panic!("run notification script {}: {err}", script.display()));
         assert!(!status.success());
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn notify_runs_script_with_env_vars() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = notification_test_dir("notify_runs_script_with_env_vars");
         let output_path = dir.path().join("test_notify_output.txt");
         let body = format!(
             "#!/bin/sh\necho \"$KEI_EVENT|$KEI_MESSAGE|$KEI_ICLOUD_USERNAME\" > {}\n",
@@ -387,14 +401,14 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        let output = std::fs::read_to_string(&output_path).unwrap();
+        let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "2fa_required|Need 2FA code|test@example.com");
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn notify_with_sync_data_sets_extended_env_vars() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = notification_test_dir("notify_with_sync_data_sets_extended_env_vars");
         let output_path = dir.path().join("test_data_output.txt");
         let body = format!(
             "#!/bin/sh\necho \"$KEI_DOWNLOADED|$KEI_FAILED|$KEI_SKIPPED|$KEI_BYTES_DOWNLOADED|$KEI_SKIPPED_BY_STATE\" > {}\n",
@@ -426,7 +440,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        let output = std::fs::read_to_string(&output_path).unwrap();
+        let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "42|3|100|1500000|80");
     }
 
@@ -449,9 +463,14 @@ mod tests {
     #[cfg(unix)]
     impl BarrierFixture {
         fn new() -> Self {
-            let dir = tempfile::tempdir().unwrap();
+            let dir = notification_test_dir("barrier notification script");
             let counter_dir = dir.path().join("inflight");
-            std::fs::create_dir_all(&counter_dir).unwrap();
+            std::fs::create_dir_all(&counter_dir).unwrap_or_else(|err| {
+                panic!(
+                    "create notification script counter dir {}: {err}",
+                    counter_dir.display()
+                )
+            });
             let release = dir.path().join("release");
             let invocations = dir.path().join("invocations");
             let body = format!(
@@ -484,7 +503,12 @@ mod tests {
         }
 
         fn release_barrier(&self) {
-            std::fs::write(&self.release, b"").unwrap();
+            std::fs::write(&self.release, b"").unwrap_or_else(|err| {
+                panic!(
+                    "write notification script release file {}: {err}",
+                    self.release.display()
+                )
+            });
         }
 
         async fn wait_until<F: FnMut() -> bool>(&self, timeout: Duration, mut pred: F) {
@@ -607,7 +631,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn notify_without_data_omits_extended_vars() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = notification_test_dir("notify_without_data_omits_extended_vars");
         let output_path = dir.path().join("test_no_data.txt");
         let body = format!(
             "#!/bin/sh\necho \"${{KEI_DOWNLOADED:-unset}}|${{KEI_FAILED:-unset}}\" > {}\n",
@@ -630,7 +654,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        let output = std::fs::read_to_string(&output_path).unwrap();
+        let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "unset|unset");
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4166,13 +4166,14 @@ mod tests {
                 .with_download_dir_replaced_on_upsert(download_root.clone()),
         );
         let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let master_record_name = "master-mid-sync-destination-fault";
         let album = make_full_album_with_session(
             "PrimarySync",
             crate::test_helpers::MockPhotosSession::new()
                 .ok(album_count_response(1))
                 .ok(full_album_page_with_download(
                     "PrimarySync",
-                    "master-mid-sync-destination-fault",
+                    master_record_name,
                     "zone-tok-after-fault",
                     "https://p01.icloud-content.com/mid-sync-destination-unavailable.jpg",
                     8,
@@ -4228,6 +4229,11 @@ mod tests {
         assert!(
             logs_contain("Download failed") && logs_contain(&root),
             "download failure log should include the target path context under {root}"
+        );
+        assert!(
+            logs_contain("Download failed")
+                && logs_contain(&format!("asset_id={master_record_name}")),
+            "download failure log should include structured asset_id={master_record_name}"
         );
 
         if download_root.is_file() {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4411,6 +4411,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn offline_replay_full_pass_reaches_sync_loop_planning_boundary() {
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosFlow::new()
+                .album_count(1)
+                .query_photo_page("master-replay-sync-loop", Some("zone-tok-replay"))
+                .empty_query_page(Some("zone-tok-replay"))
+                .build(),
+        );
+
+        let result =
+            run_full_cycle_with_album(album, false, download::DownloadControls::dry_run_hidden())
+                .await;
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(
+            result.stats.downloaded, 1,
+            "dry-run sync-loop replay must reach download planning"
+        );
+        assert_eq!(result.stats.failed, 0);
+    }
+
     // Periodic reconciliation cadence. The watch loop calls
     // `should_reconcile_this_cycle` once per cycle to decide whether to walk
     // the state DB and warn on missing local files. Tests pin the cadence

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2238,6 +2238,24 @@ mod tests {
     }
 
     fn full_album_page(zone: &str, record_name: &str, sync_token: &str) -> serde_json::Value {
+        full_album_page_with_download(
+            zone,
+            record_name,
+            sync_token,
+            "https://p01.icloud-content.com/photo.jpg",
+            1024,
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        )
+    }
+
+    fn full_album_page_with_download(
+        zone: &str,
+        record_name: &str,
+        sync_token: &str,
+        download_url: &str,
+        size: u64,
+        checksum: &str,
+    ) -> serde_json::Value {
         serde_json::json!({
             "records": [
                 {
@@ -2247,9 +2265,9 @@ mod tests {
                         "filenameEnc": {"value": "cGhvdG8uanBn", "type": "STRING"},
                         "resOriginalRes": {
                             "value": {
-                                "downloadURL": "https://p01.icloud-content.com/photo.jpg",
-                                "size": 1024,
-                                "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                                "downloadURL": download_url,
+                                "size": size,
+                                "fileChecksum": checksum
                             }
                         },
                         "resOriginalWidth": {"value": 100, "type": "INT64"},
@@ -2647,6 +2665,7 @@ mod tests {
         delete_prefix_failure: Option<&'static str>,
         message: &'static str,
         cancel_on_upsert: Option<CancellationToken>,
+        replace_download_dir_on_upsert: Option<std::path::PathBuf>,
     }
 
     impl std::fmt::Debug for FailingMetadataSetDb {
@@ -2673,6 +2692,7 @@ mod tests {
                 delete_prefix_failure: None,
                 message,
                 cancel_on_upsert: None,
+                replace_download_dir_on_upsert: None,
             }
         }
 
@@ -2696,6 +2716,11 @@ mod tests {
 
         fn with_cancel_on_upsert(mut self, token: CancellationToken) -> Self {
             self.cancel_on_upsert = Some(token);
+            self
+        }
+
+        fn with_download_dir_replaced_on_upsert(mut self, path: std::path::PathBuf) -> Self {
+            self.replace_download_dir_on_upsert = Some(path);
             self
         }
     }
@@ -2722,6 +2747,11 @@ mod tests {
         ) -> Result<(), state::error::StateError> {
             let result = self.inner.upsert_seen(record).await;
             if result.is_ok() {
+                if let Some(path) = &self.replace_download_dir_on_upsert {
+                    let _ = std::fs::remove_dir_all(path);
+                    std::fs::write(path, b"destination replaced by fault injection")
+                        .expect("replace download dir with file");
+                }
                 if let Some(token) = &self.cancel_on_upsert {
                     token.cancel();
                 }
@@ -4049,6 +4079,87 @@ mod tests {
             !download_dir.path().join("2023/11/14/photo.jpg").exists(),
             "test must not pass by completing the download before cancellation"
         );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn run_cycle_destination_replaced_after_enumeration_reports_partial_failure() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let download_root = download_dir.path().to_path_buf();
+        let db: Arc<dyn state::StateDb> = Arc::new(
+            FailingMetadataSetDb::without_set_failure(Arc::clone(&inner), "unused")
+                .with_download_dir_replaced_on_upsert(download_root.clone()),
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(full_album_page_with_download(
+                    "PrimarySync",
+                    "master-mid-sync-destination-fault",
+                    "zone-tok-after-fault",
+                    "https://p01.icloud-content.com/mid-sync-destination-unavailable.jpg",
+                    8,
+                    "AAAA",
+                )),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(
+            result.failed_count, 1,
+            "mid-sync destination loss must produce a failed sync result"
+        );
+        assert_eq!(result.stats.failed, 1);
+        assert_eq!(result.stats.downloaded, 0);
+        assert!(
+            !result.db_sync_token_advance_safe,
+            "database precheck token must not advance after a download failure"
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token"),
+            None,
+            "partial sync must not store the post-fault zone token"
+        );
+
+        let failed = db.get_failed().await.expect("read failed assets");
+        assert_eq!(failed.len(), 1, "failed asset should be persisted");
+        let last_error = failed[0].last_error.as_deref().expect("failed asset error");
+        assert!(
+            last_error.contains("Failed to open temp download file")
+                || last_error.contains("failed to create directory"),
+            "failed asset error should name the failing filesystem operation, got: {last_error}"
+        );
+        let root = download_root.display().to_string();
+        assert!(
+            logs_contain("Download failed") && logs_contain(&root),
+            "download failure log should include the target path context under {root}"
+        );
+
+        if download_root.is_file() {
+            std::fs::remove_file(&download_root).expect("remove injected download-root file");
+        }
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -405,6 +405,11 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         check_min_disk_space(avail, &config.download.directory)?;
     }
 
+    #[cfg(debug_assertions)]
+    if maybe_write_offline_fake_sync_report(&config, &notifier).await? {
+        return Ok(());
+    }
+
     let cred_store =
         credential::CredentialStore::new(&config.auth.username, &config.auth.cookie_directory);
     let source = password::build_password_source(
@@ -1126,6 +1131,74 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     } else {
         Ok(())
     }
+}
+
+// Debug-only seam for the offline binary-boundary report test. Release builds
+// must never skip authentication or CloudKit work from an environment variable.
+#[cfg(debug_assertions)]
+async fn maybe_write_offline_fake_sync_report(
+    config: &config::Config,
+    notifier: &Notifier,
+) -> anyhow::Result<bool> {
+    const ENV: &str = "KEI_UNSTABLE_FAKE_SYNC_REPORT_FOR_TESTS";
+    if std::env::var(ENV).as_deref() != Ok("1") {
+        return Ok(false);
+    }
+
+    let Some(report_path) = config.report.json.as_deref() else {
+        anyhow::bail!("{ENV}=1 requires [report].json");
+    };
+
+    tracing::warn!(
+        env = ENV,
+        "Offline fake sync report test seam enabled; exiting before authentication"
+    );
+
+    let reporter = crate::cycle_reporter::CycleReporter::<state::SqliteStateDb>::new(
+        crate::cycle_reporter::CycleReporterConfig {
+            username: &config.auth.username,
+            watch_mode: config.watch.interval.is_some(),
+            report_path: Some(report_path),
+            run_options: crate::report::RunOptions::from_config(config),
+            health_dir: &config.auth.cookie_directory,
+            personality_mode: config.ui.personality_mode,
+            state_db: None,
+            metrics_handle: None,
+            notifier,
+        },
+    );
+    let stats = download::SyncStats {
+        assets_seen: 3,
+        downloaded: 2,
+        skipped: download::SkipBreakdown {
+            by_state: 1,
+            ..download::SkipBreakdown::default()
+        },
+        bytes_downloaded: 4096,
+        disk_bytes_written: 4096,
+        elapsed_secs: 0.125,
+        photos_downloaded: 1,
+        videos_downloaded: 1,
+        ..download::SyncStats::default()
+    };
+    let mut health = health::HealthStatus::new();
+    reporter
+        .report_completed_cycle(
+            &mut health,
+            crate::cycle_reporter::CycleReportInput {
+                stats: &stats,
+                failed_count: 0,
+                session_expired: false,
+                elapsed: std::time::Duration::from_millis(125),
+            },
+        )
+        .await;
+
+    if !report_path.is_file() {
+        anyhow::bail!("offline fake sync did not write {}", report_path.display());
+    }
+
+    Ok(true)
 }
 
 /// Re-authenticate via SRP after a session-error signature from CloudKit.

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -354,6 +354,10 @@ impl MockPhotosFlow {
         self
     }
 
+    pub fn query_photo_page(self, record_name: &str, sync_token: Option<&str>) -> Self {
+        self.query_page(mock_photo_records(record_name), sync_token)
+    }
+
     pub fn empty_query_page(self, sync_token: Option<&str>) -> Self {
         self.query_page(Vec::new(), sync_token)
     }
@@ -398,6 +402,15 @@ impl MockPhotosFlow {
         self
     }
 
+    pub fn changes_photo_page(
+        self,
+        record_name: &str,
+        sync_token: &str,
+        more_coming: bool,
+    ) -> Self {
+        self.changes_zone_page(mock_photo_records(record_name), sync_token, more_coming)
+    }
+
     pub fn changes_zone_error(
         mut self,
         server_error_code: &str,
@@ -424,6 +437,47 @@ impl MockPhotosFlow {
     pub fn build(self) -> MockPhotosSession {
         self.session
     }
+}
+
+fn mock_photo_records(record_name: &str) -> Vec<Value> {
+    vec![
+        json!({
+            "recordName": record_name,
+            "recordType": "CPLMaster",
+            "fields": {
+                "filenameEnc": {"value": "dGVzdC5qcGc=", "type": "STRING"},
+                "resOriginalRes": {
+                    "value": {
+                        "downloadURL": "https://p01.icloud-content.com/photo.jpg",
+                        "size": 1024,
+                        "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    }
+                },
+                "resOriginalWidth": {"value": 100, "type": "INT64"},
+                "resOriginalHeight": {"value": 100, "type": "INT64"},
+                "resOriginalFileType": {"value": "public.jpeg"},
+                "itemType": {"value": "public.jpeg"},
+                "adjustmentRenderType": {"value": 0, "type": "INT64"}
+            },
+            "recordChangeTag": "ct1"
+        }),
+        json!({
+            "recordName": format!("asset-{record_name}"),
+            "recordType": "CPLAsset",
+            "fields": {
+                "masterRef": {
+                    "value": {
+                        "recordName": record_name,
+                        "zoneID": {"zoneName": "PrimarySync"}
+                    },
+                    "type": "REFERENCE"
+                },
+                "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+            },
+            "recordChangeTag": "ct2"
+        }),
+    ]
 }
 
 impl Default for MockPhotosFlow {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -319,6 +319,119 @@ impl TestPhotoAsset {
     }
 }
 
+// ── CloudKit/Photos response flow builder ───────────────────────────
+
+/// Small builder for the queued CloudKit responses used by `MockPhotosSession`.
+///
+/// This intentionally only covers the response shapes current tests repeat:
+/// album-count batches, `/records/query` pages, `/changes/database` pages,
+/// `/changes/zone` pages, and queued transport errors. It is not a fake
+/// CloudKit implementation.
+pub struct MockPhotosFlow {
+    session: MockPhotosSession,
+}
+
+impl MockPhotosFlow {
+    pub fn new() -> Self {
+        Self {
+            session: MockPhotosSession::new(),
+        }
+    }
+
+    pub fn album_count(mut self, count: u64) -> Self {
+        self.session = self.session.ok(json!({
+            "batch": [{"records": [{"fields": {"itemCount": {"value": count}}}]}]
+        }));
+        self
+    }
+
+    pub fn query_page(mut self, records: Vec<Value>, sync_token: Option<&str>) -> Self {
+        let mut page = json!({ "records": records });
+        if let Some(token) = sync_token {
+            page["syncToken"] = json!(token);
+        }
+        self.session = self.session.ok(page);
+        self
+    }
+
+    pub fn empty_query_page(self, sync_token: Option<&str>) -> Self {
+        self.query_page(Vec::new(), sync_token)
+    }
+
+    pub fn changes_database(
+        mut self,
+        sync_token: &str,
+        changed_zones: &[(&str, &str)],
+        more_coming: bool,
+    ) -> Self {
+        let zones: Vec<Value> = changed_zones
+            .iter()
+            .map(|(zone_name, zone_sync_token)| {
+                json!({
+                    "zoneID": {"zoneName": zone_name, "ownerRecordName": "_defaultOwner"},
+                    "syncToken": zone_sync_token,
+                })
+            })
+            .collect();
+        self.session = self.session.ok(json!({
+            "syncToken": sync_token,
+            "moreComing": more_coming,
+            "zones": zones,
+        }));
+        self
+    }
+
+    pub fn changes_zone_page(
+        mut self,
+        records: Vec<Value>,
+        sync_token: &str,
+        more_coming: bool,
+    ) -> Self {
+        self.session = self.session.ok(json!({
+            "zones": [{
+                "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                "syncToken": sync_token,
+                "moreComing": more_coming,
+                "records": records,
+            }]
+        }));
+        self
+    }
+
+    pub fn changes_zone_error(
+        mut self,
+        server_error_code: &str,
+        reason: &str,
+        sync_token: &str,
+    ) -> Self {
+        self.session = self.session.ok(json!({
+            "zones": [{
+                "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                "syncToken": sync_token,
+                "moreComing": false,
+                "serverErrorCode": server_error_code,
+                "reason": reason,
+            }]
+        }));
+        self
+    }
+
+    pub fn error(mut self, message: &str) -> Self {
+        self.session = self.session.err(message);
+        self
+    }
+
+    pub fn build(self) -> MockPhotosSession {
+        self.session
+    }
+}
+
+impl Default for MockPhotosFlow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ── Mock PhotosSession ──────────────────────────────────────────────
 
 /// Recorded call to `MockPhotosSession::post()`.
@@ -462,5 +575,38 @@ mod tests {
         assert_eq!(calls.len(), 3);
         assert_eq!(calls[0].url, "https://example.com/query");
         assert_eq!(calls[1].url, "https://example.com/changes");
+    }
+
+    #[tokio::test]
+    async fn mock_photos_flow_queues_common_cloudkit_shapes() {
+        let mock = MockPhotosFlow::new()
+            .album_count(7)
+            .changes_database("db-token", &[("PrimarySync", "zone-token")], true)
+            .error("transport failure")
+            .build();
+
+        let count = mock
+            .post("https://example.com/count", "{}".to_owned(), &[])
+            .await
+            .expect("count response");
+        assert_eq!(
+            count["batch"][0]["records"][0]["fields"]["itemCount"]["value"],
+            7
+        );
+
+        let changes = mock
+            .post("https://example.com/changes/database", "{}".to_owned(), &[])
+            .await
+            .expect("changes database response");
+        assert_eq!(changes["syncToken"], "db-token");
+        assert_eq!(changes["zones"][0]["zoneID"]["zoneName"], "PrimarySync");
+        assert_eq!(changes["zones"][0]["syncToken"], "zone-token");
+        assert!(changes["moreComing"].as_bool().unwrap_or(false));
+
+        let err = mock
+            .post("https://example.com/fail", "{}".to_owned(), &[])
+            .await
+            .expect_err("queued transport error");
+        assert!(err.to_string().contains("transport failure"));
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -354,8 +354,11 @@ impl MockPhotosFlow {
         self
     }
 
-    pub fn query_photo_page(self, record_name: &str, sync_token: Option<&str>) -> Self {
-        self.query_page(mock_photo_records(record_name), sync_token)
+    pub fn query_photo_page(mut self, record_name: &str, sync_token: Option<&str>) -> Self {
+        self.session = self
+            .session
+            .ok(mock_photo_query_page(record_name, sync_token));
+        self
     }
 
     pub fn empty_query_page(self, sync_token: Option<&str>) -> Self {
@@ -437,6 +440,14 @@ impl MockPhotosFlow {
     pub fn build(self) -> MockPhotosSession {
         self.session
     }
+}
+
+pub(crate) fn mock_photo_query_page(record_name: &str, sync_token: Option<&str>) -> Value {
+    let mut page = json!({ "records": mock_photo_records(record_name) });
+    if let Some(token) = sync_token {
+        page["syncToken"] = json!(token);
+    }
+    page
 }
 
 fn mock_photo_records(record_name: &str) -> Vec<Value> {

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -242,6 +242,101 @@ fn behavioral_helper_schema_matches_production() {
     );
 }
 
+#[cfg(debug_assertions)]
+#[test]
+fn sync_report_json_offline_binary_boundary_writes_current_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    let download_dir = dir.path().join("photos");
+    let report_path = dir.path().join("sync_report.json");
+    let config_path = dir.path().join("config.toml");
+    let username = "offline-report@example.com";
+    std::fs::write(
+        &config_path,
+        format!(
+            "\
+[auth]
+username = {username}
+
+[download]
+directory = {download_dir}
+folder_structure = \"%Y/%m/%d\"
+threads = 3
+
+[filters]
+media = [\"photos\", \"videos\"]
+
+[report]
+json = {report_path}
+
+[ui]
+friendly = false
+",
+            username = common::toml_string(username),
+            download_dir = common::toml_string(&download_dir.to_string_lossy()),
+            report_path = common::toml_string(&report_path.to_string_lossy()),
+        ),
+    )
+    .unwrap();
+
+    let data_dir = dir.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_kei"))
+        .env_remove("ICLOUD_USERNAME")
+        .env_remove("ICLOUD_PASSWORD")
+        .env_remove("KEI_CONFIG")
+        .env_remove("KEI_DATA_DIR")
+        .env_remove("KEI_DOWNLOAD_DIR")
+        .env_remove("KEI_LOG_LEVEL")
+        .env_remove("KEI_NO_AUTO_CONFIG")
+        .env("KEI_DATA_DIR", &data_dir)
+        .env("KEI_UNSTABLE_FAKE_SYNC_REPORT_FOR_TESTS", "1")
+        .args(["sync", "--config", config_path.to_str().unwrap()])
+        .output()
+        .expect("run kei");
+    assert!(
+        output.status.success(),
+        "kei sync failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let body = std::fs::read_to_string(&report_path).expect("sync_report.json");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("valid report JSON");
+    assert_eq!(json["version"], "2", "schema version");
+    assert!(json["kei_version"].as_str().is_some_and(|v| !v.is_empty()));
+    assert!(
+        json["timestamp"]
+            .as_str()
+            .is_some_and(|ts| chrono::DateTime::parse_from_rfc3339(ts).is_ok()),
+        "timestamp must be RFC3339: {}",
+        json["timestamp"]
+    );
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["options"]["username"], username);
+    assert_eq!(
+        json["options"]["download_dir"],
+        download_dir.display().to_string()
+    );
+    assert_eq!(json["options"]["folder_structure"], "%Y/%m/%d");
+    assert_eq!(json["options"]["threads"], 3);
+    assert_eq!(
+        json["options"]["media"],
+        serde_json::json!(["photos", "videos"])
+    );
+    assert_eq!(json["options"]["dry_run"], false);
+    assert_eq!(json["stats"]["assets_seen"], 3);
+    assert_eq!(json["stats"]["downloaded"], 2);
+    assert_eq!(json["stats"]["skipped"]["by_state"], 1);
+    assert_eq!(json["stats"]["bytes_downloaded"], 4096);
+    assert_eq!(json["stats"]["disk_bytes_written"], 4096);
+    assert_eq!(json["stats"]["photos_downloaded"], 1);
+    assert_eq!(json["stats"]["videos_downloaded"], 1);
+    assert!(
+        json.get("failed_assets").is_none(),
+        "clean success report should omit failed_assets: {json}"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Current commands: no deprecation warnings
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added offline coverage for sync safety gaps: destination loss after enumeration, generated path/collision cases, sync report JSON, download-failure log fields, and CloudKit replay flows.
- Added `MockPhotosFlow` so tests can declare common CloudKit response queues without repeating raw JSON.
- Table-drove the download filter matrix and reused the shared photo query fixture in album tests.
- Broadened HEIC metadata rewrite coverage and added contextual IO failures around Unix notification script tests.

## Context
Closes #423.
Closes #440.
Closes #435.
Closes #429.
Closes #428.
Closes #430.
Closes #427.
Closes #425.
Closes #439.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test download::filter::tests::`
- `cargo test download::paths::tests::`
- `cargo test generated_`
- `cargo test run_cycle_destination_replaced_after_enumeration_reports_partial_failure`
- `cargo test --test behavioral sync_report_json_offline_binary_boundary_writes_current_schema`
- `cargo test test_helpers::tests::mock_photos_flow_queues_common_cloudkit_shapes`
- `cargo test icloud::photos::album::tests::test_photo_stream_with_token`
- `cargo test icloud::photos::album::tests::test_changes_stream`
- `cargo test offline_replay`
- `cargo test download::metadata::tests::apply_metadata_heic --all-features`
- `cargo test notifications::tests --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
