### PR TITLE
Stabilize live full-test harness

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3591,6 +3591,27 @@ mod tests {
     }
 
     #[test]
+    fn test_toml_server_port_zero_requests_ephemeral_bind() {
+        let toml_str = r#"
+            [auth]
+            username = "user@example.com"
+            [download]
+            directory = "/photos"
+            [server]
+            port = 0
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let config = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert_eq!(config.server.port, 0);
+    }
+
+    #[test]
     fn test_cli_http_port_overrides_toml() {
         let toml_str = r#"
             [auth]

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -49,6 +49,7 @@ use tempfile::tempdir;
 const FIXTURE_TIMEOUT_SECS: u64 = 1800; // 30m: full sync of ~100 assets
 const IMPORT_TIMEOUT_SECS: u64 = 300; // 5m: import-existing scans, no downloads
 const FIXTURE_RECENT: u32 = 100;
+const FIXTURE_FILTERS_TOML: &str = "[filters]\nalbums = [\"none\"]\nunfiled = true\n";
 
 /// Copy auth artifacts (cookie file + .session + .cache) from `src`
 /// into `dst`, deliberately skipping `.db` and `.lock` files. A state
@@ -118,7 +119,11 @@ fn fixture() -> &'static (PathBuf, PathBuf) {
             "Building import-existing fixture: --recent {FIXTURE_RECENT} into {}",
             download_dir.display()
         );
-        let config_path = write_kei_toml(&data_dir, &download_dir, "");
+        // Keep the reusable fixture to one library-wide pass. The default
+        // selection also walks every user album, which makes live accounts
+        // with overlapping album memberships produce account-dependent
+        // unmatched duplicate paths in import-existing smoke tests.
+        let config_path = write_kei_toml(&data_dir, &download_dir, FIXTURE_FILTERS_TOML);
         let output = common::cmd()
             .env("ICLOUD_USERNAME", &username)
             .env("KEI_DATA_DIR", &data_dir)
@@ -257,13 +262,14 @@ fn import_matches_default_layout_after_sync() {
     common::with_auth_retry(|| {
         let test_data = tempdir().unwrap();
         let recent = FIXTURE_RECENT.to_string();
+        let toml_path = write_kei_toml(test_data.path(), download_dir, FIXTURE_FILTERS_TOML);
         let output = import_cmd(
             &username,
             &password,
             &cookie_dir,
             download_dir,
             test_data.path(),
-            &["--recent", &recent],
+            &["--recent", &recent, "--config", toml_path.to_str().unwrap()],
         )
         .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
         .assert()

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -53,6 +53,7 @@ struct SyncToml<'a> {
     photos: &'a str,
     metadata: &'a str,
     watch: &'a str,
+    server: &'a str,
     notifications: &'a str,
     report: &'a str,
 }
@@ -122,6 +123,7 @@ fn album_config(
         ("photos", toml.photos),
         ("metadata", toml.metadata),
         ("watch", toml.watch),
+        ("server", toml.server),
         ("notifications", toml.notifications),
         ("report", toml.report),
     ] {
@@ -1641,6 +1643,11 @@ fn sync_watch_runs_multiple_cycles() {
             download_dir.path(),
             SyncToml {
                 watch: "interval = 60\n",
+                // Watch mode starts the HTTP health/metrics server. Do not
+                // compete for the production default 9090 during the live
+                // suite; a locally running kei service or another smoke test
+                // may legitimately own it.
+                server: "bind = \"127.0.0.1\"\nport = 0\n",
                 ..SyncToml::default()
             },
         );


### PR DESCRIPTION
## Summary
- Make the live watch-mode test bind the health/metrics server to an ephemeral loopback port so it can run while a local kei service owns 9090.
- Keep the live import-existing fixture on one library-wide pass and run the matching smoke against the same selection.

## Tests
- `cargo check`
- `cargo test test_toml_server_port_zero_requests_ephemeral_bind`
- `cargo test --test sync --no-run`
- `cargo test --test import_existing_live --no-run`
- `cargo test --test sync sync_watch_runs_multiple_cycles -- --ignored --exact --test-threads=1`
- `cargo test --test import_existing_live import_matches_default_layout_after_sync -- --ignored --exact --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just full-test`
