### PR TITLE
Improve onboarding defaults and sync messaging

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,8 +195,10 @@ pub struct PasswordArgs {
 /// Arguments for the sync command (also used as default when no subcommand).
 #[derive(Parser, Debug, Clone, Default)]
 pub struct SyncArgs {
-    /// Number of recent photos to download (e.g. `--recent 100`) or a recency
-    /// window in days (e.g. `--recent 30d`). Days form maps to
+    /// Limit recent assets per selected library/album/smart-folder pass
+    /// (e.g. `--recent 100`) or use a days window (e.g. `--recent 30d`).
+    /// This is not a global exact file count - filters and live-photo parts
+    /// can change the final number of downloaded files. Days form maps to
     /// `--skip-created-before` internally.
     #[arg(long, value_parser = parse_recent_limit)]
     pub recent: Option<RecentLimit>,

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -7,6 +7,7 @@ use crate::auth;
 use crate::cli;
 use crate::config;
 use crate::retry;
+use std::collections::BTreeSet;
 
 use super::service::{init_photos_service, resolve_libraries, retry_on_lock_contention};
 
@@ -49,16 +50,15 @@ pub(crate) async fn run_list(
 
     match what {
         cli::ListCommand::Libraries => {
-            println!("Private libraries:");
-            let private = photos_service.fetch_private_libraries().await?;
-            for name in private.keys() {
-                println!("  {name}");
-            }
-            println!("Shared libraries:");
-            let shared = photos_service.fetch_shared_libraries().await?;
-            for name in shared.keys() {
-                println!("  {name}");
-            }
+            let private: Vec<String> = {
+                let private = photos_service.fetch_private_libraries().await?;
+                private.keys().cloned().collect()
+            };
+            let shared: Vec<String> = {
+                let shared = photos_service.fetch_shared_libraries().await?;
+                shared.keys().cloned().collect()
+            };
+            print!("{}", format_libraries(private, shared));
         }
         cli::ListCommand::Albums => {
             let selector = config::resolve_library_selector(
@@ -76,4 +76,81 @@ pub(crate) async fn run_list(
         }
     }
     Ok(())
+}
+
+fn classify_library(zone_name: &str) -> Option<&'static str> {
+    if zone_name == "PrimarySync" {
+        Some("primary")
+    } else if zone_name.starts_with("SharedSync-") {
+        Some("shared")
+    } else {
+        None
+    }
+}
+
+fn format_libraries(
+    private: impl IntoIterator<Item = String>,
+    shared: impl IntoIterator<Item = String>,
+) -> String {
+    let mut all: BTreeSet<String> = BTreeSet::new();
+    all.extend(private);
+    all.extend(shared);
+
+    let mut ordered: Vec<String> = Vec::with_capacity(all.len());
+    if all.contains("PrimarySync") {
+        ordered.push("PrimarySync".to_string());
+    }
+    ordered.extend(all.into_iter().filter(|name| name != "PrimarySync"));
+
+    let mut out = String::from("Libraries:\n");
+    for zone_name in ordered {
+        match classify_library(&zone_name) {
+            Some(kind) => {
+                out.push_str(&format!("  {zone_name} ({kind})\n"));
+            }
+            None => {
+                out.push_str(&format!("  {zone_name}\n"));
+            }
+        }
+    }
+    out.push_str("\nUse these names in [filters].libraries, or use: primary, shared, all, none.\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_libraries;
+
+    #[test]
+    fn format_libraries_primary_then_shared_with_labels() {
+        let rendered = format_libraries(
+            ["SharedSync-AAAA", "PrimarySync"].map(str::to_string),
+            ["SharedSync-BBBB"].map(str::to_string),
+        );
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert_eq!(lines[0], "Libraries:");
+        assert_eq!(lines[1], "  PrimarySync (primary)");
+        assert_eq!(lines[2], "  SharedSync-AAAA (shared)");
+        assert_eq!(lines[3], "  SharedSync-BBBB (shared)");
+        assert_eq!(
+            lines[5],
+            "Use these names in [filters].libraries, or use: primary, shared, all, none."
+        );
+    }
+
+    #[test]
+    fn format_libraries_dedupes_names_from_private_and_shared_sources() {
+        let rendered = format_libraries(
+            ["PrimarySync", "SharedSync-AAAA"].map(str::to_string),
+            ["SharedSync-AAAA"].map(str::to_string),
+        );
+        assert_eq!(rendered.matches("SharedSync-AAAA").count(), 1);
+    }
+
+    #[test]
+    fn format_libraries_unknown_zone_stays_copy_pasteable() {
+        let rendered = format_libraries(["CustomZone".to_string()], Vec::new());
+        assert!(rendered.contains("  CustomZone"));
+        assert!(!rendered.contains("CustomZone ("));
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -57,6 +57,9 @@ struct SetupAnswers {
     /// v0.13+ smart-folder selector (Favorites, Hidden, etc.). Empty = default
     /// (`none`); non-empty = emit `[filters].smart_folders`.
     smart_folders: Vec<String>,
+    /// Optional smart-folder pass template for `[download].folder_structure_smart_folders`.
+    /// `None` leaves the runtime default (`{smart-folder}`).
+    folder_structure_smart_folders: Option<String>,
     /// `Some(false)` emits `[filters].unfiled = false` (used when the user
     /// picks specific albums and doesn't also want every other photo).
     /// `None` keeps the v0.13 default (`true`).
@@ -124,6 +127,7 @@ impl Default for SetupAnswers {
             albums: Vec::new(),
             libraries: vec!["all".to_string()],
             smart_folders: Vec::new(),
+            folder_structure_smart_folders: None,
             unfiled: None,
             filename_exclude: Vec::new(),
             skip_videos: false,
@@ -294,6 +298,8 @@ pub(crate) fn run_setup(config_path: &Path) -> anyhow::Result<SetupResult> {
     section_header("Extras");
     ask_extras(&mut answers)?;
 
+    apply_library_scoped_templates_for_all_libraries(&mut answers);
+
     // Generate TOML with a brief spinner so the user sees something happening.
     let toml_content: String = spinner_for("Building your config...", || generate_toml(&answers));
     check("All done.");
@@ -367,10 +373,44 @@ pub(crate) fn run_setup(config_path: &Path) -> anyhow::Result<SetupResult> {
         if let Some(env_path) = &write_result.env_path {
             print_load_env_snippet(env_path);
         }
-        println!("  kei sync");
+        println!("  {}", sync_command_for_config(config_path));
         println!();
         Ok(SetupResult::Done)
     }
+}
+
+fn apply_library_scoped_templates_for_all_libraries(answers: &mut SetupAnswers) {
+    if answers.libraries.as_slice() != ["all"] {
+        return;
+    }
+
+    answers.folder_structure = Some(library_template_or_default(
+        answers.folder_structure.as_deref(),
+        "%Y/%m/%d",
+    ));
+}
+
+fn ensure_library_token(template: &str) -> String {
+    if template.contains("{library}") {
+        return template.to_string();
+    }
+    if template.is_empty() {
+        return "{library}".to_string();
+    }
+    format!("{{library}}/{template}")
+}
+
+fn library_template_or_default(template: Option<&str>, default: &str) -> String {
+    ensure_library_token(template.unwrap_or(default))
+}
+
+fn single_quoted_shell(value: &str) -> String {
+    format!("'{}'", shell_single_quote_escape(value))
+}
+
+fn sync_command_for_config(config_path: &Path) -> String {
+    let path = config_path.to_string_lossy();
+    format!("kei --config {} sync", single_quoted_shell(&path))
 }
 
 /// Print the right "load .env into this shell" command for the user's shell.
@@ -922,7 +962,9 @@ fn ask_date_range(answers: &mut SetupAnswers) -> anyhow::Result<()> {
     answers.skip_created_after = date_prompt("Only sync photos created before")?;
 
     let recent: String = Input::new()
-        .with_prompt("Only sync the N most-recently-created photos (blank = all)")
+        .with_prompt(
+            "Only consider the N most-recent assets per selected library/album/smart-folder pass (blank = all)",
+        )
         .default(String::new())
         .show_default(false)
         .allow_empty(true)
@@ -1347,10 +1389,17 @@ fn generate_toml(answers: &SetupAnswers) -> String {
             )?,
             None => writeln!(out, "# folder_structure_albums = \"{{album}}\"")?,
         };
-        writeln!(
-            out,
-            "# folder_structure_smart_folders = \"{{smart-folder}}\""
-        )?;
+        match &answers.folder_structure_smart_folders {
+            Some(fs) => writeln!(
+                out,
+                "folder_structure_smart_folders = \"{}\"",
+                escape_toml_string(fs)
+            )?,
+            None => writeln!(
+                out,
+                "# folder_structure_smart_folders = \"{{smart-folder}}\""
+            )?,
+        };
         match answers.threads_num {
             Some(n) => writeln!(out, "threads = {n}")?,
             None => writeln!(out, "# threads = 10")?,
@@ -1453,7 +1502,10 @@ fn generate_toml(answers: &SetupAnswers) -> String {
         // `live_photo_mode` is emitted in the [photos] section below.
         match answers.recent {
             Some(n) => writeln!(out, "recent = {n}")?,
-            None => writeln!(out, "# recent = 0  (0 = all)")?,
+            None => writeln!(
+                out,
+                "# recent = 0  # 0 = all; cap applies per selected library/album/smart-folder pass"
+            )?,
         };
         match &answers.skip_created_before {
             Some(d) => writeln!(out, "skip_created_before = \"{}\"", escape_toml_string(d))?,
@@ -1644,6 +1696,82 @@ mod tests {
         assert!(
             !SetupSecretSource::PasswordCommand("op read item kei".to_string())
                 .needs_password_prompt()
+        );
+    }
+
+    #[test]
+    fn apply_library_scoped_templates_sets_library_safe_defaults_for_all_libraries() {
+        let mut answers = SetupAnswers {
+            username: "user@example.com".to_string(),
+            password: secrecy::SecretString::from("secret"),
+            directory: "~/Photos/iCloud".to_string(),
+            libraries: vec!["all".to_string()],
+            folder_structure_albums: Some("{album}/%Y/%m/%d".to_string()),
+            ..Default::default()
+        };
+
+        apply_library_scoped_templates_for_all_libraries(&mut answers);
+
+        assert_eq!(
+            answers.folder_structure.as_deref(),
+            Some("{library}/%Y/%m/%d")
+        );
+        assert_eq!(
+            answers.folder_structure_albums.as_deref(),
+            Some("{album}/%Y/%m/%d")
+        );
+        assert_eq!(answers.folder_structure_smart_folders.as_deref(), None);
+    }
+
+    #[test]
+    fn apply_library_scoped_templates_does_not_mutate_primary_only_setup() {
+        let mut answers = SetupAnswers {
+            username: "user@example.com".to_string(),
+            password: secrecy::SecretString::from("secret"),
+            directory: "~/Photos/iCloud".to_string(),
+            libraries: Vec::new(),
+            ..Default::default()
+        };
+
+        apply_library_scoped_templates_for_all_libraries(&mut answers);
+
+        assert_eq!(answers.folder_structure, None);
+        assert_eq!(answers.folder_structure_albums, None);
+        assert_eq!(answers.folder_structure_smart_folders, None);
+    }
+
+    #[test]
+    fn apply_library_scoped_templates_avoids_double_prefixing() {
+        let mut answers = SetupAnswers {
+            username: "user@example.com".to_string(),
+            password: secrecy::SecretString::from("secret"),
+            directory: "~/Photos/iCloud".to_string(),
+            libraries: vec!["all".to_string()],
+            folder_structure: Some("{library}/%Y/%m".to_string()),
+            folder_structure_albums: Some("{album}".to_string()),
+            folder_structure_smart_folders: Some("{smart-folder}".to_string()),
+            ..Default::default()
+        };
+
+        apply_library_scoped_templates_for_all_libraries(&mut answers);
+
+        assert_eq!(answers.folder_structure.as_deref(), Some("{library}/%Y/%m"));
+        assert_eq!(answers.folder_structure_albums.as_deref(), Some("{album}"));
+        assert_eq!(
+            answers.folder_structure_smart_folders.as_deref(),
+            Some("{smart-folder}")
+        );
+    }
+
+    #[test]
+    fn sync_command_for_config_shell_quotes_paths() {
+        assert_eq!(
+            sync_command_for_config(Path::new("/tmp/kei config.toml")),
+            "kei --config '/tmp/kei config.toml' sync"
+        );
+        assert_eq!(
+            sync_command_for_config(Path::new("/tmp/rob's-config.toml")),
+            "kei --config '/tmp/rob'\\''s-config.toml' sync"
         );
     }
 
@@ -1971,6 +2099,7 @@ mod tests {
             albums: vec!["Favorites".to_string(), "Vacation".to_string()],
             libraries: vec!["all".to_string()],
             smart_folders: vec!["all".to_string()],
+            folder_structure_smart_folders: None,
             unfiled: Some(false),
             filename_exclude: vec!["IMG_screenshot*.png".to_string()],
             skip_videos: true,
@@ -2056,6 +2185,7 @@ mod tests {
             albums: vec!["A".to_string()],
             libraries: Vec::new(),
             smart_folders: vec!["Favorites".to_string()],
+            folder_structure_smart_folders: None,
             unfiled: Some(false),
             filename_exclude: vec!["*.tmp".to_string()],
             skip_videos: true,
@@ -2203,6 +2333,7 @@ mod tests {
                 albums: vec!["A".to_string()],
                 libraries: Vec::new(),
                 smart_folders: vec!["all".to_string()],
+                folder_structure_smart_folders: None,
                 unfiled: Some(false),
                 filename_exclude: vec!["*.tmp".to_string()],
                 skip_videos: true,

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -101,6 +101,25 @@ pub(crate) fn should_store_sync_token_for_cycle(
     should_store_sync_token(outcome, dry_run) && !cycle_has_stale_plan
 }
 
+fn has_active_passes(lib_state: &LibraryState) -> bool {
+    !lib_state.plan.passes.is_empty()
+}
+
+fn should_warn_zero_assets(
+    sync_result: &download::SyncResult,
+    library_completed_without_errors: bool,
+    run_mode: download::DownloadRunMode,
+    is_retry_failed: bool,
+    lib_state: &LibraryState,
+) -> bool {
+    sync_result.full_enumeration_ran
+        && library_completed_without_errors
+        && run_mode.downloads_files()
+        && !is_retry_failed
+        && sync_result.stats.assets_seen == 0
+        && has_active_passes(lib_state)
+}
+
 /// Closure shape used to derive a per-library `DownloadConfig` from the
 /// shared base config. Boxed dyn so `run_cycle` can accept a single
 /// reference instead of a generic parameter (avoids reuse-by-monomorphization
@@ -312,12 +331,13 @@ pub(crate) async fn run_cycle(
                 && !sync_result.stats.interrupted
                 && sync_result.stats.enumeration_errors == 0
                 && !shutdown_token.is_cancelled();
-        if sync_result.full_enumeration_ran
-            && library_completed_without_errors
-            && download_controls.run_mode.downloads_files()
-            && !is_retry_failed
-            && sync_result.stats.assets_seen == 0
-        {
+        if should_warn_zero_assets(
+            &sync_result,
+            library_completed_without_errors,
+            download_controls.run_mode,
+            is_retry_failed,
+            lib_state,
+        ) {
             tracing::warn!(
                 library = %lib_state.zone_name,
                 library_count = library_states.len(),
@@ -475,5 +495,83 @@ where
         }
     } else {
         download::SyncMode::Full
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::PassKind;
+
+    fn make_library_state(has_passes: bool) -> LibraryState {
+        LibraryState {
+            library: crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
+                Box::new(crate::test_helpers::MockPhotosSession::new()),
+                "PrimarySync",
+            ),
+            cross_zone_libraries: Vec::new(),
+            pass_scope: crate::commands::PassScope {
+                include_albums: false,
+                include_smart_folders: false,
+                include_unfiled: has_passes,
+            },
+            zone_name: "PrimarySync".to_string(),
+            sync_token_key: "sync_token:PrimarySync".to_string(),
+            plan: crate::commands::AlbumPlan {
+                passes: if has_passes {
+                    vec![crate::commands::AlbumPass {
+                        kind: PassKind::Unfiled,
+                        album: crate::icloud::photos::PhotoAlbum::stub_for_test(Arc::from(
+                            "PrimarySync",
+                        )),
+                        exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+                    }]
+                } else {
+                    Vec::new()
+                },
+            },
+            plan_is_stale: false,
+            plan_needs_refresh: false,
+        }
+    }
+
+    #[test]
+    fn should_warn_zero_assets_requires_active_passes() {
+        let sync_result = download::SyncResult {
+            outcome: download::DownloadOutcome::Success,
+            sync_token: Some("zone-token".to_string()),
+            stats: download::SyncStats {
+                assets_seen: 0,
+                ..download::SyncStats::default()
+            },
+            full_enumeration_ran: true,
+        };
+        assert!(!should_warn_zero_assets(
+            &sync_result,
+            true,
+            download::DownloadRunMode::Download,
+            false,
+            &make_library_state(false),
+        ));
+    }
+
+    #[test]
+    fn should_warn_zero_assets_when_all_gates_are_true() {
+        let sync_result = download::SyncResult {
+            outcome: download::DownloadOutcome::Success,
+            sync_token: Some("zone-token".to_string()),
+            stats: download::SyncStats {
+                assets_seen: 0,
+                ..download::SyncStats::default()
+            },
+            full_enumeration_ran: true,
+        };
+        assert!(should_warn_zero_assets(
+            &sync_result,
+            true,
+            download::DownloadRunMode::Download,
+            false,
+            &make_library_state(true),
+        ));
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -1636,26 +1636,39 @@ fn find_multi_library_commingle_flags(
         return Vec::new();
     }
 
-    let unfiled_active = library_states.iter().any(|s| s.pass_scope.include_unfiled);
-    let album_active = library_states.iter().any(|s| s.pass_scope.include_albums);
-    let smart_folder_active = library_states
-        .iter()
-        .any(|s| s.pass_scope.include_smart_folders);
+    let mut active_unfiled_libraries = 0usize;
+    let mut active_album_libraries = 0usize;
+    let mut active_smart_folder_libraries = 0usize;
+    for state in library_states {
+        let (album_passes, smart_folder_passes, has_unfiled_pass) = count_passes(&state.plan);
+        if has_unfiled_pass {
+            active_unfiled_libraries += 1;
+        }
+        if album_passes > 0 {
+            active_album_libraries += 1;
+        }
+        if smart_folder_passes > 0 {
+            active_smart_folder_libraries += 1;
+        }
+    }
 
-    // All passes disabled — resolve_passes returns an empty plan, no path
+    // All passes disabled - resolve_passes returns an empty plan, no path
     // ever renders, multi-library can't commingle.
-    if !unfiled_active && !album_active && !smart_folder_active {
+    if active_unfiled_libraries == 0
+        && active_album_libraries == 0
+        && active_smart_folder_libraries == 0
+    {
         return Vec::new();
     }
 
     let mut missing: Vec<&'static str> = Vec::new();
-    if unfiled_active && !folder_structure.contains("{library}") {
+    if active_unfiled_libraries > 1 && !folder_structure.contains("{library}") {
         missing.push("--folder-structure");
     }
-    if album_active && !folder_structure_albums.contains("{library}") {
+    if active_album_libraries > 1 && !folder_structure_albums.contains("{library}") {
         missing.push("--folder-structure-albums");
     }
-    if smart_folder_active && !folder_structure_smart_folders.contains("{library}") {
+    if active_smart_folder_libraries > 1 && !folder_structure_smart_folders.contains("{library}") {
         missing.push("--folder-structure-smart-folders");
     }
     missing
@@ -2304,6 +2317,7 @@ mod tests {
         count: usize,
         selection: &crate::selection::Selection,
     ) -> Vec<LibraryState> {
+        use crate::commands::PassKind;
         use crate::selection::{AlbumSelector, SmartFolderSelector};
 
         let pass_scope = PassScope {
@@ -2328,7 +2342,22 @@ mod tests {
                     pass_scope,
                     zone_name: zone_name.clone(),
                     sync_token_key: format!("sync_token:{zone_name}"),
-                    plan: crate::commands::AlbumPlan { passes: Vec::new() },
+                    plan: crate::commands::AlbumPlan {
+                        passes: [
+                            pass_scope
+                                .include_albums
+                                .then(|| make_pass("album", PassKind::Album)),
+                            pass_scope
+                                .include_smart_folders
+                                .then(|| make_pass("smart-folder", PassKind::SmartFolder)),
+                            pass_scope
+                                .include_unfiled
+                                .then(|| make_pass("unfiled", PassKind::Unfiled)),
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .collect(),
+                    },
                     plan_is_stale: false,
                     plan_needs_refresh: false,
                 }
@@ -2452,6 +2481,32 @@ mod tests {
             )
             .is_empty(),
             "smart-folder inactive - its `{{library}}`-less template is irrelevant"
+        );
+    }
+
+    #[test]
+    fn find_multi_library_commingle_flags_ignores_visibility_only_libraries() {
+        use crate::commands::PassKind;
+        let mut states = commingle_test_states(2, &selection_all_passes_active());
+        states[1].plan = crate::commands::AlbumPlan { passes: Vec::new() };
+        states[1].pass_scope = PassScope {
+            include_albums: true,
+            include_smart_folders: true,
+            include_unfiled: true,
+        };
+        states[0].plan = crate::commands::AlbumPlan {
+            passes: vec![make_pass("Album A", PassKind::Album)],
+        };
+        states[0].pass_scope = PassScope {
+            include_albums: true,
+            include_smart_folders: false,
+            include_unfiled: false,
+        };
+        let missing =
+            find_multi_library_commingle_flags(&states, "%Y/%m/%d", "{album}", "{smart-folder}");
+        assert!(
+            missing.is_empty(),
+            "only one library has active passes - visibility-only zones must not trigger commingle warnings"
         );
     }
 


### PR DESCRIPTION
## Summary
- keep setup default at `libraries = ["all"]` while making unfiled templates library-scoped by default
- avoid misleading multi-library commingle and zero-asset warnings when a library has no active passes
- refresh `kei list libraries` output to show primary/shared labels plus selector guidance
- clarify `--recent` help/prompt text and print an explicit `kei --config '<path>' sync` follow-up command after setup

## Tests
- `cargo check`
- `cargo test --lib setup::tests::`
- `cargo test --lib commands::list::tests::`
- `cargo test --lib sync_loop::tests::find_multi_library_commingle_flags_`
- `cargo test --lib sync_loop::tests::warn_if_multi_library_paths_commingle`
- `cargo test --lib sync_cycle::tests::should_warn_zero_assets`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- sync --help`
