### PR TITLE
Soften v0.20 upgrade failures with migration hints

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,6 +27,123 @@ else
     esac
 fi
 
+collect_removed_sync_env_names() {
+    found=""
+    for name in \
+        KEI_DOWNLOAD_DIR \
+        KEI_DIRECTORY \
+        KEI_FOLDER_STRUCTURE \
+        KEI_FOLDER_STRUCTURE_ALBUMS \
+        KEI_FOLDER_STRUCTURE_SMART_FOLDERS \
+        KEI_ALBUM \
+        KEI_EXCLUDE_ALBUM \
+        KEI_LIBRARY \
+        KEI_SKIP_VIDEOS \
+        KEI_SKIP_PHOTOS \
+        KEI_THREADS \
+        KEI_THREADS_NUM \
+        KEI_BANDWIDTH_LIMIT \
+        KEI_TEMP_SUFFIX \
+        KEI_MAX_RETRIES \
+        KEI_MAX_DOWNLOAD_ATTEMPTS \
+        KEI_WATCH_WITH_INTERVAL \
+        KEI_NOTIFY_SYSTEMD \
+        KEI_PID_FILE \
+        KEI_RECONCILE_EVERY_N_CYCLES \
+        KEI_NOTIFICATION_SCRIPT \
+        KEI_REPORT_JSON \
+        KEI_METRICS_PORT
+    do
+        if env | grep -q "^${name}="; then
+            if [ -n "$found" ]; then
+                found="$found, $name"
+            else
+                found="$name"
+            fi
+        fi
+    done
+    printf '%s' "$found"
+}
+
+has_help_or_version_flag() {
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help|-V|--version)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+is_sync_like_command() {
+    if has_help_or_version_flag "$@"; then
+        return 1
+    fi
+
+    if [ "${1:-}" = "kei" ]; then
+        shift
+    fi
+
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+
+    case "${1:-}" in
+        sync|import-existing)
+            return 0
+            ;;
+        service)
+            [ "${2:-}" = "run" ]
+            return
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+has_explicit_nondefault_config() {
+    if [ "${1:-}" = "kei" ]; then
+        shift
+    fi
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --config)
+                cfg="${2:-}"
+                [ "$cfg" != "/config/config.toml" ]
+                return
+                ;;
+            --config=*)
+                cfg="${1#--config=}"
+                [ "$cfg" != "/config/config.toml" ]
+                return
+                ;;
+        esac
+        shift
+    done
+
+    return 1
+}
+
+docker_upgrade_preflight() {
+    [ -f /config/config.toml ] && return 0
+    is_sync_like_command "$@" || return 0
+    has_explicit_nondefault_config "$@" && return 0
+
+    removed="$(collect_removed_sync_env_names)"
+    [ -n "$removed" ] || return 0
+
+    echo "kei: /config/config.toml is required for v0.20 Docker sync settings." >&2
+    echo "kei: found removed env config: $removed" >&2
+    echo "kei: move durable settings into /config/config.toml; keep env for secrets and runtime glue." >&2
+    echo "kei: see https://github.com/rhoopr/kei/blob/main/docs/v0.20-migration.md" >&2
+    exit 1
+}
+
+docker_upgrade_preflight "$@"
+
 if [ -z "${PUID:-}" ] && [ -z "${PGID:-}" ]; then
     exec "$@"
 fi

--- a/scripts/full-test/run_docker_puid_smoke.sh
+++ b/scripts/full-test/run_docker_puid_smoke.sh
@@ -72,6 +72,40 @@ partial_out=$(docker run --rm \
 printf '%s\n' "$partial_out"
 echo "$partial_out" | grep -q "must be set together"
 
+echo "--- v0.20 Docker preflight: removed env config requires /config/config.toml ---"
+prefail_out=$(docker run --rm \
+  -e KEI_DOWNLOAD_DIR=/legacy/photos \
+  -e KEI_ALBUM="Legacy Album" \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" sync --dry-run 2>&1 || true)
+printf '%s\n' "$prefail_out"
+echo "$prefail_out" | grep -q "/config/config.toml is required for v0.20 Docker sync settings"
+echo "$prefail_out" | grep -q "KEI_DOWNLOAD_DIR"
+echo "$prefail_out" | grep -q "docs/v0.20-migration.md"
+
+echo "--- v0.20 Docker preflight: --version bypasses removed env config check ---"
+preflight_version_out=$(docker run --rm \
+  -e KEI_DOWNLOAD_DIR=/legacy/photos \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" --version 2>&1)
+printf '%s\n' "$preflight_version_out"
+echo "$preflight_version_out" | grep -q "^kei "
+
+echo "--- v0.20 Docker preflight: explicit non-default --config bypasses check ---"
+custom_cfg_dir="$work/custom-config"
+mkdir -p "$custom_cfg_dir"
+cat > "$custom_cfg_dir/custom.toml" <<'TOML'
+[auth]
+username = "docker-preflight@example.invalid"
+TOML
+preflight_custom_out=$(docker run --rm \
+  -e KEI_DOWNLOAD_DIR=/legacy/photos \
+  -v "$custom_cfg_dir:/tmp/cfg" \
+  --entrypoint /usr/local/bin/entrypoint.sh \
+  "$image" config show --config /tmp/cfg/custom.toml 2>&1)
+printf '%s\n' "$preflight_custom_out"
+echo "$preflight_custom_out" | grep -q "docker-preflight@example.invalid"
+
 echo "--- kei subcommand under dropped uid ---"
 sub_out=$(docker run --rm \
   -e ICLOUD_USERNAME=docker-puid@example.invalid \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::types::LogLevel;
 use clap::{Args, FromArgMatches, Parser, Subcommand};
+use std::ffi::{OsStr, OsString};
 
 /// Reject empty strings at CLI parse time.
 fn non_empty_string(s: &str) -> Result<String, String> {
@@ -877,26 +878,104 @@ fn explicit_top_level_sync_flags(matches: &clap::ArgMatches) -> Vec<&'static str
     out
 }
 
+/// Rendered CLI parse failure with a concrete process exit code.
+#[derive(Debug)]
+pub struct ParseCliError {
+    rendered: String,
+    exit_code: i32,
+}
+
+impl ParseCliError {
+    #[must_use]
+    pub fn rendered(&self) -> &str {
+        &self.rendered
+    }
+
+    #[must_use]
+    pub const fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+}
+
+impl std::fmt::Display for ParseCliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.rendered)
+    }
+}
+
+impl std::error::Error for ParseCliError {}
+
+fn command_context_from_argv(argv: &[OsString]) -> Option<&str> {
+    const KNOWN_COMMANDS: [&str; 11] = [
+        "sync",
+        "login",
+        "list",
+        "password",
+        "reset",
+        "config",
+        "status",
+        "verify",
+        "import-existing",
+        "reconcile",
+        "service",
+    ];
+    argv.iter()
+        .skip(1)
+        .filter_map(|token| token.to_str())
+        .find(|token| KNOWN_COMMANDS.contains(token))
+}
+
+fn should_append_removed_sync_surface_hint(argv: &[OsString], err: &clap::Error) -> bool {
+    if err.kind() != clap::error::ErrorKind::UnknownArgument {
+        return false;
+    }
+
+    match command_context_from_argv(argv) {
+        None | Some("sync") | Some("import-existing") => true,
+        Some("service") => argv
+            .iter()
+            .skip(1)
+            .skip_while(|token| *token != OsStr::new("service"))
+            .skip(1)
+            .any(|token| token == OsStr::new("run")),
+        Some(_) => false,
+    }
+}
+
+fn with_removed_sync_surface_hint(message: String) -> String {
+    format!(
+        "{message}\n\nnote: v0.20 removed durable sync CLI flags. Put persistent sync settings in config.toml instead.\n      See {}",
+        crate::upgrade_hints::V020_MIGRATION_URL
+    )
+}
+
 /// Parse CLI arguments and return both the parsed struct and the list of
 /// sync-only flags that were explicitly provided on the command line.
 ///
 /// This is the production entry point. It replaces `Cli::parse()` so the
 /// validator can distinguish between CLI-provided and env-provided flags.
-pub fn parse_cli_with_sources<I, T>(itr: I) -> Result<(Cli, Vec<&'static str>), clap::Error>
+pub fn parse_cli_with_sources<I, T>(itr: I) -> Result<(Cli, Vec<&'static str>), ParseCliError>
 where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
+    let argv: Vec<OsString> = itr.into_iter().map(Into::into).collect();
     let cmd = <Cli as clap::CommandFactory>::command();
-    let matches = match cmd.try_get_matches_from(itr) {
-        Ok(m) => m,
-        Err(e) => e.exit(),
-    };
+    let matches = cmd
+        .try_get_matches_from(&argv)
+        .map_err(|err| ParseCliError {
+            rendered: if should_append_removed_sync_surface_hint(&argv, &err) {
+                with_removed_sync_surface_hint(err.to_string())
+            } else {
+                err.to_string()
+            },
+            exit_code: err.exit_code(),
+        })?;
     let explicit_sync_flags = explicit_top_level_sync_flags(&matches);
-    let cli = match Cli::from_arg_matches(&matches) {
-        Ok(c) => c,
-        Err(e) => e.exit(),
-    };
+    let cli = Cli::from_arg_matches(&matches).map_err(|err| ParseCliError {
+        rendered: err.to_string(),
+        exit_code: err.exit_code(),
+    })?;
     Ok((cli, explicit_sync_flags))
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -883,6 +883,7 @@ fn explicit_top_level_sync_flags(matches: &clap::ArgMatches) -> Vec<&'static str
 pub struct ParseCliError {
     rendered: String,
     exit_code: i32,
+    use_stderr: bool,
 }
 
 impl ParseCliError {
@@ -894,6 +895,11 @@ impl ParseCliError {
     #[must_use]
     pub const fn exit_code(&self) -> i32 {
         self.exit_code
+    }
+
+    #[must_use]
+    pub const fn use_stderr(&self) -> bool {
+        self.use_stderr
     }
 }
 
@@ -970,11 +976,13 @@ where
                 err.to_string()
             },
             exit_code: err.exit_code(),
+            use_stderr: err.use_stderr(),
         })?;
     let explicit_sync_flags = explicit_top_level_sync_flags(&matches);
     let cli = Cli::from_arg_matches(&matches).map_err(|err| ParseCliError {
         rendered: err.to_string(),
         exit_code: err.exit_code(),
+        use_stderr: err.use_stderr(),
     })?;
     Ok((cli, explicit_sync_flags))
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1002,7 +1002,9 @@ fn build_import_download_config(
         .and_then(|d| d.directory.clone())
         .unwrap_or_default();
     if directory_str.is_empty() {
-        anyhow::bail!("[download] directory is required for import-existing");
+        anyhow::bail!(crate::upgrade_hints::with_stale_env_hint(String::from(
+            "[download] directory is required for import-existing",
+        )));
     }
     let directory_path = config::expand_tilde(&directory_str);
     config::validate_download_dir(&directory_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -388,8 +388,18 @@ pub(crate) fn load_toml_config(path: &Path, required: bool) -> anyhow::Result<Op
 
     match std::fs::read_to_string(path) {
         Ok(contents) => {
-            let config: TomlConfig = toml::from_str(&contents)
-                .context(format!("Failed to parse config file {}", path.display()))?;
+            let config: TomlConfig = toml::from_str(&contents).map_err(|err| {
+                let parse_error = err.to_string();
+                let mut message = format!(
+                    "Failed to parse config file {}: {parse_error}",
+                    path.display()
+                );
+                if parse_error.contains("unknown field") {
+                    message.push_str("\n\n");
+                    message.push_str(&crate::upgrade_hints::toml_unknown_field_hint());
+                }
+                anyhow::anyhow!(message)
+            })?;
             // Warn if config contains a password and file permissions are too open
             #[cfg(unix)]
             if config.auth.as_ref().is_some_and(|a| a.password.is_some()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,12 +498,12 @@ pub fn main_inner() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             if let Some(parse_err) = e.downcast_ref::<cli::ParseCliError>() {
-                #[allow(
-                    clippy::print_stderr,
-                    reason = "clap parse errors are already rendered for stderr output"
-                )]
-                {
+                #[allow(clippy::print_stdout, reason = "clap routes help/version to stdout")]
+                #[allow(clippy::print_stderr, reason = "clap routes parse failures to stderr")]
+                if parse_err.use_stderr() {
                     eprint!("{}", parse_err.rendered());
+                } else {
+                    print!("{}", parse_err.rendered());
                 }
                 let code = u8::try_from(parse_err.exit_code()).unwrap_or(1);
                 return ExitCode::from(code);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ mod sync_cycle;
 mod sync_loop;
 mod systemd;
 mod types;
+mod upgrade_hints;
 
 #[cfg(test)]
 mod test_helpers;
@@ -496,6 +497,18 @@ pub fn main_inner() -> ExitCode {
     match rt.block_on(run(env_password)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
+            if let Some(parse_err) = e.downcast_ref::<cli::ParseCliError>() {
+                #[allow(
+                    clippy::print_stderr,
+                    reason = "clap parse errors are already rendered for stderr output"
+                )]
+                {
+                    eprint!("{}", parse_err.rendered());
+                }
+                let code = u8::try_from(parse_err.exit_code()).unwrap_or(1);
+                return ExitCode::from(code);
+            }
+
             let classification = classify_exit_error(&e);
             if classification.should_log() {
                 // Route the final error through tracing so it carries the same

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -415,10 +415,11 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // Validate download directory early (before auth) to avoid wasting a 2FA code
     // when the user simply forgot the destination.
     if config.download.directory.as_os_str().is_empty() {
-        anyhow::bail!(
+        let message = crate::upgrade_hints::with_stale_env_hint(String::from(
             "[download] directory is required for downloading \
-             (set it in the config file)"
-        );
+             (set it in the config file)",
+        ));
+        anyhow::bail!(message);
     }
 
     // Validate download directory is writable before spending time on authentication.

--- a/src/upgrade_hints.rs
+++ b/src/upgrade_hints.rs
@@ -1,0 +1,62 @@
+pub(crate) const V020_MIGRATION_URL: &str =
+    "https://github.com/rhoopr/kei/blob/main/docs/v0.20-migration.md";
+
+pub(crate) const REMOVED_DURABLE_ENV_VARS: &[&str] = &[
+    "KEI_DOWNLOAD_DIR",
+    "KEI_DIRECTORY",
+    "KEI_FOLDER_STRUCTURE",
+    "KEI_FOLDER_STRUCTURE_ALBUMS",
+    "KEI_FOLDER_STRUCTURE_SMART_FOLDERS",
+    "KEI_ALBUM",
+    "KEI_EXCLUDE_ALBUM",
+    "KEI_LIBRARY",
+    "KEI_SKIP_VIDEOS",
+    "KEI_SKIP_PHOTOS",
+    "KEI_THREADS",
+    "KEI_THREADS_NUM",
+    "KEI_BANDWIDTH_LIMIT",
+    "KEI_TEMP_SUFFIX",
+    "KEI_MAX_RETRIES",
+    "KEI_MAX_DOWNLOAD_ATTEMPTS",
+    "KEI_WATCH_WITH_INTERVAL",
+    "KEI_NOTIFY_SYSTEMD",
+    "KEI_PID_FILE",
+    "KEI_RECONCILE_EVERY_N_CYCLES",
+    "KEI_NOTIFICATION_SCRIPT",
+    "KEI_REPORT_JSON",
+    "KEI_METRICS_PORT",
+];
+
+pub(crate) fn present_removed_durable_env_vars() -> Vec<&'static str> {
+    REMOVED_DURABLE_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|name| std::env::var_os(name).is_some())
+        .collect()
+}
+
+pub(crate) fn stale_env_hint() -> Option<String> {
+    let present = present_removed_durable_env_vars();
+    if present.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "note: found removed v0.20 env config: {}.\n      These env vars are ignored in v0.20. Move durable sync settings into config.toml.\n      See {V020_MIGRATION_URL}",
+        present.join(", ")
+    ))
+}
+
+pub(crate) fn with_stale_env_hint(mut message: String) -> String {
+    if let Some(hint) = stale_env_hint() {
+        message.push_str("\n\n");
+        message.push_str(&hint);
+    }
+    message
+}
+
+pub(crate) fn toml_unknown_field_hint() -> String {
+    format!(
+        "note: this config contains a key kei does not recognize. If this is a pre-v0.20 config, move durable sync settings to the v0.20 config.toml shape.\n      See {V020_MIGRATION_URL}"
+    )
+}

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -3149,6 +3149,17 @@ fn run_config_show_error(body: &str) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }
 
+fn assert_removed_env_config_hint(stderr: &str) {
+    assert!(
+        stderr.contains("found removed v0.20 env config"),
+        "stale sync env vars should emit a migration hint; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("KEI_DOWNLOAD_DIR"),
+        "stale sync env vars should name KEI_DOWNLOAD_DIR; stderr: {stderr}"
+    );
+}
+
 /// Build a `kei sync` invocation pre-populated with username, fresh tempdir
 /// config/data directories, and `--only-print-filenames` so the
 /// run exits before auth. Returns the live `Command` so callers can append
@@ -3452,6 +3463,14 @@ fn removed_toml_filter_aliases_error() {
             stderr.contains(&format!("unknown field `{field}`")),
             "expected unknown-field error for {field}; stderr:\n{stderr}"
         );
+        assert!(
+            stderr.contains("pre-v0.20 config"),
+            "expected v0.20 migration hint for {field}; stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("docs/v0.20-migration.md"),
+            "expected migration guide URL for {field}; stderr:\n{stderr}"
+        );
     }
 }
 #[test]
@@ -3496,10 +3515,36 @@ fn removed_sync_env_vars_do_not_supply_sync_config() {
         stderr.contains("[download] directory is required"),
         "stale sync env vars must not provide durable config; stderr: {stderr}"
     );
+    assert_removed_env_config_hint(&stderr);
+    assert!(
+        stderr.contains("ignored in v0.20"),
+        "stale sync env vars should explain they are ignored; stderr: {stderr}"
+    );
     assert!(
         !stderr.contains("unexpected argument"),
         "stale sync env vars should be ignored by clap, not parsed as CLI args; stderr: {stderr}"
     );
+}
+
+#[test]
+fn removed_sync_env_vars_do_not_supply_import_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .env("KEI_DOWNLOAD_DIR", "/legacy/photos")
+        .env("KEI_ALBUM", "Legacy Album")
+        .args(["import-existing", "--dry-run"])
+        .assert()
+        .code(1)
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[download] directory is required for import-existing"),
+        "stale sync env vars must not provide import config; stderr: {stderr}"
+    );
+    assert_removed_env_config_hint(&stderr);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,6 +34,17 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 /// Subcommands that accept `--password` (have PasswordArgs).
 const PASSWORD_SUBCOMMANDS: &[&str] = &["sync", "login", "import-existing"];
 
+fn assert_removed_sync_flag_hint(args: &[&str]) {
+    common::cmd()
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "v0.20 removed durable sync CLI flags",
+        ))
+        .stderr(predicate::str::contains("docs/v0.20-migration.md"));
+}
+
 // ── Help output ─────────────────────────────────────────────────────────
 
 #[test]
@@ -411,6 +422,21 @@ fn removed_threads_num_flag_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument"));
+}
+
+#[test]
+fn removed_sync_flag_error_includes_v020_migration_hint() {
+    assert_removed_sync_flag_hint(&["sync", "--download-dir", "/photos"]);
+}
+
+#[test]
+fn removed_import_flag_error_includes_v020_migration_hint() {
+    assert_removed_sync_flag_hint(&["import-existing", "--download-dir", "/photos"]);
+}
+
+#[test]
+fn removed_service_run_flag_error_includes_v020_migration_hint() {
+    assert_removed_sync_flag_hint(&["service", "run", "--download-dir", "/photos"]);
 }
 
 // ── submit-code requires positional CODE ────────────────────────────────

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -177,7 +177,7 @@ fn list_libraries_prints_output() {
             .timeout(Duration::from_secs(TIMEOUT_META))
             .assert()
             .success()
-            .stdout(predicate::str::contains("libraries:"));
+            .stdout(predicate::str::contains("Libraries:"));
     });
 }
 


### PR DESCRIPTION
## Summary
- Added targeted v0.20 migration hints for removed sync CLI flags (`sync`, `import-existing`, and `service run`) while preserving clap exit behavior.
- Added shared upgrade-hint helpers and attached stale removed-env guidance when `[download].directory` is missing for `sync` and `import-existing`.
- Improved TOML parse errors for unknown fields with a direct v0.20 migration note.
- Added Docker entrypoint preflight that fails early for sync-like invocations when removed durable env config is present but `/config/config.toml` is missing.
- Added and expanded CLI, behavioral, and Docker smoke coverage for the new migration guidance paths.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test cli removed_ -- --test-threads=1`
- `cargo test --test behavioral removed_sync_env_vars_do_not_supply_ -- --test-threads=1`
- `cargo test --test behavioral removed_toml_filter_aliases_error -- --test-threads=1`
- `cargo run -- sync --download-dir /photos`
- `just docker build`
- `scripts/full-test/run_docker_puid_smoke.sh`
