### PR TITLE
Share download context across pass streams

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use limiter::BandwidthLimiter;
 
 use pipeline::{
     build_download_outcome, format_duration, log_sync_summary, run_download_pass,
-    stream_and_download_from_stream, MetadataFlags, PassConfig, StreamingResult,
+    stream_and_download_from_stream, MetadataFlags, PassConfig, StreamRuntime, StreamingResult,
     AUTH_ERROR_THRESHOLD,
 };
 
@@ -1236,6 +1236,20 @@ impl DownloadContext {
     }
 }
 
+async fn preload_download_context(config: &DownloadConfig) -> Arc<DownloadContext> {
+    let download_ctx = if let Some(db) = &config.state_db {
+        tracing::debug!("Pre-loading download state from database");
+        DownloadContext::load(db.as_ref(), config.retry_only).await
+    } else {
+        DownloadContext::default()
+    };
+    tracing::debug!(
+        downloaded_ids = download_ctx.downloaded_ids.len(),
+        "Download context loaded"
+    );
+    Arc::new(download_ctx)
+}
+
 /// Pre-compute one `Arc<DownloadConfig>` per pass. Each pass_index maps to
 /// a derived config that pre-expands `{album}` and pins the pass's
 /// exclude-asset-ids set. In `{album}` mode passes may legitimately differ
@@ -1332,6 +1346,14 @@ struct CollectedUnfiledStream {
     items: Vec<anyhow::Result<PhotoAsset>>,
 }
 
+struct FullPassStreamOptions {
+    controls: DownloadControls,
+    count: u64,
+    kind: crate::commands::PassKind,
+    shutdown_token: CancellationToken,
+    download_ctx: Option<Arc<DownloadContext>>,
+}
+
 fn deferred_unfiled_index(passes: &[crate::commands::AlbumPass]) -> Option<usize> {
     let has_album_pass = passes
         .iter()
@@ -1373,10 +1395,7 @@ async fn run_full_pass_stream<S>(
     stream: S,
     token_rx: tokio::sync::oneshot::Receiver<Option<String>>,
     pass_config: Arc<DownloadConfig>,
-    controls: DownloadControls,
-    count: u64,
-    kind: crate::commands::PassKind,
-    shutdown_token: CancellationToken,
+    options: FullPassStreamOptions,
 ) -> Result<PerPassStreamingResult>
 where
     S: futures_util::Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static,
@@ -1388,30 +1407,33 @@ where
     // in scrollback so completed albums don't disappear.
     let pass_start = Instant::now();
     let (pass_pb, pass_bytes) = crate::download::pipeline::create_progress_bar_for_passes(
-        controls.reporting.no_progress_bar,
-        controls.run_mode.only_print_filenames(),
-        count,
-        controls.reporting.personality_mode,
+        options.controls.reporting.no_progress_bar,
+        options.controls.run_mode.only_print_filenames(),
+        options.count,
+        options.controls.reporting.personality_mode,
     );
 
     let result = stream_and_download_from_stream(
         &download_client,
         stream,
         &pass_config,
-        controls,
-        count,
-        shutdown_token,
-        Some(pass_pb.clone()),
-        Some(std::sync::Arc::clone(&pass_bytes)),
+        options.controls,
+        options.count,
+        options.shutdown_token,
+        StreamRuntime::with_context(
+            Some(pass_pb.clone()),
+            Some(std::sync::Arc::clone(&pass_bytes)),
+            options.download_ctx,
+        ),
     )
     .await?;
 
     let elapsed = pass_start.elapsed();
     pass_pb.finish_and_clear();
     Ok(PerPassStreamingResult {
-        kind,
+        kind: options.kind,
         label: pass_config.pass_label().to_string(),
-        count,
+        count: options.count,
         elapsed,
         token_rx,
         result,
@@ -1941,6 +1963,11 @@ async fn download_photos_full_with_token(
             config,
             per_pass_download_concurrency,
         );
+        let shared_download_ctx = if controls.run_mode.is_dry_run() {
+            None
+        } else {
+            Some(preload_download_context(config).await)
+        };
 
         // Build per-pass labels for the album divider. Friendly multi-pass
         // syncs print a done line (✓) above the bar after each album
@@ -1975,6 +2002,7 @@ async fn download_photos_full_with_token(
             let shutdown_token = shutdown_token.clone();
             let download_client = download_client.clone();
             let deferred_ids = deferred_ids.clone();
+            let download_ctx = shared_download_ctx.clone();
             async move {
                 let (stream, token_rx) = pass.album.photo_stream_with_token(
                     config.recent,
@@ -1997,10 +2025,13 @@ async fn download_photos_full_with_token(
                             stream,
                             token_rx,
                             pass_config,
-                            controls,
-                            count,
-                            pass.kind,
-                            shutdown_token,
+                            FullPassStreamOptions {
+                                controls,
+                                count,
+                                kind: pass.kind,
+                                shutdown_token,
+                                download_ctx: download_ctx.clone(),
+                            },
                         )
                         .await;
                     }
@@ -2012,10 +2043,13 @@ async fn download_photos_full_with_token(
                     stream,
                     token_rx,
                     pass_config,
-                    controls,
-                    count,
-                    pass.kind,
-                    shutdown_token,
+                    FullPassStreamOptions {
+                        controls,
+                        count,
+                        kind: pass.kind,
+                        shutdown_token,
+                        download_ctx,
+                    },
                 )
                 .await
             }
@@ -2080,10 +2114,13 @@ async fn download_photos_full_with_token(
                         stream::iter(filtered),
                         collected.token_rx,
                         pass_config,
-                        controls,
-                        collected.count,
-                        crate::commands::PassKind::Unfiled,
-                        shutdown_token.clone(),
+                        FullPassStreamOptions {
+                            controls,
+                            count: collected.count,
+                            kind: crate::commands::PassKind::Unfiled,
+                            shutdown_token: shutdown_token.clone(),
+                            download_ctx: shared_download_ctx.clone(),
+                        },
                     )
                     .await?;
                     let downloaded_u64 =
@@ -2140,8 +2177,7 @@ async fn download_photos_full_with_token(
             controls,
             total,
             shutdown_token.clone(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await?;
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -41,7 +41,8 @@ use super::planner::add_asset_album_with_retry;
 use super::planner::ADD_ASSET_ALBUM_MAX_RETRIES;
 use super::planner::{self, ExistingPathMatch, TaskPlanner};
 use super::{
-    DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome, DownloadReporting,
+    preload_download_context, DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome,
+    DownloadReporting,
 };
 
 /// Outcome of `batch_forecast_decision` — either keep queueing, emit a
@@ -806,8 +807,64 @@ pub(super) async fn stream_and_download_from_stream<S>(
     controls: DownloadControls,
     total: u64,
     shutdown_token: CancellationToken,
+    runtime: StreamRuntime,
+) -> Result<StreamingResult>
+where
+    S: futures_util::Stream<Item = anyhow::Result<crate::icloud::photos::PhotoAsset>>
+        + Send
+        + 'static,
+{
+    stream_and_download_from_stream_with_context(
+        download_client,
+        combined,
+        config,
+        controls,
+        total,
+        shutdown_token,
+        runtime,
+    )
+    .await
+}
+
+pub(super) struct StreamRuntime {
     shared_pb: Option<ProgressBar>,
     shared_bytes: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+    preloaded_download_ctx: Option<Arc<DownloadContext>>,
+}
+
+impl StreamRuntime {
+    pub(super) fn new(
+        shared_pb: Option<ProgressBar>,
+        shared_bytes: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+    ) -> Self {
+        Self {
+            shared_pb,
+            shared_bytes,
+            preloaded_download_ctx: None,
+        }
+    }
+
+    pub(super) fn with_context(
+        shared_pb: Option<ProgressBar>,
+        shared_bytes: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+        preloaded_download_ctx: Option<Arc<DownloadContext>>,
+    ) -> Self {
+        Self {
+            shared_pb,
+            shared_bytes,
+            preloaded_download_ctx,
+        }
+    }
+}
+
+pub(super) async fn stream_and_download_from_stream_with_context<S>(
+    download_client: &Client,
+    combined: S,
+    config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
+    total: u64,
+    shutdown_token: CancellationToken,
+    runtime: StreamRuntime,
 ) -> Result<StreamingResult>
 where
     S: futures_util::Stream<Item = anyhow::Result<crate::icloud::photos::PhotoAsset>>
@@ -827,10 +884,11 @@ where
     // The byte counter follows the same pairing rule: caller-supplied with
     // `shared_pb`, or freshly created for an internal bar. The friendly
     // sparkline / rate display reads from this atomic on each redraw.
-    let owns_pb = shared_pb.is_none();
-    let bytes_counter =
-        shared_bytes.unwrap_or_else(|| std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)));
-    let pb = shared_pb.unwrap_or_else(|| {
+    let owns_pb = runtime.shared_pb.is_none();
+    let bytes_counter = runtime
+        .shared_bytes
+        .unwrap_or_else(|| std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)));
+    let pb = runtime.shared_pb.unwrap_or_else(|| {
         create_progress_bar(
             reporting.no_progress_bar,
             controls.run_mode.only_print_filenames(),
@@ -860,10 +918,9 @@ where
     if controls.run_mode.only_print_filenames() {
         // Load state DB context so we skip already-downloaded assets,
         // matching the incremental path's behavior.
-        let download_ctx = if let Some(db) = &config.state_db {
-            DownloadContext::load(db.as_ref(), false).await
-        } else {
-            DownloadContext::default()
+        let download_ctx = match runtime.preloaded_download_ctx {
+            Some(ctx) => ctx,
+            None => preload_download_context(config).await,
         };
 
         tokio::pin!(combined);
@@ -978,16 +1035,10 @@ where
     let mode = reporting.personality_mode;
 
     // Pre-load download context for O(1) skip decisions
-    let download_ctx = if let Some(db) = &state_db {
-        tracing::debug!("Pre-loading download state from database");
-        DownloadContext::load(db.as_ref(), config.retry_only).await
-    } else {
-        DownloadContext::default()
+    let download_ctx = match runtime.preloaded_download_ctx {
+        Some(ctx) => ctx,
+        None => preload_download_context(config).await,
     };
-    tracing::debug!(
-        downloaded_ids = download_ctx.downloaded_ids.len(),
-        "Download context loaded"
-    );
 
     // On flag drift, clear stored sync tokens so the next cycle falls back
     // to full enumeration and picks up assets the old token would miss
@@ -3665,6 +3716,7 @@ mod tests {
         remaining_failures: AtomicUsize,
         calls: AtomicUsize,
         successes: AtomicUsize,
+        downloaded_id_loads: AtomicUsize,
         fail_metadata_clear: bool,
         fail_complete_sync_run: bool,
     }
@@ -3675,6 +3727,7 @@ mod tests {
                 remaining_failures: AtomicUsize::new(fail_count),
                 calls: AtomicUsize::new(0),
                 successes: AtomicUsize::new(0),
+                downloaded_id_loads: AtomicUsize::new(0),
                 fail_metadata_clear: false,
                 fail_complete_sync_run: false,
             }
@@ -3698,6 +3751,10 @@ mod tests {
 
         fn call_count(&self) -> usize {
             self.calls.load(Ordering::Relaxed)
+        }
+
+        fn downloaded_id_load_count(&self) -> usize {
+            self.downloaded_id_loads.load(Ordering::Relaxed)
         }
     }
 
@@ -3763,6 +3820,7 @@ mod tests {
         async fn get_downloaded_ids(
             &self,
         ) -> Result<HashSet<(String, String, String)>, StateError> {
+            self.downloaded_id_loads.fetch_add(1, Ordering::Relaxed);
             Ok(HashSet::new())
         }
 
@@ -4480,8 +4538,7 @@ mod tests {
             DownloadControls::download_hidden(),
             10_000,
             shutdown_token,
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await;
         let elapsed = start.elapsed();
@@ -4567,8 +4624,7 @@ mod tests {
             DownloadControls::download_hidden(),
             0,
             shutdown_token,
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect_err("should propagate producer panic");
@@ -4600,8 +4656,7 @@ mod tests {
             DownloadControls::dry_run_hidden(),
             1,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("dry run should scan through the real stream pipeline");
@@ -4642,8 +4697,7 @@ mod tests {
             controls,
             2,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("dry run should continue past enumeration errors");
@@ -4730,8 +4784,7 @@ mod tests {
             DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("sync must complete");
@@ -4758,8 +4811,7 @@ mod tests {
             DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("second sync must complete");
@@ -4847,8 +4899,7 @@ mod tests {
             DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("sync must complete");
@@ -4945,8 +4996,7 @@ mod tests {
             DownloadControls::download_hidden(),
             1,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("sync must complete");
@@ -5185,8 +5235,7 @@ mod tests {
             controls,
             0,
             CancellationToken::new(),
-            None,
-            None,
+            StreamRuntime::new(None, None),
         )
         .await
         .expect("empty sync should finish the stream pipeline");
@@ -5211,6 +5260,41 @@ mod tests {
             "complete_sync_run failure must not report Success, got {outcome:?}"
         );
         assert_eq!(stats.state_write_failures, 1);
+    }
+
+    #[tokio::test]
+    async fn stream_with_preloaded_download_context_does_not_reload_state_db() {
+        let db = Arc::new(FailingStateDb::new(0));
+        let dyn_db: Arc<dyn crate::state::StateDb> = db.clone();
+        let mut raw_config = DownloadConfig::test_default();
+        raw_config.state_db = Some(dyn_db);
+        let config = Arc::new(raw_config);
+        let preloaded = preload_download_context(&config).await;
+        assert_eq!(
+            db.downloaded_id_load_count(),
+            1,
+            "preload should read downloaded IDs once"
+        );
+
+        let client = reqwest::Client::new();
+        let stream = stream::empty::<anyhow::Result<PhotoAsset>>();
+        stream_and_download_from_stream_with_context(
+            &client,
+            stream,
+            &config,
+            DownloadControls::download_hidden(),
+            0,
+            CancellationToken::new(),
+            StreamRuntime::with_context(None, None, Some(preloaded)),
+        )
+        .await
+        .expect("empty stream should complete");
+
+        assert_eq!(
+            db.downloaded_id_load_count(),
+            1,
+            "stream should reuse the preloaded context instead of reloading the DB"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Load the download state context once before per-pass full-sync streams.
- Reuse the preloaded context so multi-pass syncs don't repeat the same SQLite bulk reads per album pass.

## Tests
- `cargo check`
- `cargo test stream_with_preloaded_download_context_does_not_reload_state_db -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
