### PR TITLE
Remove deprecation notice outputs

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,9 +1,7 @@
-# Deprecated
+# Removed compatibility surfaces
 
-Active deprecations scheduled for removal. Each item works and logs a warning until its target version, then it's gone.
-
-See [CHANGELOG.md](CHANGELOG.md) for the release where each item was first marked deprecated.
+There are no active warning windows. Removed flags, commands, env vars, and TOML keys fail during CLI parsing or config validation.
 
 ## v0.20.0
 
-No active v0.20 deprecations remain. The v0.20 cleanup removed the v0.13 compatibility aliases listed in [docs/v0.13-migration.md](docs/v0.13-migration.md).
+The v0.20 cleanup removed the v0.13 compatibility aliases listed in [docs/v0.13-migration.md](docs/v0.13-migration.md).

--- a/docs/v0.13-migration.md
+++ b/docs/v0.13-migration.md
@@ -34,8 +34,6 @@ kei sync --album Vacation --album Family --album '!Drafts' \
          --unfiled false
 ```
 
-kei warns once on startup whenever `--unfiled` is implicit and the album selector isn't `none`, pointing at this exact toggle.
-
 ```sh
 # Separate template for unfiled photos (closes #215)
 kei sync --folder-structure-albums '{album}' --folder-structure '%Y/%m'
@@ -128,7 +126,7 @@ These old keys worked through v0.19 with a warning and were removed in v0.20:
 ## Behavior changes worth knowing
 
 - **`kei sync` with no flags** runs N+1 enumerations (one per album, one unfiled) instead of v0.12's single library-wide pass. With the default `--folder-structure %Y/%m/%d` (no `{album}`), on-disk paths are unchanged. See "What you actually need to do" above for the full breakdown.
-- **`--unfiled` defaults to `true` regardless of `--album`.** `kei sync --album Vacation` runs the Vacation pass *and* the unfiled pass. To restrict to just Vacation, add `--unfiled false`. kei prints a one-line warning at startup whenever `--unfiled` is implicit and the album selector isn't `none`, pointing at the toggle.
+- **`--unfiled` defaults to `true` regardless of `--album`.** `kei sync --album Vacation` runs the Vacation pass *and* the unfiled pass. To restrict to just Vacation, add `--unfiled false`.
 - **`--smart-folder all` skips Hidden + Recently Deleted** (mirroring iOS Photos). Use `--smart-folder all-with-sensitive` for literal everything.
 - **A photo in N albums writes N on-disk copies** (unchanged from v0.12) when the active `--folder-structure-albums` template renders distinct paths per `{album}`. Photos in any album are excluded from the unfiled pass.
 - **Literal names that look like selector tokens** need a leading `=`. Use `--album =all`, `--album =none`, or `--album '=!Drafts'` for albums with those exact names. The same escape works for smart folders and libraries.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,7 +259,7 @@ pub struct FriendlyArgs {
     #[arg(
         long,
         overrides_with = "friendly",
-        long_help = "Force friendly progress messages off (preserves v0.13 scrollback byte-for-byte). \
+        long_help = "Force friendly progress messages off and use the plain tracing output. \
                      Overrides `--friendly`, the TOML `[ui] friendly` setting, and the auto-detected default. \
                      Use this when piping kei output to a log aggregator on an interactive TTY where \
                      auto-detection would otherwise enable friendly mode."

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,26 +611,6 @@ pub(crate) const fn unfiled_default() -> bool {
     true
 }
 
-/// Stderr deprecation warning, scheduled for removal in v0.20.0. `old` is the
-/// `--album none` callers explicitly opted out of album passes and aren't
-/// surprised when the unfiled pass runs alongside; carve them out of the
-/// warning even though `unfiled_override.is_none()`.
-pub(crate) fn should_warn_implicit_unfiled(
-    unfiled_override: Option<bool>,
-    albums: &crate::selection::AlbumSelector,
-) -> bool {
-    unfiled_override.is_none() && !matches!(albums, crate::selection::AlbumSelector::None)
-}
-
-fn warn_implicit_unfiled_pass() {
-    tracing::warn!(
-        "[filters] unfiled defaults to true in v0.13, so kei is also running an unfiled pass \
-         (every photo not in any user album) alongside the album pass(es). Pass \
-         `[filters] unfiled = false` to restrict to just the album pass(es); pass \
-         `[filters] unfiled = true` to silence this warning."
-    );
-}
-
 /// Application configuration.
 ///
 /// Fields are ordered for optimal memory layout:
@@ -1057,7 +1037,7 @@ impl Config {
         // (`kei password set`), password files, and shell-command sources.
         if toml_auth.and_then(|a| a.password.as_ref()).is_some() {
             anyhow::bail!(
-                "config file sets `[auth] password`, which is no longer supported. \
+                "config file sets `[auth] password`, which is not accepted. \
                  Plaintext passwords in config files are a security risk. \
                  Use one of: `kei password set` (OS keyring or encrypted file), \
                  `[auth] password_file`, or `[auth] password_command` instead."
@@ -1272,9 +1252,6 @@ impl Config {
             libraries: library_selector.clone(),
             unfiled: unfiled_override.unwrap_or_else(unfiled_default),
         };
-        if should_warn_implicit_unfiled(unfiled_override, &selection.albums) {
-            warn_implicit_unfiled_pass();
-        }
         let filename_exclude_strs = resolve_vec(
             overrides.filename_exclude,
             toml_filters.and_then(|f| f.filename_exclude.clone()),
@@ -3148,12 +3125,8 @@ mod tests {
             "Error should name the rejected field; got: {err}"
         );
         assert!(
-            err.contains("no longer supported"),
-            "Error should explain removal; got: {err}"
-        );
-        assert!(
             err.contains("kei password set"),
-            "Error should point at the credential-store migration; got: {err}"
+            "Error should point at the credential store; got: {err}"
         );
     }
 
@@ -3183,7 +3156,7 @@ mod tests {
     #[test]
     fn test_build_toml_password_rejected_even_with_cli_password() {
         // A CLI password does NOT rescue a TOML password; the TOML field is
-        // rejected on its own, so users can't silently ignore the deprecation.
+        // rejected on its own.
         let toml_str = r#"
             [auth]
             password = "toml-pw"
@@ -6178,80 +6151,6 @@ mod tests {
         assert!(cfg.filters.selection.unfiled);
     }
 
-    // ── should_warn_implicit_unfiled ────────────────────────────────────
-    //
-    // Pin the predicate that drives the v0.13 implicit-unfiled-pass warning.
-    // Fires whenever the user did not pin `--unfiled` (CLI or TOML) and at
-    // least one album pass is still in scope, so the silent v0.12->v0.13
-    // behavior shift surfaces in the user's terminal.
-
-    fn empty_excludes() -> std::collections::BTreeSet<String> {
-        std::collections::BTreeSet::new()
-    }
-
-    #[test]
-    fn test_should_warn_implicit_unfiled_fires_on_default_all() {
-        // No --unfiled, --album defaults to All. The default no-flag sync
-        // path is the one most users hit, and it now runs an unfiled pass
-        // alongside every album pass: the warning must fire.
-        assert!(should_warn_implicit_unfiled(
-            None,
-            &crate::selection::AlbumSelector::All {
-                excluded: empty_excludes()
-            }
-        ));
-    }
-
-    #[test]
-    fn test_should_warn_implicit_unfiled_fires_on_named_set() {
-        // --album Vacation without --unfiled: the v0.12 user expected
-        // "Vacation only", v0.13 also runs unfiled. Warn.
-        let mut included = std::collections::BTreeSet::new();
-        included.insert("Vacation".to_string());
-        assert!(should_warn_implicit_unfiled(
-            None,
-            &crate::selection::AlbumSelector::Named {
-                included,
-                excluded: empty_excludes()
-            }
-        ));
-    }
-
-    #[test]
-    fn test_should_warn_implicit_unfiled_silent_when_album_none() {
-        // --album none explicitly opts out of album passes; the unfiled
-        // pass running is the user's clear intent, not a surprise.
-        assert!(!should_warn_implicit_unfiled(
-            None,
-            &crate::selection::AlbumSelector::None
-        ));
-    }
-
-    #[test]
-    fn test_should_warn_implicit_unfiled_silent_when_unfiled_explicit_true() {
-        // User explicitly opted in. No surprise to surface.
-        assert!(!should_warn_implicit_unfiled(
-            Some(true),
-            &crate::selection::AlbumSelector::All {
-                excluded: empty_excludes()
-            }
-        ));
-    }
-
-    #[test]
-    fn test_should_warn_implicit_unfiled_silent_when_unfiled_explicit_false() {
-        // User explicitly opted out. No surprise to surface.
-        let mut included = std::collections::BTreeSet::new();
-        included.insert("Vacation".to_string());
-        assert!(!should_warn_implicit_unfiled(
-            Some(false),
-            &crate::selection::AlbumSelector::Named {
-                included,
-                excluded: empty_excludes()
-            }
-        ));
-    }
-
     #[test]
     fn test_folder_structure_albums_default_is_album_token() {
         let cfg = Config::build(
@@ -6625,7 +6524,7 @@ mod tests {
     #[test]
     fn test_to_toml_omits_delay_when_matches_smart_default() {
         // Smart default for per_transfer=3 is 5. to_toml should NOT write
-        // `delay = 5` back out because it's redundant (and deprecated).
+        // `delay = 5` back out because it's redundant.
         let mut sync = default_sync();
         sync.config_overrides.max_retries = Some(3);
         let cfg = Config::build(&default_globals(), &default_password(), sync, None).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,9 +528,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         anyhow::bail!("{msg}");
     }
 
-    // Migrate legacy icloudpd-rs paths before loading config, so the
-    // copied config.toml is found at the new location.
-    let migration_report = migration::migrate_legacy_paths();
+    // Copy legacy icloudpd-rs paths before loading config, so the
+    // copied config.toml is found at the new location. Copy failures are
+    // startup errors; kei doesn't continue against the old paths.
+    migration::migrate_legacy_paths()?;
 
     // Load TOML config early so it can influence log level.
     // If the user explicitly set --config, the file must exist.
@@ -661,13 +662,6 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             .with_env_filter(env_filter)
             .with_writer(make_writer)
             .init();
-    }
-
-    // Log migration warnings now that tracing is initialized.
-    if let Some(report) = &migration_report {
-        for msg in &report.warnings {
-            tracing::warn!(message = %msg, "Config migration warning");
-        }
     }
 
     if used_docker_fallback {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -16,19 +16,11 @@ const NEW_COOKIE_DIR: &str = "~/.config/kei/cookies";
 const OLD_CONFIG_PATH: &str = "~/.config/icloudpd-rs/config.toml";
 const OLD_COOKIE_DIR: &str = "~/.icloudpd-rs";
 
-/// Summary of what was migrated.
-#[derive(Debug, Default)]
-pub(crate) struct MigrationReport {
-    pub warnings: Vec<String>,
-    pub config_migrated: bool,
-    pub cookies_migrated: bool,
-}
-
 /// Check for legacy icloudpd-rs paths and copy data to the new kei locations.
 ///
-/// Called early in `main()`, before config loading. Returns `None` if no
+/// Called early in `main()`, before config loading. Returns `Ok(false)` if no
 /// migration was needed (new paths already exist or no old paths found).
-pub fn migrate_legacy_paths() -> Option<MigrationReport> {
+pub fn migrate_legacy_paths() -> anyhow::Result<bool> {
     let new_config = expand_tilde(NEW_CONFIG_PATH);
     let new_cookie_dir = expand_tilde(NEW_COOKIE_DIR);
     let old_config = expand_tilde(OLD_CONFIG_PATH);
@@ -42,74 +34,32 @@ fn migrate_legacy_paths_from_paths(
     new_cookie_dir: &Path,
     old_config: &Path,
     old_cookie_dir: &Path,
-) -> Option<MigrationReport> {
+) -> anyhow::Result<bool> {
     // If new config already exists, no migration needed.
     if new_config.exists() {
-        return None;
+        return Ok(false);
     }
 
     let has_old_config = old_config.is_file();
     let has_old_cookies = old_cookie_dir.is_dir();
 
     if !has_old_config && !has_old_cookies {
-        return None;
+        return Ok(false);
     }
 
-    let mut report = MigrationReport::default();
+    let mut migrated = false;
 
     // Migrate config file
-    if has_old_config {
-        match migrate_file(old_config, new_config) {
-            Ok(true) => {
-                report.config_migrated = true;
-                report.warnings.push(format!(
-                    "Migrated config from {} to {}",
-                    old_config.display(),
-                    new_config.display()
-                ));
-            }
-            Ok(false) => {} // destination already exists
-            Err(e) => {
-                report.warnings.push(format!(
-                    "Failed to migrate config from {}: {e}. Using old path as fallback.",
-                    old_config.display()
-                ));
-            }
-        }
+    if has_old_config && migrate_file(old_config, new_config)? {
+        migrated = true;
     }
 
     // Migrate cookie/session/state files
     if has_old_cookies {
-        match migrate_directory_contents(old_cookie_dir, new_cookie_dir) {
-            Ok(count) if count > 0 => {
-                report.cookies_migrated = true;
-                report.warnings.push(format!(
-                    "Migrated {count} files from {} to {}",
-                    old_cookie_dir.display(),
-                    new_cookie_dir.display()
-                ));
-            }
-            Ok(_) => {} // nothing to copy or all already existed
-            Err(e) => {
-                report.warnings.push(format!(
-                    "Failed to migrate data from {}: {e}. Using old path as fallback.",
-                    old_cookie_dir.display()
-                ));
-            }
-        }
+        migrated |= migrate_directory_contents(old_cookie_dir, new_cookie_dir)? > 0;
     }
 
-    if !report.config_migrated && !report.cookies_migrated {
-        return None;
-    }
-
-    report.warnings.push(
-        "The old paths will continue to work but are deprecated. \
-         Please update your scripts and config to use ~/.config/kei/."
-            .to_string(),
-    );
-
-    Some(report)
+    Ok(migrated)
 }
 
 /// Copy a single file to a new location, creating parent directories.
@@ -165,7 +115,7 @@ fn migrate_directory_contents(src_dir: &Path, dst_dir: &Path) -> anyhow::Result<
 mod tests {
     use super::*;
 
-    fn migrate_legacy_paths_for_test(home: &Path) -> Option<MigrationReport> {
+    fn migrate_legacy_paths_for_test(home: &Path) -> anyhow::Result<bool> {
         migrate_legacy_paths_from_paths(
             &home.join(".config/kei/config.toml"),
             &home.join(".config/kei/cookies"),
@@ -185,11 +135,7 @@ mod tests {
         std::fs::write(old_cookie_dir.join("old.session"), "session").unwrap();
         std::fs::write(old_cookie_dir.join("old.db"), "db").unwrap();
 
-        let report =
-            migrate_legacy_paths_for_test(tmp.path()).expect("legacy paths should migrate");
-
-        assert!(report.config_migrated);
-        assert!(report.cookies_migrated);
+        assert!(migrate_legacy_paths_for_test(tmp.path()).unwrap());
         assert_eq!(
             std::fs::read_to_string(tmp.path().join(".config/kei/config.toml")).unwrap(),
             "username = \"old@example.com\""
@@ -207,13 +153,6 @@ mod tests {
             old_cookie_dir.exists(),
             "legacy cookie dir must be left in place"
         );
-        assert!(
-            report
-                .warnings
-                .iter()
-                .any(|line| line.contains("deprecated")),
-            "migration report should tell users to move off old paths: {report:?}"
-        );
     }
 
     #[test]
@@ -226,7 +165,7 @@ mod tests {
         std::fs::write(&new_config, "username = \"new@example.com\"").unwrap();
         std::fs::write(&old_config, "username = \"old@example.com\"").unwrap();
 
-        assert!(migrate_legacy_paths_for_test(tmp.path()).is_none());
+        assert!(!migrate_legacy_paths_for_test(tmp.path()).unwrap());
         assert_eq!(
             std::fs::read_to_string(&new_config).unwrap(),
             "username = \"new@example.com\""
@@ -234,14 +173,34 @@ mod tests {
     }
 
     #[test]
-    fn migrate_legacy_paths_returns_none_without_legacy_inputs() {
+    fn migrate_legacy_paths_returns_false_without_legacy_inputs() {
         let tmp = tempfile::tempdir().unwrap();
 
-        assert!(migrate_legacy_paths_for_test(tmp.path()).is_none());
+        assert!(!migrate_legacy_paths_for_test(tmp.path()).unwrap());
         assert!(
             !tmp.path().join(".config/kei").exists(),
             "no legacy inputs should not create new directories"
         );
+    }
+
+    #[test]
+    fn migrate_legacy_paths_errors_when_copy_cannot_complete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_config = tmp.path().join(".config/icloudpd-rs/config.toml");
+        let new_config_parent = tmp.path().join(".config/kei");
+        let new_cookie_dir = tmp.path().join(".config/kei/cookies");
+        let old_cookie_dir = tmp.path().join(".icloudpd-rs");
+        std::fs::create_dir_all(old_config.parent().unwrap()).unwrap();
+        std::fs::write(&old_config, "username = \"old@example.com\"").unwrap();
+        std::fs::write(&new_config_parent, "not a directory").unwrap();
+
+        assert!(migrate_legacy_paths_from_paths(
+            &new_config_parent.join("config.toml"),
+            &new_cookie_dir,
+            &old_config,
+            &old_cookie_dir,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,7 +7,7 @@
 //! # Schema v2
 //!
 //! v2 renames run-option fields to match the v0.20 public CLI and removes
-//! deprecated incremental controls.
+//! old incremental controls.
 
 use std::path::{Path, PathBuf};
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -760,8 +760,8 @@ fn ask_what_to_download(answers: &mut SetupAnswers) -> anyhow::Result<()> {
         }
 
         // Default sourced from runtime so the wizard stays truthful if
-        // `unfiled_default()` ever changes. Always emit explicitly to
-        // silence the runtime's implicit-unfiled warning.
+        // `unfiled_default()` ever changes. Emit explicitly so the generated
+        // config records the user's intended album/unfiled scope.
         if !answers.albums.is_empty() {
             println!();
             let also_unfiled = Confirm::new()
@@ -772,8 +772,8 @@ fn ask_what_to_download(answers: &mut SetupAnswers) -> anyhow::Result<()> {
         }
     } else {
         // scope == 0 ("entire library") -- albums default to `all`. Set
-        // unfiled explicitly so the wizard output silences the implicit-
-        // unfiled warning that would otherwise fire on every sync.
+        // unfiled explicitly so the generated config records the full
+        // library scope.
         answers.unfiled = Some(true);
     }
 
@@ -1534,8 +1534,8 @@ fn generate_toml(answers: &SetupAnswers) -> String {
             None => writeln!(out, "# script = \"/path/to/script.sh\"")?,
         }
 
-        // [server] - HTTP/Prometheus metrics endpoint. Replaces the
-        // deprecated [metrics] section. Hint-only; no wizard prompt.
+        // [server] - HTTP/Prometheus metrics endpoint. Replaces the removed
+        // [metrics] section. Hint-only; no wizard prompt.
         writeln!(out)?;
         writeln!(out, "[server]")?;
         writeln!(out, "# port = 9090")?;
@@ -1662,7 +1662,7 @@ mod tests {
         // Must contain directory uncommented
         assert!(toml.contains("directory = \"~/Photos/iCloud\""));
         // Libraries should be set to ["all"] (v0.13 array form, not the
-        // deprecated singular `library` key).
+        // removed singular `library` key).
         assert!(toml.contains("libraries = [\"all\"]"));
         assert!(!toml.contains("library = \"all\""));
         // Password should NOT be in the TOML
@@ -2182,12 +2182,11 @@ mod tests {
         assert_eq!(albums, vec!["My Album", "Vacation \"2024\""]);
     }
 
-    /// Single source of truth: the wizard must never emit any TOML key that
-    /// `Config::build` would warn about as deprecated. If a future v0.X
-    /// adds another deprecation, add a substring to `DEPRECATED_KEYS` and the
-    /// wizard authors get a CI failure pointing them at the right field.
+    /// Single source of truth: the wizard must never emit any removed TOML key.
+    /// Add future removed keys to `REMOVED_KEYS` so wizard authors get a CI
+    /// failure pointing them at the right field.
     #[test]
-    fn test_wizard_never_emits_deprecated_keys() {
+    fn test_wizard_never_emits_removed_keys() {
         // Cover both "default" answers (most users) and "every option set"
         // answers (everything the wizard can possibly emit).
         let cases: Vec<SetupAnswers> = vec![
@@ -2226,10 +2225,10 @@ mod tests {
             },
         ];
 
-        // Removed/deprecated keys must not appear in wizard output. Match
+        // Removed keys must not appear in wizard output. Match
         // `key = ` (with the equals sign) so we don't false-positive on
         // comment hints or substring matches inside another key.
-        const DEPRECATED_KEYS: &[(&str, &str)] = &[
+        const REMOVED_KEYS: &[(&str, &str)] = &[
             (
                 "cookie_directory =",
                 "[auth].cookie_directory -> top-level data_dir",
@@ -2267,10 +2266,10 @@ mod tests {
                 .filter(|l| !l.trim_start().starts_with('#'))
                 .collect::<Vec<_>>()
                 .join("\n");
-            for (needle, msg) in DEPRECATED_KEYS {
+            for (needle, msg) in REMOVED_KEYS {
                 assert!(
                     !active.contains(needle),
-                    "wizard emitted deprecated key `{needle}` ({msg}); full output:\n{toml_str}"
+                    "wizard emitted removed key `{needle}` ({msg}); full output:\n{toml_str}"
                 );
             }
         }
@@ -2301,9 +2300,7 @@ mod tests {
 
     /// "Specific albums" + the user wants those AND every other photo
     /// (accepted the unfiled prompt) -> wizard emits `unfiled = true`
-    /// explicitly so the runtime's implicit-unfiled warning never fires.
-    /// (That warning's text says "pass `--unfiled true` to silence", so
-    /// always-explicit emission is load-bearing for a clean first sync.)
+    /// explicitly so the generated config records that selection.
     #[test]
     fn test_specific_albums_with_unfiled_enabled_emits_unfiled_true() {
         let answers = SetupAnswers {

--- a/tests/README.md
+++ b/tests/README.md
@@ -144,8 +144,7 @@ happens:
   just `Cli::try_parse_from(...)`.
 - **`behavioral.rs`** - `assert_cmd`-driven end-to-end against the real
   binary with a pre-seeded state DB. Covers everything that doesn't need
-  the network (status flags, reconcile routing, deprecation warnings,
-  config resolution).
+  the network (status flags, reconcile routing, config resolution).
 - **`sync.rs`** - live iCloud, `#[ignore]` gated. Covers the happy-path
   download flow, filters, EXIF/XMP write-through, HEIC embed, sidecars.
 - **`state_auth.rs`** - live iCloud, `#[ignore]` gated. Covers status /

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -1,7 +1,7 @@
 //! Behavioral tests -- exercise real execution paths without credentials.
 //!
 //! These tests run the actual binary and verify outputs, exit codes,
-//! deprecation warnings, config resolution, and error messages.
+//! config resolution, command routing, and error messages.
 //! No network, no iCloud credentials required.
 
 #![allow(
@@ -334,91 +334,6 @@ friendly = false
     assert!(
         json.get("failed_assets").is_none(),
         "clean success report should omit failed_assets: {json}"
-    );
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// Current commands: no deprecation warnings
-// ═══════════════════════════════════════════════════════════════════════
-#[test]
-fn no_deprecation_login() {
-    let out = clean_cmd()
-        .env("ICLOUD_USERNAME", "x@x.com")
-        .env("KEI_DATA_DIR", "/tmp")
-        .args(["login"])
-        .assert()
-        .failure() // fails at auth, not at parsing
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "new command should not print deprecation, stderr: {stderr}"
-    );
-}
-#[test]
-fn no_deprecation_list_albums() {
-    let out = clean_cmd()
-        .args(["list", "albums"])
-        .assert()
-        .failure()
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "new command should not print deprecation, stderr: {stderr}"
-    );
-}
-#[test]
-fn no_deprecation_password_backend() {
-    let dir = tempfile::tempdir().unwrap();
-    let out = clean_cmd()
-        .env("ICLOUD_USERNAME", "test@example.com")
-        .env("KEI_DATA_DIR", dir.path())
-        .args(["password", "backend"])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "new command should not print deprecation, stderr: {stderr}"
-    );
-}
-#[test]
-fn no_deprecation_reset_state() {
-    let dir = tempfile::tempdir().unwrap();
-    let out = clean_cmd()
-        .env("ICLOUD_USERNAME", "test@example.com")
-        .env("KEI_DATA_DIR", dir.path())
-        .args(["reset", "state", "--yes"])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "new command should not print deprecation, stderr: {stderr}"
-    );
-}
-#[test]
-fn no_deprecation_reset_sync_token() {
-    let dir = tempfile::tempdir().unwrap();
-    let out = clean_cmd()
-        .env("ICLOUD_USERNAME", "test@example.com")
-        .env("KEI_DATA_DIR", dir.path())
-        .args(["reset", "sync-token"])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "new command should not print deprecation, stderr: {stderr}"
     );
 }
 
@@ -968,23 +883,6 @@ fn icloud_username_env_resolves_without_cli_flag() {
         .success()
         .stdout(predicate::str::contains("env@icloud.com"));
 }
-#[test]
-fn data_dir_no_deprecation() {
-    let dir = tempfile::tempdir().unwrap();
-    let out = clean_cmd()
-        .env("ICLOUD_USERNAME", "test@example.com")
-        .env("KEI_DATA_DIR", dir.path())
-        .args(["status"])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("deprecated"),
-        "KEI_DATA_DIR should not warn, stderr: {stderr}"
-    );
-}
 
 // ═══════════════════════════════════════════════════════════════════════
 // First-run auto-config
@@ -1079,8 +977,7 @@ fn config_empty_username_in_toml() {
 }
 #[test]
 fn config_toml_password_field_rejected() {
-    // `[auth] password` is no longer accepted, empty or otherwise; kei must
-    // exit with a migration message pointing at the supported alternatives.
+    // `[auth] password` is not accepted, empty or otherwise.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -1094,7 +991,6 @@ fn config_toml_password_field_rejected() {
         .assert()
         .code(1)
         .stderr(predicate::str::contains("`[auth] password`"))
-        .stderr(predicate::str::contains("no longer supported"))
         .stderr(predicate::str::contains("kei password set"));
 }
 
@@ -1105,8 +1001,7 @@ fn config_toml_password_field_rejected() {
 #[test]
 fn config_multiple_password_sources_in_toml() {
     // Both `password_file` and `password_command` set in the same TOML is
-    // still rejected with "pick one" (the `password` variant is rejected
-    // upstream by the stronger deprecation check).
+    // still rejected with "pick one".
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -1334,8 +1229,7 @@ fn config_resolution_default_values() {
         .get_output()
         .clone();
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // Default threads = 10 (new canonical spelling; the `threads_num` TOML
-    // key is deprecated but the serialized default uses the new name).
+    // Default threads = 10 using the canonical TOML spelling.
     assert!(
         stdout.contains("threads = 10"),
         "default threads should be 10, stdout: {stdout}"
@@ -3326,39 +3220,6 @@ fn removed_legacy_album_errors_even_with_user_set_albums_template() {
         "stderr: {stderr}"
     );
 }
-#[test]
-fn migration_no_warning_when_no_album_token() {
-    sync_cmd_for_config_body("folder_structure = \"%Y/%m/%d\"\n")
-        .arg("--only-print-filenames")
-        .assert()
-        .stderr(predicate::str::contains("`{album}` in `--folder-structure`").not());
-}
-
-/// `--smart-folder Favorites` no longer prints the pre-PR6 "not yet wired
-/// into the sync pipeline" disclaimer. The flag executes end-to-end via
-/// `Selection -> resolve_passes -> AlbumPlan`; a stale warning at startup
-/// would mislead users into thinking their config is a no-op.
-#[test]
-fn smart_folder_flag_does_not_print_unwired_warning() {
-    sync_cmd_for_config_body("\n[filters]\nsmart_folders = [\"Favorites\"]\n")
-        .arg("--only-print-filenames")
-        .assert()
-        .stderr(predicate::str::contains("not yet wired").not())
-        .stderr(predicate::str::contains("not download smart folders").not());
-}
-
-/// `--unfiled false` no longer prints the pre-PR6 "not yet wired" disclaimer.
-/// The flag flows into `Selection.unfiled` and gates both the unfiled pass
-/// and the cross-album exclusion-set pre-fetch in `resolve_passes`.
-#[test]
-fn unfiled_flag_does_not_print_unwired_warning() {
-    sync_cmd_for_config_body("\n[filters]\nunfiled = false\n")
-        .arg("--only-print-filenames")
-        .assert()
-        .stderr(predicate::str::contains("not yet wired").not())
-        .stderr(predicate::str::contains("legacy unfiled-pass rules").not());
-}
-
 /// Every per-category selection flag composed in a single
 /// invocation must validate end-to-end through the
 /// `Cli -> Config -> Selection` pipeline. Per-category unit tests in
@@ -3366,7 +3227,7 @@ fn unfiled_flag_does_not_print_unwired_warning() {
 /// wiring (clap field name, config-resolver field name, the
 /// `effective_command()` mapping) can drift independently of the
 /// parsers; a regression there lands green for every per-category
-/// test even when the combined flag set bails or warns at startup.
+/// test even when the combined flag set bails at startup.
 ///
 /// Flags exercised here:
 ///   --album none              → AlbumSelector::None
@@ -3378,7 +3239,7 @@ fn unfiled_flag_does_not_print_unwired_warning() {
 /// available, network unreachable, auth bail) — those are
 /// out-of-scope. What matters is that none of the parser-level bail
 /// strings ("must not be empty", "not supported", "cannot be combined")
-/// or stale "not yet wired" disclaimers reach stderr.
+/// reach stderr.
 #[test]
 fn sync_validation_accepts_full_selection_combo() {
     let out = sync_cmd_for_config_body(
@@ -3389,11 +3250,6 @@ fn sync_validation_accepts_full_selection_combo() {
         .get_output()
         .clone();
     let stderr = String::from_utf8_lossy(&out.stderr);
-    // No stale "not yet wired" disclaimers from the pre-PR6 era.
-    assert!(
-        !stderr.contains("not yet wired"),
-        "selection combo must not surface a 'not yet wired' warning; stderr: {stderr}"
-    );
     // No parser-level bail strings — those would mean the combo got
     // rejected at parse time, which the per-category tests already
     // disprove for each flag in isolation.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -99,7 +99,7 @@ fn sync_help_omits_removed_directory_flag() {
 }
 
 #[test]
-fn sync_help_hides_deprecated_exclude_album_flag() {
+fn sync_help_omits_removed_exclude_album_flag() {
     common::cmd()
         .args(["sync", "--help"])
         .assert()


### PR DESCRIPTION
## Summary
- Removed deprecation notice output paths so retired compatibility surfaces fail instead of warning.
- Dropped tests that asserted deprecation-warning text or absence of deprecation notices.
- Updated docs and help text to stop advertising warning windows that no longer exist.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test migration -- --test-threads=1`
- `cargo test password_rejected -- --test-threads=1`
- `cargo test removed_legacy -- --test-threads=1`
- `cargo test wizard_never_emits_removed_keys -- --test-threads=1`
- `cargo test sync_help_omits_removed_exclude_album_flag -- --test-threads=1`
- `cargo run --quiet -- sync --help | rg -n "Deprecated:|deprecated|deprecation|no longer supported|v0\.13|v0\.20|warning"` - no matches
- `git diff --check`
