### PR TITLE
Reduce idle watch API probes

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -543,8 +543,16 @@ pub async fn send_2fa_push(
 /// validate endpoint. Returns `true` if valid, `false` if expired.
 pub async fn validate_session(session: &mut Session, domain: &str) -> Result<bool> {
     let endpoints = Endpoints::for_domain(domain)?;
+    if recently_validated(session).await {
+        tracing::debug!("Session validated recently, skipping idle re-validation");
+        return Ok(true);
+    }
+
     match twofa::validate_token(session, &endpoints).await {
-        Ok(_) => Ok(true),
+        Ok(d) => {
+            session.save_validation_cache(&d).await;
+            Ok(true)
+        }
         Err(_) => {
             // /validate is strict; try /accountLogin as a lenient fallback.
             // A session is valid if accountLogin succeeds and 2FA is not required
@@ -574,12 +582,21 @@ pub async fn validate_session(session: &mut Session, domain: &str) -> Result<boo
                             return Ok(false);
                         }
                     }
+                    session.save_validation_cache(&d).await;
                     Ok(true)
                 }
                 Err(_) => Ok(false),
             }
         }
     }
+}
+
+async fn recently_validated(session: &Session) -> bool {
+    session.session_data.contains_key("session_token")
+        && session
+            .load_validation_cache(responses::VALIDATION_CACHE_GRACE_SECS)
+            .await
+            .is_some()
 }
 
 /// Apple's HSA2 (two-step verification v2) requires all three conditions:
@@ -760,6 +777,35 @@ mod tests {
         assert!(
             !called.load(Ordering::SeqCst),
             "password provider must not run when endpoint resolution fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn recently_validated_requires_session_token_and_fresh_cache() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let mut session = Session::new(
+            cookies.path(),
+            "cached@example.com",
+            "https://setup.icloud.com",
+            None,
+        )
+        .await
+        .expect("session");
+
+        session
+            .save_validation_cache(&make_response(2, false, true, true))
+            .await;
+        assert!(
+            !recently_validated(&session).await,
+            "cache without a session token must not authenticate an empty session"
+        );
+
+        session
+            .session_data
+            .insert("session_token".into(), "token".into());
+        assert!(
+            recently_validated(&session).await,
+            "fresh validation cache should suppress idle re-validation"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2282,7 +2282,11 @@ async fn download_photos_incremental(
     let mut hidden_count = 0u64;
     let mut total_events = 0u64;
 
-    for (pass_index, pass) in passes.iter().enumerate() {
+    // `changes_stream` is zone-scoped, not album-scoped. Query it once and
+    // fan created assets out through the selected passes locally; querying
+    // once per pass repeats the same `/changes/zone` pages on every watch
+    // cycle with work.
+    if let Some(pass) = passes.first() {
         let (change_stream, token_rx) = pass.album.changes_stream(zone_sync_token);
         tokio::pin!(change_stream);
 
@@ -2296,7 +2300,9 @@ async fn download_photos_incremental(
                 ChangeReason::Created => {
                     created_count += 1;
                     if let Some(asset) = event.asset {
-                        downloadable_assets.push((asset, pass_index));
+                        for pass_index in 0..passes.len() {
+                            downloadable_assets.push((asset.clone(), pass_index));
+                        }
                     }
                 }
                 ChangeReason::SoftDeleted => {
@@ -2355,7 +2361,6 @@ async fn download_photos_incremental(
             }
         }
 
-        // Capture the sync token from this pass
         if let Ok(token) = token_rx.await {
             sync_token = Some(token);
         }
@@ -2611,6 +2616,92 @@ mod tests {
 
     fn test_config() -> DownloadConfig {
         DownloadConfig::test_default()
+    }
+
+    fn changes_album(name: &str, session: CountingChangesZoneSession) -> PhotoAlbum {
+        PhotoAlbum::new(
+            PhotoAlbumConfig {
+                params: Arc::new(HashMap::new()),
+                service_endpoint: Arc::from("https://example.com"),
+                name: Arc::from(name),
+                list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
+                obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
+                query_filter: None,
+                page_size: 100,
+                zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+                retry_config: RetryConfig::default(),
+            },
+            Box::new(session),
+        )
+    }
+
+    #[derive(Clone)]
+    struct CountingChangesZoneSession {
+        changes_zone_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for CountingChangesZoneSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/changes/zone?") {
+                self.changes_zone_calls.fetch_add(1, Ordering::SeqCst);
+                return Ok(json!({
+                    "zones": [{
+                        "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                        "syncToken": "zone-token-next",
+                        "moreComing": false,
+                        "records": incremental_photo_records("MASTER_CHANGED"),
+                    }]
+                }));
+            }
+
+            Ok(json!({"records": []}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn incremental_photo_records(record_name: &str) -> Vec<Value> {
+        vec![
+            json!({
+                "recordName": record_name,
+                "recordType": "CPLMaster",
+                "fields": {
+                    "filenameEnc": {"value": "changed.jpg", "type": "STRING"},
+                    "resOriginalRes": {
+                        "value": {
+                            "downloadURL": "https://p01.icloud-content.com/changed.jpg",
+                            "size": 1024,
+                            "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                        }
+                    },
+                    "resOriginalFileType": {"value": "public.jpeg"},
+                    "itemType": {"value": "public.jpeg"}
+                }
+            }),
+            json!({
+                "recordName": format!("asset-{record_name}"),
+                "recordType": "CPLAsset",
+                "fields": {
+                    "masterRef": {
+                        "value": {
+                            "recordName": record_name,
+                            "zoneID": {"zoneName": "PrimarySync"}
+                        },
+                        "type": "REFERENCE"
+                    },
+                    "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                    "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                }
+            }),
+        ]
     }
 
     #[derive(Clone)]
@@ -3323,6 +3414,52 @@ mod tests {
                 false
             ),
             Some(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_sync_queries_zone_changes_once_per_library() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = CountingChangesZoneSession {
+            changes_zone_calls: Arc::clone(&calls),
+        };
+        let passes = vec![
+            AlbumPass {
+                kind: PassKind::Album,
+                album: changes_album("album_a", session.clone()),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+            AlbumPass {
+                kind: PassKind::Album,
+                album: changes_album("album_b", session),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+        ];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("print-only incremental sync should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.sync_token, None,
+            "print-only mode must not advance the sync token"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "changes/zone is zone-scoped; querying once per pass repeats the same delta"
         );
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -96,6 +96,8 @@ impl WatchPrecheck {
 /// the version suffix (e.g. `_v2`) re-fires the notice for every existing
 /// data dir the next time it's used.
 const SHARED_LIBRARY_NOTICE_KEY: &str = "shared_library_notice_shown_v1";
+const SHARED_LIBRARY_NOTICE_CHECKED_KEY: &str = "shared_library_notice_checked_at_v1";
+const SHARED_LIBRARY_NOTICE_CHECK_TTL_SECS: i64 = 24 * 60 * 60;
 
 /// Metadata key for the database-level token used by `/changes/database`.
 const DB_SYNC_TOKEN_KEY: &str = "db_sync_token";
@@ -164,30 +166,40 @@ fn should_notify_shared_libraries(
     ))
 }
 
+fn shared_library_notice_recently_checked(checked_at: Option<&str>, now_ts: i64) -> bool {
+    let Some(checked_at) = checked_at.and_then(|value| value.parse::<i64>().ok()) else {
+        return false;
+    };
+    now_ts.saturating_sub(checked_at) < SHARED_LIBRARY_NOTICE_CHECK_TTL_SECS
+}
+
 /// Probe + warning for users on the `PrimarySync` default who also have
-/// shared libraries. The marker (stored in the state DB's `metadata` table
-/// under [`SHARED_LIBRARY_NOTICE_KEY`]) is only set after the notice fires,
-/// so accounts with no shared libraries re-probe on every sync and catch a
-/// later-added library. The probe and marker write are best-effort: failures
+/// shared libraries. The notice marker (stored in the state DB's `metadata`
+/// table under [`SHARED_LIBRARY_NOTICE_KEY`]) is set after the notice fires.
+/// A separate short-lived negative cache records "no shared libraries seen"
+/// so accounts without shared libraries do not pay a shared-zone listing on
+/// every one-shot sync. The probe and marker writes are best-effort: failures
 /// degrade to `tracing::debug!` and skip without breaking the sync.
 async fn maybe_notify_shared_libraries(
     selector: &crate::selection::LibrarySelector,
     photos_service: &mut crate::icloud::photos::PhotosService,
     state_db: Option<&dyn state::StateDb>,
 ) {
-    let already_notified = match state_db {
-        Some(db) => match db.get_metadata(SHARED_LIBRARY_NOTICE_KEY).await {
-            Ok(Some(_)) => true,
-            Ok(None) => false,
-            Err(e) => {
-                tracing::debug!(
-                    error = %e,
-                    "shared-library notice: metadata read failed; skipping"
-                );
-                return;
-            }
-        },
-        None => false,
+    let Some(db) = state_db else {
+        tracing::debug!("shared-library notice: no state DB available; skipping uncached probe");
+        return;
+    };
+
+    let already_notified = match db.get_metadata(SHARED_LIBRARY_NOTICE_KEY).await {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "shared-library notice: metadata read failed; skipping"
+            );
+            return;
+        }
     };
     if already_notified {
         return;
@@ -198,6 +210,24 @@ async fn maybe_notify_shared_libraries(
     // repeats this check defensively.
     if selector != &crate::selection::LibrarySelector::default() {
         return;
+    }
+
+    match db.get_metadata(SHARED_LIBRARY_NOTICE_CHECKED_KEY).await {
+        Ok(checked_at) => {
+            if shared_library_notice_recently_checked(
+                checked_at.as_deref(),
+                chrono::Utc::now().timestamp(),
+            ) {
+                tracing::debug!("shared-library notice: recent no-shared check cached");
+                return;
+            }
+        }
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "shared-library notice: checked-at read failed; probing"
+            );
+        }
     }
 
     let shared_count = match photos_service.fetch_shared_libraries().await {
@@ -212,17 +242,29 @@ async fn maybe_notify_shared_libraries(
     };
 
     let Some(msg) = should_notify_shared_libraries(selector, shared_count, already_notified) else {
+        if shared_count == 0 {
+            if let Err(e) = db
+                .set_metadata(
+                    SHARED_LIBRARY_NOTICE_CHECKED_KEY,
+                    &chrono::Utc::now().timestamp().to_string(),
+                )
+                .await
+            {
+                tracing::debug!(
+                    error = %e,
+                    "shared-library notice: failed to persist no-shared check marker"
+                );
+            }
+        }
         return;
     };
     tracing::warn!(message = %msg, "Shared library notice");
 
-    if let Some(db) = state_db {
-        if let Err(e) = db.set_metadata(SHARED_LIBRARY_NOTICE_KEY, "1").await {
-            tracing::debug!(
-                error = %e,
-                "shared-library notice: failed to persist marker"
-            );
-        }
+    if let Err(e) = db.set_metadata(SHARED_LIBRARY_NOTICE_KEY, "1").await {
+        tracing::debug!(
+            error = %e,
+            "shared-library notice: failed to persist marker"
+        );
     }
 }
 
@@ -1812,6 +1854,93 @@ mod tests {
     fn notice_suppressed_when_both_user_opted_out_and_already_notified() {
         // Belt-and-braces: every suppression condition stacks correctly.
         assert!(should_notify_shared_libraries(&all_libraries(), 0, true).is_none());
+    }
+
+    #[test]
+    fn shared_library_notice_recent_check_uses_ttl() {
+        let now = 1_800_000_000;
+        assert!(shared_library_notice_recently_checked(
+            Some(&(now - 60).to_string()),
+            now
+        ));
+        assert!(!shared_library_notice_recently_checked(
+            Some(&(now - SHARED_LIBRARY_NOTICE_CHECK_TTL_SECS - 1).to_string()),
+            now
+        ));
+        assert!(!shared_library_notice_recently_checked(
+            Some("not-a-ts"),
+            now
+        ));
+    }
+
+    #[derive(Clone)]
+    struct CountingSharedLibrarySession {
+        shared_calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::icloud::photos::PhotosSession for CountingSharedLibrarySession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<serde_json::Value> {
+            if url.contains("/shared/zones/list") {
+                self.shared_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return Ok(serde_json::json!({"zones": []}));
+            }
+            anyhow::bail!("unexpected URL: {url}")
+        }
+
+        fn clone_box(&self) -> Box<dyn crate::icloud::photos::PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn shared_notice_service(
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> crate::icloud::photos::PhotosService {
+        crate::icloud::photos::PhotosService::for_testing(
+            Box::new(CountingSharedLibrarySession {
+                shared_calls: calls,
+            }),
+            std::collections::HashMap::new(),
+        )
+    }
+
+    #[tokio::test]
+    async fn shared_library_notice_skips_uncached_dry_run_probe_without_state_db() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut service = shared_notice_service(Arc::clone(&calls));
+
+        maybe_notify_shared_libraries(&primary(), &mut service, None).await;
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "without a state DB the shared-library probe cannot be cached, so dry-run should not pay the API call"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_library_notice_caches_no_shared_libraries() {
+        let db = make_state_db();
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let mut first = shared_notice_service(Arc::clone(&calls));
+        maybe_notify_shared_libraries(&primary(), &mut first, Some(db.as_ref())).await;
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let mut second = shared_notice_service(Arc::clone(&calls));
+        maybe_notify_shared_libraries(&primary(), &mut second, Some(db.as_ref())).await;
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "fresh no-shared marker should suppress the next shared-zone listing"
+        );
     }
 
     // The run_sync reauth retry branch keys on whether an error from


### PR DESCRIPTION
## Summary
- Cache successful idle session revalidation so watch mode doesn't re-hit Apple auth on every short interval.
- Query incremental zone changes once per library and fan created assets through the selected passes locally.
- Cache negative shared-library notice checks and skip the uncached probe when no state DB is available.

## Tests
- `cargo check`
- `cargo test incremental_sync_queries_zone_changes_once_per_library -- --test-threads=1`
- `cargo test shared_library_notice -- --test-threads=1`
- `cargo test recently_validated_requires_session_token_and_fresh_cache -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
