### PR TITLE
Set allocator arena defaults for services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,8 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 # Container runtime glue: keep sessions, state DB, and credentials on the
 # mounted /config volume. Persistent user settings live in /config/config.toml.
 ENV KEI_DATA_DIR=/config
+# Keep glibc from reserving one large malloc arena per worker thread. This
+# lowers virtual memory size for long-running watch containers without changing
+# kei's actual resident memory target.
+ENV MALLOC_ARENA_MAX=2
 CMD ["service", "run", "--config", "/config/config.toml"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Operations:
 - `[report].json` writes an atomic per-cycle sync report.
 - Watch mode serves `/healthz` and `/metrics` on the configured HTTP bind and port.
 - Docker runs watch mode by default and supports `PUID`/`PGID` ownership for NAS deployments.
+- Docker and Linux systemd service installs set `MALLOC_ARENA_MAX=2` to keep
+  glibc from reserving large per-thread malloc arenas during long watch runs.
 - Terminal Apple auth errors during SRP sign-in exit 4 with the account recovery or stored-password update step.
 - Passwords can come from the OS keyring, encrypted file fallback, environment, file, or command.
 - Notification scripts can run on 2FA, sync start, sync success, sync failure, and session expiry.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     stop_grace_period: 30s
     environment:
       - TZ=${TZ:-UTC}
+      # The image sets MALLOC_ARENA_MAX=2 by default. Keep it unless you are
+      # debugging allocator behavior; it keeps long-running watch containers
+      # from reserving large amounts of virtual address space on glibc hosts.
+      # - MALLOC_ARENA_MAX=2
       # Put persistent settings in ./config/config.toml:
       #
       # [auth]

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -300,6 +300,8 @@ services:
     environment:
       - ICLOUD_USERNAME=${ICLOUD_USERNAME}
       - TZ=${TZ:-UTC}
+      # Already set by the image. Keep this for lower VSZ in long watch runs.
+      # - MALLOC_ARENA_MAX=2
     volumes:
       - ./config:/config
       - /path/to/photos:/photos
@@ -312,6 +314,12 @@ Avoid `ICLOUD_PASSWORD` in Docker if you can; it shows up in `docker inspect`.
 Use a Docker secret with `--password-file /run/secrets/icloud_password`, an
 external secret manager via `--password-command`, or run `kei password set`
 inside the container if your credential backend supports it.
+
+On glibc systems, long-running multi-threaded processes can reserve large
+virtual malloc arenas even when their resident memory is small. The Docker
+image sets `MALLOC_ARENA_MAX=2`, and `kei install` writes the same setting into
+Linux systemd units. If you run kei from your own service manager and care
+about VSZ, set `MALLOC_ARENA_MAX=2` before `kei service run`.
 
 For a one-shot import against an existing mounted tree:
 

--- a/docs/v0.20-migration.md
+++ b/docs/v0.20-migration.md
@@ -175,6 +175,9 @@ services:
     restart: unless-stopped
     environment:
       - TZ=${TZ:-UTC}
+      # The image sets this by default. It keeps long-running watch containers
+      # from reserving large glibc malloc arenas on multi-threaded hosts.
+      # - MALLOC_ARENA_MAX=2
       # ICLOUD_USERNAME is still fine for automation, but [auth].username is preferred.
       # - ICLOUD_USERNAME=${ICLOUD_USERNAME}
     volumes:
@@ -223,6 +226,16 @@ secrets:
 
 The image still sets `KEI_DATA_DIR=/config`. That is container runtime glue so
 sessions, the state DB, and credentials stay on the mounted config volume.
+It also sets `MALLOC_ARENA_MAX=2` for glibc-based images. This lowers virtual
+memory reservations during long watch runs. RSS stays roughly the same; the
+knob mostly stops glibc from reserving a large arena for each worker thread.
+
+Linux `kei install` writes the same `MALLOC_ARENA_MAX=2` setting into the
+systemd unit. If you manage your own unit file, add:
+
+```ini
+Environment=MALLOC_ARENA_MAX=2
+```
 
 For one-shot commands, override the command:
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -592,10 +592,20 @@ mod tests {
         fixture
             .wait_until(Duration::from_secs(5), || fixture.count_markers() == 0)
             .await;
+        fixture
+            .wait_until(Duration::from_secs(5), || {
+                notifier.concurrency.available_permits() == NOTIFIER_MAX_INFLIGHT
+            })
+            .await;
         assert_eq!(
             fixture.count_markers(),
             0,
             "scripts did not drain after release"
+        );
+        assert_eq!(
+            notifier.concurrency.available_permits(),
+            NOTIFIER_MAX_INFLIGHT,
+            "notification permits did not fully drain after release"
         );
 
         // Dropped events must not retroactively run once permits are free.

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -120,6 +120,7 @@ fn render_unit(exec_path: &Path, config_path: &Path, kind: UnitKind) -> String {
          [Service]\n\
          Type=notify\n\
          {user_line}\
+         Environment=MALLOC_ARENA_MAX=2\n\
          ExecStart={exec} service run --config {config}\n\
          Restart=on-failure\n\
          RestartSec=10s\n\
@@ -737,6 +738,7 @@ mod tests {
         assert!(unit.contains("Type=notify"));
         assert!(unit.contains("WatchdogSec=120"));
         assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("Environment=MALLOC_ARENA_MAX=2"));
         assert!(unit.contains(
             "ExecStart=/usr/local/bin/kei service run --config /home/alice/.config/kei/config.toml"
         ));
@@ -820,6 +822,7 @@ mod tests {
             unit.contains("ExecStart=/opt/kei/bin/kei service run --config /etc/kei/config.toml")
         );
         assert!(unit.contains("Type=notify"));
+        assert!(unit.contains("Environment=MALLOC_ARENA_MAX=2"));
     }
 
     #[test]

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -80,6 +80,10 @@ fn dry_run_install_user_prints_unit_without_writing_file() {
         "missing Type=notify:\n{stdout}"
     );
     assert!(
+        stdout.contains("Environment=MALLOC_ARENA_MAX=2"),
+        "missing allocator arena limit:\n{stdout}"
+    );
+    assert!(
         stdout.contains("Description=kei Media Sync Engine"),
         "missing Description:\n{stdout}"
     );


### PR DESCRIPTION
## Summary
- Set `MALLOC_ARENA_MAX=2` in Docker images and generated Linux systemd units.
- Document the glibc arena knob in Compose, README, and migration docs.
- Added service renderer checks for the new systemd environment line.

## Tests
- `cargo fmt --check`
- `cargo test user_unit_contains_required_sections_and_keys`
- `cargo test system_unit_pins_user_and_targets_multi_user`
- `cargo test --test service_linux`
- `cargo test --test branch_static`
- `cargo clippy --all-targets --all-features -- -D warnings`
