### PR TITLE
Harden v0.20 release validation

### DIFF
--- a/scripts/full-test/run_all.sh
+++ b/scripts/full-test/run_all.sh
@@ -13,13 +13,17 @@
 #   0.8  udeps         cargo +nightly udeps --all-targets
 #   0.9  offline_all   cargo test --all-features
 #   1    build_release cargo build --release
+#   1.5  release_archive_smoke
 #   2    docker_build      just docker build
 #   2    docker_multiarch  just docker multiarch
-#   2  docker_version, docker_help, docker_default_cmd
+#   2    docker_puid_smoke
+#   2    docker_version, docker_help, docker_default_cmd
 #   3  test_live       live cargo (just test live)        --live
 #   4  test_shell_*    auto-discovered shell suites       --live
 #   5  live_*          binary smokes (run_live_smokes.sh) --live
+#   5.5  live_import_rehearsal                            --live
 #   6  service_smoke   just service-smoke when supported
+#   opt  real_service_lifecycle when KEI_FULL_TEST_REAL_SERVICE=1 --live
 #   finalize_run + diff_runs on success
 #
 # Live-tagged phases honor .live-skipped (prereq fail) and .rate-limited
@@ -135,7 +139,9 @@ run_phase offline_all -- cargo test --all-features
 
 # --- Phase 1 + 2: release build + docker builds ---------------------------
 run_phase build_release -- cargo build --release
+run_phase release_archive_smoke -- "$script_dir/run_release_archive_smoke.sh"
 run_phase docker_build -- just docker build
+run_phase docker_puid_smoke -- "$script_dir/run_docker_puid_smoke.sh"
 run_phase docker_multiarch -- just docker multiarch
 
 # --- Phase 2 (cont.): docker smokes ---------------------------------------
@@ -153,12 +159,17 @@ current_phase="test_shell"
 # --- Phase 5: live binary smokes ------------------------------------------
 current_phase="live_smokes"
 "$script_dir/run_live_smokes.sh"
+run_live_phase live_import_rehearsal -- "$script_dir/run_live_import_rehearsal.sh"
 
 # --- Phase 6: service smoke ------------------------------------------------
 if ! command -v systemd-analyze >/dev/null 2>&1 && ! command -v plutil >/dev/null 2>&1; then
   "$script_dir/record_skip.sh" service_smoke skipped "not Linux or macOS"
 else
   run_phase service_smoke -- just service-smoke
+fi
+
+if [[ "${KEI_FULL_TEST_REAL_SERVICE:-0}" == "1" ]]; then
+  run_live_phase real_service_lifecycle -- "$script_dir/run_real_service_lifecycle.sh"
 fi
 
 # --- Cleanup --------------------------------------------------------------

--- a/scripts/full-test/run_docker_puid_smoke.sh
+++ b/scripts/full-test/run_docker_puid_smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Phase 2.5 - Docker entrypoint PUID/PGID smoke.
+#
+# This is offline. It verifies the NAS-facing entrypoint behavior without
+# touching iCloud: numeric PUID/PGID drop, volume chown, default root mode,
+# and clear rejection for invalid env combinations.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+image="${KEI_DOCKER_IMAGE:-kei:dev}"
+work="${TMPDIR:-/tmp/codex/kei/full-test/tmp}/docker-puid-smoke"
+rm -rf "$work"
+mkdir -p "$work/config" "$work/photos" "$work/sub-config" "$work/sub-photos"
+
+test_puid="${KEI_DOCKER_TEST_PUID:-4321}"
+test_pgid="${KEI_DOCKER_TEST_PGID:-4322}"
+
+cleanup() {
+  docker run --rm \
+    -v "$work/config:/c" \
+    -v "$work/photos:/p" \
+    -v "$work/sub-config:/sc" \
+    -v "$work/sub-photos:/sp" \
+    "$image" \
+    chown -R "$(id -u):$(id -g)" /c /p /sc /sp >/dev/null 2>&1 || true
+  rm -rf "$work" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "--- PUID/PGID drop and chown ---"
+puid_out=$(docker run --rm \
+  -e PUID="$test_puid" \
+  -e PGID="$test_pgid" \
+  -v "$work/config:/config" \
+  -v "$work/photos:/photos" \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" \
+  sh -c 'id -u; id -g; stat -c %u /config; stat -c %u /photos' 2>&1)
+printf '%s\n' "$puid_out"
+expected=$(printf '%s\n%s\n%s\n%s' "$test_puid" "$test_pgid" "$test_puid" "$test_puid")
+if [[ "$puid_out" != "$expected" ]]; then
+  echo "run_docker_puid_smoke: PUID/PGID output mismatch" >&2
+  exit 1
+fi
+
+echo "--- default root mode ---"
+root_out=$(docker run --rm \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" id -u 2>&1)
+if [[ "$root_out" != "0" ]]; then
+  echo "run_docker_puid_smoke: expected default uid 0, got $root_out" >&2
+  exit 1
+fi
+
+echo "--- invalid PUID rejected ---"
+bad_out=$(docker run --rm \
+  -e PUID=notanumber \
+  -e PGID="$test_pgid" \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" id 2>&1 || true)
+printf '%s\n' "$bad_out"
+echo "$bad_out" | grep -q "PUID/PGID must be numeric"
+
+echo "--- partial PUID/PGID rejected ---"
+partial_out=$(docker run --rm \
+  -e PUID="$test_puid" \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" id 2>&1 || true)
+printf '%s\n' "$partial_out"
+echo "$partial_out" | grep -q "must be set together"
+
+echo "--- kei subcommand under dropped uid ---"
+sub_out=$(docker run --rm \
+  -e ICLOUD_USERNAME=docker-puid@example.invalid \
+  -e KEI_DATA_DIR=/config \
+  -e PUID="$test_puid" \
+  -e PGID="$test_pgid" \
+  -v "$work/sub-config:/config" \
+  -v "$work/sub-photos:/photos" \
+  "$image" status --downloaded 2>&1)
+printf '%s\n' "$sub_out" | tail -5
+echo "$sub_out" | grep -q "No state database found"
+
+sub_owner=$(stat -c %u "$work/sub-config" 2>/dev/null || echo "")
+if [[ "$sub_owner" != "$test_puid" ]]; then
+  echo "run_docker_puid_smoke: expected /config owner $test_puid, got $sub_owner" >&2
+  exit 1
+fi
+
+echo "docker PUID smoke passed"

--- a/scripts/full-test/run_live_import_rehearsal.sh
+++ b/scripts/full-test/run_live_import_rehearsal.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Phase 5.5 - live import-existing mini rehearsal.
+#
+# Seeds a tiny real photo tree with the release binary, then imports that tree
+# into a fresh DB. This exercises the v0.20 TOML-first import path without
+# relying on prior state in .test-cookies.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "run_live_import_rehearsal: not in a git repo" >&2
+  exit 1
+}
+cd "$repo_root"
+
+PROJECT_DIR="$repo_root"
+# shellcheck disable=SC1091
+source "$repo_root/tests/shell/lib.sh"
+
+kei_require_env
+kei_require_release_binary
+
+binary=$(kei_release_bin)
+album=$(kei_album)
+cookies=$(kei_cookie_dir)
+work=$(mktemp -d "${TMPDIR:-/tmp/codex/kei/full-test/tmp}/kei-live-import-rehearsal-XXXXX")
+trap 'rm -rf "$work"' EXIT
+
+sync_data="$work/sync-data"
+import_data="$work/import-data"
+photos="$work/photos"
+mkdir -p "$sync_data" "$import_data" "$photos"
+
+copy_session() {
+  local dest="$1"
+  cp "$cookies/"* "$dest/" 2>/dev/null || true
+  cp "$cookies/".* "$dest/" 2>/dev/null || true
+  rm -f "$dest/"*.lock "$dest/.lock" "$dest/"*.db "$dest/health.json" 2>/dev/null || true
+}
+
+copy_session "$sync_data"
+copy_session "$import_data"
+
+write_config() {
+  local data_dir="$1"
+  local path="$2"
+  {
+    printf 'data_dir = %s\n' "$(kei_toml_string "$data_dir")"
+    echo
+    echo "[auth]"
+    printf 'username = %s\n' "$(kei_toml_string "$ICLOUD_USERNAME")"
+    echo
+    echo "[download]"
+    printf 'directory = %s\n' "$(kei_toml_string "$photos")"
+    echo
+    echo "[filters]"
+    printf 'albums = [%s]\n' "$(kei_toml_string "$album")"
+    echo "unfiled = false"
+    echo 'libraries = ["primary"]'
+  } > "$path"
+}
+
+sync_config="$work/sync.toml"
+import_config="$work/import.toml"
+write_config "$sync_data" "$sync_config"
+write_config "$import_data" "$import_config"
+
+run_and_show() {
+  local name="$1"
+  shift
+  local out="$work/$name.out"
+  local err="$work/$name.err"
+  "$@" >"$out" 2>"$err"
+  echo "--- $name stderr tail ---"
+  tail -30 "$err"
+  echo "--- $name stdout tail ---"
+  tail -30 "$out"
+}
+
+echo "--- seed sync ($album, recent 10) ---"
+run_and_show seed-sync \
+  "$binary" sync --recent 10 --no-progress-bar --config "$sync_config"
+
+file_count=$(find "$photos" -type f | wc -l | tr -d ' ')
+echo "seed_files=$file_count"
+if [[ "$file_count" -lt 1 ]]; then
+  echo "run_live_import_rehearsal: seed sync wrote no files" >&2
+  exit 1
+fi
+
+echo "--- import dry-run into fresh DB ---"
+run_and_show import-dry-run \
+  "$binary" import-existing --dry-run --recent 10 --force-empty --no-progress-bar --config "$import_config"
+
+echo "--- import real into fresh DB ---"
+run_and_show import-real \
+  "$binary" import-existing --recent 10 --force-empty --no-progress-bar --config "$import_config"
+
+echo "--- import repeat dry-run ---"
+run_and_show import-repeat-dry-run \
+  "$binary" import-existing --dry-run --recent 10 --force-empty --no-progress-bar --config "$import_config"
+
+matched=$(awk -F: '/Files matched/ { gsub(/[[:space:]]/, "", $2); print $2 }' "$work/import-real.out" | tail -1)
+unmatched=$(awk -F: '/Unmatched versions/ { gsub(/[[:space:]]/, "", $2); print $2 }' "$work/import-real.out" | tail -1)
+hash_errors=$(awk -F: '/Hash errors/ { gsub(/[[:space:]]/, "", $2); print $2 }' "$work/import-real.out" | tail -1)
+
+if [[ -z "$matched" || "$matched" -lt 1 ]]; then
+  echo "run_live_import_rehearsal: import matched no files" >&2
+  exit 1
+fi
+if [[ "${unmatched:-999}" != "0" ]]; then
+  echo "run_live_import_rehearsal: import left unmatched versions: $unmatched" >&2
+  exit 1
+fi
+if [[ "${hash_errors:-999}" != "0" ]]; then
+  echo "run_live_import_rehearsal: import had hash errors: $hash_errors" >&2
+  exit 1
+fi
+
+db=$(find "$import_data" -maxdepth 1 -name '*.db' | head -1)
+if [[ -z "$db" ]]; then
+  echo "run_live_import_rehearsal: import DB was not created" >&2
+  exit 1
+fi
+
+downloaded=$(sqlite3 "$db" "SELECT COUNT(*) FROM assets WHERE status='downloaded'" 2>/dev/null || echo 0)
+echo "import_matched=$matched"
+echo "db_downloaded=$downloaded"
+if [[ "$downloaded" -lt "$matched" ]]; then
+  echo "run_live_import_rehearsal: DB downloaded count $downloaded is less than matched $matched" >&2
+  exit 1
+fi
+
+echo "live import rehearsal passed"

--- a/scripts/full-test/run_real_service_lifecycle.sh
+++ b/scripts/full-test/run_real_service_lifecycle.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Opt-in phase - real Linux user-service lifecycle.
+#
+# This mutates the operator's user service state: it writes a real user
+# systemd unit, starts it, checks status, then uninstalls it. run_all.sh only
+# calls this when KEI_FULL_TEST_REAL_SERVICE=1.
+
+set -euo pipefail
+
+if [[ "${KEI_FULL_TEST_REAL_SERVICE:-0}" != "1" ]]; then
+  echo "run_real_service_lifecycle: set KEI_FULL_TEST_REAL_SERVICE=1 to run" >&2
+  exit 64
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "run_real_service_lifecycle: not in a git repo" >&2
+  exit 1
+}
+cd "$repo_root"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "run_real_service_lifecycle: Linux systemd user service smoke only" >&2
+  exit 64
+fi
+
+PROJECT_DIR="$repo_root"
+# shellcheck disable=SC1091
+source "$repo_root/tests/shell/lib.sh"
+
+kei_require_env
+kei_require_release_binary
+
+binary=$(kei_release_bin)
+album=$(kei_album)
+cookies=$(kei_cookie_dir)
+work=$(mktemp -d "${TMPDIR:-/tmp/codex/kei/full-test/tmp}/kei-real-service-XXXXX")
+service_uninstalled=0
+pre_linger=$(loginctl show-user "$(id -un)" -p Linger 2>/dev/null || true)
+
+cleanup() {
+  if [[ "$service_uninstalled" -eq 0 ]]; then
+    "$binary" uninstall >/dev/null 2>&1 || true
+  fi
+  if [[ "$pre_linger" == "Linger=no" ]]; then
+    loginctl disable-linger "$(id -un)" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$work" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+pre_enabled=$(systemctl --user is-enabled kei.service 2>/dev/null || true)
+pre_active=$(systemctl --user is-active kei.service 2>/dev/null || true)
+echo "pre_enabled=$pre_enabled"
+echo "pre_active=$pre_active"
+
+if [[ "$pre_enabled" != "not-found" || "$pre_active" != "inactive" ]]; then
+  echo "run_real_service_lifecycle: kei.service already exists or is active; refusing to mutate it" >&2
+  exit 1
+fi
+
+data="$work/data"
+photos="$work/photos"
+mkdir -p "$data" "$photos"
+cp "$cookies/"* "$data/" 2>/dev/null || true
+cp "$cookies/".* "$data/" 2>/dev/null || true
+rm -f "$data/"*.lock "$data/.lock" "$data/"*.db "$data/health.json" 2>/dev/null || true
+
+password_file="$work/icloud_password"
+printf '%s' "$ICLOUD_PASSWORD" > "$password_file"
+chmod 600 "$password_file"
+
+config="$work/config.toml"
+{
+  printf 'data_dir = %s\n' "$(kei_toml_string "$data")"
+  echo
+  echo "[auth]"
+  printf 'username = %s\n' "$(kei_toml_string "$ICLOUD_USERNAME")"
+  printf 'password_file = %s\n' "$(kei_toml_string "$password_file")"
+  echo
+  echo "[download]"
+  printf 'directory = %s\n' "$(kei_toml_string "$photos")"
+  echo
+  echo "[filters]"
+  printf 'albums = [%s]\n' "$(kei_toml_string "$album")"
+  echo "unfiled = false"
+  echo 'libraries = ["primary"]'
+  echo
+  echo "[watch]"
+  echo "interval = 86400"
+} > "$config"
+
+"$binary" install --user --config "$config"
+sleep 5
+
+post_enabled=$(systemctl --user is-enabled kei.service 2>/dev/null || true)
+post_active=$(systemctl --user is-active kei.service 2>/dev/null || true)
+echo "post_install_enabled=$post_enabled"
+echo "post_install_active=$post_active"
+
+if [[ "$post_enabled" != "enabled" || "$post_active" != "active" ]]; then
+  systemctl --user --no-pager status kei.service || true
+  exit 1
+fi
+
+"$binary" service status | tee "$work/service-status.out"
+grep -q "Service: running" "$work/service-status.out"
+
+systemctl --user --no-pager status kei.service | sed -n '1,80p'
+
+"$binary" uninstall
+service_uninstalled=1
+
+final_enabled=$(systemctl --user is-enabled kei.service 2>/dev/null || true)
+final_active=$(systemctl --user is-active kei.service 2>/dev/null || true)
+echo "post_uninstall_enabled=$final_enabled"
+echo "post_uninstall_active=$final_active"
+
+if [[ "$final_enabled" != "not-found" || "$final_active" != "inactive" ]]; then
+  echo "run_real_service_lifecycle: service was not removed cleanly" >&2
+  exit 1
+fi
+
+echo "real service lifecycle passed"

--- a/scripts/full-test/run_release_archive_smoke.sh
+++ b/scripts/full-test/run_release_archive_smoke.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Phase 1.5 - host release archive smoke.
+#
+# Packages the already-built host release binary into a throwaway archive,
+# extracts it, then smokes the extracted binary. This catches packaging drift
+# without writing to dist/ or requiring a release tag.
+#
+# Optional env:
+#   KEI_FULL_TEST_EXPECT_VERSION  exact package version expected by this run
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "run_release_archive_smoke: not in a git repo" >&2
+  exit 1
+}
+cd "$repo_root"
+
+target=$(rustc -vV | awk '/^host:/ { print $2 }')
+version=$(awk -F'"' '/^version = "/ { print $2; exit }' Cargo.toml)
+binary="$repo_root/target/release/kei"
+
+if [[ ! -x "$binary" ]]; then
+  echo "run_release_archive_smoke: missing release binary at $binary" >&2
+  echo "run build_release before this phase" >&2
+  exit 1
+fi
+
+if [[ -n "${KEI_FULL_TEST_EXPECT_VERSION:-}" && "$version" != "$KEI_FULL_TEST_EXPECT_VERSION" ]]; then
+  echo "run_release_archive_smoke: Cargo.toml version $version does not match KEI_FULL_TEST_EXPECT_VERSION=$KEI_FULL_TEST_EXPECT_VERSION" >&2
+  exit 1
+fi
+
+work="${TMPDIR:-/tmp/codex/kei/full-test/tmp}/release-archive-smoke"
+rm -rf "$work"
+mkdir -p "$work/extract" "$work/data"
+
+archive="$work/kei-$target.tar.gz"
+tar -C "$repo_root/target/release" -czf "$archive" kei
+sha256sum "$archive" > "$work/SHA256SUMS.txt"
+
+tar -C "$work/extract" -xzf "$archive"
+extracted="$work/extract/kei"
+
+version_out=$("$extracted" --version)
+expected="kei $version"
+if [[ "$version_out" != "$expected" ]]; then
+  echo "run_release_archive_smoke: expected '$expected', got '$version_out'" >&2
+  exit 1
+fi
+
+"$extracted" --help >/dev/null
+
+env \
+  ICLOUD_USERNAME=release-smoke@example.invalid \
+  KEI_PASSWORD=release-smoke-password \
+  KEI_DATA_DIR="$work/data" \
+  "$extracted" config show --config "$repo_root/example.config.toml" >/dev/null
+
+echo "release archive smoke passed: $archive"

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -7,7 +7,8 @@
 //!   `systemctl --user daemon-reload && systemctl --user enable --now`.
 //!   `loginctl enable-linger` is best-effort: a polkit denial logs a
 //!   warning and the install still succeeds, since the unit will work
-//!   for as long as the user is logged in.
+//!   for as long as the user is logged in. The prior linger state is
+//!   recorded in the unit and restored on uninstall when available.
 //! - `--system`: writes `/etc/systemd/system/kei.service` with `User=`
 //!   pointing at `$SUDO_USER`. Refuses without `EUID=0` rather than
 //!   shelling out to `sudo` itself; the operator who chose `--system`
@@ -38,6 +39,7 @@ use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;
 
 const UNIT_FILE_NAME: &str = "kei.service";
+const PREVIOUS_LINGER_MARKER: &str = "# X-Kei-Previous-Linger=";
 
 const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 
@@ -49,7 +51,15 @@ const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 /// target for a user unit; `multi-user.target` is reserved for system
 /// units.
 fn render_user_unit(exec_path: &Path, config_path: &Path) -> String {
-    render_unit(exec_path, config_path, UnitKind::User)
+    render_user_unit_with_linger(exec_path, config_path, None)
+}
+
+fn render_user_unit_with_linger(
+    exec_path: &Path,
+    config_path: &Path,
+    previous_linger: Option<LingerState>,
+) -> String {
+    render_unit(exec_path, config_path, UnitKind::User { previous_linger })
 }
 
 /// Renders the system-wide `kei.service` body.
@@ -70,24 +80,38 @@ fn render_system_unit(exec_path: &Path, config_path: &Path, user: &str) -> Strin
 
 #[derive(Debug, Clone)]
 enum UnitKind {
-    User,
-    System { user: String },
+    User {
+        previous_linger: Option<LingerState>,
+    },
+    System {
+        user: String,
+    },
 }
 
 fn render_unit(exec_path: &Path, config_path: &Path, kind: UnitKind) -> String {
     let exec = exec_path.display();
     let config = config_path.display();
     let install_target = match &kind {
-        UnitKind::User => "default.target",
+        UnitKind::User { .. } => "default.target",
         UnitKind::System { .. } => "multi-user.target",
     };
     let user_line = match &kind {
-        UnitKind::User => String::new(),
+        UnitKind::User { .. } => String::new(),
         UnitKind::System { user } => format!("User={user}\n"),
+    };
+    let previous_linger_comment = match &kind {
+        UnitKind::User {
+            previous_linger: Some(state),
+        } => format!("{PREVIOUS_LINGER_MARKER}{}\n", state.as_marker_value()),
+        UnitKind::User {
+            previous_linger: None,
+        }
+        | UnitKind::System { .. } => String::new(),
     };
 
     format!(
         "[Unit]\n\
+         {previous_linger_comment}\
          Description={SERVICE_DESCRIPTION}\n\
          Documentation=https://github.com/rhoopr/kei\n\
          After=network-online.target\n\
@@ -124,13 +148,15 @@ fn system_unit_path() -> PathBuf {
 /// default on Linux).
 pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
-    let contents = render_user_unit(&exe, config_path);
     if plan.is_preview() {
+        let contents = render_user_unit(&exe, config_path);
         print!("{contents}");
         tracing::info!("dry run: rendered per-user systemd unit; no files written");
         return Ok(());
     }
 
+    let previous_linger = current_linger_state().await;
+    let contents = render_user_unit_with_linger(&exe, config_path, previous_linger);
     let unit_path =
         user_unit_path().ok_or_else(|| anyhow!("could not resolve XDG_CONFIG_HOME or $HOME"))?;
     write_unit(&unit_path, &contents)?;
@@ -206,12 +232,14 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
     }
 
     if let Some(path) = user_path.as_ref() {
+        let previous_linger = read_previous_linger_state(path);
         // disable + daemon-reload may legitimately fail in a non-systemd
         // environment (tempdir-only test, chroot, sysvinit host). The
         // unit-file removal is the load-bearing step; log+proceed.
         let _ = disable_now_user().await;
         remove_unit_file(path)?;
         let _ = daemon_reload_user().await;
+        restore_linger_best_effort(previous_linger).await;
         tracing::info!(path = %path.display(), "removed per-user systemd unit");
     }
 
@@ -408,6 +436,29 @@ fn is_root() -> bool {
     effective_uid() == 0
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LingerState {
+    Enabled,
+    Disabled,
+}
+
+impl LingerState {
+    fn as_marker_value(self) -> &'static str {
+        match self {
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+        }
+    }
+
+    fn from_marker_value(value: &str) -> Option<Self> {
+        match value.trim() {
+            "enabled" => Some(Self::Enabled),
+            "disabled" => Some(Self::Disabled),
+            _ => None,
+        }
+    }
+}
+
 async fn daemon_reload_user() -> Result<()> {
     run_systemctl(&["--user", "daemon-reload"]).await
 }
@@ -432,9 +483,108 @@ async fn disable_now_system() -> Result<()> {
     run_systemctl(&["disable", "--now", UNIT_FILE_NAME]).await
 }
 
+fn login_user() -> Option<String> {
+    match std::env::var("USER") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => None,
+    }
+}
+
+async fn current_linger_state() -> Option<LingerState> {
+    let Some(user) = login_user() else {
+        tracing::warn!("$USER not set; cannot record prior loginctl linger state");
+        return None;
+    };
+    let output = match Command::new("loginctl")
+        .arg("show-user")
+        .arg(&user)
+        .arg("-p")
+        .arg("Linger")
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            tracing::warn!(user, error = %e, "loginctl not found; cannot record prior linger state");
+            return None;
+        }
+    };
+    if !output.status.success() {
+        tracing::warn!(
+            user,
+            code = output.status.code().unwrap_or(-1),
+            stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+            "loginctl show-user failed; cannot record prior linger state"
+        );
+        return None;
+    }
+    let parsed = parse_linger_state(&String::from_utf8_lossy(&output.stdout));
+    if let Some(state) = parsed {
+        tracing::debug!(user, ?state, "recorded prior loginctl linger state");
+    } else {
+        tracing::warn!(
+            user,
+            stdout = %String::from_utf8_lossy(&output.stdout).trim(),
+            "loginctl show-user returned an unrecognized linger state"
+        );
+    }
+    parsed
+}
+
+fn parse_linger_state(stdout: &str) -> Option<LingerState> {
+    stdout.lines().find_map(|line| {
+        let (key, value) = line.split_once('=')?;
+        if key != "Linger" {
+            return None;
+        }
+        match value.trim() {
+            "yes" => Some(LingerState::Enabled),
+            "no" => Some(LingerState::Disabled),
+            _ => None,
+        }
+    })
+}
+
+fn read_previous_linger_state(unit_path: &Path) -> Option<LingerState> {
+    match std::fs::read_to_string(unit_path) {
+        Ok(contents) => previous_linger_state_from_unit(&contents),
+        Err(e) => {
+            tracing::warn!(
+                path = %unit_path.display(),
+                error = %e,
+                "could not read unit file to restore prior linger state"
+            );
+            None
+        }
+    }
+}
+
+fn previous_linger_state_from_unit(contents: &str) -> Option<LingerState> {
+    contents.lines().find_map(|line| {
+        line.strip_prefix(PREVIOUS_LINGER_MARKER)
+            .and_then(LingerState::from_marker_value)
+    })
+}
+
+async fn restore_linger_best_effort(previous_linger: Option<LingerState>) {
+    match previous_linger {
+        Some(LingerState::Disabled) => disable_linger_best_effort().await,
+        Some(LingerState::Enabled) => {
+            tracing::info!(
+                "leaving loginctl linger enabled because it was enabled before kei install"
+            );
+        }
+        None => {
+            tracing::info!(
+                "no prior loginctl linger state was recorded; leaving current linger state unchanged"
+            );
+        }
+    }
+}
+
 async fn enable_linger_best_effort() {
-    let user = match std::env::var("USER") {
-        Ok(u) if !u.is_empty() => u,
+    let user = match login_user() {
+        Some(u) => u,
         _ => {
             tracing::warn!("$USER not set; skipping `loginctl enable-linger`");
             return;
@@ -462,6 +612,39 @@ async fn enable_linger_best_effort() {
         }
         Err(e) => {
             tracing::warn!(error = %e, "loginctl not found; skipping enable-linger");
+        }
+    }
+}
+
+async fn disable_linger_best_effort() {
+    let user = match login_user() {
+        Some(u) => u,
+        _ => {
+            tracing::warn!("$USER not set; skipping `loginctl disable-linger`");
+            return;
+        }
+    };
+    let status = Command::new("loginctl")
+        .arg("disable-linger")
+        .arg(&user)
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => {
+            tracing::info!(
+                user,
+                "restored loginctl linger to disabled because it was disabled before kei install"
+            );
+        }
+        Ok(s) => {
+            tracing::warn!(
+                user,
+                code = s.code().unwrap_or(-1),
+                "loginctl disable-linger failed; linger may remain enabled"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "loginctl not found; skipping disable-linger");
         }
     }
 }
@@ -564,6 +747,64 @@ mod tests {
             !unit.contains("\nUser="),
             "per-user unit must not declare User=:\n{unit}"
         );
+    }
+
+    #[test]
+    fn user_unit_records_previous_linger_state_when_known() {
+        let unit = render_user_unit_with_linger(
+            &PathBuf::from("/usr/local/bin/kei"),
+            &PathBuf::from("/home/alice/.config/kei/config.toml"),
+            Some(LingerState::Disabled),
+        );
+        assert!(unit.contains("# X-Kei-Previous-Linger=disabled\n"));
+        assert_eq!(
+            previous_linger_state_from_unit(&unit),
+            Some(LingerState::Disabled)
+        );
+    }
+
+    #[test]
+    fn user_unit_omits_linger_marker_when_unknown() {
+        let unit = render_user_unit(
+            &PathBuf::from("/usr/local/bin/kei"),
+            &PathBuf::from("/home/alice/.config/kei/config.toml"),
+        );
+        assert!(!unit.contains(PREVIOUS_LINGER_MARKER));
+        assert_eq!(previous_linger_state_from_unit(&unit), None);
+    }
+
+    #[test]
+    fn previous_linger_state_ignores_unknown_marker_values() {
+        assert_eq!(
+            previous_linger_state_from_unit("# X-Kei-Previous-Linger=enabled\n"),
+            Some(LingerState::Enabled)
+        );
+        assert_eq!(
+            previous_linger_state_from_unit("# X-Kei-Previous-Linger=disabled\n"),
+            Some(LingerState::Disabled)
+        );
+        assert_eq!(
+            previous_linger_state_from_unit("# X-Kei-Previous-Linger=maybe\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_linger_state_reads_loginctl_output() {
+        assert_eq!(
+            parse_linger_state("Linger=yes\n"),
+            Some(LingerState::Enabled)
+        );
+        assert_eq!(
+            parse_linger_state("Linger=no\n"),
+            Some(LingerState::Disabled)
+        );
+        assert_eq!(
+            parse_linger_state("Name=alice\nLinger=no\n"),
+            Some(LingerState::Disabled)
+        );
+        assert_eq!(parse_linger_state("Linger=\n"), None);
+        assert_eq!(parse_linger_state("Name=alice\n"), None);
     }
 
     #[test]

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,9 @@ tests/
 | `tests/shell/concurrency.sh` | 8 | yes | `just test concurrency` |
 | `tests/shell/state-machine.sh` | 20 | yes | `just test state` |
 | `tests/shell/docker.sh` | 16 | yes | `just test docker` |
+| `scripts/full-test/run_live_import_rehearsal.sh` | 1 | yes | `just full-test` |
+| `scripts/full-test/run_docker_puid_smoke.sh` | 1 | no | `just full-test` |
+| `scripts/full-test/run_release_archive_smoke.sh` | 1 | no | `just full-test` |
 | `.github/workflows/service-smoke.yml` | 3 (linux/macos/windows) | no | `just service-smoke` (linux/macOS) |
 
 Counts are approximate and drift as tests are added.
@@ -51,6 +54,7 @@ just test state       # shell: token + config-hash invariants
 just test docker      # shell: docker container scenarios
 just test PATTERN     # passes through to cargo test PATTERN
 just gate             # full pre-push gate (what CI runs)
+just full-test        # pre-release battery, including Docker and live smokes
 ```
 
 Without `just`, run the raw commands directly:
@@ -114,6 +118,8 @@ details are baked into test code.
 | `KEI_DOCKER_IMAGE` | `kei:latest` | Docker image under test |
 | `KEI_TEST_SCRATCH_DIR` | `/tmp/codex/kei/shell-tests-$USER` | Base dir for standalone shell-suite scratch; `just full-test` overrides this to `/tmp/codex/kei/full-test/shell` |
 | `KEI_IMPORT_FIXTURE_DIR` | `/tmp/codex/kei/import-fixture` | Where `import_existing_live.rs` caches its `--recent 100` sync fixture across runs |
+| `KEI_FULL_TEST_REAL_SERVICE` | unset | Set to `1` to let `just full-test` install, start, status-check, and uninstall a real Linux user systemd service |
+| `KEI_FULL_TEST_EXPECT_VERSION` | unset | Optional exact Cargo package version expected by the release-archive smoke |
 
 `just test live` applies `KEI_TEST_ALBUM=kei-test` to match this
 repo's maintainer setup. Override in your environment to point at your
@@ -174,6 +180,15 @@ happens:
   multiple kei invocations with DB mutation in between.
 - **`shell/docker.sh`** - anything that requires `docker run`, watch
   mode + SIGTERM, healthcheck probes inside the container.
+- **`scripts/full-test/run_release_archive_smoke.sh`** - packages the host
+  release binary into a temp archive, extracts it, and runs basic CLI/config
+  probes against the extracted binary.
+- **`scripts/full-test/run_docker_puid_smoke.sh`** - offline Docker entrypoint
+  checks for PUID/PGID drop, volume chown, root-default behavior, and invalid
+  env rejection.
+- **`scripts/full-test/run_live_import_rehearsal.sh`** - live mini rehearsal
+  for v0.20's TOML-first import path: seed a tiny real tree, import it into a
+  fresh DB, and verify a repeat dry-run stays matched.
 - **`service-smoke` workflow** - per-platform CI smoke for `kei install`
   / `kei uninstall`. Builds the release binary on
   `ubuntu-latest`/`macos-latest`/`windows-latest`, runs `kei install
@@ -205,3 +220,9 @@ Manual real-install coverage:
   control dispatcher startup.
 - Boot/reboot persistence and a real long-running sync against the
   `kei-test` album.
+
+`just full-test` can run the Linux user-service lifecycle with
+`KEI_FULL_TEST_REAL_SERVICE=1`. It refuses to run if `kei.service` already
+exists, and it uninstalls the service before returning. The installer may
+temporarily enable user linger; uninstall restores the prior linger state when
+that state was recorded during install.


### PR DESCRIPTION
## Summary
- Added release-archive, Docker PUID/PGID, and live import rehearsal checks to `just full-test`.
- Added an opt-in real Linux user-service lifecycle phase via `KEI_FULL_TEST_REAL_SERVICE=1`.
- Recorded the pre-install `loginctl` linger state in the user unit and restored that state on uninstall when available.
- Documented the new full-test coverage and environment knobs.

## Tests
- `bash -n scripts/full-test/run_all.sh scripts/full-test/run_release_archive_smoke.sh scripts/full-test/run_docker_puid_smoke.sh scripts/full-test/run_live_import_rehearsal.sh scripts/full-test/run_real_service_lifecycle.sh`
- `scripts/full-test/run_release_archive_smoke.sh`
- `scripts/full-test/run_docker_puid_smoke.sh`
- `scripts/full-test/run_live_import_rehearsal.sh`
- `KEI_FULL_TEST_REAL_SERVICE=1 scripts/full-test/run_real_service_lifecycle.sh`
- `cargo check`
- `cargo test service::linux::tests::`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Review notes
- The real service lifecycle test is opt-in because it installs a user systemd unit and may touch linger.
- The installer stores prior linger state as a comment in the generated unit, then uninstall uses that marker before deleting the file.
