### PR TITLE
Fail closed on incomplete media enumeration

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -24,6 +24,13 @@ use secrecy::SecretString;
 /// Service name used for keyring entries.
 const KEYRING_SERVICE: &str = "kei";
 
+#[derive(Debug)]
+enum DeleteOutcome {
+    Deleted,
+    NotFound,
+    Failed(anyhow::Error),
+}
+
 /// Backend that accepted a stored credential.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CredentialBackend {
@@ -99,22 +106,11 @@ impl CredentialStore {
 
     /// Delete stored credentials from all backends.
     pub(crate) fn delete(&self) -> Result<()> {
-        let mut deleted = false;
-        if let Err(e) = self.keyring_delete() {
-            tracing::debug!(error = %e, "Keyring delete failed or not found");
-        } else {
-            deleted = true;
-        }
-        if let Err(e) = self.file_delete() {
-            tracing::debug!(error = %e, "Encrypted file delete failed or not found");
-        } else {
-            deleted = true;
-        }
-        if deleted {
-            Ok(())
-        } else {
-            anyhow::bail!("No stored credential found for {}", self.username)
-        }
+        finish_delete(
+            &self.username,
+            self.keyring_delete_outcome(),
+            self.file_delete_outcome(),
+        )
     }
 
     /// Check whether a credential exists in any backend (keyring or file).
@@ -164,11 +160,18 @@ impl CredentialStore {
         }
     }
 
-    fn keyring_delete(&self) -> Result<()> {
-        let entry = self.keyring_entry()?;
-        entry
-            .delete_credential()
-            .context("Failed to delete keyring credential")
+    fn keyring_delete_outcome(&self) -> DeleteOutcome {
+        let entry = match self.keyring_entry() {
+            Ok(entry) => entry,
+            Err(e) => return DeleteOutcome::Failed(e),
+        };
+        match entry.delete_credential() {
+            Ok(()) => DeleteOutcome::Deleted,
+            Err(keyring::Error::NoEntry) => DeleteOutcome::NotFound,
+            Err(e) => DeleteOutcome::Failed(
+                anyhow::anyhow!(e).context("Failed to delete keyring credential"),
+            ),
+        }
     }
 
     // ── Encrypted file backend ─────────────────────────────────────
@@ -271,17 +274,79 @@ impl CredentialStore {
         Ok(Some(SecretString::from(password)))
     }
 
+    #[cfg(test)]
     fn file_delete(&self) -> Result<()> {
+        match self.file_delete_outcome() {
+            DeleteOutcome::Deleted => Ok(()),
+            DeleteOutcome::NotFound => {
+                anyhow::bail!(
+                    "No credential file found: {}",
+                    self.credential_file_path().display()
+                )
+            }
+            DeleteOutcome::Failed(e) => Err(e),
+        }
+    }
+
+    fn file_delete_outcome(&self) -> DeleteOutcome {
         let cred_path = self.credential_file_path();
         if !cred_path.exists() {
-            anyhow::bail!("No credential file found: {}", cred_path.display());
+            return DeleteOutcome::NotFound;
         }
-        std::fs::remove_file(&cred_path).with_context(|| {
-            format!("Failed to delete credential file: {}", cred_path.display())
-        })?;
-        // Leave the key file — it may be shared if the user re-stores later
-        Ok(())
+        match std::fs::remove_file(&cred_path) {
+            Ok(()) => DeleteOutcome::Deleted,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => DeleteOutcome::NotFound,
+            Err(e) => DeleteOutcome::Failed(anyhow::anyhow!(e).context(format!(
+                "Failed to delete credential file: {}",
+                cred_path.display()
+            ))),
+        }
     }
+}
+
+fn finish_delete(
+    username: &str,
+    keyring: DeleteOutcome,
+    encrypted_file: DeleteOutcome,
+) -> Result<()> {
+    let mut deleted = Vec::new();
+    let mut failed = Vec::new();
+
+    match keyring {
+        DeleteOutcome::Deleted => deleted.push("keyring"),
+        DeleteOutcome::NotFound => {}
+        DeleteOutcome::Failed(e) => failed.push(("keyring", e)),
+    }
+    match encrypted_file {
+        DeleteOutcome::Deleted => deleted.push("encrypted-file"),
+        DeleteOutcome::NotFound => {}
+        DeleteOutcome::Failed(e) => failed.push(("encrypted-file", e)),
+    }
+
+    if failed.is_empty() {
+        if deleted.is_empty() {
+            anyhow::bail!("No stored credential found for {username}");
+        }
+        return Ok(());
+    }
+
+    let failed_names = failed
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let details = failed
+        .into_iter()
+        .map(|(name, err)| format!("{name}: {err:#}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    if deleted.is_empty() {
+        anyhow::bail!("Failed to delete credential backend(s) {failed_names}: {details}");
+    }
+    anyhow::bail!(
+        "Credential deletion partially failed; deleted from {}, but failed backend(s) {failed_names}: {details}",
+        deleted.join(", ")
+    );
 }
 
 /// Atomically write data to a file with 0o600 permissions (synchronous).
@@ -372,6 +437,60 @@ mod tests {
     }
 
     #[test]
+    fn delete_outcome_file_only_success_when_keyring_missing() {
+        let result = finish_delete(
+            "user@example.com",
+            DeleteOutcome::NotFound,
+            DeleteOutcome::Deleted,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn delete_outcome_both_missing_reports_no_stored_credential() {
+        let err = finish_delete(
+            "user@example.com",
+            DeleteOutcome::NotFound,
+            DeleteOutcome::NotFound,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("No stored credential found"),
+            "expected no-credential error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn delete_outcome_deleted_plus_failure_reports_partial_backend() {
+        let err = finish_delete(
+            "user@example.com",
+            DeleteOutcome::Deleted,
+            DeleteOutcome::Failed(anyhow::anyhow!("permission denied")),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("partially failed") && msg.contains("encrypted-file"),
+            "partial failure must name the failed backend: {msg}"
+        );
+    }
+
+    #[test]
+    fn delete_outcome_failure_without_delete_names_backend() {
+        let err = finish_delete(
+            "user@example.com",
+            DeleteOutcome::Failed(anyhow::anyhow!("keyring locked")),
+            DeleteOutcome::NotFound,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("keyring") && msg.contains("keyring locked"),
+            "failed deletion must name backend and source error: {msg}"
+        );
+    }
+
+    #[test]
     fn encrypted_file_corrupt_data() {
         let (_td, dir) = test_dir("corrupt");
         let store = CredentialStore::new("user@example.com", &dir);
@@ -437,7 +556,17 @@ mod tests {
         store.store("to_delete").unwrap();
         assert!(store.retrieve().unwrap().is_some());
 
-        store.delete().unwrap();
+        let delete_result = store.delete();
+        if let Err(err) = delete_result {
+            assert!(
+                err.to_string().contains("partially failed") && err.to_string().contains("keyring"),
+                "headless keyring failures should surface as partial deletion, got: {err}"
+            );
+            assert!(
+                !store.credential_file_path().exists(),
+                "partial delete should still remove the encrypted-file credential"
+            );
+        }
         assert!(store.retrieve().unwrap().is_none());
     }
 

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -167,10 +167,7 @@ impl CredentialStore {
         };
         match entry.delete_credential() {
             Ok(()) => DeleteOutcome::Deleted,
-            Err(keyring::Error::NoEntry) => DeleteOutcome::NotFound,
-            Err(e) => DeleteOutcome::Failed(
-                anyhow::anyhow!(e).context("Failed to delete keyring credential"),
-            ),
+            Err(e) => keyring_delete_error_outcome(e),
         }
     }
 
@@ -302,6 +299,31 @@ impl CredentialStore {
             ))),
         }
     }
+}
+
+fn keyring_delete_error_outcome(error: keyring::Error) -> DeleteOutcome {
+    match error {
+        keyring::Error::NoEntry => DeleteOutcome::NotFound,
+        keyring::Error::PlatformFailure(e) if is_keyring_platform_unavailable(e.as_ref()) => {
+            tracing::debug!(
+                error = %e,
+                "Keyring unavailable during credential deletion; treating it as absent"
+            );
+            DeleteOutcome::NotFound
+        }
+        e => {
+            DeleteOutcome::Failed(anyhow::anyhow!(e).context("Failed to delete keyring credential"))
+        }
+    }
+}
+
+fn is_keyring_platform_unavailable(error: &(dyn std::error::Error + Send + Sync)) -> bool {
+    let message = error.to_string();
+    message.contains("org.freedesktop.secrets")
+        || message.contains("The name is not activatable")
+        || (message.contains("Failed to connect")
+            && message.contains("/run/user/")
+            && message.contains("/bus"))
 }
 
 fn finish_delete(
@@ -487,6 +509,33 @@ mod tests {
         assert!(
             msg.contains("keyring") && msg.contains("keyring locked"),
             "failed deletion must name backend and source error: {msg}"
+        );
+    }
+
+    #[test]
+    fn unavailable_secret_service_delete_is_not_found() {
+        for message in [
+            "DBus error: The name org.freedesktop.secrets was not provided by any .service files",
+            "DBus error: The name is not activatable",
+        ] {
+            let outcome = keyring_delete_error_outcome(keyring::Error::PlatformFailure(Box::new(
+                std::io::Error::other(message),
+            )));
+            assert!(
+                matches!(outcome, DeleteOutcome::NotFound),
+                "headless Secret Service delete should behave like an absent keyring"
+            );
+        }
+    }
+
+    #[test]
+    fn inaccessible_keyring_delete_still_fails() {
+        let outcome = keyring_delete_error_outcome(keyring::Error::NoStorageAccess(Box::new(
+            std::io::Error::other("keyring locked"),
+        )));
+        assert!(
+            matches!(outcome, DeleteOutcome::Failed(_)),
+            "locked keyrings should not be treated as absent"
         );
     }
 

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -867,10 +867,9 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
 /// Validate that downloaded content matches expected format for the file extension.
 ///
 /// For known media types (JPEG, PNG, HEIC, MOV, etc.), checks magic bytes in the
-/// file header. Magic byte mismatches are logged as warnings but allowed through,
-/// since format variants exist (e.g. classic QuickTime MOV without `ftyp` box).
-/// HTML and JSON error-page sentinels are always rejected as hard errors —
-/// Apple's CDN occasionally returns them with HTTP 200.
+/// file header. HTML and JSON error-page sentinels are always rejected before
+/// extension-specific checks because Apple's CDN occasionally returns them with
+/// HTTP 200.
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,
@@ -918,11 +917,11 @@ fn validate_downloaded_content(
             reason = "`n.min(8)` caps the slice at `header.len()`"
         )]
         let preview = &header[..n.min(8)];
-        tracing::warn!(
-            path = %download_path.display(),
-            header = %format_args!("{preview:02x?}"),
-            "File header does not match expected format for .{ext}, saving anyway",
-        );
+        return Err(DownloadError::InvalidContent {
+            path: download_path.display().to_string().into(),
+            reason: format!("file header {preview:02x?} does not match expected format for .{ext}")
+                .into(),
+        });
     }
 
     Ok(())
@@ -1471,20 +1470,32 @@ mod tests {
     }
 
     #[test]
-    fn validate_warns_but_accepts_mismatched_heic_magic() {
-        // Non-ftyp header with .heic extension — warn but accept
+    fn validate_rejects_mismatched_heic_magic() {
+        // Non-ftyp header with .heic extension is not valid HEIC.
         let mut buf = [0u8; 12];
         buf[0..4].copy_from_slice(&[0x00, 0x00, 0x00, 0x08]);
         buf[4..8].copy_from_slice(b"wide");
         let (part, dest, _dir) = write_temp_file("photo.heic", &buf);
-        assert!(validate_downloaded_content(&part, &dest).is_ok());
+        let err = validate_downloaded_content(&part, &dest).unwrap_err();
+        assert!(matches!(err, DownloadError::InvalidContent { .. }));
     }
 
     #[test]
-    fn validate_warns_but_accepts_mismatched_png_magic() {
-        // JPEG magic with .png extension — warn but accept
+    fn validate_rejects_mismatched_png_magic() {
+        // JPEG magic with .png extension should not be promoted.
         let (part, dest, _dir) = write_temp_file("photo.png", &[0xFF, 0xD8, 0xFF, 0xE0]);
-        assert!(validate_downloaded_content(&part, &dest).is_ok());
+        let err = validate_downloaded_content(&part, &dest).unwrap_err();
+        assert!(matches!(err, DownloadError::InvalidContent { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_mismatched_jpeg_magic() {
+        let (part, dest, _dir) = write_temp_file(
+            "photo.jpg",
+            &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+        );
+        let err = validate_downloaded_content(&part, &dest).unwrap_err();
+        assert!(matches!(err, DownloadError::InvalidContent { .. }));
     }
 
     #[test]

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -19,8 +19,13 @@ use crate::types::{
 };
 
 use super::paths;
-use super::planner::MalformedTaskResource;
 use super::DownloadConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MalformedTaskResource {
+    pub(super) field: Box<str>,
+    pub(super) reason: Box<str>,
+}
 
 /// Reason an asset was filtered out during content/metadata filtering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -19,6 +19,7 @@ use crate::types::{
 };
 
 use super::paths;
+use super::planner::MalformedTaskResource;
 use super::DownloadConfig;
 
 /// Reason an asset was filtered out during content/metadata filtering.
@@ -733,6 +734,77 @@ fn select_mov_companion<'a>(
         config.force_resolution,
     )?;
     (!url_seen(selected.0, seen_urls)).then_some(selected)
+}
+
+fn malformed_for_keys(
+    asset: &crate::icloud::photos::PhotoAsset,
+    keys: impl IntoIterator<Item = AssetVersionSize>,
+) -> Option<MalformedTaskResource> {
+    let malformed = asset.malformed_resources();
+    keys.into_iter().find_map(|key| {
+        malformed
+            .iter()
+            .find(|resource| resource.version_size == key)
+            .map(|resource| MalformedTaskResource {
+                field: resource.field.clone(),
+                reason: resource.reason.clone(),
+            })
+    })
+}
+
+fn primary_candidate_keys(config: &DownloadConfig) -> SmallVec<[AssetVersionSize; 2]> {
+    let mut keys = SmallVec::new();
+    let Some(requested) = config.resolution.to_asset_version_size() else {
+        return keys;
+    };
+    keys.push(requested);
+    if !config.force_resolution && requested != AssetVersionSize::Original {
+        keys.push(AssetVersionSize::Original);
+    }
+    keys
+}
+
+fn live_candidate_keys(config: &DownloadConfig) -> SmallVec<[AssetVersionSize; 2]> {
+    let mut keys = SmallVec::new();
+    keys.push(config.live_resolution);
+    if !config.force_resolution && config.live_resolution != AssetVersionSize::LiveOriginal {
+        keys.push(AssetVersionSize::LiveOriginal);
+    }
+    keys
+}
+
+/// Return the malformed resource that explains a post-filter asset producing
+/// no downloadable tasks, if CloudKit advertised a selected resource but made
+/// it unusable.
+pub(super) fn malformed_no_task_resource(
+    asset: &crate::icloud::photos::PhotoAsset,
+    config: &DownloadConfig,
+) -> Option<MalformedTaskResource> {
+    if !derive_expected_paths(asset, config).is_empty() {
+        return None;
+    }
+
+    if !matches!(
+        config.live_photo_mode,
+        LivePhotoMode::Skip | LivePhotoMode::VideoOnly
+    ) || !asset.is_live_photo()
+    {
+        if let Some(resource) = malformed_for_keys(asset, primary_candidate_keys(config)) {
+            return Some(resource);
+        }
+    }
+
+    if matches!(
+        config.live_photo_mode,
+        LivePhotoMode::Both | LivePhotoMode::VideoOnly
+    ) && asset.item_type() == Some(AssetItemType::Image)
+    {
+        if let Some(resource) = malformed_for_keys(asset, live_candidate_keys(config)) {
+            return Some(resource);
+        }
+    }
+
+    None
 }
 
 /// Build the primary `DerivedPath` (or `None` if no primary should be

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2029,21 +2029,14 @@ async fn build_pass_count_plan(
 }
 
 /// Classification of how the producer-observed asset count compared with the
-/// pre-enumeration API total. Drives the two-tier pagination-undercount gate.
+/// pre-enumeration API total.
 ///
-/// - `Match`: producer saw at least as many assets as `total` reported. Token
-///   advances silently.
-/// - `WithinTolerance`: producer saw fewer than `total` but the gap is below
-///   the 5% suppression threshold. Token advances; a `warn!` fires so a slow
-///   drift is visible before it grows past 5%.
-/// - `Suppress`: gap is at or above 5% of `total`. Token is suppressed so the
-///   next cycle re-enumerates. Without this gate, missed change events would
-///   sit behind an advanced token forever (silent data loss).
+/// Any shortfall is token-unsafe. The severity split is kept only so logs can
+/// distinguish a small mismatch from a larger truncation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PaginationShortfall {
     Match,
-    WithinTolerance { shortfall: u64 },
-    Suppress,
+    Shortfall { shortfall: u64 },
 }
 
 /// Pure classifier for the pagination-undercount gate. `total` is the
@@ -2054,13 +2047,8 @@ fn classify_pagination_shortfall(total: u64, seen: u64) -> PaginationShortfall {
     if seen >= total {
         return PaginationShortfall::Match;
     }
-    let suppress_threshold = total * 95 / 100; // 5% tolerance
-    if seen < suppress_threshold {
-        PaginationShortfall::Suppress
-    } else {
-        PaginationShortfall::WithinTolerance {
-            shortfall: total - seen,
-        }
+    PaginationShortfall::Shortfall {
+        shortfall: total - seen,
     }
 }
 
@@ -2428,20 +2416,11 @@ async fn download_photos_full_with_token(
             let decision = classify_pagination_shortfall(total, streaming_result.assets_seen);
             match decision {
                 PaginationShortfall::Match => false,
-                PaginationShortfall::WithinTolerance { shortfall } => {
+                PaginationShortfall::Shortfall { shortfall } => {
                     tracing::warn!(
                         expected = total,
                         seen = streaming_result.assets_seen,
                         shortfall,
-                        "Enumeration saw slightly fewer assets than expected; within \
-                         5% tolerance so sync token will still advance"
-                    );
-                    false
-                }
-                PaginationShortfall::Suppress => {
-                    tracing::warn!(
-                        expected = total,
-                        seen = streaming_result.assets_seen,
                         "Enumeration saw fewer assets than expected — blocking sync token \
                          advancement to force full re-enumeration on next run"
                     );
@@ -2454,6 +2433,9 @@ async fn download_photos_full_with_token(
     } else {
         false
     };
+    if pagination_undercount {
+        streaming_result.enumeration_errors += 1;
+    }
 
     // Collect the sync token from every album's token receiver and require
     // agreement before advancing. In practice, all passes for a zone should
@@ -2461,7 +2443,10 @@ async fn download_photos_full_with_token(
     // observe one coherent snapshot.
     // Don't advance the token for read-only operations, or when pagination
     // was incomplete (would permanently skip missed assets).
-    let sync_token = if !controls.run_mode.only_print_filenames() && !pagination_undercount {
+    let sync_token = if !controls.run_mode.only_print_filenames()
+        && !pagination_undercount
+        && streaming_result.enumeration_errors == 0
+    {
         let mut tokens = Vec::new();
         for rx in token_receivers {
             if let Ok(Some(token)) = rx.await {
@@ -5307,57 +5292,44 @@ mod tests {
         assert_eq!(decision, PaginationShortfall::Match);
     }
 
-    /// A 1% undercount (within 5% tolerance) classifies as
-    /// `WithinTolerance` so the caller emits a `warn!` but still advances the
-    /// sync token. This is the visible-but-non-blocking layer that closes the
-    /// pre-existing 4%-silent-drop gap (the prior gate fired only at >=5%).
+    /// A 1% undercount is token-unsafe. Small mismatches still keep the
+    /// shortfall count for log/report context, but the token must not advance.
     #[test]
-    fn classify_pagination_shortfall_one_percent_below_warns_but_advances() {
+    fn classify_pagination_shortfall_one_percent_below_blocks_token() {
         // 1000 expected, 990 seen → 1% shortfall, within 5% tolerance.
         let decision = classify_pagination_shortfall(1000, 990);
         assert_eq!(
             decision,
-            PaginationShortfall::WithinTolerance { shortfall: 10 },
-            "1% undercount must classify as WithinTolerance so the caller emits \
-             a warn but does NOT suppress the sync token"
+            PaginationShortfall::Shortfall { shortfall: 10 },
+            "1% undercount must block sync-token advancement"
         );
     }
 
-    /// A 4% undercount (still within 5% tolerance) classifies as
-    /// `WithinTolerance`. Pre-fix this slipped through silently with no log;
-    /// post-fix the `warn!` makes the drift visible before it grows past 5%.
+    /// A 4% undercount is also token-unsafe. There is no tolerance for
+    /// write-capable syncs because a short page can hide never-downloaded
+    /// records behind an advanced token.
     #[test]
-    fn classify_pagination_shortfall_four_percent_below_still_advances() {
+    fn classify_pagination_shortfall_four_percent_below_blocks_token() {
         // 1000 expected, 960 seen → 4% shortfall.
         let decision = classify_pagination_shortfall(1000, 960);
-        assert_eq!(
-            decision,
-            PaginationShortfall::WithinTolerance { shortfall: 40 }
-        );
+        assert_eq!(decision, PaginationShortfall::Shortfall { shortfall: 40 });
     }
 
-    /// A 6% undercount crosses the 5% threshold and must `Suppress` so
-    /// the sync token is held back, forcing full re-enumeration on the next
-    /// run rather than skipping the missing change events forever.
+    /// A 6% undercount is token-unsafe for the same reason as a small
+    /// undercount.
     #[test]
-    fn classify_pagination_shortfall_six_percent_below_suppresses_token() {
-        // 1000 expected, 940 seen → 6% shortfall, above the 5% suppression
-        // threshold. `total * 95 / 100 = 950`, and 940 < 950 → Suppress.
+    fn classify_pagination_shortfall_six_percent_below_blocks_token() {
+        // 1000 expected, 940 seen → 6% shortfall.
         let decision = classify_pagination_shortfall(1000, 940);
-        assert_eq!(decision, PaginationShortfall::Suppress);
+        assert_eq!(decision, PaginationShortfall::Shortfall { shortfall: 60 });
     }
 
-    /// Boundary case at exactly 5% shortfall. `total * 95 / 100 = 950`,
-    /// and seen == 950 is NOT below the threshold, so it stays in
-    /// `WithinTolerance` (the gate is strict less-than). Pinning this so a
-    /// future tweak to the threshold math doesn't flip the boundary silently.
+    /// Boundary case at exactly 5% shortfall. The old tolerance boundary is
+    /// still token-unsafe under fail-closed enumeration.
     #[test]
-    fn classify_pagination_shortfall_at_threshold_is_within_tolerance() {
+    fn classify_pagination_shortfall_at_old_threshold_blocks_token() {
         let decision = classify_pagination_shortfall(1000, 950);
-        assert_eq!(
-            decision,
-            PaginationShortfall::WithinTolerance { shortfall: 50 }
-        );
+        assert_eq!(decision, PaginationShortfall::Shortfall { shortfall: 50 });
     }
 
     /// The orphan-part walk must remove .part files older

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2031,8 +2031,8 @@ async fn build_pass_count_plan(
 /// Classification of how the producer-observed asset count compared with the
 /// pre-enumeration API total.
 ///
-/// Any shortfall is token-unsafe. The severity split is kept only so logs can
-/// distinguish a small mismatch from a larger truncation.
+/// Any shortfall is token-unsafe. The shortfall count is kept so logs can
+/// report how many assets were missed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PaginationShortfall {
     Match,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2660,6 +2660,7 @@ async fn download_photos_incremental(
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut task_planner = planner::TaskPlanner::new();
     let mut skip_breakdown = SkipBreakdown::default();
+    let mut enumeration_errors = 0usize;
     let pass_configs = build_pass_configs_resolving_deferred_excludes(passes, config).await?;
 
     for (asset, pass_index) in &downloadable_assets {
@@ -2673,6 +2674,16 @@ async fn download_photos_incremental(
         let plan = task_planner.plan_asset(asset, effective_config).await;
         if let Some(reason) = plan.filter_reason {
             skip_breakdown.record_filter_reason(reason);
+            continue;
+        }
+        if let Some(resource) = &plan.malformed_resource {
+            enumeration_errors += 1;
+            tracing::error!(
+                asset_id = %asset.id(),
+                field = %resource.field,
+                reason = %resource.reason,
+                "Malformed CloudKit resource prevented incremental download planning"
+            );
             continue;
         }
 
@@ -2726,15 +2737,23 @@ async fn download_photos_incremental(
     if tasks.is_empty() {
         let stats = SyncStats {
             skipped: skip_breakdown,
+            enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
             interrupted: shutdown_token.is_cancelled(),
             ..SyncStats::default()
         };
         tracing::info!("All incremental assets already downloaded or filtered");
         tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
+        let outcome = if enumeration_errors > 0 {
+            DownloadOutcome::PartialFailure {
+                failed_count: enumeration_errors,
+            }
+        } else {
+            DownloadOutcome::Success
+        };
         return Ok(SyncResult {
-            outcome: DownloadOutcome::Success,
-            sync_token,
+            outcome,
+            sync_token: (enumeration_errors == 0).then_some(sync_token).flatten(),
             stats,
             full_enumeration_ran: false,
         });
@@ -2750,12 +2769,19 @@ async fn download_photos_incremental(
         }
         let stats = SyncStats {
             skipped: skip_breakdown,
+            enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
             ..SyncStats::default()
         };
         // Don't advance the sync token — this is a read-only operation.
         return Ok(SyncResult {
-            outcome: DownloadOutcome::Success,
+            outcome: if enumeration_errors > 0 {
+                DownloadOutcome::PartialFailure {
+                    failed_count: enumeration_errors,
+                }
+            } else {
+                DownloadOutcome::Success
+            },
             sync_token: None,
             stats,
             full_enumeration_ran: false,
@@ -2803,7 +2829,7 @@ async fn download_photos_incremental(
         disk_bytes_written: pass_result.disk_bytes_written,
         exif_failures: pass_result.exif_failures,
         state_write_failures: pass_result.state_write_failures,
-        enumeration_errors: 0,
+        enumeration_errors,
         elapsed_secs: started.elapsed().as_secs_f64(),
         interrupted: shutdown_token.is_cancelled()
             || pass_result.auth_errors >= AUTH_ERROR_THRESHOLD
@@ -2829,18 +2855,24 @@ async fn download_photos_incremental(
         });
     }
 
-    let outcome =
-        if failed > 0 || pass_result.exif_failures > 0 || pass_result.state_write_failures > 0 {
-            DownloadOutcome::PartialFailure {
-                failed_count: failed + pass_result.exif_failures + pass_result.state_write_failures,
-            }
-        } else {
-            DownloadOutcome::Success
-        };
+    let outcome = if failed > 0
+        || pass_result.exif_failures > 0
+        || pass_result.state_write_failures > 0
+        || enumeration_errors > 0
+    {
+        DownloadOutcome::PartialFailure {
+            failed_count: failed
+                + pass_result.exif_failures
+                + pass_result.state_write_failures
+                + enumeration_errors,
+        }
+    } else {
+        DownloadOutcome::Success
+    };
 
     Ok(SyncResult {
         outcome,
-        sync_token,
+        sync_token: (enumeration_errors == 0).then_some(sync_token).flatten(),
         stats,
         full_enumeration_ran: false,
     })

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1375,7 +1375,6 @@ struct PerPassStreamingResult {
 }
 
 struct CollectedUnfiledStream {
-    count: u64,
     token_rx: tokio::sync::oneshot::Receiver<Option<String>>,
     items: Vec<anyhow::Result<PhotoAsset>>,
 }
@@ -1402,7 +1401,6 @@ fn deferred_unfiled_index(passes: &[crate::commands::AlbumPass]) -> Option<usize
 
 async fn collect_unfiled_stream(
     pass: &crate::commands::AlbumPass,
-    count: u64,
     stream_total_count: Option<u64>,
     config: &DownloadConfig,
     controls: DownloadControls,
@@ -1430,11 +1428,7 @@ async fn collect_unfiled_stream(
         }
         items.push(item);
     }
-    CollectedUnfiledStream {
-        count,
-        token_rx,
-        items,
-    }
+    CollectedUnfiledStream { token_rx, items }
 }
 
 async fn run_full_pass_stream<S>(
@@ -1979,6 +1973,11 @@ struct PassCountPlan {
     len_errors: usize,
 }
 
+fn capped_exact_total(counts: &[u64], recent: Option<u32>) -> u64 {
+    let total = counts.iter().sum::<u64>();
+    total.min(recent.map(u64::from).unwrap_or(u64::MAX))
+}
+
 fn should_skip_pass_count_fetch(config: &DownloadConfig, controls: DownloadControls) -> bool {
     config.recent.is_some()
         && (controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames())
@@ -2015,10 +2014,7 @@ async fn build_pass_count_plan(
     let pass_count_results = crate::icloud::photos::PhotoAlbum::len_many(&pass_albums).await;
     let (display_counts, len_errors) = fold_pass_count_results(pass_count_results, passes);
     let stream_total_counts = display_counts.iter().copied().map(Some).collect();
-    let mut exact_total: u64 = display_counts.iter().sum();
-    if let Some(recent) = config.recent {
-        exact_total = exact_total.min(u64::from(recent));
-    }
+    let exact_total = capped_exact_total(&display_counts, config.recent);
 
     PassCountPlan {
         display_counts,
@@ -2110,7 +2106,8 @@ async fn download_photos_full_with_token(
     let pass_count_plan = build_pass_count_plan(passes, config, controls).await;
     let pass_counts = pass_count_plan.display_counts;
     let pass_stream_counts = pass_count_plan.stream_total_counts;
-    let exact_total = pass_count_plan.exact_total;
+    let mut pagination_counts = pass_counts.clone();
+    let mut exact_total = pass_count_plan.exact_total;
     let len_errors = pass_count_plan.len_errors;
     let display_total = pass_counts
         .iter()
@@ -2252,11 +2249,10 @@ async fn download_photos_full_with_token(
 
         let unfiled_collection = async {
             match deferred_unfiled {
-                Some(index) => match (passes.get(index), pass_counts.get(index).copied()) {
-                    (Some(pass), Some(count)) => Some(
+                Some(index) => match passes.get(index) {
+                    Some(pass) => Some(
                         collect_unfiled_stream(
                             pass,
-                            count,
                             pass_stream_counts.get(index).copied().flatten(),
                             config,
                             controls,
@@ -2310,14 +2306,24 @@ async fn download_photos_full_with_token(
                         .map_or(true, |asset| !excluded_ids.contains(asset.id()))
                 });
                 if let Some(pass_config) = pass_configs.get(index).cloned() {
+                    let filtered_items = filtered.collect::<Vec<_>>();
+                    let filtered_count = filtered_items
+                        .iter()
+                        .filter(|item| item.is_ok())
+                        .count()
+                        .try_into()
+                        .unwrap_or(u64::MAX);
+                    if let Some(slot) = pagination_counts.get_mut(index) {
+                        *slot = filtered_count;
+                    }
                     let pass_result = run_full_pass_stream(
                         download_client.clone(),
-                        stream::iter(filtered),
+                        stream::iter(filtered_items),
                         collected.token_rx,
                         pass_config,
                         FullPassStreamOptions {
                             controls,
-                            count: collected.count,
+                            count: filtered_count,
                             kind: crate::commands::PassKind::Unfiled,
                             shutdown_token: shutdown_token.clone(),
                             download_ctx: shared_download_ctx.clone(),
@@ -2403,6 +2409,9 @@ async fn download_photos_full_with_token(
     // stay set even if the producer drained its (possibly truncated) stream.
     if len_errors > 0 {
         streaming_result.enumeration_complete = false;
+    }
+    if exact_total.is_some() {
+        exact_total = Some(capped_exact_total(&pagination_counts, config.recent));
     }
 
     // Check if enumeration saw significantly fewer assets than the API reported.
@@ -3145,6 +3154,47 @@ mod tests {
         )
     }
 
+    fn mock_photo_records_with_filename(record_name: &str, filename: &str) -> Vec<Value> {
+        vec![
+            json!({
+                "recordName": record_name,
+                "recordType": "CPLMaster",
+                "fields": {
+                    "filenameEnc": {"value": filename, "type": "STRING"},
+                    "resOriginalRes": {
+                        "value": {
+                            "downloadURL": "https://p01.icloud-content.com/photo.jpg",
+                            "size": 1024,
+                            "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                        }
+                    },
+                    "resOriginalWidth": {"value": 100, "type": "INT64"},
+                    "resOriginalHeight": {"value": 100, "type": "INT64"},
+                    "resOriginalFileType": {"value": "public.jpeg"},
+                    "itemType": {"value": "public.jpeg"},
+                    "adjustmentRenderType": {"value": 0, "type": "INT64"}
+                },
+                "recordChangeTag": "ct1"
+            }),
+            json!({
+                "recordName": format!("asset-{record_name}"),
+                "recordType": "CPLAsset",
+                "fields": {
+                    "masterRef": {
+                        "value": {
+                            "recordName": record_name,
+                            "zoneID": {"zoneName": "PrimarySync"}
+                        },
+                        "type": "REFERENCE"
+                    },
+                    "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                    "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                },
+                "recordChangeTag": "ct2"
+            }),
+        ]
+    }
+
     #[tokio::test]
     async fn full_sync_per_pass_streams_overlap_when_paths_are_pass_specific() {
         let session = ConcurrentRecordsSession::new(Duration::from_millis(100));
@@ -3233,6 +3283,73 @@ mod tests {
         assert!(
             matches!(result.outcome, DownloadOutcome::Success),
             "filtered duplicate should not make the run partial"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_sync_deferred_unfiled_write_mode_exclusion_does_not_count_as_shortfall() {
+        let records = mock_photo_records_with_filename("MASTER_1", "test.jpg");
+        let album_session = MockPhotosFlow::new()
+            .album_count(1)
+            .query_page(records.clone(), Some("zone-token"))
+            .build();
+        let unfiled_session = MockPhotosFlow::new()
+            .album_count(1)
+            .query_page(records.clone(), Some("zone-token"))
+            .build();
+        let passes = vec![
+            AlbumPass {
+                kind: PassKind::Album,
+                album: mock_album("Vacation", album_session),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+            AlbumPass {
+                kind: PassKind::Unfiled,
+                album: mock_album("", unfiled_session),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+        ];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 2;
+
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let album_config = config.with_pass(&passes[0]);
+        let expected_path = filter::expected_paths_for(&asset, &album_config)
+            .into_iter()
+            .next()
+            .expect("mock asset should have an expected path");
+        tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
+            .await
+            .expect("create parent dir");
+        tokio::fs::write(&expected_path.path, vec![0u8; 1024])
+            .await
+            .expect("seed existing file");
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("write-mode full sync should succeed");
+
+        assert_eq!(
+            result.stats.enumeration_errors, 0,
+            "deferred unfiled exclusions are intentional and must not be counted as pagination undercount"
+        );
+        assert_eq!(
+            result.sync_token.as_deref(),
+            Some("zone-token"),
+            "clean write-mode enumeration should still advance the agreed sync token"
+        );
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "filtered duplicate should not make the write-mode run partial"
         );
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -982,6 +982,16 @@ where
                     }
 
                     let plan = task_planner.plan_asset(&asset, config).await;
+                    if let Some(resource) = &plan.malformed_resource {
+                        enum_errors += 1;
+                        tracing::error!(
+                            asset_id = %asset.id(),
+                            field = %resource.field,
+                            reason = %resource.reason,
+                            "Malformed CloudKit resource prevented filename planning"
+                        );
+                        continue;
+                    }
                     #[allow(
                         clippy::print_stdout,
                         reason = "--only-print-filenames writes target paths to stdout so callers can pipe to xargs/etc"
@@ -1021,6 +1031,16 @@ where
                 Ok(asset) => {
                     let plan = task_planner.plan_asset(&asset, config).await;
                     if plan.filter_reason.is_some() {
+                        continue;
+                    }
+                    if let Some(resource) = &plan.malformed_resource {
+                        enum_errors += 1;
+                        tracing::error!(
+                            asset_id = %asset.id(),
+                            field = %resource.field,
+                            reason = %resource.reason,
+                            "Malformed CloudKit resource prevented dry-run planning"
+                        );
                         continue;
                     }
                     for task in &plan.tasks {
@@ -1289,6 +1309,17 @@ where
                     let plan = task_planner.plan_asset(&asset, config).await;
                     if let Some(reason) = plan.filter_reason {
                         skips.record_filter_reason(reason);
+                        producer_pb.inc(1);
+                        continue;
+                    }
+                    if let Some(resource) = &plan.malformed_resource {
+                        enum_errors_producer.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::error!(
+                            asset_id = %asset.id(),
+                            field = %resource.field,
+                            reason = %resource.reason,
+                            "Malformed CloudKit resource prevented download planning"
+                        );
                         producer_pb.inc(1);
                         continue;
                     }

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -14,7 +14,7 @@ use crate::state::{AssetRecord, DownloadStateStore, MembershipStore};
 
 use super::filter::{
     determine_media_type, filter_asset_to_tasks, is_asset_filtered, pre_ensure_asset_dir,
-    DownloadTask, FilterReason, NormalizedPath,
+    DownloadTask, FilterReason, MalformedTaskResource, NormalizedPath,
 };
 use super::paths;
 use super::DownloadConfig;
@@ -81,12 +81,6 @@ pub(super) struct AssetTaskPlan {
     pub(super) tasks: SmallVec<[DownloadTask; 5]>,
     pub(super) filter_reason: Option<FilterReason>,
     pub(super) malformed_resource: Option<MalformedTaskResource>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct MalformedTaskResource {
-    pub(super) field: Box<str>,
-    pub(super) reason: Box<str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -45,15 +45,22 @@ impl TaskPlanner {
             return AssetTaskPlan {
                 tasks: SmallVec::new(),
                 filter_reason: Some(filter_reason),
+                malformed_resource: None,
             };
         }
 
         pre_ensure_asset_dir(&mut self.dir_cache, asset, config).await;
         let tasks =
             filter_asset_to_tasks(asset, config, &mut self.claimed_paths, &mut self.dir_cache);
+        let malformed_resource = if tasks.is_empty() {
+            super::filter::malformed_no_task_resource(asset, config)
+        } else {
+            None
+        };
         AssetTaskPlan {
             tasks,
             filter_reason: None,
+            malformed_resource,
         }
     }
 
@@ -73,6 +80,13 @@ impl TaskPlanner {
 pub(super) struct AssetTaskPlan {
     pub(super) tasks: SmallVec<[DownloadTask; 5]>,
     pub(super) filter_reason: Option<FilterReason>,
+    pub(super) malformed_resource: Option<MalformedTaskResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MalformedTaskResource {
+    pub(super) field: Box<str>,
+    pub(super) reason: Box<str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,9 +215,10 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::commands::{AlbumPass, PassKind};
-    use crate::icloud::photos::PhotoAlbum;
+    use crate::icloud::photos::{PhotoAlbum, PhotoAsset};
     use crate::state::SqliteStateDb;
     use crate::test_helpers::TestPhotoAsset;
+    use serde_json::json;
 
     use super::*;
 
@@ -296,6 +311,63 @@ mod tests {
         let plan = second.plan_asset(&asset, &config).await;
         assert_eq!(plan.filter_reason, None);
         assert!(plan.tasks.is_empty(), "existing same-size file should skip");
+    }
+
+    #[tokio::test]
+    async fn planner_reports_null_selected_primary_resource_as_malformed() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let asset = PhotoAsset::new(
+            json!({
+                "recordName": "MALFORMED_PRIMARY",
+                "fields": {
+                    "filenameEnc": {"value": "bad.jpg", "type": "STRING"},
+                    "itemType": {"value": "public.jpeg"},
+                    "resOriginalRes": {"value": null},
+                    "resOriginalFileType": {"value": "public.jpeg"}
+                }
+            }),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &config).await;
+
+        assert!(plan.tasks.is_empty());
+        let malformed = plan.malformed_resource.unwrap();
+        assert_eq!(malformed.field.as_ref(), "resOriginalRes");
+        assert_eq!(malformed.reason.as_ref(), "resource value is null");
+    }
+
+    #[tokio::test]
+    async fn planner_ignores_malformed_optional_alternative_when_primary_is_valid() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.alternative = true;
+        let asset = PhotoAsset::new(
+            json!({
+                "recordName": "VALID_PRIMARY_BAD_ALT",
+                "fields": {
+                    "filenameEnc": {"value": "good.jpg", "type": "STRING"},
+                    "itemType": {"value": "public.jpeg"},
+                    "resOriginalRes": {"value": {
+                        "size": 1000,
+                        "downloadURL": "https://p01.icloud-content.com/orig",
+                        "fileChecksum": "ck_orig"
+                    }},
+                    "resOriginalFileType": {"value": "public.jpeg"},
+                    "resOriginalAltRes": {"value": null},
+                    "resOriginalAltFileType": {"value": "public.camera-raw-image"}
+                }
+            }),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+
+        let mut planner = TaskPlanner::new();
+        let plan = planner.plan_asset(&asset, &config).await;
+
+        assert_eq!(plan.tasks.len(), 1);
+        assert!(plan.malformed_resource.is_none());
     }
 
     #[tokio::test]

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -19,6 +19,17 @@ use crate::state::AssetMetadata;
 /// (original + optional medium/thumb + optional live photo).
 pub type VersionsMap = SmallVec<[(AssetVersionSize, AssetVersion); 4]>;
 
+/// Malformed resource fields seen while extracting downloadable versions.
+///
+/// Absence of an optional resource is normal; this records only resources
+/// CloudKit advertised with an unusable value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MalformedResource {
+    pub(crate) version_size: AssetVersionSize,
+    pub(crate) field: Box<str>,
+    pub(crate) reason: Box<str>,
+}
+
 /// A change event from the `changes/zone` delta API.
 #[derive(Debug)]
 pub struct ChangeEvent {
@@ -58,6 +69,7 @@ pub struct PhotoAsset {
     asset_metadata: Arc<AssetMetadata>,
     // SmallVec with inline storage
     versions: VersionsMap,
+    malformed_resources: Arc<[MalformedResource]>,
     // f64 primitives
     asset_date_ms: Option<f64>,
     added_date_ms: Option<f64>,
@@ -98,11 +110,6 @@ pub(crate) fn f64_to_millis_datetime(ms: f64) -> Option<DateTime<Utc>> {
     }
 }
 
-/// True when `fields.key` is a non-null `Value`.
-fn field_present(fields: &Value, key: &str) -> bool {
-    fields.get(key).is_some_and(|v| !v.is_null())
-}
-
 /// Determine asset type from the `itemType` `CloudKit` field, falling back to
 /// file extension heuristics. Defaults to Movie for unknown types because
 /// videos are more likely to have non-standard UTI strings.
@@ -138,7 +145,7 @@ fn extract_versions(
     master_fields: &Value,
     asset_fields: &Value,
     record_name: &str,
-) -> VersionsMap {
+) -> (VersionsMap, Vec<MalformedResource>) {
     let lookup = if item_type == Some(AssetItemType::Movie) {
         VIDEO_VERSION_LOOKUP
     } else {
@@ -146,12 +153,13 @@ fn extract_versions(
     };
 
     let mut versions = VersionsMap::new();
+    let mut malformed_resources = Vec::new();
     for (key, res_field, type_field) in lookup {
         // Asset record has adjusted versions; master has originals.
         // Prefer asset record so adjusted/edited versions take priority.
-        let fields = if field_present(asset_fields, res_field) {
+        let fields = if asset_fields.get(res_field).is_some() {
             asset_fields
-        } else if field_present(master_fields, res_field) {
+        } else if master_fields.get(res_field).is_some() {
             master_fields
         } else {
             continue;
@@ -162,6 +170,11 @@ fn extract_versions(
             .and_then(|f| f.get("value"))
             .unwrap_or(&Value::Null);
         if res_entry.is_null() {
+            malformed_resources.push(MalformedResource {
+                version_size: *key,
+                field: (*res_field).into(),
+                reason: "resource value is null".into(),
+            });
             continue;
         }
 
@@ -173,6 +186,11 @@ fn extract_versions(
                 field = format_args!("{res_field}.size"),
                 "Missing size, skipping version"
             );
+            malformed_resources.push(MalformedResource {
+                version_size: *key,
+                field: format!("{res_field}.size").into_boxed_str(),
+                reason: "missing size".into(),
+            });
             continue;
         };
 
@@ -187,6 +205,11 @@ fn extract_versions(
                         reason,
                         "Rejected downloadURL, skipping version"
                     );
+                    malformed_resources.push(MalformedResource {
+                        version_size: *key,
+                        field: format!("{res_field}.downloadURL").into_boxed_str(),
+                        reason: reason.into(),
+                    });
                     continue;
                 }
             },
@@ -196,6 +219,11 @@ fn extract_versions(
                     field = format_args!("{res_field}.downloadURL"),
                     "Missing downloadURL, skipping version"
                 );
+                malformed_resources.push(MalformedResource {
+                    version_size: *key,
+                    field: format!("{res_field}.downloadURL").into_boxed_str(),
+                    reason: "missing downloadURL".into(),
+                });
                 continue;
             }
         };
@@ -208,6 +236,11 @@ fn extract_versions(
                     field = format_args!("{res_field}.fileChecksum"),
                     "Empty fileChecksum, skipping version"
                 );
+                malformed_resources.push(MalformedResource {
+                    version_size: *key,
+                    field: format!("{res_field}.fileChecksum").into_boxed_str(),
+                    reason: "empty fileChecksum".into(),
+                });
                 continue;
             }
             None => {
@@ -216,6 +249,11 @@ fn extract_versions(
                     field = format_args!("{res_field}.fileChecksum"),
                     "Missing fileChecksum, skipping version"
                 );
+                malformed_resources.push(MalformedResource {
+                    version_size: *key,
+                    field: format!("{res_field}.fileChecksum").into_boxed_str(),
+                    reason: "missing fileChecksum".into(),
+                });
                 continue;
             }
         };
@@ -232,6 +270,11 @@ fn extract_versions(
                     field = %type_field,
                     "Missing or empty asset type, skipping version"
                 );
+                malformed_resources.push(MalformedResource {
+                    version_size: *key,
+                    field: (*type_field).into(),
+                    reason: "missing or empty asset type".into(),
+                });
                 continue;
             }
         };
@@ -246,7 +289,7 @@ fn extract_versions(
             },
         ));
     }
-    versions
+    (versions, malformed_resources)
 }
 
 /// Host suffixes kei will download from. Narrow to content-delivery hosts
@@ -293,7 +336,8 @@ impl PhotoAsset {
         let item_type_val = Some(resolve_item_type(&master_fields, filename.as_deref()));
         let asset_date_ms = asset_fields["assetDate"]["value"].as_f64();
         let added_date_ms = asset_fields["addedDate"]["value"].as_f64();
-        let versions = extract_versions(item_type_val, &master_fields, &asset_fields, &record_name);
+        let (versions, malformed_resources) =
+            extract_versions(item_type_val, &master_fields, &asset_fields, &record_name);
         let asset_metadata = Arc::new(metadata::extract(&master_fields, &asset_fields));
         let asset_record_name: Arc<str> = asset_record["recordName"]
             .as_str()
@@ -309,6 +353,7 @@ impl PhotoAsset {
             asset_date_ms,
             added_date_ms,
             versions,
+            malformed_resources: Arc::from(malformed_resources.into_boxed_slice()),
         }
     }
 
@@ -335,7 +380,7 @@ impl PhotoAsset {
             .get("addedDate")
             .and_then(|f| f.get("value"))
             .and_then(Value::as_f64);
-        let versions = extract_versions(
+        let (versions, malformed_resources) = extract_versions(
             item_type_val,
             &master.fields,
             &asset.fields,
@@ -352,6 +397,7 @@ impl PhotoAsset {
             asset_date_ms,
             added_date_ms,
             versions,
+            malformed_resources: Arc::from(malformed_resources.into_boxed_slice()),
         }
     }
 
@@ -439,6 +485,10 @@ impl PhotoAsset {
     /// Pre-parsed at construction so no JSON traversal happens at download time.
     pub fn versions(&self) -> &VersionsMap {
         &self.versions
+    }
+
+    pub(crate) fn malformed_resources(&self) -> &[MalformedResource] {
+        &self.malformed_resources
     }
 
     /// Get a specific version by size key. Test-only convenience.
@@ -2045,6 +2095,11 @@ mod tests {
             asset.versions().is_empty(),
             "null resOriginalRes value should produce empty versions"
         );
+        assert_eq!(asset.malformed_resources().len(), 1);
+        assert_eq!(
+            asset.malformed_resources()[0].field.as_ref(),
+            "resOriginalRes"
+        );
     }
 
     // ── Gap: asset with missing size skips the version ───────────────
@@ -2067,6 +2122,10 @@ mod tests {
         assert!(
             asset.versions().is_empty(),
             "version with missing size should be skipped"
+        );
+        assert_eq!(
+            asset.malformed_resources()[0].field.as_ref(),
+            "resOriginalRes.size"
         );
     }
 

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -73,7 +73,7 @@ impl std::fmt::Debug for PhotoLibrary {
 }
 
 impl PhotoLibrary {
-    /// Create a new `PhotoLibrary`, warning if indexing has not finished.
+    /// Create a new `PhotoLibrary`, failing if indexing has not finished.
     pub async fn new(
         service_endpoint: String,
         params: Arc<HashMap<String, Value>>,
@@ -157,22 +157,21 @@ impl PhotoLibrary {
 
         let query: super::cloudkit::QueryResponse =
             serde_json::from_value(response).map_err(|e| ICloudError::Connection(e.to_string()))?;
-        let indexing_state = query
-            .records
-            .first()
-            .and_then(|r| {
-                r.fields
-                    .get("state")
-                    .and_then(|f| f.get("value"))
-                    .and_then(Value::as_str)
-            })
-            .unwrap_or("");
+        let indexing_state = query.records.first().and_then(|r| {
+            r.fields
+                .get("state")
+                .and_then(|f| f.get("value"))
+                .and_then(Value::as_str)
+        });
+        let Some(indexing_state) = indexing_state else {
+            return Err(ICloudError::Connection(
+                "Photo library indexing state is missing; results may be incomplete".into(),
+            ));
+        };
         if indexing_state != "FINISHED" {
-            tracing::warn!(
-                state = indexing_state,
-                "Photo library indexing state is not FINISHED — proceeding anyway, \
-                 results may be incomplete"
-            );
+            return Err(ICloudError::Connection(format!(
+                "Photo library indexing state is {indexing_state}; expected FINISHED"
+            )));
         }
 
         Ok(Self {
@@ -450,6 +449,28 @@ mod tests {
         }
     }
 
+    struct IndexingStateSession {
+        response: Value,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for IndexingStateSession {
+        async fn post(
+            &self,
+            _url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            Ok(self.response.clone())
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(IndexingStateSession {
+                response: self.response.clone(),
+            })
+        }
+    }
+
     /// Build a `PhotoLibrary` directly (bypassing `new()` which requires a live session).
     fn make_library(zone_id: Value) -> PhotoLibrary {
         PhotoLibrary {
@@ -460,6 +481,60 @@ mod tests {
             library_type: Arc::from("personal"),
             retry_config: RetryConfig::default(),
         }
+    }
+
+    async fn new_library_with_indexing_response(
+        response: Value,
+    ) -> Result<PhotoLibrary, ICloudError> {
+        PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(IndexingStateSession { response }),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn indexing_state_finished_initializes_library() {
+        let lib = new_library_with_indexing_response(json!({
+            "records": [{"fields": {"state": {"value": "FINISHED"}}}]
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(lib.zone_name(), "PrimarySync");
+    }
+
+    #[tokio::test]
+    async fn indexing_state_running_fails_library_initialization() {
+        let err = new_library_with_indexing_response(json!({
+            "records": [{"fields": {"state": {"value": "RUNNING"}}}]
+        }))
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("RUNNING") && err.to_string().contains("FINISHED"),
+            "error should name observed and expected indexing states: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn indexing_state_missing_fails_library_initialization() {
+        let err = new_library_with_indexing_response(json!({"records": []}))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("indexing state is missing"),
+            "missing indexing state must fail closed: {err}"
+        );
     }
 
     #[test]

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -226,6 +226,7 @@ impl PhotosService {
                 }
                 Err(e) => {
                     tracing::error!(zone = %zone_name, error = %e, "Failed to load library zone");
+                    anyhow::bail!("Failed to load library zone {zone_name}: {e}");
                 }
             }
         }
@@ -554,15 +555,51 @@ mod tests {
         async fn post(
             &self,
             _url: &str,
-            _body: String,
+            body: String,
             _headers: &[(&str, &str)],
         ) -> anyhow::Result<Value> {
+            if body.contains("CheckIndexingState") {
+                return Ok(json!({
+                    "records": [{
+                        "fields": {"state": {"value": "FINISHED"}}
+                    }]
+                }));
+            }
             Ok(self.response.clone())
         }
 
         fn clone_box(&self) -> Box<dyn session::PhotosSession> {
             Box::new(CloneableSession {
                 response: self.response.clone(),
+            })
+        }
+    }
+
+    struct RunningIndexSession {
+        zone_response: Value,
+    }
+
+    #[async_trait::async_trait]
+    impl session::PhotosSession for RunningIndexSession {
+        async fn post(
+            &self,
+            _url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if body.contains("CheckIndexingState") {
+                return Ok(json!({
+                    "records": [{
+                        "fields": {"state": {"value": "RUNNING"}}
+                    }]
+                }));
+            }
+            Ok(self.zone_response.clone())
+        }
+
+        fn clone_box(&self) -> Box<dyn session::PhotosSession> {
+            Box::new(RunningIndexSession {
+                zone_response: self.zone_response.clone(),
             })
         }
     }
@@ -643,6 +680,37 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_fetch_libraries_fails_on_non_deleted_zone_initialization_failure() {
+        let session = RunningIndexSession {
+            zone_response: json!({
+                "zones": [
+                    {"zoneID": {"zoneName": "LiveZone"}, "syncToken": "tok"},
+                    {
+                        "zoneID": {"zoneName": "CMM-657AE284-D1E0-4C7F-9B4D-987888651AC6"},
+                        "syncToken": "tok2",
+                    },
+                    {
+                        "zoneID": {"zoneName": "GoneZone"},
+                        "syncToken": "tok3",
+                        "deleted": true,
+                    }
+                ]
+            }),
+        };
+        let mut svc = make_service(Box::new(session), HashMap::new());
+        let err = svc.fetch_private_libraries().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LiveZone") && msg.contains("RUNNING"),
+            "regular non-deleted zone failure must fail discovery: {msg}"
+        );
+        assert!(
+            svc.private_libraries.is_none(),
+            "failed discovery must not cache a partial private library map"
+        );
+    }
+
     /// Second call to fetch_private_libraries reuses the cached map
     /// rather than re-issuing the HTTP request. A session that only
     /// responds correctly once would fail on the second call if caching
@@ -690,9 +758,16 @@ mod tests {
         async fn post(
             &self,
             url: &str,
-            _body: String,
+            body: String,
             _headers: &[(&str, &str)],
         ) -> anyhow::Result<Value> {
+            if body.contains("CheckIndexingState") {
+                return Ok(json!({
+                    "records": [{
+                        "fields": {"state": {"value": "FINISHED"}}
+                    }]
+                }));
+            }
             if url.contains("/private/") {
                 Ok(self.private_response.clone())
             } else if url.contains("/shared/") {

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -251,19 +251,17 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
         .into());
     }
 
-    // Per-record errors: filter out errored records and keep valid ones.
-    // Only return Err if ALL records are errored.
+    // Per-record errors make the whole page unusable. Filtering errored
+    // records out of a mixed page can make enumeration look complete while
+    // silently dropping assets from the snapshot.
     if let Some(records) = response.get("records").and_then(Value::as_array) {
-        // Check if any records have errors before taking the mutable path
         let has_errors = records
             .iter()
             .any(|r| r.get("serverErrorCode").and_then(Value::as_str).is_some());
 
         if has_errors {
-            // Log each errored record and capture the last error
-            let mut last_ck_err = None;
-            let mut permanent_errors = 0usize;
-            let mut retryable_errors = 0usize;
+            let mut first_retryable = None;
+            let mut first_permanent = None;
             for record in records {
                 if let Some(code) = record.get("serverErrorCode").and_then(Value::as_str) {
                     let reason = record
@@ -278,13 +276,7 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                         .iter()
                         .any(|&s| s.eq_ignore_ascii_case(code));
                     let service_not_activated = is_service_not_activated(code, reason);
-                    // Permanent errors (e.g. ACCESS_DENIED on a revoked
-                    // shared asset) silently drop records from the
-                    // enumeration; log at error! so operators can audit
-                    // which assets were skipped and why. Retryable errors
-                    // are a matter of the retry loop and stay at warn!.
                     if retryable {
-                        retryable_errors += 1;
                         tracing::warn!(
                             record_name,
                             error_code = code,
@@ -292,53 +284,37 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                             service_not_activated,
                             "CloudKit per-record error (retryable): {reason}"
                         );
+                        first_retryable.get_or_insert_with(|| CloudKitServerError {
+                            code: code.into(),
+                            reason: reason.into(),
+                            retryable,
+                            service_not_activated,
+                        });
                     } else {
-                        permanent_errors += 1;
                         tracing::error!(
                             record_name,
                             error_code = code,
                             retryable,
                             service_not_activated,
-                            "CloudKit per-record error (permanent, record skipped): {reason}"
+                            "CloudKit per-record error (permanent): {reason}"
                         );
+                        first_permanent.get_or_insert_with(|| CloudKitServerError {
+                            code: code.into(),
+                            reason: reason.into(),
+                            retryable,
+                            service_not_activated,
+                        });
                     }
-                    last_ck_err = Some(CloudKitServerError {
-                        code: code.into(),
-                        reason: reason.into(),
-                        retryable,
-                        service_not_activated,
-                    });
                 }
             }
 
-            // Now mutate in-place: retain only valid records
-            let mut response = response;
-            let total = response
-                .get("records")
-                .and_then(Value::as_array)
-                .map_or(0, Vec::len);
-            if let Some(records) = response.get_mut("records").and_then(Value::as_array_mut) {
-                records.retain(|r| r.get("serverErrorCode").and_then(Value::as_str).is_none());
-                let valid_count = records.len();
-                if valid_count == 0 {
-                    let Some(last_ck_err) = last_ck_err else {
-                        anyhow::bail!(
-                            "CloudKit response contained no valid records, \
-                             but no per-record server error was available"
-                        );
-                    };
-                    return Err(last_ck_err.into());
-                }
-                tracing::warn!(
-                    errored = total - valid_count,
-                    permanent = permanent_errors,
-                    retryable = retryable_errors,
-                    valid = valid_count,
-                    total,
-                    "Filtered errored records from CloudKit response"
-                );
+            if let Some(err) = first_retryable.or(first_permanent) {
+                return Err(err.into());
             }
-            return Ok(response);
+            anyhow::bail!(
+                "CloudKit response contained per-record errors, \
+                 but no per-record server error was available"
+            );
         }
     }
 
@@ -526,17 +502,17 @@ mod tests {
 
     #[test]
     fn test_check_cloudkit_errors_per_record_mixed() {
-        // When some records are valid and some errored, valid ones are kept
         let response = serde_json::json!({
             "records": [
                 {"recordName": "A"},
                 {"serverErrorCode": "RETRY_LATER", "reason": "busy"}
             ]
         });
-        let result = check_cloudkit_errors(response).unwrap();
-        let records = result["records"].as_array().unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0]["recordName"], "A");
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert_eq!(&*ck_err.code, "RETRY_LATER");
+        assert!(ck_err.retryable);
+        assert_eq!(classify_api_error(&err), RetryAction::Retry);
     }
 
     #[test]
@@ -926,8 +902,6 @@ mod tests {
 
     #[test]
     fn test_check_cloudkit_errors_per_record_non_retryable_still_filters() {
-        // When a per-record error is non-retryable (e.g., ZONE_NOT_FOUND),
-        // but there are still valid records, the valid ones should be kept.
         let response = serde_json::json!({
             "records": [
                 {"recordName": "VALID_1"},
@@ -935,11 +909,11 @@ mod tests {
                 {"recordName": "VALID_2"}
             ]
         });
-        let result = check_cloudkit_errors(response).unwrap();
-        let records = result["records"].as_array().unwrap();
-        assert_eq!(records.len(), 2, "two valid records should be preserved");
-        assert_eq!(records[0]["recordName"], "VALID_1");
-        assert_eq!(records[1]["recordName"], "VALID_2");
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert_eq!(&*ck_err.code, "ZONE_NOT_FOUND");
+        assert!(!ck_err.retryable);
+        assert_eq!(classify_api_error(&err), RetryAction::Abort);
     }
 
     // ── Gap: SyncTokenError::should_fallback_to_full classification ──


### PR DESCRIPTION
## Summary
- Fail closed when CloudKit enumeration is incomplete: pagination shortfalls, per-record errors, non-FINISHED indexing, and failed zone discovery now block token advancement instead of returning partial views as usable.
- Track malformed advertised resource fields through asset planning so selected no-task assets count as enumeration errors in full and incremental syncs.
- Reject known media extension magic-byte mismatches before promotion, and report partial credential deletion when one backend fails.

## Tests
- `cargo check`
- `cargo test --lib`
- `cargo test classify_pagination_shortfall`
- `cargo test test_check_cloudkit_errors`
- `cargo test indexing_state`
- `cargo test test_fetch_libraries_fails_on_non_deleted_zone_initialization_failure`
- `cargo test malformed_optional`
- `cargo test null_selected_primary`
- `cargo test validate_rejects_mismatched`
- `cargo test delete_outcome`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
