### PR TITLE
Batch count and state probes

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1234,6 +1234,40 @@ impl DownloadContext {
             None
         }
     }
+
+    fn downloaded_version_count(&self) -> usize {
+        count_version_set_entries(&self.downloaded_ids)
+    }
+
+    fn downloaded_metadata_hash_count(&self) -> usize {
+        count_value_map_entries(&self.downloaded_metadata_hashes)
+    }
+
+    fn has_downloaded_without_metadata_hash(&self) -> bool {
+        self.downloaded_version_count() > self.downloaded_metadata_hash_count()
+    }
+}
+
+fn count_version_set_entries(map: &LibraryAssetVersionSet) -> usize {
+    map.values()
+        .map(|assets| {
+            assets
+                .values()
+                .map(|versions| versions.len())
+                .sum::<usize>()
+        })
+        .sum()
+}
+
+fn count_value_map_entries(map: &LibraryAssetVersionValueMap) -> usize {
+    map.values()
+        .map(|assets| {
+            assets
+                .values()
+                .map(|versions| versions.len())
+                .sum::<usize>()
+        })
+        .sum()
 }
 
 async fn preload_download_context(config: &DownloadConfig) -> Arc<DownloadContext> {
@@ -1369,12 +1403,15 @@ fn deferred_unfiled_index(passes: &[crate::commands::AlbumPass]) -> Option<usize
 async fn collect_unfiled_stream(
     pass: &crate::commands::AlbumPass,
     count: u64,
+    stream_total_count: Option<u64>,
     config: &DownloadConfig,
     shutdown_token: CancellationToken,
 ) -> CollectedUnfiledStream {
-    let (stream, token_rx) =
-        pass.album
-            .photo_stream_with_token(config.recent, Some(count), config.concurrent_downloads);
+    let (stream, token_rx) = pass.album.photo_stream_with_token(
+        config.recent,
+        stream_total_count,
+        config.concurrent_downloads,
+    );
     tokio::pin!(stream);
     let mut items = Vec::new();
     while let Some(item) = stream.next().await {
@@ -1824,6 +1861,63 @@ fn fold_pass_count_results(
     (counts, errors)
 }
 
+#[derive(Debug)]
+struct PassCountPlan {
+    display_counts: Vec<u64>,
+    stream_total_counts: Vec<Option<u64>>,
+    exact_total: Option<u64>,
+    len_errors: usize,
+}
+
+fn should_skip_pass_count_fetch(config: &DownloadConfig, controls: DownloadControls) -> bool {
+    config.recent.is_some()
+        && (controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames())
+}
+
+async fn build_pass_count_plan(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    controls: DownloadControls,
+) -> PassCountPlan {
+    if should_skip_pass_count_fetch(config, controls) {
+        let display_count = config.recent.map(u64::from).unwrap_or(0);
+        return PassCountPlan {
+            display_counts: vec![display_count; passes.len()],
+            stream_total_counts: vec![None; passes.len()],
+            exact_total: None,
+            len_errors: 0,
+        };
+    }
+
+    // Album counts share CloudKit's `/internal/records/query/batch`
+    // endpoint, so the same-library pass set can fetch all counts with one
+    // HTTP call. This matters for default multi-pass syncs and especially
+    // `-a all`, where the old per-pass count probe scaled linearly before
+    // the first byte of the first download.
+    // Capture per-pass `len()` errors instead of swallowing them as zero.
+    // A swallowed `len()` failure converted `total` to 0, which short-circuited
+    // the pagination-undercount check at line ~1450 (it only fires when
+    // `total > 0`); the cycle then returned `Success` with zero assets and the
+    // sync token advanced past un-enumerated change events. Treat any failure
+    // as a per-album enumeration error so token advancement is suppressed.
+    let pass_albums: Vec<&crate::icloud::photos::PhotoAlbum> =
+        passes.iter().map(|pass| &pass.album).collect();
+    let pass_count_results = crate::icloud::photos::PhotoAlbum::len_many(&pass_albums).await;
+    let (display_counts, len_errors) = fold_pass_count_results(pass_count_results, passes);
+    let stream_total_counts = display_counts.iter().copied().map(Some).collect();
+    let mut exact_total: u64 = display_counts.iter().sum();
+    if let Some(recent) = config.recent {
+        exact_total = exact_total.min(u64::from(recent));
+    }
+
+    PassCountPlan {
+        display_counts,
+        stream_total_counts,
+        exact_total: Some(exact_total),
+        len_errors,
+    }
+}
+
 /// Classification of how the producer-observed asset count compared with the
 /// pre-enumeration API total. Drives the two-tier pagination-undercount gate.
 ///
@@ -1915,27 +2009,16 @@ async fn download_photos_full_with_token(
         }
     }
 
-    // `album.len()` is one HTTP call per pass. Serialising it scaled fine
-    // when users typed out a few `-a` flags by hand; with `-a all` it's
-    // routinely 20+ round-trips before the first byte of the first
-    // download. `buffered` (not `buffer_unordered`) preserves pass order
-    // so the `zip(&pass_counts)` below stays aligned.
-    // Capture per-pass `len()` errors instead of swallowing them as zero.
-    // A swallowed `len()` failure converted `total` to 0, which short-circuited
-    // the pagination-undercount check at line ~1450 (it only fires when
-    // `total > 0`); the cycle then returned `Success` with zero assets and the
-    // sync token advanced past un-enumerated change events. Treat any failure
-    // as a per-album enumeration error so token advancement is suppressed.
-    let pass_count_results: Vec<anyhow::Result<u64>> = stream::iter(passes)
-        .map(|pass| async move { pass.album.len().await })
-        .buffered(config.concurrent_downloads)
-        .collect()
-        .await;
-    let (pass_counts, len_errors) = fold_pass_count_results(pass_count_results, passes);
-    let mut total: u64 = pass_counts.iter().sum();
-    if let Some(recent) = config.recent {
-        total = total.min(u64::from(recent));
-    }
+    let pass_count_plan = build_pass_count_plan(passes, config, controls).await;
+    let pass_counts = pass_count_plan.display_counts;
+    let pass_stream_counts = pass_count_plan.stream_total_counts;
+    let exact_total = pass_count_plan.exact_total;
+    let len_errors = pass_count_plan.len_errors;
+    let display_total = pass_counts
+        .iter()
+        .copied()
+        .sum::<u64>()
+        .min(config.recent.map(u64::from).unwrap_or(u64::MAX));
 
     // Pass-specific path mode still needs one derived config per pass so
     // `{album}` / `{smart-folder}` / `{library}` expand correctly, but the
@@ -1995,10 +2078,13 @@ async fn download_photos_full_with_token(
                 .iter()
                 .enumerate()
                 .zip(&pass_counts)
+                .zip(&pass_stream_counts)
                 .zip(pass_configs.iter().cloned())
-                .filter(|(((index, _pass), _count), _config)| Some(*index) != deferred_unfiled),
+                .filter(|((((index, _pass), _count), _total_count), _config)| {
+                    Some(*index) != deferred_unfiled
+                }),
         )
-        .map(|(((index, pass), &count), pass_config)| {
+        .map(|((((index, pass), &count), total_count), pass_config)| {
             let shutdown_token = shutdown_token.clone();
             let download_client = download_client.clone();
             let deferred_ids = deferred_ids.clone();
@@ -2006,7 +2092,7 @@ async fn download_photos_full_with_token(
             async move {
                 let (stream, token_rx) = pass.album.photo_stream_with_token(
                     config.recent,
-                    Some(count),
+                    *total_count,
                     config.concurrent_downloads,
                 );
 
@@ -2061,7 +2147,14 @@ async fn download_photos_full_with_token(
             match deferred_unfiled {
                 Some(index) => match (passes.get(index), pass_counts.get(index).copied()) {
                     (Some(pass), Some(count)) => Some(
-                        collect_unfiled_stream(pass, count, config, shutdown_token.clone()).await,
+                        collect_unfiled_stream(
+                            pass,
+                            count,
+                            pass_stream_counts.get(index).copied().flatten(),
+                            config,
+                            shutdown_token.clone(),
+                        )
+                        .await,
                     ),
                     _ => None,
                 },
@@ -2155,11 +2248,11 @@ async fn download_photos_full_with_token(
         let mut token_receivers = Vec::with_capacity(passes.len());
         let streams: Vec<_> = passes
             .iter()
-            .zip(&pass_counts)
-            .map(|(pass, &count)| {
+            .zip(&pass_stream_counts)
+            .map(|(pass, total_count)| {
                 let (stream, token_rx) = pass.album.photo_stream_with_token(
                     config.recent,
-                    Some(count),
+                    *total_count,
                     config.concurrent_downloads,
                 );
                 token_receivers.push(token_rx);
@@ -2175,7 +2268,7 @@ async fn download_photos_full_with_token(
             combined,
             &merged_config,
             controls,
-            total,
+            display_total,
             shutdown_token.clone(),
             StreamRuntime::new(None, None),
         )
@@ -2201,32 +2294,33 @@ async fn download_photos_full_with_token(
     // suppression because the recorded `total` is missing those passes.
     let pagination_undercount = if len_errors > 0 {
         true
-    } else if total > 0
-        && !controls.run_mode.only_print_filenames()
-        && !controls.run_mode.is_dry_run()
-    {
-        let decision = classify_pagination_shortfall(total, streaming_result.assets_seen);
-        match decision {
-            PaginationShortfall::Match => false,
-            PaginationShortfall::WithinTolerance { shortfall } => {
-                tracing::warn!(
-                    expected = total,
-                    seen = streaming_result.assets_seen,
-                    shortfall,
-                    "Enumeration saw slightly fewer assets than expected; within \
-                     5% tolerance so sync token will still advance"
-                );
-                false
+    } else if !controls.run_mode.only_print_filenames() && !controls.run_mode.is_dry_run() {
+        if let Some(total) = exact_total.filter(|total| *total > 0) {
+            let decision = classify_pagination_shortfall(total, streaming_result.assets_seen);
+            match decision {
+                PaginationShortfall::Match => false,
+                PaginationShortfall::WithinTolerance { shortfall } => {
+                    tracing::warn!(
+                        expected = total,
+                        seen = streaming_result.assets_seen,
+                        shortfall,
+                        "Enumeration saw slightly fewer assets than expected; within \
+                         5% tolerance so sync token will still advance"
+                    );
+                    false
+                }
+                PaginationShortfall::Suppress => {
+                    tracing::warn!(
+                        expected = total,
+                        seen = streaming_result.assets_seen,
+                        "Enumeration saw fewer assets than expected — blocking sync token \
+                         advancement to force full re-enumeration on next run"
+                    );
+                    true
+                }
             }
-            PaginationShortfall::Suppress => {
-                tracing::warn!(
-                    expected = total,
-                    seen = streaming_result.assets_seen,
-                    "Enumeration saw fewer assets than expected — blocking sync token \
-                     advancement to force full re-enumeration on next run"
-                );
-                true
-            }
+        } else {
+            false
         }
     } else {
         false
@@ -3702,6 +3796,34 @@ mod tests {
         assert!(!ctx.known_ids.contains("new_asset"));
     }
 
+    #[test]
+    fn download_context_detects_downloaded_rows_missing_metadata_hashes() {
+        let mut ctx = DownloadContext::default();
+        ctx.downloaded_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .entry("asset_meta".into())
+            .or_default()
+            .insert("original".into());
+
+        assert!(
+            ctx.has_downloaded_without_metadata_hash(),
+            "a downloaded row with no matching metadata hash needs the backfill notice"
+        );
+
+        ctx.downloaded_metadata_hashes
+            .entry("PrimarySync".into())
+            .or_default()
+            .entry("asset_meta".into())
+            .or_default()
+            .insert("original".into(), "metadata_hash".into());
+
+        assert!(
+            !ctx.has_downloaded_without_metadata_hash(),
+            "matching downloaded and metadata-hash sets should avoid the extra SQLite scan"
+        );
+    }
+
     // ── Change event classification tests ───────────────────────────────
 
     #[test]
@@ -4868,6 +4990,72 @@ mod tests {
 
         assert_eq!(counts, vec![0, 0]);
         assert_eq!(errors, 2);
+    }
+
+    #[test]
+    fn read_only_recent_runs_skip_pass_count_fetch() {
+        let mut config = test_config();
+        config.recent = Some(25);
+
+        assert!(
+            should_skip_pass_count_fetch(&config, DownloadControls::dry_run_hidden()),
+            "dry-run recent syncs do not advance tokens, so the pre-count is redundant"
+        );
+        assert!(
+            should_skip_pass_count_fetch(
+                &config,
+                DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden())
+            ),
+            "print-only recent syncs do not advance tokens, so the pre-count is redundant"
+        );
+    }
+
+    #[test]
+    fn download_runs_keep_pass_count_fetch_for_token_safety() {
+        let mut config = test_config();
+        config.recent = Some(25);
+
+        assert!(
+            !should_skip_pass_count_fetch(&config, DownloadControls::download_hidden()),
+            "real downloads need the exact count for pagination-undercount token safety"
+        );
+
+        config.recent = None;
+        assert!(
+            !should_skip_pass_count_fetch(&config, DownloadControls::dry_run_hidden()),
+            "unbounded read-only runs still use the exact count for progress bounds"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_pass_count_plan_uses_recent_bound_without_exact_counts_for_read_only_runs() {
+        use crate::commands::{AlbumPass, PassKind};
+        use crate::icloud::photos::PhotoAlbum;
+        use rustc_hash::FxHashSet;
+        use std::sync::Arc;
+
+        let passes = vec![
+            AlbumPass {
+                kind: PassKind::Album,
+                album: PhotoAlbum::stub_for_test(Arc::from("album_a")),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+            AlbumPass {
+                kind: PassKind::Album,
+                album: PhotoAlbum::stub_for_test(Arc::from("album_b")),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+        ];
+        let mut config = test_config();
+        config.recent = Some(10);
+
+        let plan =
+            build_pass_count_plan(&passes, &config, DownloadControls::dry_run_hidden()).await;
+
+        assert_eq!(plan.display_counts, vec![10, 10]);
+        assert_eq!(plan.stream_total_counts, vec![None, None]);
+        assert_eq!(plan.exact_total, None);
+        assert_eq!(plan.len_errors, 0);
     }
 
     #[test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1085,17 +1085,11 @@ where
     };
 
     // Log a one-time backfill notice when pre-v5 assets still have NULL
-    // metadata_hash. The sync token invalidation in the v5 migration forces
-    // a full enumeration that populates metadata for these rows without
-    // re-downloading files.
-    if let Some(db) = &state_db {
-        match db.has_downloaded_without_metadata_hash().await {
-            Ok(true) => {
-                tracing::info!("Backfilling metadata for existing assets (one-time after upgrade)");
-            }
-            Ok(false) => {}
-            Err(e) => tracing::debug!(error = %e, "Failed to check for metadata backfill"),
-        }
+    // metadata_hash. `download_ctx` already loaded downloaded ids and
+    // non-null metadata hashes, so avoid a redundant SQLite EXISTS scan per
+    // album pass.
+    if download_ctx.has_downloaded_without_metadata_hash() {
+        tracing::info!("Backfilling metadata for existing assets (one-time after upgrade)");
     }
 
     let mut downloaded = 0usize;

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -173,22 +173,7 @@ impl PhotoAlbum {
             encode_params(&self.params)
         );
         let body = json!({
-            "batch": [{
-                "resultsLimit": 1,
-                "query": {
-                    "filterBy": {
-                        "fieldName": "indexCountID",
-                        "fieldValue": {
-                            "type": "STRING_LIST",
-                            "value": [&*self.obj_type]
-                        },
-                        "comparator": "IN",
-                    },
-                    "recordType": "HyperionIndexCountLookup",
-                },
-                "zoneWide": true,
-                "zoneID": *self.zone_id,
-            }]
+            "batch": [Self::count_query(&self.obj_type, &self.zone_id)]
         });
 
         let response = super::session::retry_post(
@@ -202,9 +187,106 @@ impl PhotoAlbum {
 
         let batch: super::cloudkit::BatchQueryResponse =
             serde_json::from_value(response).context("failed to parse album count response")?;
-        let count = batch
-            .batch
-            .first()
+        Ok(Self::count_from_query(batch.batch.first()))
+    }
+
+    /// Return item counts for a same-library pass set with one
+    /// `/internal/records/query/batch` call. Falls back to per-album count
+    /// calls if the albums do not share the same endpoint/params context.
+    pub(crate) async fn len_many(albums: &[&Self]) -> Vec<anyhow::Result<u64>> {
+        let Some(first) = albums.first() else {
+            return Vec::new();
+        };
+        if albums.len() == 1 {
+            return vec![first.len().await];
+        }
+        let can_batch = albums.iter().all(|album| {
+            Arc::ptr_eq(&album.service_endpoint, &first.service_endpoint)
+                && Arc::ptr_eq(&album.params, &first.params)
+        });
+        if !can_batch {
+            let mut results = Vec::with_capacity(albums.len());
+            for album in albums {
+                results.push(album.len().await);
+            }
+            return results;
+        }
+
+        let url = format!(
+            "{}/internal/records/query/batch?{}",
+            first.service_endpoint,
+            encode_params(&first.params)
+        );
+        let batch: Vec<Value> = albums
+            .iter()
+            .map(|album| Self::count_query(&album.obj_type, &album.zone_id))
+            .collect();
+        let body = json!({ "batch": batch });
+
+        let response = match super::session::retry_post(
+            first.session.as_ref(),
+            &url,
+            &body.to_string(),
+            &[("Content-type", "text/plain")],
+            &first.retry_config,
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(e) => {
+                tracing::debug!(error = %e, "Batched album count failed; falling back to per-pass counts");
+                let mut results = Vec::with_capacity(albums.len());
+                for album in albums {
+                    results.push(album.len().await);
+                }
+                return results;
+            }
+        };
+
+        let batch: super::cloudkit::BatchQueryResponse = match serde_json::from_value(response) {
+            Ok(batch) => batch,
+            Err(e) => {
+                tracing::debug!(error = %e, "Failed to parse batched album count response; falling back to per-pass counts");
+                let mut results = Vec::with_capacity(albums.len());
+                for album in albums {
+                    results.push(album.len().await);
+                }
+                return results;
+            }
+        };
+
+        (0..albums.len())
+            .map(|index| {
+                batch
+                    .batch
+                    .get(index)
+                    .map(|query| Self::count_from_query(Some(query)))
+                    .ok_or_else(|| anyhow::anyhow!("missing batched count result for pass {index}"))
+            })
+            .collect()
+    }
+
+    fn count_query(obj_type: &str, zone_id: &Value) -> Value {
+        json!({
+            "resultsLimit": 1,
+            "query": {
+                "filterBy": {
+                    "fieldName": "indexCountID",
+                    "fieldValue": {
+                        "type": "STRING_LIST",
+                        "value": [obj_type]
+                    },
+                    "comparator": "IN",
+                },
+                "recordType": "HyperionIndexCountLookup",
+            },
+            "zoneWide": true,
+            "zoneID": zone_id,
+        })
+    }
+
+    fn count_from_query(query: Option<&super::cloudkit::QueryResponse>) -> u64 {
+        query
             .and_then(|q| q.records.first())
             .and_then(|r| {
                 r.fields
@@ -212,8 +294,7 @@ impl PhotoAlbum {
                     .and_then(|f| f.get("value"))
                     .and_then(Value::as_u64)
             })
-            .unwrap_or(0);
-        Ok(count)
+            .unwrap_or(0)
     }
 
     /// Convenience wrapper over `photo_stream()` that collects all assets
@@ -948,6 +1029,49 @@ mod tests {
     use super::*;
     use crate::test_helpers::{mock_photo_query_page, MockPhotosFlow, MockPhotosSession};
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    #[derive(Clone)]
+    struct BatchCountSession {
+        calls: Arc<AtomicUsize>,
+        batch_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for BatchCountSession {
+        async fn post(
+            &self,
+            url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            assert!(
+                url.contains("/internal/records/query/batch"),
+                "unexpected URL: {url}"
+            );
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let body: Value = serde_json::from_str(&body)?;
+            let batch_len = body["batch"].as_array().map_or(0, Vec::len);
+            self.batch_sizes.lock().unwrap().push(batch_len);
+            let batch: Vec<Value> = (0..batch_len)
+                .map(|index| {
+                    json!({
+                        "records": [{
+                            "fields": {
+                                "itemCount": {"value": ((index + 1) as u64) * 10}
+                            }
+                        }]
+                    })
+                })
+                .collect();
+            Ok(json!({ "batch": batch }))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
 
     fn make_album(
         page_size: usize,
@@ -972,6 +1096,50 @@ mod tests {
 
     fn default_zone() -> Value {
         json!({"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner", "zoneType": "REGULAR_CUSTOM_ZONE"})
+    }
+
+    #[tokio::test]
+    async fn len_many_batches_same_library_count_queries() {
+        let params = Arc::new(HashMap::new());
+        let service_endpoint: Arc<str> = Arc::from("https://example.com");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let session = BatchCountSession {
+            calls: Arc::clone(&calls),
+            batch_sizes: Arc::clone(&batch_sizes),
+        };
+        let make_count_album = |name: &str| {
+            PhotoAlbum::new(
+                PhotoAlbumConfig {
+                    params: Arc::clone(&params),
+                    service_endpoint: Arc::clone(&service_endpoint),
+                    name: Arc::from(name),
+                    list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
+                    obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
+                    query_filter: None,
+                    page_size: 100,
+                    zone_id: Arc::new(default_zone()),
+                    retry_config: RetryConfig::default(),
+                },
+                Box::new(session.clone()),
+            )
+        };
+        let albums = [
+            make_count_album("Album A"),
+            make_count_album("Album B"),
+            make_count_album("Album C"),
+        ];
+        let album_refs: Vec<&PhotoAlbum> = albums.iter().collect();
+
+        let counts = PhotoAlbum::len_many(&album_refs)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(counts, vec![10, 20, 30]);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(*batch_sizes.lock().unwrap(), vec![3]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Batch same-library album count queries into one CloudKit batch request.
- Skip count prefetch for read-only recent runs, where no sync token can advance.
- Derive the metadata-hash backfill check from the preloaded download context instead of running a separate SQLite query per pass.

## Tests
- `cargo check`
- `cargo test pass_count -- --test-threads=1`
- `cargo test len_many_batches_same_library_count_queries -- --test-threads=1`
- `cargo test download_context_detects_downloaded_rows_missing_metadata_hashes -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
