### PR TITLE
Handle expired iCloud download URLs

### DIFF
--- a/src/download/error.rs
+++ b/src/download/error.rs
@@ -86,6 +86,15 @@ impl DownloadError {
         )
     }
 
+    /// Whether this error likely means the signed CDN URL expired.
+    ///
+    /// Apple returns HTTP 410 Gone when a previously-issued iCloud content URL
+    /// is no longer valid. Retrying the same URL only burns attempts; callers
+    /// should re-enumerate the asset to get a fresh URL and retry that task.
+    pub const fn is_expired_url(&self) -> bool {
+        matches!(self, Self::HttpStatus { status: 410, .. })
+    }
+
     pub const fn is_interrupted(&self) -> bool {
         matches!(self, Self::Interrupted { .. })
     }
@@ -151,6 +160,17 @@ mod tests {
             path: "x".into(),
         };
         assert!(!e.is_retryable());
+    }
+
+    #[test]
+    fn test_http_410_is_expired_url_not_same_url_retryable() {
+        let e = DownloadError::HttpStatus {
+            status: 410,
+            path: "x".into(),
+        };
+        assert!(e.is_expired_url());
+        assert!(!e.is_retryable());
+        assert!(!e.is_session_expired());
     }
 
     #[test]

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -2319,6 +2319,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_file_aborts_on_expired_url_410_for_cleanup_refresh() {
+        let (result, calls, _, _dir) = run_retry_download(1, 410, 3).await;
+        let err = result.unwrap_err();
+        assert_eq!(
+            calls, 1,
+            "410 means the signed URL expired; retrying the same URL is pointless"
+        );
+        assert!(
+            matches!(err, DownloadError::HttpStatus { status: 410, .. }),
+            "expected HttpStatus 410, got: {err:?}"
+        );
+        assert!(err.is_expired_url());
+    }
+
+    #[tokio::test]
     async fn download_file_exhausts_retries_on_persistent_429() {
         let (result, calls, _, _dir) = run_retry_download(10, 429, 2).await;
         let err = result.unwrap_err();

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1405,13 +1405,23 @@ async fn collect_unfiled_stream(
     count: u64,
     stream_total_count: Option<u64>,
     config: &DownloadConfig,
+    controls: DownloadControls,
     shutdown_token: CancellationToken,
 ) -> CollectedUnfiledStream {
-    let (stream, token_rx) = pass.album.photo_stream_with_token(
-        config.recent,
-        stream_total_count,
-        config.concurrent_downloads,
-    );
+    let (stream, token_rx) =
+        if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
+            pass.album.photo_stream_with_token(
+                config.recent,
+                stream_total_count,
+                config.concurrent_downloads,
+            )
+        } else {
+            pass.album.photo_stream_with_token_for_download(
+                config.recent,
+                stream_total_count,
+                config.concurrent_downloads,
+            )
+        };
     tokio::pin!(stream);
     let mut items = Vec::new();
     while let Some(item) = stream.next().await {
@@ -1491,10 +1501,49 @@ fn merge_streaming_result(combined: &mut StreamingResult, result: StreamingResul
     combined.enumeration_complete = combined.enumeration_complete && result.enumeration_complete;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RetryTaskKey {
+    asset_id: Arc<str>,
+    version_size: VersionSizeKey,
+    download_path: std::path::PathBuf,
+}
+
+impl From<&DownloadTask> for RetryTaskKey {
+    fn from(task: &DownloadTask) -> Self {
+        Self {
+            asset_id: Arc::clone(&task.asset_id),
+            version_size: task.version_size,
+            download_path: task.download_path.clone(),
+        }
+    }
+}
+
+fn take_matching_retry_tasks<I>(
+    tasks: I,
+    pending_keys: &mut FxHashSet<RetryTaskKey>,
+    out: &mut Vec<DownloadTask>,
+) where
+    I: IntoIterator<Item = DownloadTask>,
+{
+    for task in tasks {
+        let key = RetryTaskKey::from(&task);
+        if pending_keys.remove(&key) {
+            out.push(task);
+            if pending_keys.is_empty() {
+                break;
+            }
+        }
+    }
+}
+
 /// Eagerly enumerate all albums and build a complete task list.
 ///
 /// Used only by the Phase 2 cleanup pass — re-contacts the API so each call
 /// yields fresh CDN URLs that haven't expired during a long download session.
+#[allow(
+    dead_code,
+    reason = "kept for focused tests and future non-selective tooling"
+)]
 async fn build_download_tasks(
     passes: &[crate::commands::AlbumPass],
     config: &DownloadConfig,
@@ -1526,6 +1575,67 @@ async fn build_download_tasks(
             }
             tasks.extend(plan.tasks);
         }
+    }
+
+    Ok(tasks)
+}
+
+/// Re-enumerate iCloud and rebuild only the failed tasks with fresh CDN URLs.
+///
+/// The first pass may fail because signed content URLs expired before the
+/// worker reached them. Retrying the complete library after that is both slow
+/// and risky: newly-issued URLs for early tasks can age again while unrelated
+/// albums are planned. Limit cleanup to the exact asset/version/path tuples
+/// that failed so the retry pass starts consuming refreshed URLs quickly.
+async fn build_retry_download_tasks(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    failed_tasks: &[DownloadTask],
+    shutdown_token: CancellationToken,
+) -> Result<Vec<DownloadTask>> {
+    if failed_tasks.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut pending_keys: FxHashSet<RetryTaskKey> =
+        failed_tasks.iter().map(RetryTaskKey::from).collect();
+    let requested_count = pending_keys.len();
+    let pass_configs = build_pass_configs_resolving_deferred_excludes(passes, config).await?;
+    let mut tasks: Vec<DownloadTask> = Vec::with_capacity(requested_count);
+    let mut task_planner = planner::TaskPlanner::new();
+
+    for (pass_index, pass) in passes.iter().enumerate() {
+        if pending_keys.is_empty() || shutdown_token.is_cancelled() {
+            break;
+        }
+
+        let assets = pass.album.photos(config.recent).await?;
+        #[allow(
+            clippy::indexing_slicing,
+            reason = "pass_index comes from enumerate() over `passes`; pass_configs is \
+                      built 1:1 from the same slice"
+        )]
+        let pass_config = &pass_configs[pass_index];
+
+        for asset in &assets {
+            if pending_keys.is_empty() || shutdown_token.is_cancelled() {
+                break;
+            }
+            let plan = task_planner.plan_asset(asset, pass_config).await;
+            if plan.filter_reason.is_some() {
+                continue;
+            }
+            take_matching_retry_tasks(plan.tasks, &mut pending_keys, &mut tasks);
+        }
+    }
+
+    if !pending_keys.is_empty() {
+        tracing::warn!(
+            requested = requested_count,
+            refreshed = tasks.len(),
+            missing = pending_keys.len(),
+            "Cleanup pass could not refresh every failed task; unmatched failures remain pending"
+        );
     }
 
     Ok(tasks)
@@ -2090,11 +2200,20 @@ async fn download_photos_full_with_token(
             let deferred_ids = deferred_ids.clone();
             let download_ctx = shared_download_ctx.clone();
             async move {
-                let (stream, token_rx) = pass.album.photo_stream_with_token(
-                    config.recent,
-                    *total_count,
-                    config.concurrent_downloads,
-                );
+                let (stream, token_rx) =
+                    if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
+                        pass.album.photo_stream_with_token(
+                            config.recent,
+                            *total_count,
+                            config.concurrent_downloads,
+                        )
+                    } else {
+                        pass.album.photo_stream_with_token_for_download(
+                            config.recent,
+                            *total_count,
+                            pass_config.concurrent_downloads,
+                        )
+                    };
 
                 if pass.kind == crate::commands::PassKind::Album {
                     if let Some(deferred_ids) = deferred_ids {
@@ -2152,6 +2271,7 @@ async fn download_photos_full_with_token(
                             count,
                             pass_stream_counts.get(index).copied().flatten(),
                             config,
+                            controls,
                             shutdown_token.clone(),
                         )
                         .await,
@@ -2250,11 +2370,20 @@ async fn download_photos_full_with_token(
             .iter()
             .zip(&pass_stream_counts)
             .map(|(pass, total_count)| {
-                let (stream, token_rx) = pass.album.photo_stream_with_token(
-                    config.recent,
-                    *total_count,
-                    config.concurrent_downloads,
-                );
+                let (stream, token_rx) =
+                    if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
+                        pass.album.photo_stream_with_token(
+                            config.recent,
+                            *total_count,
+                            config.concurrent_downloads,
+                        )
+                    } else {
+                        pass.album.photo_stream_with_token_for_download(
+                            config.recent,
+                            *total_count,
+                            config.concurrent_downloads,
+                        )
+                    };
                 token_receivers.push(token_rx);
                 stream
             })
@@ -2692,7 +2821,8 @@ async fn download_photos_incremental(
         enumeration_errors: 0,
         elapsed_secs: started.elapsed().as_secs_f64(),
         interrupted: shutdown_token.is_cancelled()
-            || pass_result.auth_errors >= AUTH_ERROR_THRESHOLD,
+            || pass_result.auth_errors >= AUTH_ERROR_THRESHOLD
+            || pass_result.url_expired_abort,
         rate_limited: pass_result.rate_limit_observations,
         photos_downloaded: pass_result.photos_downloaded,
         videos_downloaded: pass_result.videos_downloaded,
@@ -2746,6 +2876,56 @@ mod tests {
 
     fn test_config() -> DownloadConfig {
         DownloadConfig::test_default()
+    }
+
+    fn retry_test_task(asset_id: &str, version_size: VersionSizeKey, path: &str) -> DownloadTask {
+        DownloadTask {
+            url: format!("https://p01.icloud-content.com/{asset_id}").into(),
+            download_path: Path::new("/tmp/codex/kei/retry-tests").join(path),
+            checksum: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
+            asset_id: Arc::from(asset_id),
+            metadata: Arc::new(filter::MetadataPayload::default()),
+            size: 1024,
+            created_local: chrono::Local::now(),
+            version_size,
+            media_type: crate::state::MediaType::Photo,
+        }
+    }
+
+    #[test]
+    fn cleanup_retry_filter_keeps_only_exact_failed_task_keys() {
+        let failed = retry_test_task("ASSET_A", VersionSizeKey::Original, "a.jpg");
+        let matching_refresh = DownloadTask {
+            url: "https://p01.icloud-content.com/fresh-a".into(),
+            ..failed.clone()
+        };
+        let wrong_version = retry_test_task("ASSET_A", VersionSizeKey::Medium, "a.jpg");
+        let wrong_path = retry_test_task("ASSET_A", VersionSizeKey::Original, "elsewhere/a.jpg");
+        let unrelated = retry_test_task("ASSET_B", VersionSizeKey::Original, "b.jpg");
+        let mut pending_keys: FxHashSet<RetryTaskKey> =
+            std::iter::once(RetryTaskKey::from(&failed)).collect();
+        let mut out = Vec::new();
+
+        take_matching_retry_tasks(
+            vec![
+                wrong_version,
+                wrong_path,
+                unrelated,
+                matching_refresh.clone(),
+            ],
+            &mut pending_keys,
+            &mut out,
+        );
+
+        assert!(pending_keys.is_empty());
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].asset_id.as_ref(), "ASSET_A");
+        assert_eq!(out[0].version_size, VersionSizeKey::Original);
+        assert_eq!(out[0].download_path, matching_refresh.download_path);
+        assert_eq!(
+            out[0].url.as_ref(),
+            "https://p01.icloud-content.com/fresh-a"
+        );
     }
 
     fn changes_album(name: &str, session: CountingChangesZoneSession) -> PhotoAlbum {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -217,6 +217,10 @@ pub(super) struct StreamingResult {
     /// Count of 429/503 observations during Phase 1 downloads (per retry
     /// attempt, not per unique task). Feeds SyncStats.rate_limited.
     pub(super) rate_limit_observations: usize,
+    /// True when any worker observed HTTP 410 for a signed CDN URL. Once this
+    /// happens, the rest of the current URL batch is presumed stale too, so
+    /// the pass aborts instead of hammering thousands of expired URLs.
+    pub(super) url_expired_abort: bool,
     /// `true` when the producer reached the natural end of the API
     /// stream (so the `enum_in_progress:<zone>` marker can be cleared even
     /// when downstream downloads partially failed). `false` when the
@@ -785,6 +789,7 @@ pub(super) struct PassResult {
     pub(super) bytes_downloaded: u64,
     pub(super) disk_bytes_written: u64,
     pub(super) rate_limit_observations: usize,
+    pub(super) url_expired_abort: bool,
     /// Photos / videos / recap observed during this pass, mirroring
     /// `StreamingResult`. Folded into the cycle's `SyncStats` at the
     /// caller. Defaults are zero / empty so the existing cleanup-pass
@@ -1099,6 +1104,7 @@ where
     let mut pending_state_writes: Vec<PendingStateWrite> = Vec::new();
     let mut bytes_downloaded_total: u64 = 0;
     let mut disk_bytes_total: u64 = 0;
+    let mut url_expired_abort = false;
     let mut photos_downloaded = 0usize;
     let mut videos_downloaded = 0usize;
     let mut recap = super::recap::RunRecap::default();
@@ -1724,6 +1730,18 @@ where
                             });
                             break;
                         }
+                    } else if download_err.is_expired_url() {
+                        url_expired_abort = true;
+                        pb.suspend(|| {
+                            tracing::warn!(
+                                asset_id = %task.asset_id,
+                                path = %task.download_path.display(),
+                                error = %e,
+                                "Download URL expired; aborting current URL batch"
+                            );
+                        });
+                        pipeline_shutdown.cancel();
+                        continue;
                     } else {
                         pb.suspend(|| {
                             tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), error = %e, "Download failed");
@@ -1782,7 +1800,8 @@ where
             .unwrap_or(u64::MAX),
             interrupted: pipeline_shutdown.is_cancelled()
                 || auth_errors >= AUTH_ERROR_THRESHOLD
-                || producer_panicked,
+                || producer_panicked
+                || url_expired_abort,
         };
         if let Err(e) = db.complete_sync_run(run_id, &stats).await {
             tracing::warn!(error = %e, "Failed to complete sync run tracking");
@@ -1877,6 +1896,7 @@ where
         photos_downloaded,
         videos_downloaded,
         recap,
+        url_expired_abort,
     })
 }
 
@@ -1935,7 +1955,7 @@ pub(super) async fn build_download_outcome(
             state_write_failures,
             enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
-            interrupted: shutdown_token.is_cancelled(),
+            interrupted: shutdown_token.is_cancelled() || streaming_result.url_expired_abort,
             ..super::SyncStats::default()
         };
         if run_mode.is_dry_run() {
@@ -1945,7 +1965,10 @@ pub(super) async fn build_download_outcome(
         } else {
             tracing::info!("No new photos to download");
         }
-        let failed_count = state_write_failures + retry_exhausted + enumeration_errors;
+        let failed_count = state_write_failures
+            + retry_exhausted
+            + enumeration_errors
+            + usize::from(streaming_result.url_expired_abort);
         if failed_count > 0 {
             return Ok((DownloadOutcome::PartialFailure { failed_count }, stats));
         }
@@ -1979,6 +2002,39 @@ pub(super) async fn build_download_outcome(
             ));
         }
         return Ok((DownloadOutcome::Success, stats));
+    }
+
+    if streaming_result.url_expired_abort {
+        let retry_exhausted = skip_breakdown.retry_exhausted;
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            downloaded,
+            failed: failed_tasks.len(),
+            skipped: skip_breakdown,
+            bytes_downloaded: streaming_result.bytes_downloaded,
+            disk_bytes_written: streaming_result.disk_bytes_written,
+            exif_failures,
+            state_write_failures,
+            enumeration_errors,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: true,
+            rate_limited: streaming_result.rate_limit_observations,
+            photos_downloaded: streaming_result.photos_downloaded,
+            videos_downloaded: streaming_result.videos_downloaded,
+            recap: streaming_result.recap.clone(),
+        };
+        log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);
+        return Ok((
+            DownloadOutcome::PartialFailure {
+                failed_count: failed_tasks.len()
+                    + state_write_failures
+                    + enumeration_errors
+                    + exif_failures
+                    + retry_exhausted
+                    + 1,
+            },
+            stats,
+        ));
     }
 
     if failed_tasks.is_empty() {
@@ -2028,10 +2084,12 @@ pub(super) async fn build_download_outcome(
         "── Cleanup pass: re-fetching URLs and retrying failed downloads ──"
     );
 
-    let fresh_tasks = super::build_download_tasks(passes, config, shutdown_token.clone()).await?;
+    let fresh_tasks =
+        super::build_retry_download_tasks(passes, config, &failed_tasks, shutdown_token.clone())
+            .await?;
     tracing::debug!(
         count = fresh_tasks.len(),
-        "  Re-fetched tasks with fresh URLs"
+        "  Re-fetched failed tasks with fresh URLs"
     );
 
     let phase2_task_count = fresh_tasks.len();
@@ -2116,7 +2174,7 @@ pub(super) async fn build_download_outcome(
         state_write_failures,
         enumeration_errors,
         elapsed_secs: started.elapsed().as_secs_f64(),
-        interrupted: shutdown_token.is_cancelled(),
+        interrupted: shutdown_token.is_cancelled() || pass_result.url_expired_abort,
         rate_limited: streaming_result.rate_limit_observations
             + pass_result.rate_limit_observations,
         photos_downloaded: streaming_result.photos_downloaded + pass_result.photos_downloaded,
@@ -2205,6 +2263,7 @@ pub(super) async fn run_download_pass(
     let mut videos_downloaded = 0usize;
     let mut recap = super::recap::RunRecap::default();
     let mut state_write_circuit_open = false;
+    let mut url_expired_abort = false;
     // Cleanup pass doesn't carry an album label (it's a flat retry list);
     // recap.observe gets the library name so a recovered asset still
     // counts toward the per-album newest tracker rather than vanishing.
@@ -2294,6 +2353,20 @@ pub(super) async fn run_download_pass(
                     pb.suspend(|| {
                         tracing::warn!(path = %task.download_path.display(), error = %e, "Auth error");
                     });
+                } else if e
+                    .downcast_ref::<DownloadError>()
+                    .is_some_and(DownloadError::is_expired_url)
+                {
+                    url_expired_abort = true;
+                    pb.suspend(|| {
+                        tracing::warn!(
+                            asset_id = %task.asset_id,
+                            path = %task.download_path.display(),
+                            error = %e,
+                            "Download URL expired; aborting current URL batch"
+                        );
+                    });
+                    pass_shutdown.cancel();
                 } else {
                     pb.suspend(|| {
                         tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), error = %e, "Download failed");
@@ -2336,6 +2409,7 @@ pub(super) async fn run_download_pass(
         bytes_downloaded: bytes_downloaded_total,
         disk_bytes_written: disk_bytes_total,
         rate_limit_observations: rate_limit_counter.load(std::sync::atomic::Ordering::Relaxed),
+        url_expired_abort,
         photos_downloaded,
         videos_downloaded,
         recap,
@@ -5206,6 +5280,29 @@ mod tests {
             "expected PartialFailure with failed_count=1, got {outcome:?}"
         );
         assert_eq!(stats.state_write_failures, 1);
+    }
+
+    #[tokio::test]
+    async fn expired_url_abort_returns_interrupted_partial_failure() {
+        use crate::download::DownloadOutcome;
+
+        let streaming_result = StreamingResult {
+            downloaded: 1,
+            url_expired_abort: true,
+            ..StreamingResult::default()
+        };
+        let (outcome, stats) =
+            build_zero_download_outcome(streaming_result, DownloadControls::download_hidden())
+                .await;
+        assert!(
+            matches!(outcome, DownloadOutcome::PartialFailure { failed_count: 1 }),
+            "expired CDN URL must stop the batch as an interrupted PartialFailure, got {outcome:?}"
+        );
+        assert_eq!(stats.downloaded, 1);
+        assert!(
+            stats.interrupted,
+            "expired URL aborts must not look like clean syncs"
+        );
     }
 
     #[tokio::test]

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -32,6 +32,18 @@ const MAX_EMPTY_PAGE_PROBES: u32 = 5;
 /// A boxed, pinned stream of photo asset results.
 type PhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
 
+/// Keep signed CDN URLs close to the download workers that will consume them.
+///
+/// A normal CloudKit page is optimized for fast enumeration, but each
+/// `PhotoAsset` also carries short-lived content URLs. During real downloads,
+/// fetch only a small number of waves ahead of the worker pool so slow media
+/// cannot age thousands of prefetched URLs before transfer starts.
+fn download_stream_page_size(default_page_size: usize, download_concurrency: usize) -> usize {
+    default_page_size
+        .min(download_concurrency.max(1).saturating_mul(2))
+        .max(1)
+}
+
 /// Await all fetcher handles, logging and returning `true` if any panicked.
 async fn await_fetcher_handles(handles: Vec<JoinHandle<()>>) -> bool {
     let mut panicked = false;
@@ -344,7 +356,8 @@ impl PhotoAlbum {
         concurrency: usize,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<bool>) {
         let (panic_tx, panic_rx) = tokio::sync::oneshot::channel();
-        let (stream, handles) = self.photo_stream_inner(limit, total_count, concurrency, None);
+        let (stream, handles) =
+            self.photo_stream_inner_with_page_size(limit, total_count, concurrency, None, None);
         tokio::spawn(async move {
             let panicked = await_fetcher_handles(handles).await;
             let _ = panic_tx.send(panicked);
@@ -371,6 +384,38 @@ impl PhotoAlbum {
         total_count: Option<u64>,
         concurrency: usize,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
+        self.photo_stream_with_token_inner(limit, total_count, concurrency, None)
+    }
+
+    /// Like `photo_stream_with_token`, but tuned for live downloads.
+    ///
+    /// This intentionally gives up parallel page fetchers and shrinks the page
+    /// size so CloudKit content URLs are produced just ahead of the download
+    /// workers instead of in a large, long-lived backlog.
+    pub(crate) fn photo_stream_with_token_for_download(
+        &self,
+        limit: Option<u32>,
+        total_count: Option<u64>,
+        download_concurrency: usize,
+    ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
+        self.photo_stream_with_token_inner(
+            limit,
+            total_count,
+            1,
+            Some(download_stream_page_size(
+                self.page_size,
+                download_concurrency,
+            )),
+        )
+    }
+
+    fn photo_stream_with_token_inner(
+        &self,
+        limit: Option<u32>,
+        total_count: Option<u64>,
+        concurrency: usize,
+        page_size_override: Option<usize>,
+    ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
         let (token_tx, token_rx) = tokio::sync::oneshot::channel();
         let fetcher_sync_tokens: Arc<tokio::sync::Mutex<Vec<String>>> =
             Arc::new(tokio::sync::Mutex::new(Vec::new()));
@@ -380,6 +425,7 @@ impl PhotoAlbum {
             total_count,
             concurrency,
             Some(fetcher_sync_tokens.clone()),
+            page_size_override,
         );
         let album_name = Arc::clone(&self.name);
 
@@ -546,8 +592,26 @@ impl PhotoAlbum {
         total_count: Option<u64>,
         concurrency: usize,
         fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
+        page_size_override: Option<usize>,
     ) -> (PhotoStream, Vec<JoinHandle<()>>) {
-        let page_size = self.page_size;
+        self.photo_stream_inner_with_page_size(
+            limit,
+            total_count,
+            concurrency,
+            fetcher_sync_tokens,
+            page_size_override,
+        )
+    }
+
+    fn photo_stream_inner_with_page_size(
+        &self,
+        limit: Option<u32>,
+        total_count: Option<u64>,
+        concurrency: usize,
+        fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
+        page_size_override: Option<usize>,
+    ) -> (PhotoStream, Vec<JoinHandle<()>>) {
+        let page_size = page_size_override.unwrap_or(self.page_size).max(1);
         let mut handles = Vec::new();
 
         // Compute effective total, capped by --recent if set.
@@ -1223,6 +1287,14 @@ mod tests {
     }
 
     #[test]
+    fn download_stream_page_size_stays_near_worker_pool() {
+        assert_eq!(download_stream_page_size(100, 1), 2);
+        assert_eq!(download_stream_page_size(100, 4), 8);
+        assert_eq!(download_stream_page_size(100, 50), 100);
+        assert_eq!(download_stream_page_size(0, 4), 1);
+    }
+
+    #[test]
     fn test_fetcher_count_partial_page() {
         // 150 items, page_size 100 → 2 pages, concurrency 10 → 2 fetchers
         assert_eq!(determine_fetcher_count(150, 100, 10), 2);
@@ -1428,7 +1500,7 @@ mod tests {
             .build();
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None, None);
 
         assert_eq!(
             drain_photo_stream_count(stream).await,
@@ -1805,7 +1877,7 @@ mod tests {
             .ok(json!({"records": []}));
         let album = make_album_with_session(100, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(Some(0), Some(10), 1, None);
+        let (stream, _handles) = album.photo_stream_inner(Some(0), Some(10), 1, None, None);
         tokio::pin!(stream);
 
         let items: Vec<_> = stream.collect().await;
@@ -1822,7 +1894,7 @@ mod tests {
             .ok(json!({"records": []}));
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(Some(1), Some(10), 1, None);
+        let (stream, _handles) = album.photo_stream_inner(Some(1), Some(10), 1, None, None);
         tokio::pin!(stream);
 
         let items: Vec<_> = stream.collect().await;
@@ -1868,7 +1940,7 @@ mod tests {
             .ok(json!({"records": []}));
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None, None);
         tokio::pin!(stream);
 
         let mut count = 0u32;
@@ -1901,7 +1973,7 @@ mod tests {
         // consecutive empties to commit to EOF.
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None, None);
         tokio::pin!(stream);
 
         let mut count = 0u32;
@@ -1936,7 +2008,7 @@ mod tests {
             .ok(mock_photo_query_page("master-2", None));
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None, None);
         tokio::pin!(stream);
 
         let mut count = 0u32;
@@ -1974,7 +2046,7 @@ mod tests {
             .ok(mock_photo_query_page("master-unreachable", None));
         let album = make_album_with_session(1, Box::new(mock));
 
-        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None);
+        let (stream, _handles) = album.photo_stream_inner(None, None, 1, None, None);
         tokio::pin!(stream);
 
         let mut count = 0u32;


### PR DESCRIPTION
## Summary
- Keep live download enumeration close to the worker pool so signed iCloud URLs don't sit in a large backlog before transfer.
- Treat HTTP 410 as an expired CDN URL: don't retry the same URL, abort the current URL batch, and report an interrupted partial result so tokens don't advance.
- Rebuild cleanup retries only for the exact failed asset/version/path entries instead of re-enumerating and retrying the whole library.

## Validation
- `cargo check`
- `cargo test expired_url`
- `cargo test cleanup_retry_filter_keeps_only_exact_failed_task_keys`
- `cargo test download_stream_page_size_stays_near_worker_pool`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Live full-sync rehearsal on this branch for 44m45s: 910 downloads, 0 HTTP 410s, 0 401s, 0 429/503/auth/rate-limit signals. Stopped manually before the full 2TB library completed.

## Risk
- Full download enumeration now favors URL freshness over maximum CloudKit metadata prefetch. Download concurrency is unchanged.
