### PR TITLE
Improve test review coverage

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1418,6 +1418,40 @@ mod wiremock_tests {
         std::fs::write(path, bytes).expect("write file");
     }
 
+    #[cfg(unix)]
+    fn set_mtime_for_test(path: &StdPath, secs: i64) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let times = [
+            libc::timespec {
+                tv_sec: secs,
+                tv_nsec: 0,
+            },
+            libc::timespec {
+                tv_sec: secs,
+                tv_nsec: 0,
+            },
+        ];
+        // SAFETY: `c_path` is a valid, NUL-terminated copy of `path`, and
+        // `times` points to two initialized timespec values for the duration
+        // of the call.
+        let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+        assert_eq!(rc, 0, "set mtime for {}", path.display());
+    }
+
+    #[cfg(not(unix))]
+    fn set_mtime_for_test(path: &StdPath, _secs: i64) {
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open for mtime bump");
+        f.set_len(f.metadata().expect("metadata").len())
+            .expect("set_len same size");
+    }
+
     /// Stage every file `expected_paths_for` would emit for `asset` so
     /// they all match. Returns the list of staged paths.
     fn stage_expected(asset: &PhotoAsset, config: &DownloadConfig) -> Vec<std::path::PathBuf> {
@@ -3175,17 +3209,11 @@ mod wiremock_tests {
         )
         .await;
 
-        // Bump mtime on every staged file. Keep size identical (to stay
-        // matched) and touch the file to force a fresh mtime. The 1.1s
-        // sleep covers filesystems with second-granularity mtime.
-        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // Bump mtime on every staged file without relying on wall-clock
+        // sleeps. Keep size identical so the path still matches and only
+        // the rehash guard changes.
         for path in &staged {
-            let f = std::fs::OpenOptions::new()
-                .write(true)
-                .open(path)
-                .expect("open for mtime bump");
-            f.set_len(2048).expect("set_len same size");
-            drop(f);
+            set_mtime_for_test(path, 1_800_000_000);
         }
 
         // See sibling test for why reset() is necessary between passes.

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -460,12 +460,19 @@ mod tests {
 
     #[test]
     fn delete_outcome_file_only_success_when_keyring_missing() {
-        let result = finish_delete(
+        finish_delete(
             "user@example.com",
             DeleteOutcome::NotFound,
             DeleteOutcome::Deleted,
-        );
-        assert!(result.is_ok());
+        )
+        .expect("encrypted-file deletion must succeed when keyring entry is absent");
+
+        finish_delete(
+            "user@example.com",
+            DeleteOutcome::Deleted,
+            DeleteOutcome::NotFound,
+        )
+        .expect("keyring deletion must succeed when encrypted-file entry is absent");
     }
 
     #[test]
@@ -562,6 +569,28 @@ mod tests {
         assert!(
             err.to_string().contains("decrypt"),
             "Expected decryption error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn encrypted_file_rejects_valid_decrypt_invalid_utf8() {
+        let (_td, dir) = test_dir("invalid_utf8");
+        let store = CredentialStore::new("user@example.com", &dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let key_bytes = store.load_or_create_key().unwrap();
+        let cipher = Aes256Gcm::new_from_slice(&key_bytes).unwrap();
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = cipher.encrypt(&nonce, [0xff, 0xfe].as_slice()).unwrap();
+        let mut data = Vec::with_capacity(12 + ciphertext.len());
+        data.extend_from_slice(&nonce);
+        data.extend_from_slice(&ciphertext);
+        atomic_write_sync(&store.credential_file_path(), &data).unwrap();
+
+        let err = store.file_retrieve().unwrap_err();
+        assert!(
+            err.to_string().contains("valid UTF-8"),
+            "invalid UTF-8 plaintext must be rejected loudly, got: {err}"
         );
     }
 

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -3395,23 +3395,4 @@ mod tests {
         );
         assert!(!err.is_retryable(), "404 should not be retryable");
     }
-
-    /// When the downloaded SHA-256 does not match the API-provided checksum,
-    /// the caller must detect the mismatch. This verifies that two different
-    /// byte sequences produce different SHA-256 hashes, which is the
-    /// foundation of the checksum-verification safety net.
-    #[test]
-    fn checksum_mismatch_detectable_different_bytes_produce_different_hashes() {
-        let a = compute_sha256_of_bytes(b"correct photo bytes");
-        let b = compute_sha256_of_bytes(b"corrupted photo bytes");
-        assert_ne!(a, b, "different content must produce different SHA-256");
-        assert_eq!(a.len(), 44, "base64-encoded SHA-256 is 44 chars");
-    }
-
-    fn compute_sha256_of_bytes(data: &[u8]) -> String {
-        use base64::Engine;
-        use sha2::{Digest, Sha256};
-        let hash = Sha256::digest(data);
-        base64::engine::general_purpose::STANDARD.encode(hash)
-    }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2901,11 +2901,10 @@ async fn download_photos_incremental(
 mod tests {
     use super::*;
     use crate::commands::{AlbumPass, PassKind};
-    use crate::icloud::photos::asset::ChangeEvent;
     use crate::icloud::photos::{PhotoAlbum, PhotoAlbumConfig, PhotosSession};
     use crate::test_helpers::{
         mock_photo_records_for_zone_with_filename, DynamicRecentPhotosSession, MockPhotosFlow,
-        TestPhotoAsset,
+        TestAssetRecord,
     };
     use serde_json::{json, Value};
     use std::collections::HashMap;
@@ -3614,88 +3613,89 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_change_event_asset_extraction() {
-        // Verify that events with None assets are filtered out
-        let event_with_asset = ChangeEvent {
-            record_name: "REC_1".into(),
-            record_type: Some("CPLAsset".into()),
-            reason: ChangeReason::Created,
-            asset: Some(TestPhotoAsset::new("TEST_1").build()),
-        };
-        let event_without_asset = ChangeEvent {
-            record_name: "REC_2".into(),
-            record_type: Some("CPLAsset".into()),
-            reason: ChangeReason::Created,
-            asset: None,
-        };
-
-        let events = vec![event_with_asset, event_without_asset];
-        let downloadable: Vec<_> = events
-            .into_iter()
-            .filter(|e| matches!(e.reason, ChangeReason::Created))
-            .filter_map(|e| e.asset)
-            .collect();
-
-        assert_eq!(downloadable.len(), 1);
-        assert_eq!(downloadable[0].id(), "TEST_1");
+    fn hard_deleted_change_record(record_name: &str) -> Value {
+        json!({
+            "recordName": record_name,
+            "recordType": null,
+            "fields": {},
+            "deleted": true,
+        })
     }
 
-    #[test]
-    fn test_incremental_filters_skip_deletions() {
-        let events = vec![
-            ChangeEvent {
-                record_name: "REC_1".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::Created,
-                asset: Some(TestPhotoAsset::new("TEST_1").build()),
-            },
-            ChangeEvent {
-                record_name: "REC_2".into(),
-                record_type: None,
-                reason: ChangeReason::HardDeleted,
-                asset: None,
-            },
-            ChangeEvent {
-                record_name: "REC_3".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::SoftDeleted,
-                asset: None,
-            },
-            ChangeEvent {
-                record_name: "REC_4".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::Hidden,
-                asset: None,
-            },
-        ];
-
-        let downloadable: Vec<_> = events
-            .into_iter()
-            .filter(|e| matches!(e.reason, ChangeReason::Created))
-            .filter_map(|e| e.asset)
-            .collect();
-
-        assert_eq!(downloadable.len(), 1);
-        assert_eq!(downloadable[0].id(), "TEST_1");
+    fn flagged_incremental_records(record_name: &str, flag: (&str, i64)) -> Vec<Value> {
+        let mut records = incremental_photo_records(record_name);
+        records[0]["fields"][flag.0] = json!({"value": flag.1, "type": "INT64"});
+        records
     }
 
-    #[test]
-    fn test_incremental_modified_events_are_downloadable() {
-        let events = vec![ChangeEvent {
-            record_name: "MOD_1".into(),
-            record_type: Some("CPLAsset".into()),
-            reason: ChangeReason::Created,
-            asset: Some(TestPhotoAsset::new("TEST_1").build()),
+    fn assert_source_flags(
+        records: &[crate::state::AssetRecord],
+        asset_id: &str,
+        expected_deleted: bool,
+        expected_hidden: bool,
+    ) {
+        let record = records
+            .iter()
+            .find(|record| record.id.as_ref() == asset_id)
+            .unwrap_or_else(|| panic!("missing state row for {asset_id}"));
+        assert_eq!(
+            record.metadata.is_deleted, expected_deleted,
+            "is_deleted mismatch for {asset_id}"
+        );
+        assert_eq!(
+            record.metadata.is_hidden, expected_hidden,
+            "is_hidden mismatch for {asset_id}"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_incremental_delete_and_hidden_events_mark_state_without_downloads() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        for id in ["SOFT_DELETE", "HARD_DELETE", "HIDDEN_ASSET"] {
+            db.upsert_seen(&TestAssetRecord::new(id).build())
+                .await
+                .unwrap();
+        }
+
+        let mut records = Vec::new();
+        records.extend(flagged_incremental_records("SOFT_DELETE", ("isDeleted", 1)));
+        records.push(hard_deleted_change_record("HARD_DELETE"));
+        records.extend(flagged_incremental_records("HIDDEN_ASSET", ("isHidden", 1)));
+        records.extend(incremental_photo_records("CREATED_ASSET"));
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(records, "zone-token-after", false)
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Library", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
         }];
 
-        let downloadable: Vec<_> = events
-            .into_iter()
-            .filter(|e| matches!(e.reason, ChangeReason::Created))
-            .filter_map(|e| e.asset)
-            .collect();
+        let mut config = test_config();
+        let dir = TempDir::new().unwrap();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
 
-        assert_eq!(downloadable.len(), 1);
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-before",
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.sync_token, None,
+            "print-only incremental runs must not advance the sync token"
+        );
+        let pending = db.get_pending().await.unwrap();
+        assert_source_flags(&pending, "SOFT_DELETE", true, false);
+        assert_source_flags(&pending, "HARD_DELETE", true, false);
+        assert_source_flags(&pending, "HIDDEN_ASSET", false, true);
     }
 
     // ── NormalizedPath additional tests ──────────────────────────────────
@@ -4192,72 +4192,6 @@ mod tests {
             !ctx.has_downloaded_without_metadata_hash(),
             "matching downloaded and metadata-hash sets should avoid the extra SQLite scan"
         );
-    }
-
-    // ── Change event classification tests ───────────────────────────────
-
-    #[test]
-    fn test_change_event_filtering_counts_and_extraction() {
-        // Simulate the inline filtering loop from download_photos_incremental
-        let events = vec![
-            ChangeEvent {
-                record_name: "A".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::Created,
-                asset: Some(TestPhotoAsset::new("TEST_1").build()),
-            },
-            ChangeEvent {
-                record_name: "B".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::Created,
-                asset: None, // Unpaired record
-            },
-            ChangeEvent {
-                record_name: "C".into(),
-                record_type: None,
-                reason: ChangeReason::HardDeleted,
-                asset: None,
-            },
-            ChangeEvent {
-                record_name: "D".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::SoftDeleted,
-                asset: None,
-            },
-            ChangeEvent {
-                record_name: "E".into(),
-                record_type: Some("CPLAsset".into()),
-                reason: ChangeReason::Hidden,
-                asset: None,
-            },
-        ];
-
-        let mut created_count = 0u32;
-        let mut soft_deleted_count = 0u32;
-        let mut hard_deleted_count = 0u32;
-        let mut hidden_count = 0u32;
-        let mut downloadable_assets = Vec::new();
-
-        for event in events {
-            match event.reason {
-                ChangeReason::Created => {
-                    created_count += 1;
-                    if let Some(asset) = event.asset {
-                        downloadable_assets.push(asset);
-                    }
-                }
-                ChangeReason::SoftDeleted => soft_deleted_count += 1,
-                ChangeReason::HardDeleted => hard_deleted_count += 1,
-                ChangeReason::Hidden => hidden_count += 1,
-            }
-        }
-
-        assert_eq!(created_count, 2);
-        assert_eq!(soft_deleted_count, 1);
-        assert_eq!(hard_deleted_count, 1);
-        assert_eq!(hidden_count, 1);
-        assert_eq!(downloadable_assets.len(), 1);
-        assert_eq!(downloadable_assets[0].id(), "TEST_1");
     }
 
     // ── Gap coverage: empty versions, path traversal, empty filename ───

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4530,6 +4530,14 @@ mod tests {
             db.call_count() > STATE_DB_UNWRITABLE_THRESHOLD,
             "deferred writes must be retried before opening the circuit"
         );
+        for i in 0..STATE_DB_UNWRITABLE_THRESHOLD {
+            let landed = dir.path().join(format!("photo_{i}.jpg"));
+            assert!(
+                landed.exists(),
+                "state write failures must not remove an already-published file: {}",
+                landed.display()
+            );
+        }
     }
 
     /// T-11: When the API returns the same asset ID on two different pages,
@@ -4566,9 +4574,8 @@ mod tests {
         assert_eq!(seen_ids.len(), 2, "only 2 unique IDs should be tracked");
     }
 
-    /// When a CancellationToken fires during a download pass with
-    /// concurrent tasks, the function must return promptly (well within the
-    /// Docker stop_grace_period) rather than blocking on the remaining stream.
+    /// When a CancellationToken is already cancelled as the next asset is
+    /// yielded, the pass must stop before planning or downloading that asset.
     #[tokio::test]
     async fn shutdown_cancellation_exits_download_pass_promptly() {
         use crate::download::{DownloadConfig, SyncMode};
@@ -4576,20 +4583,16 @@ mod tests {
         use crate::types::{
             AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, RawPolicy,
         };
-        use futures_util::stream;
         use rustc_hash::FxHashSet;
-        use std::time::Instant;
 
-        // Build a slow infinite stream of photo assets — yields one every 50ms.
-        // Without cancellation this would run forever.
-        let asset_stream = stream::unfold(0u32, |i| async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            let asset = TestPhotoAsset::new(&format!("SHUTDOWN_{i}"))
-                .orig_size(100)
-                .orig_url("http://127.0.0.1:1/photo.jpg")
-                .orig_checksum(&format!("ck_{i}"))
-                .build();
-            Some((Ok(asset) as anyhow::Result<PhotoAsset>, i + 1))
+        let asset_stream = futures_util::stream::repeat_with(|| {
+            Ok::<PhotoAsset, anyhow::Error>(
+                TestPhotoAsset::new("SHUTDOWN_ALREADY_CANCELLED")
+                    .orig_size(100)
+                    .orig_url("http://127.0.0.1:1/photo.jpg")
+                    .orig_checksum("ck_shutdown")
+                    .build(),
+            )
         });
 
         let dir = TempDir::new().unwrap();
@@ -4648,13 +4651,8 @@ mod tests {
             .expect("client");
 
         let shutdown_token = CancellationToken::new();
-        let token_clone = shutdown_token.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(300)).await;
-            token_clone.cancel();
-        });
+        shutdown_token.cancel();
 
-        let start = Instant::now();
         let result = stream_and_download_from_stream(
             &client,
             asset_stream,
@@ -4664,16 +4662,13 @@ mod tests {
             shutdown_token,
             StreamRuntime::new(None, None),
         )
-        .await;
-        let elapsed = start.elapsed();
+        .await
+        .expect("cancelled pass should return a streaming result");
 
+        assert_eq!(result.downloaded, 0, "cancelled pass must not download");
         assert!(
-            result.is_ok(),
-            "should return Ok after cancellation, got: {result:?}"
-        );
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "should exit promptly after cancellation, took {elapsed:?}"
+            !result.enumeration_complete,
+            "cancelled enumeration must not be considered complete"
         );
     }
 

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -440,14 +440,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_shared_session_implements_photos_session() {
-        // Verify that SharedSession can be used as a PhotosSession trait object
-        let dir = std::env::temp_dir()
-            .join("claude")
-            .join("shared_session_test");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let session = crate::auth::session::Session::new(
-            &dir,
+            dir.path(),
             "test@shared.com",
             "https://example.com",
             None,
@@ -459,10 +454,25 @@ mod tests {
 
         // Verify it can be boxed as a PhotosSession
         let boxed: Box<dyn PhotosSession> = Box::new(shared.clone());
+        assert_eq!(
+            std::sync::Arc::strong_count(&shared),
+            2,
+            "boxing SharedSession as PhotosSession must retain the same shared session"
+        );
         let _cloned = boxed.clone_box();
+        assert_eq!(
+            std::sync::Arc::strong_count(&shared),
+            3,
+            "clone_box must clone the underlying SharedSession"
+        );
 
         // Verify clone_box produces a valid trait object
         let _cloned2 = _cloned.clone_box();
+        assert_eq!(
+            std::sync::Arc::strong_count(&shared),
+            4,
+            "cloned trait object must remain cloneable"
+        );
     }
 
     #[test]

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -380,26 +380,16 @@ mod tests {
         );
         let script_path = write_test_script(dir.path(), "test_notify.sh", body.as_bytes());
 
-        let notifier = Notifier::new(Some(script_path.clone()));
-        notifier.notify(
-            Event::TwoFaRequired,
+        let status = run_script(
+            &script_path,
+            Event::TwoFaRequired.as_str(),
             "Need 2FA code",
             "test@example.com",
             None,
-        );
-
-        // Wait for the spawned background task to complete (poll instead of fixed sleep)
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if output_path.exists() {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "notification script did not produce output within timeout"
-            );
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        )
+        .await
+        .expect("run notification script");
+        assert!(status.success());
 
         let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "2fa_required|Need 2FA code|test@example.com");
@@ -425,20 +415,16 @@ mod tests {
             ..SyncNotificationData::default()
         };
 
-        let notifier = Notifier::new(Some(script_path));
-        notifier.notify(Event::SyncComplete, "test", "user@example.com", Some(&data));
-
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if output_path.exists() {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "notification script did not produce output"
-            );
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        let status = run_script(
+            &script_path,
+            Event::SyncComplete.as_str(),
+            "test",
+            "user@example.com",
+            Some(&data),
+        )
+        .await
+        .expect("run notification script with sync data");
+        assert!(status.success());
 
         let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "42|3|100|1500000|80");
@@ -649,20 +635,16 @@ mod tests {
         );
         let script_path = write_test_script(dir.path(), "test_no_data.sh", body.as_bytes());
 
-        let notifier = Notifier::new(Some(script_path));
-        notifier.notify(Event::SyncComplete, "test", "user@example.com", None);
-
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if output_path.exists() {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "notification script did not produce output"
-            );
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        let status = run_script(
+            &script_path,
+            Event::SyncComplete.as_str(),
+            "test",
+            "user@example.com",
+            None,
+        )
+        .await
+        .expect("run notification script without sync data");
+        assert!(status.success());
 
         let output = read_script_output(&output_path);
         assert_eq!(output.trim(), "unset|unset");

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -3194,6 +3194,103 @@ mod tests {
         )));
     }
 
+    #[tokio::test]
+    async fn concurrent_asset_writers_preserve_library_id_version_pk() {
+        let dir = test_dir();
+        let db_path = dir.path().join("concurrent-writers.db");
+        let db = std::sync::Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+        let media_dir = dir.path().join("photos");
+        std::fs::create_dir_all(&media_dir).unwrap();
+
+        let cases = [
+            (
+                "PrimarySync",
+                "ASSET_PK",
+                VersionSizeKey::Original,
+                "ck_orig",
+            ),
+            ("PrimarySync", "ASSET_PK", VersionSizeKey::Medium, "ck_med"),
+            (
+                "SharedSync-A1B2C3D4",
+                "ASSET_PK",
+                VersionSizeKey::Original,
+                "ck_shared",
+            ),
+        ];
+        let mut handles = Vec::new();
+        for (library, id, version_size, checksum) in cases {
+            let db = std::sync::Arc::clone(&db);
+            let path = media_dir.join(format!("{}_{}_{}.jpg", library, id, version_size.as_str()));
+            handles.push(tokio::spawn(async move {
+                std::fs::write(&path, b"image-bytes").unwrap();
+                let record = TestAssetRecord::new(id)
+                    .library(library)
+                    .version_size(version_size)
+                    .checksum(checksum)
+                    .build();
+                db.upsert_seen(&record).await.unwrap();
+                db.mark_downloaded(
+                    library,
+                    id,
+                    version_size.as_str(),
+                    &path,
+                    checksum,
+                    Some(checksum),
+                )
+                .await
+                .unwrap();
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        let conn = db.acquire_lock("verify concurrent writer rows").unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT library, id, version_size, status FROM assets \
+                 WHERE id = 'ASSET_PK' ORDER BY library, version_size",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "PrimarySync".to_string(),
+                    "ASSET_PK".to_string(),
+                    "medium".to_string(),
+                    "downloaded".to_string()
+                ),
+                (
+                    "PrimarySync".to_string(),
+                    "ASSET_PK".to_string(),
+                    "original".to_string(),
+                    "downloaded".to_string()
+                ),
+                (
+                    "SharedSync-A1B2C3D4".to_string(),
+                    "ASSET_PK".to_string(),
+                    "original".to_string(),
+                    "downloaded".to_string()
+                ),
+            ],
+            "concurrent writers must preserve every library/id/version row"
+        );
+    }
+
     /// `mark_failed` must scope to one zone; the other zone's row for
     /// the same (id, version_size) keeps its prior status.
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -5102,15 +5102,21 @@ mod tests {
         );
     }
 
-    /// An empty remote library (zero assets) must exit cleanly with
-    /// exit code 0 and a summary showing zero synced — not treated as
-    /// an error or incomplete response.
+    /// An empty local state must keep all summary and pending views
+    /// internally consistent. This pins the read side that user-facing
+    /// status/verify commands rely on before any remote assets have been
+    /// observed.
     #[tokio::test]
-    async fn empty_remote_library_summary_shows_zero_synced() {
+    async fn empty_state_summary_has_no_pending_or_downloaded_rows() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
         let summary = db.get_summary().await.unwrap();
-        // Fresh in-memory DB starts empty
         assert_eq!(summary.total_assets, 0, "empty DB must have zero assets");
         assert_eq!(summary.downloaded, 0, "empty DB must have zero downloaded");
+        assert_eq!(summary.pending, 0, "empty DB must have zero pending");
+        assert_eq!(summary.failed, 0, "empty DB must have zero failed");
+        assert!(
+            db.get_pending().await.unwrap().is_empty(),
+            "fresh state must not surface phantom pending work"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replaced weak incremental-change filtering tests with a production-path state assertion.
- Added coverage for invalid UTF-8 credential plaintext and concurrent state writers.
- Removed a dead checksum helper test and made timing-sensitive tests more deterministic.

## Tests
- `cargo test --lib`
- `cargo test`
- `cargo test -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
