### PR TITLE
Harden test-review phase 2 test quality coverage

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -460,19 +460,23 @@ mod tests {
 
     #[test]
     fn delete_outcome_file_only_success_when_keyring_missing() {
-        finish_delete(
-            "user@example.com",
-            DeleteOutcome::NotFound,
-            DeleteOutcome::Deleted,
-        )
-        .expect("encrypted-file deletion must succeed when keyring entry is absent");
+        let cases = [
+            (
+                "only encrypted-file deleted",
+                DeleteOutcome::NotFound,
+                DeleteOutcome::Deleted,
+            ),
+            (
+                "only keyring deleted",
+                DeleteOutcome::Deleted,
+                DeleteOutcome::NotFound,
+            ),
+        ];
 
-        finish_delete(
-            "user@example.com",
-            DeleteOutcome::Deleted,
-            DeleteOutcome::NotFound,
-        )
-        .expect("keyring deletion must succeed when encrypted-file entry is absent");
+        for (label, keyring, file) in cases {
+            finish_delete("user@example.com", keyring, file)
+                .unwrap_or_else(|err| panic!("{label} must be treated as success: {err}"));
+        }
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3586,33 +3586,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_change_event_filtering_downloadable_reasons() {
-        // Verify that the filtering logic in download_photos_incremental
-        // correctly identifies which ChangeReasons are downloadable
-        let downloadable = [ChangeReason::Created];
-        let skippable = [
-            ChangeReason::SoftDeleted,
-            ChangeReason::HardDeleted,
-            ChangeReason::Hidden,
-        ];
-
-        for reason in &downloadable {
-            assert!(
-                matches!(reason, ChangeReason::Created),
-                "{:?} should be downloadable",
-                reason
-            );
-        }
-        for reason in &skippable {
-            assert!(
-                !matches!(reason, ChangeReason::Created),
-                "{:?} should be skippable",
-                reason
-            );
-        }
-    }
-
     fn hard_deleted_change_record(record_name: &str) -> Value {
         json!({
             "recordName": record_name,

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -521,30 +521,27 @@ mod tests {
             notifier.notify(Event::SyncStarted, "msg", "user@example.com", None);
         }
 
-        let mut max_concurrent = 0usize;
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        while tokio::time::Instant::now() < deadline {
-            max_concurrent = max_concurrent.max(fixture.count_markers());
-            if max_concurrent >= NOTIFIER_MAX_INFLIGHT {
-                for _ in 0..10 {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    max_concurrent = max_concurrent.max(fixture.count_markers());
-                }
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        fixture
+            .wait_until(Duration::from_secs(5), || {
+                fixture.count_markers() == NOTIFIER_MAX_INFLIGHT
+            })
+            .await;
+        assert_eq!(
+            fixture.count_markers(),
+            NOTIFIER_MAX_INFLIGHT,
+            "semaphore must cap in-flight scripts at the hard limit"
+        );
+        assert_eq!(
+            fixture.count_invocations(),
+            NOTIFIER_MAX_INFLIGHT,
+            "while barrier is closed, only permit-sized scripts should start"
+        );
 
         fixture.release_barrier();
         fixture
             .wait_until(Duration::from_secs(5), || fixture.count_markers() == 0)
             .await;
-
-        assert!(max_concurrent >= 1, "no scripts ever ran -- test setup bug");
-        assert!(
-            max_concurrent <= NOTIFIER_MAX_INFLIGHT,
-            "semaphore did not cap concurrent scripts: max observed {max_concurrent}, cap is {NOTIFIER_MAX_INFLIGHT}",
-        );
+        assert_eq!(fixture.count_markers(), 0, "scripts did not drain");
     }
 
     /// When more than `NOTIFIER_MAX_INFLIGHT` events are fired while every


### PR DESCRIPTION
## Summary
- Removed a weak download change-reason test that duplicated local pattern matching instead of exercising production incremental behavior.
- Reworked credential deletion partial-success coverage into a table-driven assertion matrix.
- Reworked notifier concurrency-cap coverage to use deterministic barrier assertions instead of max-concurrency polling.

## Tests
- `cargo test` (pass)
- `cargo test -- --test-threads=1` (pass)
- `cargo fmt --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)
