### PR TITLE
Handle SIGINT during import-existing

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -19,6 +19,7 @@ use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
 use crate::state::ImportStateStore;
+use crate::systemd::SystemdNotifier;
 use crate::types::FileMatchPolicy;
 
 use super::service::{
@@ -97,11 +98,12 @@ pub(crate) trait StrictImportVerifier {
     ) -> BoxFuture<'a, anyhow::Result<StrictImportDecision>>;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub(crate) struct ImportRunOptions<'a> {
     pub(crate) dry_run: bool,
     pub(crate) show_progress: bool,
     pub(crate) strict_verifier: Option<&'a dyn StrictImportVerifier>,
+    pub(crate) shutdown_token: Option<&'a tokio_util::sync::CancellationToken>,
 }
 
 impl std::fmt::Debug for ImportRunOptions<'_> {
@@ -110,6 +112,7 @@ impl std::fmt::Debug for ImportRunOptions<'_> {
             .field("dry_run", &self.dry_run)
             .field("show_progress", &self.show_progress)
             .field("strict", &self.strict_verifier.is_some())
+            .field("shutdown", &self.shutdown_token.is_some())
             .finish()
     }
 }
@@ -450,7 +453,24 @@ where
         }
     };
 
-    while let Some(result) = stream.next().await {
+    loop {
+        let result = if let Some(shutdown_token) = options.shutdown_token {
+            tokio::select! {
+                () = shutdown_token.cancelled() => {
+                    anyhow::bail!(
+                        "import-existing interrupted by shutdown signal for library '{library_label}'"
+                    );
+                }
+                result = stream.next() => result,
+            }
+        } else {
+            stream.next().await
+        };
+
+        let Some(result) = result else {
+            break;
+        };
+
         // Emit a one-shot marker as soon as the first asset is dequeued so
         // tests (and operators tailing logs) can synchronise on real work
         // having started, rather than racing on a wall-clock sleep against
@@ -706,6 +726,10 @@ pub(crate) async fn run_import_existing(
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
 ) -> anyhow::Result<()> {
+    let shutdown_token = crate::shutdown::install_signal_handler(
+        SystemdNotifier::new(false),
+        crate::personality::Mode::Off,
+    )?;
     let db_path = super::super::get_db_path(globals, toml)?;
     let download_config = build_import_download_config(toml)?;
     let directory = Arc::clone(&download_config.directory);
@@ -850,6 +874,7 @@ pub(crate) async fn run_import_existing(
                     strict_verifier: strict_verifier
                         .as_ref()
                         .map(|v| v as &dyn StrictImportVerifier),
+                    shutdown_token: Some(&shutdown_token),
                 },
             )
             .await?;
@@ -1439,8 +1464,8 @@ mod wiremock_tests {
             &mut dir_cache,
             ImportRunOptions {
                 dry_run,
-                show_progress: false,
                 strict_verifier,
+                ..Default::default()
             },
         )
         .await
@@ -2733,17 +2758,58 @@ mod wiremock_tests {
             &config,
             "test-all",
             &mut dir_cache,
-            ImportRunOptions {
-                dry_run: false,
-                show_progress: false,
-                strict_verifier: None,
-            },
+            ImportRunOptions::default(),
         )
         .await
         .expect("clean exit must be Ok");
         assert_eq!(stats.total, 0);
         assert_eq!(stats.matched, 0);
         assert_eq!(stats.unmatched, 0);
+    }
+
+    /// Cancellation must make `import-existing` leave the scan loop instead
+    /// of relying on default SIGINT process termination. That protects the
+    /// SQLite state DB from being killed mid-write and lets a rerun recover
+    /// from the last committed import rows.
+    #[tokio::test]
+    async fn import_assets_bails_promptly_when_shutdown_token_cancels() {
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+        let db = open_db(&tmp).await;
+
+        let stream = futures_util::stream::pending::<anyhow::Result<PhotoAsset>>();
+        let (_tx, rx) = tokio::sync::oneshot::channel::<bool>();
+        let shutdown_token = tokio_util::sync::CancellationToken::new();
+        shutdown_token.cancel();
+
+        let mut dir_cache = DirCache::new();
+        let err = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            import_assets(
+                stream,
+                rx,
+                db.as_ref(),
+                &config,
+                "test-all",
+                &mut dir_cache,
+                ImportRunOptions {
+                    shutdown_token: Some(&shutdown_token),
+                    ..Default::default()
+                },
+            ),
+        )
+        .await
+        .expect("shutdown cancellation must not hang")
+        .expect_err("shutdown cancellation must abort the scan");
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("import-existing interrupted by shutdown signal")
+                && msg.contains("test-all"),
+            "error message must name the shutdown and library label, got: {msg}",
+        );
     }
 
     /// Fetcher panic: the panic_rx delivers `true`. import_assets must
@@ -2769,11 +2835,7 @@ mod wiremock_tests {
             &config,
             "test-all",
             &mut dir_cache,
-            ImportRunOptions {
-                dry_run: false,
-                show_progress: false,
-                strict_verifier: None,
-            },
+            ImportRunOptions::default(),
         )
         .await
         .expect_err("must bail on fetcher panic");
@@ -2852,8 +2914,7 @@ mod wiremock_tests {
             &mut dir_cache,
             ImportRunOptions {
                 dry_run: true,
-                show_progress: false,
-                strict_verifier: None,
+                ..Default::default()
             },
         )
         .await
@@ -2984,8 +3045,7 @@ mod wiremock_tests {
             &mut dir_cache,
             ImportRunOptions {
                 dry_run: true,
-                show_progress: false,
-                strict_verifier: None,
+                ..Default::default()
             },
         )
         .await
@@ -3025,8 +3085,7 @@ mod wiremock_tests {
             &mut dir_cache,
             ImportRunOptions {
                 dry_run: true,
-                show_progress: false,
-                strict_verifier: None,
+                ..Default::default()
             },
         )
         .await

--- a/src/commands/import/wiremock_tests/icloudpd_compat.rs
+++ b/src/commands/import/wiremock_tests/icloudpd_compat.rs
@@ -775,11 +775,7 @@ async fn kei_uses_fingerprint_filename_when_filename_missing() {
         &config,
         "test-all",
         &mut dir_cache,
-        ImportRunOptions {
-            dry_run: false,
-            show_progress: false,
-            strict_verifier: None,
-        },
+        ImportRunOptions::default(),
     )
     .await
     .expect("import_assets ok");

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4976,7 +4976,7 @@ mod tests {
                 .item_type("public.jpeg")
                 .orig_file_type("public.jpeg")
                 .orig_size(1234)
-                .orig_url("http://127.0.0.1:1/stuck.jpg")
+                .orig_url("https://p01.icloud-content.com/stuck.jpg")
                 .orig_checksum("ck_stuck")
                 .build()
                 .with_source_zone(Arc::from("SharedSync-abc"))
@@ -5000,17 +5000,14 @@ mod tests {
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 
-        // Pre-create the on-disk file at the path the producer will
-        // compute so `filter_asset_to_tasks` returns no tasks. Reuses
-        // `local_download_path` to stay tz-independent.
+        // Pre-create the on-disk file at the path the producer will compute
+        // so `filter_asset_to_tasks` returns no tasks.
         let asset = carryover_asset();
-        let target_path = crate::download::paths::local_download_path(
-            &config.directory,
-            &config.folder_structure,
-            &asset.created().with_timezone(&chrono::Local),
-            "stuck.jpg",
-            None,
-        );
+        let target_path = crate::download::filter::expected_paths_for(&asset, &config)
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
         if let Some(parent) = target_path.parent() {
             fs::create_dir_all(parent).unwrap();
         }


### PR DESCRIPTION
## Summary
- Handle SIGINT in `import-existing` through kei's shutdown token.
- Abort the import scan cleanly on shutdown so restart sees the last committed DB state.
- Add focused coverage for import scan cancellation and align the no-default pending-skip fixture with current URL/path validation.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test commands::import::tests::import_assets_bails_promptly_when_shutdown_token_cancels --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-default-features download::pipeline::tests::producer_flushes_touched_ids_so_pending_on_disk_skip_promotes -- --exact`
- `cargo test --no-default-features --lib`
- `cargo test --test import_existing_live import_sigint_then_rerun_is_idempotent -- --ignored --exact --test-threads=1`
