### PR TITLE
Scope smart-folder passes across libraries

### DIFF
--- a/scripts/full-test/diff_runs.sh
+++ b/scripts/full-test/diff_runs.sh
@@ -61,6 +61,7 @@ PHASE_META = {
     "fuzz_build":               (17, "0.75", None),
     "udeps":                    (18, "0.8", None),
     "offline_all":              (19, "0.9", None),
+    "scope_matrix":             (19, "0.95", 1),
     "build_release":            (20, "1", None),
     "docker_build":             (30, "2", None),
     "docker_multiarch":         (31, "2", None),

--- a/scripts/full-test/render_summary.py
+++ b/scripts/full-test/render_summary.py
@@ -14,6 +14,7 @@ PHASE_ORDER = {
     "fuzz_build": 17,
     "udeps": 18,
     "offline_all": 19,
+    "scope_matrix": 19,
     "build_release": 20,
     "docker_build": 30,
     "docker_multiarch": 31,

--- a/scripts/full-test/run_all.sh
+++ b/scripts/full-test/run_all.sh
@@ -12,6 +12,7 @@
 #   0.75 fuzz_build    cargo +nightly fuzz build (skip if missing)
 #   0.8  udeps         cargo +nightly udeps --all-targets
 #   0.9  offline_all   cargo test --all-features
+#   0.95 scope_matrix  matrix test for library/album/smart-folder/unfiled scope
 #   1    build_release cargo build --release
 #   1.5  release_archive_smoke
 #   2    docker_build      just docker build
@@ -136,6 +137,9 @@ run_phase udeps -- cargo +nightly udeps --all-targets
 
 # --- Phase 0.9: full offline ----------------------------------------------
 run_phase offline_all -- cargo test --all-features
+
+# --- Phase 0.95: scope matrix ----------------------------------------------
+run_phase scope_matrix -- cargo test scope_contract_matrix --lib
 
 # --- Phase 1 + 2: release build + docker builds ---------------------------
 run_phase build_release -- cargo build --release

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1110,19 +1110,20 @@ mod build_selection_tests {
         )
     }
 
-    fn smart_folder_filters() -> TomlFilters {
+    fn smart_folder_filters_with_unfiled(unfiled: bool) -> TomlFilters {
         TomlFilters {
             smart_folders: Some(vec!["Hidden".to_string()]),
-            unfiled: Some(false),
+            unfiled: Some(unfiled),
             ..TomlFilters::default()
         }
     }
 
     #[test]
-    fn import_scope_planning_shared_only_smart_folder_excludes_primary_zone() {
+    fn import_scope_planning_shared_only_smart_folder_widens_zone_scope() {
         let selector = crate::selection::parse_library_selector(&["shared".to_string()]).unwrap();
         let selection =
-            build_import_selection(Some(&smart_folder_filters()), &selector).expect("ok");
+            build_import_selection(Some(&smart_folder_filters_with_unfiled(false)), &selector)
+                .expect("ok");
         let primary = test_library("PrimarySync");
         let shared = test_library("SharedSync-ABCD1234");
         let selected_libraries = vec![shared.clone()];
@@ -1146,8 +1147,8 @@ mod build_selection_tests {
         );
 
         assert!(
-            primary_scope.is_empty(),
-            "import-existing planning must not schedule PrimarySync when library selector is shared-only"
+            primary_scope.include_smart_folders,
+            "explicit smart-folder selection should widen import pass planning beyond the library selector"
         );
         assert!(
             shared_scope.include_smart_folders,
@@ -1156,10 +1157,11 @@ mod build_selection_tests {
     }
 
     #[test]
-    fn import_scope_planning_primary_only_smart_folder_excludes_shared_zone() {
+    fn import_scope_planning_primary_only_still_filters_unfiled() {
         let selector = crate::selection::parse_library_selector(&["primary".to_string()]).unwrap();
         let selection =
-            build_import_selection(Some(&smart_folder_filters()), &selector).expect("ok");
+            build_import_selection(Some(&smart_folder_filters_with_unfiled(true)), &selector)
+                .expect("ok");
         let primary = test_library("PrimarySync");
         let shared = test_library("SharedSync-ABCD1234");
         let selected_libraries = vec![primary.clone()];
@@ -1187,8 +1189,16 @@ mod build_selection_tests {
             "import-existing planning should keep smart-folder passes in the selected primary zone"
         );
         assert!(
-            shared_scope.is_empty(),
-            "import-existing planning must not schedule shared-zone passes when selector is primary-only"
+            shared_scope.include_smart_folders,
+            "explicit smart-folder selection should widen import scope to shared zones too"
+        );
+        assert!(
+            primary_scope.include_unfiled,
+            "selected primary zone should keep unfiled pass when unfiled=true"
+        );
+        assert!(
+            !shared_scope.include_unfiled,
+            "library selector should still filter unfiled passes to selected zones"
         );
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -23,9 +23,9 @@ use crate::systemd::SystemdNotifier;
 use crate::types::FileMatchPolicy;
 
 use super::service::{
-    build_collection_context, init_photos_service,
+    build_collection_context, collection_libraries, init_photos_service, pass_scope_for_zone,
     resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
-    PassScope,
+    zone_name_set,
 };
 
 /// Value of the `stage` field on the one-shot tracing event emitted by
@@ -811,22 +811,10 @@ pub(crate) async fn run_import_existing(
             Ok::<_, anyhow::Error>(all_libraries.clone())
         })
         .await?;
-    use crate::selection::{AlbumSelector, SmartFolderSelector};
-    let smart_selector_active = !matches!(selection.smart_folders, SmartFolderSelector::None);
-    let collection_libraries = if selection.albums_explicit || smart_selector_active {
-        all_libraries.clone()
-    } else {
-        libraries.clone()
-    };
-    let collection_context = build_collection_context(&selection, &collection_libraries).await?;
-    let selected_zones: rustc_hash::FxHashSet<String> = libraries
-        .iter()
-        .map(|library| library.zone_name().to_string())
-        .collect();
-    let collection_zones: rustc_hash::FxHashSet<String> = collection_libraries
-        .iter()
-        .map(|library| library.zone_name().to_string())
-        .collect();
+    let collection_libraries = collection_libraries(&selection, &libraries, &all_libraries);
+    let collection_context = build_collection_context(&selection, collection_libraries).await?;
+    let selected_zones = zone_name_set(&libraries);
+    let collection_zones = zone_name_set(collection_libraries);
 
     let prior_db_total = db.get_summary().await?.total_assets;
     if prior_db_total > 0 && !args.force_empty {
@@ -861,22 +849,8 @@ pub(crate) async fn run_import_existing(
 
     for library in &all_libraries {
         let zone = library.zone_name();
-        let include_unfiled = selection.unfiled && selected_zones.contains(zone);
-        let include_albums = match selection.albums {
-            AlbumSelector::None => false,
-            _ if selection.albums_explicit => collection_zones.contains(zone),
-            _ => selected_zones.contains(zone),
-        };
-        let include_smart_folders = smart_selector_active && collection_zones.contains(zone);
-        let pass_scope = PassScope {
-            include_albums,
-            include_smart_folders,
-            include_unfiled,
-        };
-        if !pass_scope.include_albums
-            && !pass_scope.include_smart_folders
-            && !pass_scope.include_unfiled
-        {
+        let pass_scope = pass_scope_for_zone(&selection, zone, &selected_zones, &collection_zones);
+        if pass_scope.is_empty() {
             continue;
         }
         tracing::debug!(zone = %zone, "Scanning library");

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -23,8 +23,9 @@ use crate::systemd::SystemdNotifier;
 use crate::types::FileMatchPolicy;
 
 use super::service::{
-    init_photos_service, resolve_cross_zone_libraries_for_album_hydration, resolve_libraries,
-    resolve_passes,
+    build_collection_context, init_photos_service,
+    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
+    PassScope,
 };
 
 /// Value of the `stage` field on the one-shot tracing event emitted by
@@ -804,11 +805,28 @@ pub(crate) async fn run_import_existing(
     // the same passes sync would, and each pass uses its own
     // `folder_structure_*` template when deriving expected paths.
     let selection = build_import_selection(toml_filters, &selector)?;
-    let cross_zone_libraries = resolve_cross_zone_libraries_for_album_hydration(
-        &selection,
-        photos_service.all_libraries(),
-    )
-    .await?;
+    let all_libraries = photos_service.all_libraries().await?;
+    let cross_zone_libraries =
+        resolve_cross_zone_libraries_for_album_hydration(&selection, async {
+            Ok::<_, anyhow::Error>(all_libraries.clone())
+        })
+        .await?;
+    use crate::selection::{AlbumSelector, SmartFolderSelector};
+    let smart_selector_active = !matches!(selection.smart_folders, SmartFolderSelector::None);
+    let collection_libraries = if selection.albums_explicit || smart_selector_active {
+        all_libraries.clone()
+    } else {
+        libraries.clone()
+    };
+    let collection_context = build_collection_context(&selection, &collection_libraries).await?;
+    let selected_zones: rustc_hash::FxHashSet<String> = libraries
+        .iter()
+        .map(|library| library.zone_name().to_string())
+        .collect();
+    let collection_zones: rustc_hash::FxHashSet<String> = collection_libraries
+        .iter()
+        .map(|library| library.zone_name().to_string())
+        .collect();
 
     let prior_db_total = db.get_summary().await?.total_assets;
     if prior_db_total > 0 && !args.force_empty {
@@ -841,12 +859,37 @@ pub(crate) async fn run_import_existing(
     // once per library scan, not once per pass.
     let mut dir_cache = DirCache::new();
 
-    for library in &libraries {
+    for library in &all_libraries {
         let zone = library.zone_name();
+        let include_unfiled = selection.unfiled && selected_zones.contains(zone);
+        let include_albums = match selection.albums {
+            AlbumSelector::None => false,
+            _ if selection.albums_explicit => collection_zones.contains(zone),
+            _ => selected_zones.contains(zone),
+        };
+        let include_smart_folders = smart_selector_active && collection_zones.contains(zone);
+        let pass_scope = PassScope {
+            include_albums,
+            include_smart_folders,
+            include_unfiled,
+        };
+        if !pass_scope.include_albums
+            && !pass_scope.include_smart_folders
+            && !pass_scope.include_unfiled
+        {
+            continue;
+        }
         tracing::debug!(zone = %zone, "Scanning library");
         let library_config = download_config.with_library(zone);
 
-        let plan = resolve_passes(library, &selection, &cross_zone_libraries).await?;
+        let plan = resolve_passes_for_scope(
+            library,
+            &selection,
+            pass_scope,
+            &collection_context,
+            &cross_zone_libraries,
+        )
+        .await?;
         if plan.passes.is_empty() {
             tracing::debug!(zone = %zone, "No passes resolved; nothing to import");
             continue;
@@ -927,7 +970,9 @@ fn build_import_selection(
 
     Ok(Selection {
         albums: parse_album_selector(&raw_albums, true)?,
+        albums_explicit: !raw_albums.is_empty(),
         smart_folders: parse_smart_folder_selector(&raw_smart_folders)?,
+        smart_folders_explicit: !raw_smart_folders.is_empty(),
         libraries: libraries.clone(),
         unfiled,
     })
@@ -1020,7 +1065,6 @@ mod build_selection_tests {
     use super::build_import_selection;
     use crate::commands::resolve_cross_zone_libraries_for_album_hydration;
     use crate::config::TomlFilters;
-    use crate::icloud::photos::PhotoLibrary;
     use crate::selection::{AlbumSelector, LibrarySelector, Selection, SmartFolderSelector};
     use std::collections::BTreeSet;
 
@@ -1060,7 +1104,9 @@ mod build_selection_tests {
             selection,
             Selection {
                 albums: AlbumSelector::default(),
+                albums_explicit: false,
                 smart_folders: SmartFolderSelector::None,
+                smart_folders_explicit: false,
                 libraries: primary(),
                 unfiled: true,
             }
@@ -1068,24 +1114,15 @@ mod build_selection_tests {
     }
 
     #[tokio::test]
-    async fn default_import_album_selection_requires_cross_zone_resolution() {
+    async fn default_import_album_selection_skips_cross_zone_resolution() {
         let selection = build_import_selection(None, &primary()).expect("ok");
 
-        let err = resolve_cross_zone_libraries_for_album_hydration(&selection, async {
-            Err::<Vec<PhotoLibrary>, anyhow::Error>(anyhow::anyhow!("all-libraries unavailable"))
+        let libraries = resolve_cross_zone_libraries_for_album_hydration(&selection, async {
+            panic!("implicit default album scope must not request all libraries")
         })
         .await
-        .unwrap_err();
-        let msg = format!("{err:#}");
-
-        assert!(
-            msg.contains("failed to resolve cross-zone album hydration libraries"),
-            "missing hydration context: {msg}"
-        );
-        assert!(
-            msg.contains("all-libraries unavailable"),
-            "missing cause: {msg}"
-        );
+        .unwrap();
+        assert!(libraries.is_empty());
     }
 }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1037,9 +1037,13 @@ mod build_selection_tests {
     //! Sync vs. import-existing parity for the current selector resolution.
     //! Both commands must produce the same `Selection` from the same TOML.
     use super::build_import_selection;
-    use crate::commands::resolve_cross_zone_libraries_for_album_hydration;
+    use crate::commands::{
+        collection_libraries, pass_scope_for_zone,
+        resolve_cross_zone_libraries_for_album_hydration, zone_name_set,
+    };
     use crate::config::TomlFilters;
     use crate::selection::{AlbumSelector, LibrarySelector, Selection, SmartFolderSelector};
+    use crate::test_helpers::MockPhotosSession;
     use std::collections::BTreeSet;
 
     fn primary() -> LibrarySelector {
@@ -1097,6 +1101,95 @@ mod build_selection_tests {
         .await
         .unwrap();
         assert!(libraries.is_empty());
+    }
+
+    fn test_library(zone_name: &str) -> crate::icloud::photos::PhotoLibrary {
+        crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
+            Box::new(MockPhotosSession::new()),
+            zone_name,
+        )
+    }
+
+    fn smart_folder_filters() -> TomlFilters {
+        TomlFilters {
+            smart_folders: Some(vec!["Hidden".to_string()]),
+            unfiled: Some(false),
+            ..TomlFilters::default()
+        }
+    }
+
+    #[test]
+    fn import_scope_planning_shared_only_smart_folder_excludes_primary_zone() {
+        let selector = crate::selection::parse_library_selector(&["shared".to_string()]).unwrap();
+        let selection =
+            build_import_selection(Some(&smart_folder_filters()), &selector).expect("ok");
+        let primary = test_library("PrimarySync");
+        let shared = test_library("SharedSync-ABCD1234");
+        let selected_libraries = vec![shared.clone()];
+        let all_libraries = vec![primary.clone(), shared.clone()];
+
+        let collection = collection_libraries(&selection, &selected_libraries, &all_libraries);
+        let selected_zones = zone_name_set(&selected_libraries);
+        let collection_zones = zone_name_set(collection);
+
+        let primary_scope = pass_scope_for_zone(
+            &selection,
+            primary.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+        let shared_scope = pass_scope_for_zone(
+            &selection,
+            shared.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+
+        assert!(
+            primary_scope.is_empty(),
+            "import-existing planning must not schedule PrimarySync when library selector is shared-only"
+        );
+        assert!(
+            shared_scope.include_smart_folders,
+            "import-existing planning should schedule smart-folder passes for selected shared zone"
+        );
+    }
+
+    #[test]
+    fn import_scope_planning_primary_only_smart_folder_excludes_shared_zone() {
+        let selector = crate::selection::parse_library_selector(&["primary".to_string()]).unwrap();
+        let selection =
+            build_import_selection(Some(&smart_folder_filters()), &selector).expect("ok");
+        let primary = test_library("PrimarySync");
+        let shared = test_library("SharedSync-ABCD1234");
+        let selected_libraries = vec![primary.clone()];
+        let all_libraries = vec![primary.clone(), shared.clone()];
+
+        let collection = collection_libraries(&selection, &selected_libraries, &all_libraries);
+        let selected_zones = zone_name_set(&selected_libraries);
+        let collection_zones = zone_name_set(collection);
+
+        let primary_scope = pass_scope_for_zone(
+            &selection,
+            primary.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+        let shared_scope = pass_scope_for_zone(
+            &selection,
+            shared.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+
+        assert!(
+            primary_scope.include_smart_folders,
+            "import-existing planning should keep smart-folder passes in the selected primary zone"
+        );
+        assert!(
+            shared_scope.is_empty(),
+            "import-existing planning must not schedule shared-zone passes when selector is primary-only"
+        );
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,9 +17,10 @@ pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
 pub(crate) use reset::{run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
-    attempt_reauth, init_photos_service, resolve_cross_zone_libraries_for_album_hydration,
-    resolve_libraries, resolve_passes, validate_smart_folder_fulfillability, wait_and_retry_2fa,
-    AlbumPass, AlbumPlan, PassKind, MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, build_collection_context, init_photos_service,
+    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
+    wait_and_retry_2fa, AlbumPass, AlbumPlan, CollectionContext, PassKind, PassScope,
+    MAX_REAUTH_ATTEMPTS,
 };
 pub(crate) use status::run_status;
 pub(crate) use verify::run_verify;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,10 +17,10 @@ pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
 pub(crate) use reset::{run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
-    attempt_reauth, build_collection_context, init_photos_service,
-    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
-    wait_and_retry_2fa, AlbumPass, AlbumPlan, CollectionContext, PassKind, PassScope,
-    MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, build_collection_context, collection_libraries, init_photos_service,
+    pass_scope_for_zone, resolve_cross_zone_libraries_for_album_hydration, resolve_libraries,
+    resolve_passes_for_scope, wait_and_retry_2fa, zone_name_set, AlbumPass, AlbumPlan,
+    CollectionContext, PassKind, PassScope, MAX_REAUTH_ATTEMPTS,
 };
 pub(crate) use status::run_status;
 pub(crate) use verify::run_verify;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -488,7 +488,7 @@ where
     use crate::selection::AlbumSelector;
     use anyhow::Context;
 
-    if matches!(selection.albums, AlbumSelector::None) {
+    if matches!(selection.albums, AlbumSelector::None) || !selection.albums_explicit {
         return Ok(Vec::new());
     }
 
@@ -505,43 +505,143 @@ fn library_entry_matches_zone(entry: &str, zone: &str, truncated: &str) -> bool 
     entry.eq_ignore_ascii_case(zone) || entry.eq_ignore_ascii_case(truncated)
 }
 
-/// Pre-flight: bail when the resolved library set cannot fulfill the
-/// requested smart-folder selection. Apple's CloudKit shared zones don't
-/// expose smart folders (`library.albums()` skips smart-folder injection
-/// for `SharedSync-*` zones), so a `--library shared --smart-folder X`
-/// configuration produces zero smart-folder passes and exit 0 — silent
-/// failure. Detect that at startup, before per-library `resolve_passes`
-/// runs, so the user gets an actionable message instead of a
-/// successful-looking sync that quietly skipped what they asked for.
-///
-/// Mixed library sets (primary + shared) pass: smart folders apply to the
-/// primary library, and the shared zones' lack of smart-folder passes is
-/// expected behavior.
-pub(crate) fn validate_smart_folder_fulfillability(
-    libraries: &[icloud::photos::PhotoLibrary],
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PassScope {
+    pub include_albums: bool,
+    pub include_smart_folders: bool,
+    pub include_unfiled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CollectionContext {
+    pub(crate) collection_album_names: std::collections::BTreeSet<String>,
+    pub(crate) selected_smart_folder_names: Vec<String>,
+}
+
+pub(crate) async fn build_collection_context(
     selection: &crate::selection::Selection,
+    collection_libraries: &[icloud::photos::PhotoLibrary],
+) -> anyhow::Result<CollectionContext> {
+    use crate::selection::AlbumSelector;
+
+    let smart_names = smart_folder_name_set();
+    let selected_smart_folder_names =
+        pick_selected_smart_folder_names(&selection.smart_folders, &smart_names)?;
+
+    let mut collection_album_names = std::collections::BTreeSet::new();
+    if selection.albums_explicit && !matches!(selection.albums, AlbumSelector::None) {
+        for library in collection_libraries {
+            let album_map = library.albums().await?;
+            for name in album_map.keys() {
+                if !smart_names.contains(name.as_str()) {
+                    collection_album_names.insert(name.clone());
+                }
+            }
+        }
+        validate_collection_album_selector(
+            &selection.albums,
+            &collection_album_names,
+            &smart_names,
+        )?;
+    }
+
+    Ok(CollectionContext {
+        collection_album_names,
+        selected_smart_folder_names,
+    })
+}
+
+fn validate_collection_album_selector(
+    selector: &crate::selection::AlbumSelector,
+    collection_album_names: &std::collections::BTreeSet<String>,
+    smart_names: &rustc_hash::FxHashSet<&'static str>,
 ) -> anyhow::Result<()> {
+    use crate::selection::AlbumSelector;
+    match selector {
+        AlbumSelector::None => Ok(()),
+        AlbumSelector::All { excluded } => {
+            bail_unknown_excluded_collection_albums(excluded, collection_album_names)
+        }
+        AlbumSelector::Named { included, excluded } => {
+            for name in included {
+                if smart_names.contains(name.as_str()) {
+                    anyhow::bail!(
+                        "'{name}' is a smart folder; pass `--smart-folder {name}` instead of `--album`"
+                    );
+                }
+                if excluded.contains(name) {
+                    continue;
+                }
+                if !collection_album_names.contains(name) {
+                    let available: Vec<&str> =
+                        collection_album_names.iter().map(String::as_str).collect();
+                    anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+                }
+            }
+            bail_unknown_excluded_collection_albums(excluded, collection_album_names)
+        }
+    }
+}
+
+fn bail_unknown_excluded_collection_albums(
+    excluded: &std::collections::BTreeSet<String>,
+    collection_album_names: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<()> {
+    for name in excluded {
+        if !collection_album_names.contains(name) {
+            let available: Vec<&str> = collection_album_names.iter().map(String::as_str).collect();
+            anyhow::bail!("Excluded album '{name}' not found. Available albums: {available:?}");
+        }
+    }
+    Ok(())
+}
+
+fn pick_selected_smart_folder_names(
+    selector: &crate::selection::SmartFolderSelector,
+    smart_names: &rustc_hash::FxHashSet<&'static str>,
+) -> anyhow::Result<Vec<String>> {
     use crate::selection::SmartFolderSelector;
-    if matches!(selection.smart_folders, SmartFolderSelector::None) {
-        return Ok(());
+    let sensitive: rustc_hash::FxHashSet<&'static str> =
+        icloud::photos::smart_folders::sensitive_smart_folder_names().collect();
+
+    match selector {
+        SmartFolderSelector::None => Ok(Vec::new()),
+        SmartFolderSelector::All {
+            include_sensitive,
+            excluded,
+        } => {
+            for name in excluded {
+                bail_excluded_not_a_smart_folder(name, smart_names)?;
+            }
+            let mut names: Vec<String> = smart_names
+                .iter()
+                .filter(|name| *include_sensitive || !sensitive.contains(**name))
+                .filter(|name| !excluded.contains(**name))
+                .map(|name| (*name).to_string())
+                .collect();
+            names.sort();
+            Ok(names)
+        }
+        SmartFolderSelector::Named { included, excluded } => {
+            for name in included {
+                if !smart_names.contains(name.as_str()) {
+                    let mut available: Vec<&str> = smart_names.iter().copied().collect();
+                    available.sort();
+                    anyhow::bail!(
+                        "'{name}' is not an Apple smart folder. Available: {available:?}"
+                    );
+                }
+            }
+            for name in excluded {
+                bail_excluded_not_a_smart_folder(name, smart_names)?;
+            }
+            Ok(included
+                .iter()
+                .filter(|name| !excluded.contains(*name))
+                .cloned()
+                .collect())
+        }
     }
-    let any_supports = libraries
-        .iter()
-        .any(|l| !icloud::photos::is_shared_zone(l.zone_name()));
-    if any_supports {
-        return Ok(());
-    }
-    let zones: Vec<&str> = libraries
-        .iter()
-        .map(icloud::photos::PhotoLibrary::zone_name)
-        .collect();
-    anyhow::bail!(
-        "--smart-folder requires a library that supports smart folders, but \
-         --library resolved to only shared zones: {zones:?}. Apple does not \
-         expose smart folders on shared libraries. Either include the primary \
-         library (e.g. `--library all` or `--library primary`) or drop \
-         `--smart-folder` (`--smart-folder none`)."
-    )
 }
 
 /// Category of a download pass: a named user album, an Apple-defined smart
@@ -664,26 +764,78 @@ fn smart_folder_name_set() -> rustc_hash::FxHashSet<&'static str> {
 ///
 /// Album member IDs are fetched in parallel before the album map is
 /// consumed into passes; each `PhotoAlbum` is moved into exactly one pass.
+#[cfg(test)]
 pub(crate) async fn resolve_passes(
     library: &icloud::photos::PhotoLibrary,
     selection: &crate::selection::Selection,
     cross_zone_libraries: &[icloud::photos::PhotoLibrary],
 ) -> anyhow::Result<AlbumPlan> {
+    let mut selection_for_test = selection.clone();
+    selection_for_test.albums_explicit = false;
+    let scope = PassScope {
+        include_albums: true,
+        include_smart_folders: true,
+        include_unfiled: selection_for_test.unfiled,
+    };
+    let collection_context = build_collection_context(&selection_for_test, &[]).await?;
+    resolve_passes_for_scope(
+        library,
+        &selection_for_test,
+        scope,
+        &collection_context,
+        cross_zone_libraries,
+    )
+    .await
+}
+
+pub(crate) async fn resolve_passes_for_scope(
+    library: &icloud::photos::PhotoLibrary,
+    selection: &crate::selection::Selection,
+    scope: PassScope,
+    collection_context: &CollectionContext,
+    cross_zone_libraries: &[icloud::photos::PhotoLibrary],
+) -> anyhow::Result<AlbumPlan> {
     use crate::selection::{AlbumSelector, SmartFolderSelector};
 
-    let album_active = !matches!(selection.albums, AlbumSelector::None);
-    let smart_active = !matches!(selection.smart_folders, SmartFolderSelector::None);
+    let album_active = scope.include_albums && !matches!(selection.albums, AlbumSelector::None);
+    let smart_active = scope.include_smart_folders
+        && !matches!(selection.smart_folders, SmartFolderSelector::None);
+    let unfiled_active = scope.include_unfiled;
 
-    if !album_active && !smart_active && !selection.unfiled {
+    if !album_active && !smart_active && !unfiled_active {
         return Ok(AlbumPlan { passes: Vec::new() });
     }
 
-    let mut album_map = library.albums().await?;
+    let mut album_map = if album_active || smart_active {
+        library.albums().await?
+    } else {
+        std::collections::HashMap::new()
+    };
     let smart_names = smart_folder_name_set();
 
-    let selected_album_names = pick_album_names(&selection.albums, &album_map, &smart_names)?;
-    let selected_smart_names =
-        pick_smart_folder_names(&selection.smart_folders, &album_map, &smart_names)?;
+    let selected_album_names = if album_active {
+        if selection.albums_explicit {
+            pick_collection_scoped_album_names_for_library(
+                &selection.albums,
+                &album_map,
+                &smart_names,
+                &collection_context.collection_album_names,
+            )?
+        } else {
+            pick_album_names(&selection.albums, &album_map, &smart_names)?
+        }
+    } else {
+        Vec::new()
+    };
+    let selected_smart_names = if smart_active {
+        pick_collection_scoped_smart_folder_names_for_library(
+            library,
+            &album_map,
+            &collection_context.selected_smart_folder_names,
+        )
+    } else {
+        Vec::new()
+    };
 
     let empty = empty_exclude_ids();
     let mut passes: Vec<AlbumPass> = Vec::new();
@@ -712,7 +864,7 @@ pub(crate) async fn resolve_passes(
         &mut passes,
     );
 
-    if selection.unfiled {
+    if unfiled_active {
         passes.push(AlbumPass {
             kind: PassKind::Unfiled,
             album: library.all(),
@@ -721,6 +873,60 @@ pub(crate) async fn resolve_passes(
     }
 
     Ok(AlbumPlan { passes })
+}
+
+fn pick_collection_scoped_album_names_for_library(
+    selector: &crate::selection::AlbumSelector,
+    album_map: &std::collections::HashMap<String, icloud::photos::PhotoAlbum>,
+    smart_names: &rustc_hash::FxHashSet<&'static str>,
+    collection_album_names: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<Vec<String>> {
+    use crate::selection::AlbumSelector;
+
+    match selector {
+        AlbumSelector::None => Ok(Vec::new()),
+        AlbumSelector::All { excluded } => {
+            bail_unknown_excluded_collection_albums(excluded, collection_album_names)?;
+            Ok(album_map
+                .keys()
+                .filter(|name| {
+                    !smart_names.contains(name.as_str()) && !excluded.contains(name.as_str())
+                })
+                .cloned()
+                .collect())
+        }
+        AlbumSelector::Named { included, excluded } => {
+            validate_collection_album_selector(selector, collection_album_names, smart_names)?;
+            Ok(included
+                .iter()
+                .filter(|name| !excluded.contains(*name))
+                .filter(|name| album_map.contains_key(name.as_str()))
+                .cloned()
+                .collect())
+        }
+    }
+}
+
+fn pick_collection_scoped_smart_folder_names_for_library(
+    library: &icloud::photos::PhotoLibrary,
+    album_map: &std::collections::HashMap<String, icloud::photos::PhotoAlbum>,
+    selected_smart_folder_names: &[String],
+) -> Vec<String> {
+    selected_smart_folder_names
+        .iter()
+        .filter_map(|name| {
+            if album_map.contains_key(name.as_str()) {
+                Some(name.clone())
+            } else {
+                tracing::warn!(
+                    zone = %library.zone_name(),
+                    smart_folder = %name,
+                    "Smart folder not present in this library, skipping"
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 /// Pick the user-album names selected by `albums`. Bails on missing
@@ -792,66 +998,6 @@ fn bail_unknown_excluded_albums(
         }
     }
     Ok(())
-}
-
-/// Pick the smart-folder names selected by `smart_folders`. Bails on
-/// `Named` entries that aren't smart folders and on excluded entries
-/// that aren't smart folders (a typo'd exclusion would silently match
-/// nothing).
-fn pick_smart_folder_names(
-    selector: &crate::selection::SmartFolderSelector,
-    album_map: &std::collections::HashMap<String, icloud::photos::PhotoAlbum>,
-    smart_names: &rustc_hash::FxHashSet<&'static str>,
-) -> anyhow::Result<Vec<String>> {
-    use crate::selection::SmartFolderSelector;
-    let sensitive: rustc_hash::FxHashSet<&'static str> =
-        icloud::photos::smart_folders::sensitive_smart_folder_names().collect();
-
-    match selector {
-        SmartFolderSelector::None => Ok(Vec::new()),
-        SmartFolderSelector::All {
-            include_sensitive,
-            excluded,
-        } => {
-            for name in excluded {
-                bail_excluded_not_a_smart_folder(name, smart_names)?;
-            }
-            Ok(album_map
-                .keys()
-                .filter(|name| smart_names.contains(name.as_str()))
-                .filter(|name| *include_sensitive || !sensitive.contains(name.as_str()))
-                .filter(|name| !excluded.contains(name.as_str()))
-                .cloned()
-                .collect())
-        }
-        SmartFolderSelector::Named { included, excluded } => {
-            let mut chosen = Vec::with_capacity(included.len());
-            for name in included {
-                if !smart_names.contains(name.as_str()) {
-                    let mut available: Vec<&str> = smart_names.iter().copied().collect();
-                    available.sort();
-                    anyhow::bail!(
-                        "'{name}' is not an Apple smart folder. Available: {available:?}"
-                    );
-                }
-                if excluded.contains(name) {
-                    continue;
-                }
-                if album_map.contains_key(name.as_str()) {
-                    chosen.push(name.clone());
-                } else {
-                    tracing::warn!(
-                        smart_folder = %name,
-                        "Smart folder not present in this library, skipping"
-                    );
-                }
-            }
-            for name in excluded {
-                bail_excluded_not_a_smart_folder(name, smart_names)?;
-            }
-            Ok(chosen)
-        }
-    }
 }
 
 fn bail_excluded_not_a_smart_folder(
@@ -1045,9 +1191,12 @@ mod tests {
     }
 
     fn selection_with_albums(albums: AlbumSelector, unfiled: bool) -> Selection {
+        let albums_explicit = !matches!(albums, AlbumSelector::None);
         Selection {
             albums,
+            albums_explicit,
             smart_folders: SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled,
         }
@@ -1197,10 +1346,12 @@ mod tests {
         let library = stub_library(mock);
         let sel = Selection {
             albums: AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::Named {
                 included: names(&["Favorites"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: false,
         };
@@ -1216,10 +1367,12 @@ mod tests {
         let library = stub_library(mock);
         let sel = Selection {
             albums: AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::Named {
                 included: names(&["NotASmartFolder"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: false,
         };
@@ -1231,93 +1384,40 @@ mod tests {
         );
     }
 
-    // ── validate_smart_folder_fulfillability (CF-2, 2026-05-03) ─────────
-    //
-    // Apple's CloudKit shared zones don't have smart folders. Before the
-    // fix, `--library shared --smart-folder Favorites` (or any shared-only
-    // library set with a smart-folder selection) silently warn-and-skipped
-    // every smart-folder pass and exited 0. The user looked at their
-    // primary-library Favorites and assumed shared-Favorites came along.
-    //
-    // The fix is a pre-flight check that bails at startup when the
-    // selected library set cannot fulfill the smart-folder selection.
-
     fn shared_lib_stub(zone: &str) -> PhotoLibrary {
         PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), zone)
     }
 
-    #[test]
-    fn validate_smart_folder_named_against_shared_only_libraries_bails() {
+    #[tokio::test]
+    async fn resolve_passes_shared_library_smart_folder_now_builds_pass() {
         let libs = vec![shared_lib_stub("SharedSync-AAAA1111")];
         let sel = Selection {
             albums: AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::Named {
                 included: names(&["Favorites"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: false,
         };
-        let err = validate_smart_folder_fulfillability(&libs, &sel).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("--smart-folder"),
-            "error must name the offending flag, got: {msg}"
-        );
-        assert!(
-            msg.contains("primary"),
-            "error must guide the user toward the primary library, got: {msg}"
-        );
-    }
-
-    #[test]
-    fn validate_smart_folder_all_against_shared_only_libraries_bails() {
-        let libs = vec![shared_lib_stub("SharedSync-BBBB2222")];
-        let sel = Selection {
-            albums: AlbumSelector::None,
-            smart_folders: SmartFolderSelector::All {
-                include_sensitive: false,
-                excluded: BTreeSet::new(),
+        let ctx = build_collection_context(&sel, &libs).await.unwrap();
+        let plan = resolve_passes_for_scope(
+            &libs[0],
+            &sel,
+            PassScope {
+                include_albums: false,
+                include_smart_folders: true,
+                include_unfiled: false,
             },
-            libraries: crate::selection::LibrarySelector::default(),
-            unfiled: false,
-        };
-        let err = validate_smart_folder_fulfillability(&libs, &sel).unwrap_err();
-        assert!(err.to_string().contains("--smart-folder"));
-    }
-
-    #[test]
-    fn validate_smart_folder_named_against_mixed_libraries_passes() {
-        // Primary in the set fulfills smart folders; shared zones simply
-        // get no smart-folder passes (expected and documented).
-        let primary =
-            PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), "PrimarySync");
-        let shared = shared_lib_stub("SharedSync-CCCC3333");
-        let sel = Selection {
-            albums: AlbumSelector::None,
-            smart_folders: SmartFolderSelector::Named {
-                included: names(&["Favorites"]),
-                excluded: BTreeSet::new(),
-            },
-            libraries: crate::selection::LibrarySelector::default(),
-            unfiled: false,
-        };
-        validate_smart_folder_fulfillability(&[primary, shared], &sel)
-            .expect("primary in mix fulfills smart folders");
-    }
-
-    #[test]
-    fn validate_smart_folder_none_passes_even_on_shared_only() {
-        // No smart-folder pass requested -> nothing to validate.
-        let libs = vec![shared_lib_stub("SharedSync-DDDD4444")];
-        let sel = Selection {
-            albums: AlbumSelector::None,
-            smart_folders: SmartFolderSelector::None,
-            libraries: crate::selection::LibrarySelector::default(),
-            unfiled: false,
-        };
-        validate_smart_folder_fulfillability(&libs, &sel)
-            .expect("smart-folder None imposes no constraint on the library set");
+            &ctx,
+            &[],
+        )
+        .await
+        .unwrap();
+        assert_eq!(plan.passes.len(), 1);
+        assert_eq!(plan.passes[0].album.name.as_ref(), "Favorites");
     }
 
     #[tokio::test]
@@ -1327,10 +1427,12 @@ mod tests {
             let library = stub_library(mock);
             let sel = Selection {
                 albums: AlbumSelector::None,
+                albums_explicit: false,
                 smart_folders: SmartFolderSelector::All {
                     include_sensitive,
                     excluded: BTreeSet::new(),
                 },
+                smart_folders_explicit: true,
                 libraries: crate::selection::LibrarySelector::default(),
                 unfiled: false,
             };
@@ -1634,10 +1736,12 @@ mod tests {
     async fn cross_zone_hydration_libraries_skip_fetch_without_album_selection() {
         let sel = Selection {
             albums: AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::Named {
                 included: names(&["Favorites"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: false,
         };
@@ -1692,10 +1796,12 @@ mod tests {
                 included: names(&["Vacation"]),
                 excluded: BTreeSet::new(),
             },
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::Named {
                 included: names(&["Favorites"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: true,
         };

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -2001,6 +2001,149 @@ libraries = ["shared"]
             .collect()
     }
 
+    #[test]
+    fn scope_contract_matrix_zone_widening_and_unfiled_scoping() {
+        use crate::selection::{AlbumSelector, Selection, SmartFolderSelector};
+        use std::collections::BTreeSet;
+
+        let primary_zone = "PrimarySync";
+        let shared_zone = "SharedSync-AAAA1111";
+        let primary =
+            PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), primary_zone);
+        let shared =
+            PhotoLibrary::new_stub_with_zone(Box::new(MockPhotosSession::new()), shared_zone);
+        let all_libraries = vec![primary.clone(), shared.clone()];
+
+        let all_zones = zone_name_set(&all_libraries);
+        let library_cases: [(
+            &str,
+            crate::selection::LibrarySelector,
+            Vec<icloud::photos::PhotoLibrary>,
+        ); 3] = [
+            (
+                "primary",
+                selector_from(&["primary"]),
+                vec![primary.clone()],
+            ),
+            ("shared", selector_from(&["shared"]), vec![shared.clone()]),
+            (
+                "all",
+                selector_from(&["all"]),
+                vec![primary.clone(), shared.clone()],
+            ),
+        ];
+        let album_cases: [(&str, AlbumSelector, bool, bool); 3] = [
+            (
+                "default",
+                AlbumSelector::All {
+                    excluded: BTreeSet::new(),
+                },
+                false,
+                true,
+            ),
+            ("none", AlbumSelector::None, true, false),
+            (
+                "named",
+                AlbumSelector::Named {
+                    included: names(&["Vacation"]),
+                    excluded: BTreeSet::new(),
+                },
+                true,
+                true,
+            ),
+        ];
+        let smart_cases: [(&str, SmartFolderSelector, bool, bool); 3] = [
+            ("default", SmartFolderSelector::None, false, false),
+            ("none", SmartFolderSelector::None, true, false),
+            (
+                "named",
+                SmartFolderSelector::Named {
+                    included: names(&["Hidden"]),
+                    excluded: BTreeSet::new(),
+                },
+                true,
+                true,
+            ),
+        ];
+
+        let mut matrix_cases = 0usize;
+        for (library_label, library_selector, selected_libraries) in &library_cases {
+            let selected_zones = zone_name_set(selected_libraries);
+            for (album_label, album_selector, albums_explicit, albums_active) in &album_cases {
+                for (smart_label, smart_selector, smart_explicit, smart_active) in &smart_cases {
+                    for unfiled in [false, true] {
+                        matrix_cases += 1;
+                        let selection = Selection {
+                            albums: album_selector.clone(),
+                            albums_explicit: *albums_explicit,
+                            smart_folders: smart_selector.clone(),
+                            smart_folders_explicit: *smart_explicit,
+                            libraries: library_selector.clone(),
+                            unfiled,
+                        };
+
+                        let collection_libraries =
+                            collection_libraries(&selection, selected_libraries, &all_libraries);
+                        let collection_zones = zone_name_set(collection_libraries);
+
+                        let expected_collection_zones = if *albums_explicit || *smart_active {
+                            all_zones.clone()
+                        } else {
+                            selected_zones.clone()
+                        };
+                        assert_eq!(
+                            collection_zones, expected_collection_zones,
+                            "collection scope mismatch for --library={library_label} --album={album_label} --smart-folder={smart_label} --unfiled={unfiled}"
+                        );
+
+                        let primary_scope = pass_scope_for_zone(
+                            &selection,
+                            primary_zone,
+                            &selected_zones,
+                            &collection_zones,
+                        );
+                        let shared_scope = pass_scope_for_zone(
+                            &selection,
+                            shared_zone,
+                            &selected_zones,
+                            &collection_zones,
+                        );
+
+                        for (zone_name, scope) in
+                            [(primary_zone, primary_scope), (shared_zone, shared_scope)]
+                        {
+                            let expected_unfiled = unfiled && selected_zones.contains(zone_name);
+                            let expected_albums = if !albums_active {
+                                false
+                            } else if *albums_explicit {
+                                expected_collection_zones.contains(zone_name)
+                            } else {
+                                selected_zones.contains(zone_name)
+                            };
+                            let expected_smart =
+                                *smart_active && expected_collection_zones.contains(zone_name);
+
+                            assert_eq!(
+                                scope.include_unfiled, expected_unfiled,
+                                "unfiled scope mismatch for zone={zone_name}, --library={library_label} --album={album_label} --smart-folder={smart_label} --unfiled={unfiled}"
+                            );
+                            assert_eq!(
+                                scope.include_albums, expected_albums,
+                                "album scope mismatch for zone={zone_name}, --library={library_label} --album={album_label} --smart-folder={smart_label} --unfiled={unfiled}"
+                            );
+                            assert_eq!(
+                                scope.include_smart_folders, expected_smart,
+                                "smart-folder scope mismatch for zone={zone_name}, --library={library_label} --album={album_label} --smart-folder={smart_label} --unfiled={unfiled}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        assert_eq!(matrix_cases, 54, "expected full 3x3x3x2 matrix coverage");
+    }
+
     #[tokio::test]
     async fn resolve_libraries_default_returns_primary_only() {
         let mut ps = photos_service_with_zones(&["SharedSync-AAAA1111", "SharedSync-BBBB2222"]);

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -512,10 +512,67 @@ pub(crate) struct PassScope {
     pub include_unfiled: bool,
 }
 
+impl PassScope {
+    pub(crate) fn is_empty(self) -> bool {
+        !self.include_albums && !self.include_smart_folders && !self.include_unfiled
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CollectionContext {
     pub(crate) collection_album_names: std::collections::BTreeSet<String>,
     pub(crate) selected_smart_folder_names: Vec<String>,
+}
+
+pub(crate) fn smart_selector_active(selection: &crate::selection::Selection) -> bool {
+    !matches!(
+        selection.smart_folders,
+        crate::selection::SmartFolderSelector::None
+    )
+}
+
+pub(crate) fn collection_libraries<'a>(
+    selection: &crate::selection::Selection,
+    selected_libraries: &'a [icloud::photos::PhotoLibrary],
+    all_libraries: &'a [icloud::photos::PhotoLibrary],
+) -> &'a [icloud::photos::PhotoLibrary] {
+    if selection.albums_explicit || smart_selector_active(selection) {
+        all_libraries
+    } else {
+        selected_libraries
+    }
+}
+
+pub(crate) fn zone_name_set(
+    libraries: &[icloud::photos::PhotoLibrary],
+) -> rustc_hash::FxHashSet<String> {
+    libraries
+        .iter()
+        .map(|library| library.zone_name().to_string())
+        .collect()
+}
+
+pub(crate) fn pass_scope_for_zone(
+    selection: &crate::selection::Selection,
+    zone_name: &str,
+    selected_zones: &rustc_hash::FxHashSet<String>,
+    collection_zones: &rustc_hash::FxHashSet<String>,
+) -> PassScope {
+    use crate::selection::AlbumSelector;
+
+    let include_unfiled = selection.unfiled && selected_zones.contains(zone_name);
+    let include_albums = match selection.albums {
+        AlbumSelector::None => false,
+        _ if selection.albums_explicit => collection_zones.contains(zone_name),
+        _ => selected_zones.contains(zone_name),
+    };
+    let include_smart_folders =
+        smart_selector_active(selection) && collection_zones.contains(zone_name);
+    PassScope {
+        include_albums,
+        include_smart_folders,
+        include_unfiled,
+    }
 }
 
 pub(crate) async fn build_collection_context(

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -532,15 +532,11 @@ pub(crate) fn smart_selector_active(selection: &crate::selection::Selection) -> 
 }
 
 pub(crate) fn collection_libraries<'a>(
-    selection: &crate::selection::Selection,
+    _selection: &crate::selection::Selection,
     selected_libraries: &'a [icloud::photos::PhotoLibrary],
-    all_libraries: &'a [icloud::photos::PhotoLibrary],
+    _all_libraries: &'a [icloud::photos::PhotoLibrary],
 ) -> &'a [icloud::photos::PhotoLibrary] {
-    if selection.albums_explicit || smart_selector_active(selection) {
-        all_libraries
-    } else {
-        selected_libraries
-    }
+    selected_libraries
 }
 
 pub(crate) fn zone_name_set(

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -532,11 +532,15 @@ pub(crate) fn smart_selector_active(selection: &crate::selection::Selection) -> 
 }
 
 pub(crate) fn collection_libraries<'a>(
-    _selection: &crate::selection::Selection,
+    selection: &crate::selection::Selection,
     selected_libraries: &'a [icloud::photos::PhotoLibrary],
-    _all_libraries: &'a [icloud::photos::PhotoLibrary],
+    all_libraries: &'a [icloud::photos::PhotoLibrary],
 ) -> &'a [icloud::photos::PhotoLibrary] {
-    selected_libraries
+    if selection.albums_explicit || smart_selector_active(selection) {
+        all_libraries
+    } else {
+        selected_libraries
+    }
 }
 
 pub(crate) fn zone_name_set(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1248,7 +1248,9 @@ impl Config {
 
         let selection = crate::selection::Selection {
             albums: crate::selection::parse_album_selector(&raw_albums, true)?,
+            albums_explicit: !raw_albums.is_empty(),
             smart_folders: crate::selection::parse_smart_folder_selector(&raw_smart_folders)?,
+            smart_folders_explicit: !raw_smart_folders.is_empty(),
             libraries: library_selector.clone(),
             unfiled: unfiled_override.unwrap_or_else(unfiled_default),
         };

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -188,32 +188,32 @@ impl PhotoLibrary {
     pub async fn albums(&self) -> anyhow::Result<HashMap<String, PhotoAlbum>> {
         let mut albums = HashMap::new();
 
-        // Shared libraries don't support smart folder or user album queries —
-        // their CloudKit zones lack the required indexes. Check the zone name
-        // because Apple's private endpoint also returns SharedSync zones
-        // (library_type reflects the API endpoint, not the zone type).
-        if !self.zone_name().starts_with("SharedSync") {
-            for (name, def) in smart_folders() {
-                albums.insert(
-                    name.to_string(),
-                    PhotoAlbum::new(
-                        PhotoAlbumConfig {
-                            params: Arc::clone(&self.params),
-                            service_endpoint: Arc::clone(&self.service_endpoint),
-                            name: Arc::from(name),
-                            list_type: Arc::from(def.list_type),
-                            obj_type: Arc::from(def.obj_type),
-                            query_filter: def.query_filter,
-                            page_size: DEFAULT_PAGE_SIZE,
-                            zone_id: Arc::clone(&self.zone_id),
-                            retry_config: self.retry_config,
-                            container_id: None,
-                            cross_zone_sources: Vec::new(),
-                        },
-                        self.clone_session(),
-                    ),
-                );
-            }
+        // Smart folders are user-scoped and can include assets from shared
+        // zones, so always inject their query definitions for every zone.
+        for (name, def) in smart_folders() {
+            albums.insert(
+                name.to_string(),
+                PhotoAlbum::new(
+                    PhotoAlbumConfig {
+                        params: Arc::clone(&self.params),
+                        service_endpoint: Arc::clone(&self.service_endpoint),
+                        name: Arc::from(name),
+                        list_type: Arc::from(def.list_type),
+                        obj_type: Arc::from(def.obj_type),
+                        query_filter: def.query_filter,
+                        page_size: DEFAULT_PAGE_SIZE,
+                        zone_id: Arc::clone(&self.zone_id),
+                        retry_config: self.retry_config,
+                        container_id: None,
+                        cross_zone_sources: Vec::new(),
+                    },
+                    self.clone_session(),
+                ),
+            );
+        }
+
+        // Shared zones currently skip user-created album folder queries.
+        if !is_shared_zone(self.zone_name()) {
             let folders = self.fetch_folders().await?;
             for folder in &folders {
                 let record_name = &folder.record_name;

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -112,7 +112,9 @@ impl LibrarySelector {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Selection {
     pub albums: AlbumSelector,
+    pub albums_explicit: bool,
     pub smart_folders: SmartFolderSelector,
+    pub smart_folders_explicit: bool,
     pub libraries: LibrarySelector,
     /// Run the unfiled (no-album) pass. Default `true` — orthogonal to
     /// `albums`, so `--album Vacation` still produces an unfiled pass unless
@@ -124,7 +126,9 @@ impl Default for Selection {
     fn default() -> Self {
         Self {
             albums: AlbumSelector::default(),
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::default(),
+            smart_folders_explicit: false,
             libraries: LibrarySelector::default(),
             unfiled: true,
         }
@@ -469,7 +473,9 @@ pub(crate) fn build_selection(
 ) -> anyhow::Result<Selection> {
     Ok(Selection {
         albums: parse_album_selector(raw_albums, true)?,
+        albums_explicit: !raw_albums.is_empty(),
         smart_folders: parse_smart_folder_selector(raw_smart_folders)?,
+        smart_folders_explicit: !raw_smart_folders.is_empty(),
         libraries: parse_library_selector(raw_libraries)?,
         unfiled: unfiled_explicit.unwrap_or(true),
     })
@@ -984,7 +990,9 @@ mod tests {
     fn selection_defaults() {
         let s = Selection::default();
         assert_eq!(s.albums, AlbumSelector::default());
+        assert!(!s.albums_explicit);
         assert_eq!(s.smart_folders, SmartFolderSelector::None);
+        assert!(!s.smart_folders_explicit);
         assert!(s.libraries.primary);
         assert!(!s.libraries.shared_all);
         assert!(s.unfiled);
@@ -1024,6 +1032,8 @@ mod tests {
                 excluded: BTreeSet::new(),
             }
         );
+        assert!(s.albums_explicit);
+        assert!(s.smart_folders_explicit);
         assert!(s.libraries.primary);
         assert!(s.libraries.shared_all);
         assert!(s.unfiled);
@@ -1199,10 +1209,12 @@ mod tests {
             albums: AlbumSelector::All {
                 excluded: set(&["Family"]),
             },
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::Named {
                 included: set(&["Favorites"]),
                 excluded: BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: LibrarySelector {
                 primary: true,
                 shared_all: true,

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -18,6 +18,7 @@ use crate::state;
 pub(crate) struct LibraryState {
     pub(crate) library: crate::icloud::photos::PhotoLibrary,
     pub(crate) cross_zone_libraries: Vec<crate::icloud::photos::PhotoLibrary>,
+    pub(crate) pass_scope: crate::commands::PassScope,
     pub(crate) zone_name: String,
     pub(crate) sync_token_key: String,
     /// Ordered list of download passes. Each pass carries its own

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -10,10 +10,13 @@ use anyhow::Context;
 
 use crate::auth;
 use crate::cli;
+#[cfg(test)]
+use crate::commands::PassScope;
 use crate::commands::{
-    attempt_reauth, build_collection_context, init_photos_service,
-    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
-    wait_and_retry_2fa, CollectionContext, PassScope, MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, build_collection_context, collection_libraries, init_photos_service,
+    pass_scope_for_zone, resolve_cross_zone_libraries_for_album_hydration, resolve_libraries,
+    resolve_passes_for_scope, wait_and_retry_2fa, zone_name_set, CollectionContext,
+    MAX_REAUTH_ATTEMPTS,
 };
 use crate::config;
 use crate::credential;
@@ -817,51 +820,23 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         })
         .await?;
 
-    use crate::selection::{AlbumSelector, SmartFolderSelector};
-    let smart_selector_active = !matches!(
-        config.filters.selection.smart_folders,
-        SmartFolderSelector::None
-    );
-    let collection_libraries = if config.filters.selection.albums_explicit || smart_selector_active
-    {
-        all_libraries.clone()
-    } else {
-        libraries.clone()
-    };
+    let collection_libraries =
+        collection_libraries(&config.filters.selection, &libraries, &all_libraries);
     let collection_context =
-        build_collection_context(&config.filters.selection, &collection_libraries).await?;
-    let selected_zones: rustc_hash::FxHashSet<String> = libraries
-        .iter()
-        .map(|library| library.zone_name().to_string())
-        .collect();
-    let collection_zones: rustc_hash::FxHashSet<String> = collection_libraries
-        .iter()
-        .map(|library| library.zone_name().to_string())
-        .collect();
+        build_collection_context(&config.filters.selection, collection_libraries).await?;
+    let selected_zones = zone_name_set(&libraries);
+    let collection_zones = zone_name_set(collection_libraries);
 
     let mut library_states: Vec<LibraryState> = Vec::with_capacity(all_libraries.len());
     for library in &all_libraries {
         let zone_name = library.zone_name().to_string();
-        let include_unfiled =
-            config.filters.selection.unfiled && selected_zones.contains(zone_name.as_str());
-        let include_albums = match config.filters.selection.albums {
-            AlbumSelector::None => false,
-            _ if config.filters.selection.albums_explicit => {
-                collection_zones.contains(zone_name.as_str())
-            }
-            _ => selected_zones.contains(zone_name.as_str()),
-        };
-        let include_smart_folders =
-            smart_selector_active && collection_zones.contains(zone_name.as_str());
-        let pass_scope = PassScope {
-            include_albums,
-            include_smart_folders,
-            include_unfiled,
-        };
-        if !pass_scope.include_albums
-            && !pass_scope.include_smart_folders
-            && !pass_scope.include_unfiled
-        {
+        let pass_scope = pass_scope_for_zone(
+            &config.filters.selection,
+            zone_name.as_str(),
+            &selected_zones,
+            &collection_zones,
+        );
+        if pass_scope.is_empty() {
             continue;
         }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -11,9 +11,9 @@ use anyhow::Context;
 use crate::auth;
 use crate::cli;
 use crate::commands::{
-    attempt_reauth, init_photos_service, resolve_cross_zone_libraries_for_album_hydration,
-    resolve_libraries, resolve_passes, validate_smart_folder_fulfillability, wait_and_retry_2fa,
-    MAX_REAUTH_ATTEMPTS,
+    attempt_reauth, build_collection_context, init_photos_service,
+    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
+    wait_and_retry_2fa, CollectionContext, PassScope, MAX_REAUTH_ATTEMPTS,
 };
 use crate::config;
 use crate::credential;
@@ -602,12 +602,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         libraries.len(),
     );
 
-    // CloudKit shared zones don't expose smart folders. Catch the
-    // impossible-config case (e.g. shared libraries plus a smart-folder selector)
-    // here, before any per-library work, so the user gets a clear error
-    // instead of a silent zero-pass run with exit code 0.
-    validate_smart_folder_fulfillability(&libraries, &config.filters.selection)?;
-
     // Initialize state database.
     // Skip for --dry-run so a preview doesn't create the DB or poison
     // sync tokens, which would cause a subsequent real sync to believe
@@ -816,18 +810,70 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // failures behind a clean final cycle.
     let mut cumulative_failed_count = 0usize;
 
-    let cross_zone_libraries = resolve_cross_zone_libraries_for_album_hydration(
-        &config.filters.selection,
-        photos_service.all_libraries(),
-    )
-    .await?;
+    let all_libraries = photos_service.all_libraries().await?;
+    let cross_zone_libraries =
+        resolve_cross_zone_libraries_for_album_hydration(&config.filters.selection, async {
+            Ok::<_, anyhow::Error>(all_libraries.clone())
+        })
+        .await?;
 
-    let mut library_states: Vec<LibraryState> = Vec::with_capacity(libraries.len());
-    for library in &libraries {
+    use crate::selection::{AlbumSelector, SmartFolderSelector};
+    let smart_selector_active = !matches!(
+        config.filters.selection.smart_folders,
+        SmartFolderSelector::None
+    );
+    let collection_libraries = if config.filters.selection.albums_explicit || smart_selector_active
+    {
+        all_libraries.clone()
+    } else {
+        libraries.clone()
+    };
+    let collection_context =
+        build_collection_context(&config.filters.selection, &collection_libraries).await?;
+    let selected_zones: rustc_hash::FxHashSet<String> = libraries
+        .iter()
+        .map(|library| library.zone_name().to_string())
+        .collect();
+    let collection_zones: rustc_hash::FxHashSet<String> = collection_libraries
+        .iter()
+        .map(|library| library.zone_name().to_string())
+        .collect();
+
+    let mut library_states: Vec<LibraryState> = Vec::with_capacity(all_libraries.len());
+    for library in &all_libraries {
         let zone_name = library.zone_name().to_string();
+        let include_unfiled =
+            config.filters.selection.unfiled && selected_zones.contains(zone_name.as_str());
+        let include_albums = match config.filters.selection.albums {
+            AlbumSelector::None => false,
+            _ if config.filters.selection.albums_explicit => {
+                collection_zones.contains(zone_name.as_str())
+            }
+            _ => selected_zones.contains(zone_name.as_str()),
+        };
+        let include_smart_folders =
+            smart_selector_active && collection_zones.contains(zone_name.as_str());
+        let pass_scope = PassScope {
+            include_albums,
+            include_smart_folders,
+            include_unfiled,
+        };
+        if !pass_scope.include_albums
+            && !pass_scope.include_smart_folders
+            && !pass_scope.include_unfiled
+        {
+            continue;
+        }
+
         let sync_token_key = make_sync_token_key(&zone_name);
-        let plan =
-            resolve_passes(library, &config.filters.selection, &cross_zone_libraries).await?;
+        let plan = resolve_passes_for_scope(
+            library,
+            &config.filters.selection,
+            pass_scope,
+            &collection_context,
+            &cross_zone_libraries,
+        )
+        .await?;
         let (album_passes, smart_folder_passes, unfiled) = count_passes(&plan);
         tracing::info!(
             zone = %zone_name,
@@ -839,6 +885,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         library_states.push(LibraryState {
             library: library.clone(),
             cross_zone_libraries: cross_zone_libraries.clone(),
+            pass_scope,
             zone_name,
             sync_token_key,
             plan,
@@ -847,11 +894,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         });
     }
     warn_if_multi_library_paths_commingle(
-        library_states.len(),
+        &library_states,
         &config.download.folder_structure,
         &config.download.folder_structure_albums,
         &config.download.folder_structure_smart_folders,
-        &config.filters.selection,
     );
     sd_notifier.notify_ready();
     // Friendly-mode greeting. Lands above any future bar via
@@ -935,6 +981,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             refresh_needed_library_plans(
                 &mut library_states,
                 &config.filters.selection,
+                &collection_context,
                 watch_precheck.changed_zones(),
                 &mut consecutive_album_refresh_failures,
             )
@@ -1422,6 +1469,7 @@ pub(crate) fn should_wait_for_2fa(is_watch_mode: bool, err: &anyhow::Error) -> b
 async fn refresh_needed_library_plans(
     library_states: &mut [LibraryState],
     selection: &crate::selection::Selection,
+    collection_context: &CollectionContext,
     changed_zones: Option<&rustc_hash::FxHashSet<String>>,
     consecutive_album_refresh_failures: &mut u32,
 ) {
@@ -1438,9 +1486,11 @@ async fn refresh_needed_library_plans(
         // phase; incremental/cleanup paths resolve them before planning tasks.
         // This refresh is intentionally delayed until a selected zone has
         // changes so quiet watch cycles avoid the album-listing traffic.
-        match resolve_passes(
+        match resolve_passes_for_scope(
             &lib_state.library,
             selection,
+            lib_state.pass_scope,
+            collection_context,
             &lib_state.cross_zone_libraries,
         )
         .await
@@ -1602,21 +1652,20 @@ pub(crate) fn count_passes(plan: &crate::commands::AlbumPlan) -> (usize, usize, 
 /// when `--smart-folder none`) don't render any path so they don't need
 /// `{library}` to keep the sync safe.
 fn find_multi_library_commingle_flags(
-    library_count: usize,
+    library_states: &[LibraryState],
     folder_structure: &str,
     folder_structure_albums: &str,
     folder_structure_smart_folders: &str,
-    selection: &crate::selection::Selection,
 ) -> Vec<&'static str> {
-    use crate::selection::{AlbumSelector, SmartFolderSelector};
-
-    if library_count < 2 {
+    if library_states.len() < 2 {
         return Vec::new();
     }
 
-    let unfiled_active = selection.unfiled;
-    let album_active = !matches!(selection.albums, AlbumSelector::None);
-    let smart_folder_active = !matches!(selection.smart_folders, SmartFolderSelector::None);
+    let unfiled_active = library_states.iter().any(|s| s.pass_scope.include_unfiled);
+    let album_active = library_states.iter().any(|s| s.pass_scope.include_albums);
+    let smart_folder_active = library_states
+        .iter()
+        .any(|s| s.pass_scope.include_smart_folders);
 
     // All passes disabled — resolve_passes returns an empty plan, no path
     // ever renders, multi-library can't commingle.
@@ -1645,22 +1694,21 @@ fn find_multi_library_commingle_flags(
 /// user can add `{library}` to their templates if they want zone-disjoint
 /// trees.
 fn warn_if_multi_library_paths_commingle(
-    library_count: usize,
+    library_states: &[LibraryState],
     folder_structure: &str,
     folder_structure_albums: &str,
     folder_structure_smart_folders: &str,
-    selection: &crate::selection::Selection,
 ) {
     let missing = find_multi_library_commingle_flags(
-        library_count,
+        library_states,
         folder_structure,
         folder_structure_albums,
         folder_structure_smart_folders,
-        selection,
     );
     if missing.is_empty() {
         return;
     }
+    let library_count = library_states.len();
     tracing::warn!(
         library_count,
         missing = ?missing,
@@ -2144,10 +2192,12 @@ mod tests {
             albums: AlbumSelector::All {
                 excluded: std::collections::BTreeSet::new(),
             },
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::All {
                 include_sensitive: false,
                 excluded: std::collections::BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: LibrarySelector::default(),
             unfiled: true,
         }
@@ -2158,10 +2208,48 @@ mod tests {
         use crate::selection::{AlbumSelector, LibrarySelector, Selection, SmartFolderSelector};
         Selection {
             albums: AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: LibrarySelector::default(),
             unfiled: true,
         }
+    }
+
+    fn commingle_test_states(
+        count: usize,
+        selection: &crate::selection::Selection,
+    ) -> Vec<LibraryState> {
+        use crate::selection::{AlbumSelector, SmartFolderSelector};
+
+        let pass_scope = PassScope {
+            include_albums: !matches!(selection.albums, AlbumSelector::None),
+            include_smart_folders: !matches!(selection.smart_folders, SmartFolderSelector::None),
+            include_unfiled: selection.unfiled,
+        };
+        (0..count)
+            .map(|idx| {
+                let zone_name = if idx == 0 {
+                    "PrimarySync".to_string()
+                } else {
+                    format!("SharedSync-{:08X}", idx)
+                };
+                let library = crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
+                    Box::new(crate::test_helpers::MockPhotosSession::new()),
+                    &zone_name,
+                );
+                LibraryState {
+                    library,
+                    cross_zone_libraries: Vec::new(),
+                    pass_scope,
+                    zone_name: zone_name.clone(),
+                    sync_token_key: format!("sync_token:{zone_name}"),
+                    plan: crate::commands::AlbumPlan { passes: Vec::new() },
+                    plan_is_stale: false,
+                    plan_needs_refresh: false,
+                }
+            })
+            .collect()
     }
 
     #[test]
@@ -2169,20 +2257,20 @@ mod tests {
         // Zero or one library never flags any template, regardless of
         // template content or active-pass selection.
         let sel = selection_all_passes_active();
+        let states0 = commingle_test_states(0, &sel);
         assert!(find_multi_library_commingle_flags(
-            0,
+            &states0,
             "%Y/%m/%d",
             "{album}",
-            "{smart-folder}",
-            &sel
+            "{smart-folder}"
         )
         .is_empty());
+        let states1 = commingle_test_states(1, &sel);
         assert!(find_multi_library_commingle_flags(
-            1,
+            &states1,
             "%Y/%m/%d",
             "{album}",
-            "{smart-folder}",
-            &sel
+            "{smart-folder}"
         )
         .is_empty());
     }
@@ -2193,13 +2281,13 @@ mod tests {
         // multi-library is safe. Inactive templates are irrelevant -
         // their pass kind doesn't run.
         let all = selection_all_passes_active();
+        let all_states = commingle_test_states(2, &all);
         assert!(
             find_multi_library_commingle_flags(
-                2,
+                &all_states,
                 "{library}/%Y/%m/%d",
                 "{library}/{album}",
                 "{library}/{smart-folder}",
-                &all,
             )
             .is_empty(),
             "every active template carries `{{library}}` - no commingle"
@@ -2209,13 +2297,13 @@ mod tests {
         // the only one that needs `{library}`. The album / smart-folder
         // templates can be anything because no pass reads them.
         let unfiled = selection_unfiled_only();
+        let unfiled_states = commingle_test_states(2, &unfiled);
         assert!(
             find_multi_library_commingle_flags(
-                2,
+                &unfiled_states,
                 "{library}/%Y/%m/%d",
                 "{album}",
                 "{smart-folder}",
-                &unfiled,
             )
             .is_empty(),
             "only unfiled active and its template has `{{library}}`"
@@ -2236,19 +2324,21 @@ mod tests {
             albums: AlbumSelector::All {
                 excluded: std::collections::BTreeSet::new(),
             },
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::All {
                 include_sensitive: false,
                 excluded: std::collections::BTreeSet::new(),
             },
+            smart_folders_explicit: true,
             libraries: LibrarySelector::default(),
             unfiled: false,
         };
+        let states = commingle_test_states(2, &sel);
         let missing = find_multi_library_commingle_flags(
-            2,
+            &states,
             "%Y/%m/%d",
             "{library}/{album}",
             "{smart-folder}",
-            &sel,
         );
         assert_eq!(
             missing,
@@ -2262,17 +2352,19 @@ mod tests {
             albums: AlbumSelector::All {
                 excluded: std::collections::BTreeSet::new(),
             },
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: LibrarySelector::default(),
             unfiled: false,
         };
+        let states_no_smart = commingle_test_states(2, &sel_no_smart);
         assert!(
             find_multi_library_commingle_flags(
-                2,
+                &states_no_smart,
                 "%Y/%m/%d",
                 "{library}/{album}",
                 "{smart-folder}",
-                &sel_no_smart,
             )
             .is_empty(),
             "smart-folder inactive - its `{{library}}`-less template is irrelevant"
@@ -2283,8 +2375,9 @@ mod tests {
     fn find_multi_library_commingle_flags_reports_all_missing_when_every_active_template_lacks_token(
     ) {
         let sel = selection_all_passes_active();
+        let states = commingle_test_states(2, &sel);
         let missing =
-            find_multi_library_commingle_flags(2, "%Y/%m/%d", "{album}", "{smart-folder}", &sel);
+            find_multi_library_commingle_flags(&states, "%Y/%m/%d", "{album}", "{smart-folder}");
         assert_eq!(
             missing,
             vec![
@@ -2302,8 +2395,9 @@ mod tests {
         // every asset lands directly in the download dir. Still surfaces
         // the unfiled flag so the user knows the namespace is shared.
         let sel = selection_all_passes_active();
+        let states = commingle_test_states(5, &sel);
         let missing =
-            find_multi_library_commingle_flags(5, "none", "{album}", "{smart-folder}", &sel);
+            find_multi_library_commingle_flags(&states, "none", "{album}", "{smart-folder}");
         assert!(missing.contains(&"--folder-structure"));
     }
 
@@ -2316,12 +2410,15 @@ mod tests {
         use crate::selection::{AlbumSelector, LibrarySelector, Selection, SmartFolderSelector};
         let sel = Selection {
             albums: AlbumSelector::None,
+            albums_explicit: true,
             smart_folders: SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: LibrarySelector::default(),
             unfiled: false,
         };
+        let states = commingle_test_states(3, &sel);
         assert!(
-            find_multi_library_commingle_flags(3, "%Y/%m/%d", "{album}", "{smart-folder}", &sel)
+            find_multi_library_commingle_flags(&states, "%Y/%m/%d", "{album}", "{smart-folder}")
                 .is_empty(),
             "no active passes - find_* must report empty"
         );
@@ -2339,7 +2436,8 @@ mod tests {
     #[test]
     fn warn_if_multi_library_paths_commingle_emits_structured_fields() {
         let sel = selection_all_passes_active();
-        warn_if_multi_library_paths_commingle(3, "%Y/%m/%d", "{album}", "{smart-folder}", &sel);
+        let states = commingle_test_states(3, &sel);
+        warn_if_multi_library_paths_commingle(&states, "%Y/%m/%d", "{album}", "{smart-folder}");
         assert!(
             logs_contain("library_count=3"),
             "structured library_count field expected on warn line"
@@ -2372,12 +2470,12 @@ mod tests {
     #[test]
     fn warn_if_multi_library_paths_commingle_silent_when_no_commingle() {
         let sel = selection_all_passes_active();
+        let states = commingle_test_states(3, &sel);
         warn_if_multi_library_paths_commingle(
-            3,
+            &states,
             "{library}/%Y/%m/%d",
             "{library}/{album}",
             "{library}/{smart-folder}",
-            &sel,
         );
         assert!(
             !logs_contain("library_count="),
@@ -2600,6 +2698,11 @@ mod tests {
                 Box::new(crate::test_helpers::MockPhotosSession::new()),
                 zone,
             ),
+            pass_scope: PassScope {
+                include_albums: false,
+                include_smart_folders: false,
+                include_unfiled: true,
+            },
             zone_name: zone.to_string(),
             sync_token_key: sync_token_key.to_string(),
             plan: crate::commands::AlbumPlan {
@@ -3634,6 +3737,11 @@ mod tests {
         );
         LibraryState {
             library: crate::icloud::photos::PhotoLibrary::new_stub(stub_session),
+            pass_scope: PassScope {
+                include_albums: false,
+                include_smart_folders: false,
+                include_unfiled: false,
+            },
             zone_name: zone.to_string(),
             sync_token_key: sync_token_key.to_string(),
             plan: crate::commands::AlbumPlan { passes: Vec::new() },
@@ -3971,14 +4079,26 @@ mod tests {
         changed_zones.insert("PrimarySync".to_string());
         let selection = crate::selection::Selection {
             albums: crate::selection::AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: crate::selection::SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: crate::selection::LibrarySelector::default(),
             unfiled: false,
         };
+        let collection_context = CollectionContext {
+            collection_album_names: std::collections::BTreeSet::new(),
+            selected_smart_folder_names: Vec::new(),
+        };
         let mut failures = 0;
 
-        refresh_needed_library_plans(&mut states, &selection, Some(&changed_zones), &mut failures)
-            .await;
+        refresh_needed_library_plans(
+            &mut states,
+            &selection,
+            &collection_context,
+            Some(&changed_zones),
+            &mut failures,
+        )
+        .await;
 
         assert!(
             !states[0].plan_needs_refresh,
@@ -4003,13 +4123,26 @@ mod tests {
         }
         let selection = crate::selection::Selection {
             albums: crate::selection::AlbumSelector::None,
+            albums_explicit: false,
             smart_folders: crate::selection::SmartFolderSelector::None,
+            smart_folders_explicit: false,
             libraries: all_libraries(),
             unfiled: false,
         };
+        let collection_context = CollectionContext {
+            collection_album_names: std::collections::BTreeSet::new(),
+            selected_smart_folder_names: Vec::new(),
+        };
         let mut failures = 2;
 
-        refresh_needed_library_plans(&mut states, &selection, None, &mut failures).await;
+        refresh_needed_library_plans(
+            &mut states,
+            &selection,
+            &collection_context,
+            None,
+            &mut failures,
+        )
+        .await;
 
         assert!(
             states.iter().all(|state| !state.plan_needs_refresh),

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1822,6 +1822,104 @@ mod tests {
         crate::selection::parse_library_selector(&["SharedSync-ABCD1234".to_string()]).unwrap()
     }
 
+    fn selection_with_smart_folder(
+        libraries: crate::selection::LibrarySelector,
+    ) -> crate::selection::Selection {
+        use crate::selection::{AlbumSelector, Selection, SmartFolderSelector};
+        Selection {
+            albums: AlbumSelector::None,
+            albums_explicit: false,
+            smart_folders: SmartFolderSelector::Named {
+                included: std::collections::BTreeSet::from(["Hidden".to_string()]),
+                excluded: std::collections::BTreeSet::new(),
+            },
+            smart_folders_explicit: true,
+            libraries,
+            unfiled: false,
+        }
+    }
+
+    fn test_library(zone_name: &str) -> crate::icloud::photos::PhotoLibrary {
+        crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
+            Box::new(crate::test_helpers::MockPhotosSession::new()),
+            zone_name,
+        )
+    }
+
+    #[test]
+    fn run_sync_scope_planning_shared_only_smart_folder_excludes_primary_zone() {
+        let selection = selection_with_smart_folder(
+            crate::selection::parse_library_selector(&["shared".to_string()]).unwrap(),
+        );
+        let primary = test_library("PrimarySync");
+        let shared = test_library("SharedSync-ABCD1234");
+        let selected_libraries = vec![shared.clone()];
+        let all_libraries = vec![primary.clone(), shared.clone()];
+
+        let collection = collection_libraries(&selection, &selected_libraries, &all_libraries);
+        let selected_zones = zone_name_set(&selected_libraries);
+        let collection_zones = zone_name_set(collection);
+
+        let primary_scope = pass_scope_for_zone(
+            &selection,
+            primary.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+        let shared_scope = pass_scope_for_zone(
+            &selection,
+            shared.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+
+        assert!(
+            primary_scope.is_empty(),
+            "run_sync planning must not schedule PrimarySync when library selector is shared-only"
+        );
+        assert!(
+            shared_scope.include_smart_folders,
+            "run_sync planning should schedule smart-folder passes for selected shared zone"
+        );
+    }
+
+    #[test]
+    fn run_sync_scope_planning_primary_only_smart_folder_excludes_shared_zone() {
+        let selection = selection_with_smart_folder(
+            crate::selection::parse_library_selector(&["primary".to_string()]).unwrap(),
+        );
+        let primary = test_library("PrimarySync");
+        let shared = test_library("SharedSync-ABCD1234");
+        let selected_libraries = vec![primary.clone()];
+        let all_libraries = vec![primary.clone(), shared.clone()];
+
+        let collection = collection_libraries(&selection, &selected_libraries, &all_libraries);
+        let selected_zones = zone_name_set(&selected_libraries);
+        let collection_zones = zone_name_set(collection);
+
+        let primary_scope = pass_scope_for_zone(
+            &selection,
+            primary.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+        let shared_scope = pass_scope_for_zone(
+            &selection,
+            shared.zone_name(),
+            &selected_zones,
+            &collection_zones,
+        );
+
+        assert!(
+            primary_scope.include_smart_folders,
+            "run_sync planning should keep smart-folder passes in the selected primary zone"
+        );
+        assert!(
+            shared_scope.is_empty(),
+            "run_sync planning must not schedule shared-zone passes when selector is primary-only"
+        );
+    }
+
     #[test]
     fn notice_suppressed_when_already_shown() {
         // The marker overrides everything: even a user with 5 shared libraries

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1824,6 +1824,7 @@ mod tests {
 
     fn selection_with_smart_folder(
         libraries: crate::selection::LibrarySelector,
+        unfiled: bool,
     ) -> crate::selection::Selection {
         use crate::selection::{AlbumSelector, Selection, SmartFolderSelector};
         Selection {
@@ -1835,7 +1836,7 @@ mod tests {
             },
             smart_folders_explicit: true,
             libraries,
-            unfiled: false,
+            unfiled,
         }
     }
 
@@ -1847,9 +1848,10 @@ mod tests {
     }
 
     #[test]
-    fn run_sync_scope_planning_shared_only_smart_folder_excludes_primary_zone() {
+    fn run_sync_scope_planning_shared_only_smart_folder_widens_zone_scope() {
         let selection = selection_with_smart_folder(
             crate::selection::parse_library_selector(&["shared".to_string()]).unwrap(),
+            false,
         );
         let primary = test_library("PrimarySync");
         let shared = test_library("SharedSync-ABCD1234");
@@ -1874,8 +1876,8 @@ mod tests {
         );
 
         assert!(
-            primary_scope.is_empty(),
-            "run_sync planning must not schedule PrimarySync when library selector is shared-only"
+            primary_scope.include_smart_folders,
+            "explicit smart-folder selection should widen pass planning beyond the library selector"
         );
         assert!(
             shared_scope.include_smart_folders,
@@ -1884,9 +1886,10 @@ mod tests {
     }
 
     #[test]
-    fn run_sync_scope_planning_primary_only_smart_folder_excludes_shared_zone() {
+    fn run_sync_scope_planning_primary_only_still_filters_unfiled() {
         let selection = selection_with_smart_folder(
             crate::selection::parse_library_selector(&["primary".to_string()]).unwrap(),
+            true,
         );
         let primary = test_library("PrimarySync");
         let shared = test_library("SharedSync-ABCD1234");
@@ -1915,8 +1918,16 @@ mod tests {
             "run_sync planning should keep smart-folder passes in the selected primary zone"
         );
         assert!(
-            shared_scope.is_empty(),
-            "run_sync planning must not schedule shared-zone passes when selector is primary-only"
+            shared_scope.include_smart_folders,
+            "explicit smart-folder selection should widen scope to shared zones too"
+        );
+        assert!(
+            primary_scope.include_unfiled,
+            "selected primary zone should keep unfiled pass when unfiled=true"
+        );
+        assert!(
+            !shared_scope.include_unfiled,
+            "library selector should still filter unfiled passes to selected zones"
         );
     }
 

--- a/tests/shell/docker.sh
+++ b/tests/shell/docker.sh
@@ -33,7 +33,18 @@ echo ""
 # ── Setup: copy the pre-authenticated session into a fresh config dir ───
 DOCKER_CONFIG=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-config-XXXXX")
 DOCKER_PHOTOS=$(mktemp -d "${TMPDIR:-/tmp}/kei-docker-photos-XXXXX")
-trap "rm -rf '$DOCKER_CONFIG' '$DOCKER_PHOTOS'" EXIT
+docker_cleanup() {
+    local exit_code=$?
+    # Root-owned files can be left behind on bind mounts; hand ownership
+    # back before removing scratch dirs so EXIT cleanup never flips the
+    # suite result with Permission denied.
+    docker run --rm -v "$DOCKER_CONFIG:/c" -v "$DOCKER_PHOTOS:/p" "$IMAGE" \
+        chown -R "$(id -u):$(id -g)" /c /p >/dev/null 2>&1 || true
+    chmod -R u+rwX "$DOCKER_CONFIG" "$DOCKER_PHOTOS" >/dev/null 2>&1 || true
+    rm -rf "$DOCKER_CONFIG" "$DOCKER_PHOTOS" >/dev/null 2>&1 || true
+    return "$exit_code"
+}
+trap docker_cleanup EXIT
 
 cp "$COOKIES/"* "$DOCKER_CONFIG/" 2>/dev/null
 cp "$COOKIES/".* "$DOCKER_CONFIG/" 2>/dev/null
@@ -105,7 +116,7 @@ fi
 
 echo ""
 echo "--- 6. Idempotent re-sync (no new downloads) ---"
-docker run --rm \
+RESYNC_OUT=$(docker run --rm \
     -e ICLOUD_USERNAME="$ICLOUD_USERNAME" \
     -e KEI_DATA_DIR=/config \
     -v "$DOCKER_CONFIG:/config" \
@@ -115,7 +126,13 @@ docker run --rm \
         --password "$ICLOUD_PASSWORD" \
         --no-progress-bar \
         --log-level info \
-    2>&1 | tee /dev/stderr | grep -qE "downloaded=0|No new photos"
+    2>&1)
+RESYNC_EC=$?
+echo "$RESYNC_OUT"
+[ "$RESYNC_EC" -eq 0 ] && case "$RESYNC_OUT" in
+    *downloaded=0*|*"No new photos"*) true ;;
+    *) false ;;
+esac
 kei_check "re-sync downloads 0 files"
 
 echo ""
@@ -184,7 +201,9 @@ echo "  Container exit code:   $EXIT_CODE"
 # 0 = normal, 130 = SIGINT, 143 = SIGTERM after handler.
 case "$EXIT_CODE" in 0|130|143) true;; *) false;; esac
 kei_check "container exited cleanly on SIGTERM (exit $EXIT_CODE)"
-rm -rf "$WATCH_PHOTOS"
+docker run --rm -v "$WATCH_PHOTOS:/p" "$IMAGE" \
+    chown -R "$(id -u):$(id -g)" /p >/dev/null 2>&1 || true
+rm -rf "$WATCH_PHOTOS" >/dev/null 2>&1 || true
 
 echo ""
 echo "--- 11. HEALTHCHECK probe ---"
@@ -192,14 +211,20 @@ echo "--- 11. HEALTHCHECK probe ---"
 # depend on jq being installed in the production image (slim debian, no
 # jq). The field is a top-level integer; the regex scopes the match to
 # its key so adjacent fields can't bleed in.
-docker run --rm --entrypoint sh \
+HEALTHCHECK_OUT=$(docker run --rm --entrypoint sh \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" -c '
       test -f /config/health.json || exit 1
       cf=$(grep -oE "\"consecutive_failures\"[[:space:]]*:[[:space:]]*[0-9]+" /config/health.json \
            | grep -oE "[0-9]+$")
       test -n "$cf" && test "$cf" -lt 5 && echo HEALTHY
-    ' 2>&1 | tee /dev/stderr | grep -q HEALTHY
+    ' 2>&1)
+HEALTHCHECK_EC=$?
+echo "$HEALTHCHECK_OUT"
+[ "$HEALTHCHECK_EC" -eq 0 ] && case "$HEALTHCHECK_OUT" in
+    *HEALTHY*) true ;;
+    *) false ;;
+esac
 kei_check "healthcheck probe reports HEALTHY"
 
 echo ""


### PR DESCRIPTION
## Summary
- add explicitness tracking to selection (`albums_explicit`, `smart_folders_explicit`) so config/CLI can distinguish implicit defaults from user-requested collection passes.
- make smart-folder definitions available in every zone and replace the old shared-zone smart-folder preflight with scoped pass planning (`PassScope`, `CollectionContext`, `build_collection_context`, `resolve_passes_for_scope`).
- update `sync` and `import-existing` to build passes from collection scope (primary/shared/all) while keeping unfiled scoped to selected libraries, and base multi-library commingle warnings on final active pass scope.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- live dry-run matrix: `cargo run -- sync --config <matrix-config> --dry-run --only-print-filenames --no-progress-bar` across `--library primary/shared/all` for all account smart folders (logs under `/tmp/codex/kei/issue491/logs*`).

Closes #491 
