### PR TITLE
Update v0.20 release candidate docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.20.0] - 2026-05-24
+## [0.20.0] - 2026-05-25 release candidate
 
 ### Added
 
 - **v0.20 migration guide and example config.** Added `docs/v0.20-migration.md` and `example.config.toml` to show every supported TOML key, default, and allowed value. README, Docker Compose, and migration docs now describe the v0.20 source model: TOML for persistent settings, CLI flags for one-run actions, and env vars for secrets or runtime glue. ([#411])
 - **Keyring-first setup wizard.** `kei config setup` now stores accepted passwords through the same credential path as `kei password set`, keeps `.env` as an explicit fallback, and shows which credential backend was used. Generated TOML stays password-free. ([#410])
 - **Strict import adoption.** `import-existing --strict` and `[import].strict = true` verify a small iCloud prefix before adopting same-name, same-size local files. Strict refusals are counted in the import summary. ([#408])
+- **Upgrade hints for v0.20 config failures.** Removed sync flags now print a direct v0.20 migration note, unknown TOML fields point at the migration guide, and stale removed env vars are named when `[download].directory` is missing. The Docker entrypoint also fails early when a sync-like command still relies on removed durable env config and `/config/config.toml` is absent. ([#496])
 
 ### Changed
 
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JPEG/TIFF EXIF writes no longer require the `xmp` feature.** Native EXIF updates now work in default builds. XMP sidecars and HEIC metadata writes still require the `xmp` feature. ([#409])
 - **Watch and full-sync runs make fewer Apple and SQLite calls.** Idle watch cycles can skip album refresh when `/changes/database` reports no selected-library changes. Multi-pass full syncs preload download state once, batch same-library album counts, bound known-count streams, and run independent album streams concurrently. ([#416], [#464], [#465], [#466], [#467], [#468])
 - **Download scheduling now keeps iCloud URLs fresher.** Full download enumeration stays close to the worker pool so signed URLs spend less time waiting before transfer. Cleanup retries target the exact failed asset/version/path entries instead of retrying the whole library. ([#473])
+- **Explicit album and smart-folder selection is collection-scoped.** When users ask for albums or smart folders by config, sync and `import-existing` resolve those passes across every visible library. Unfiled photos still follow `[filters].libraries`, so a primary-only unfiled pass does not unexpectedly widen to shared libraries. Named sensitive smart folders such as `Hidden` and `Recently Deleted` follow the same collection scope. ([#492], [#493])
+- **Setup and listing guide multi-library users more clearly.** `kei config setup` still defaults to all visible libraries, but now writes library-scoped unfiled templates by default when that choice would otherwise mix primary and shared files. `kei list libraries` now labels primary/shared zones and prints the selector values users can paste into `[filters].libraries`. `--recent` help now says the cap is per selected library, album, or smart-folder pass. ([#495])
 - **Service behavior is safer to preview and easier to operate.** `kei install --dry-run` on Linux and macOS prints the service artifact without writing unit/plist files or log directories. Linux system install previews work without root. `kei status` gives clearer background-sync guidance, Docker and generated Linux systemd units set `MALLOC_ARENA_MAX=2`, and Linux uninstall restores the pre-install linger state when kei recorded it. ([#413], [#417], [#451], [#471], [#472])
 - **Sync internals have narrower ownership boundaries.** Selection config, post-cycle reporting, cycle execution, download planning/finalization, and state access were split into smaller owner modules and role traits. These changes keep the v0.20 behavior easier to test without changing the user command shape. ([#418], [#449], [#450], [#452], [#453], [#455], [#456])
 - **Release validation now carries more of the release-candidate checks.** The repo-owned full-test path covers release archive smoke tests, Docker image smoke tests, live import rehearsal, service lifecycle checks, and stricter sync safety assertions. ([#457], [#459], [#460], [#471], [#488], [#489], [#490])
@@ -34,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Old v0.13-v0.19 compatibility names were removed.** v0.20 rejects the deprecated durable flags, env mirrors, TOML keys, and hidden command aliases from the warning window. Removed names include `--directory` / `KEI_DIRECTORY`, `--threads-num`, `--cookie-directory`, `[auth].cookie_directory`, `[download].threads_num`, `[metrics].port`, `--exclude-album` / `KEI_EXCLUDE_ALBUM`, `{album}` in the base folder template, implicit `--album all` from that token, `[filters].album`, `[filters].exclude_albums`, `[filters].library`, and the legacy `kei setup` / `kei retry-failed` / `kei reset-state` aliases. Use the v0.20 TOML keys and current subcommands instead. ([#402], [#403], [#405], [#406], [#409], [#485])
 - **Import-only durable flags and env mirrors were removed.** `import-existing` now reads durable matching settings from TOML, like sync. `--library`, `--recent`, `--dry-run`, `--force-empty`, `--no-progress-bar`, and `--strict` remain one-off import controls. ([#408])
+- **Stale local docs and old logo experiments were removed.** The deleted v0.13 migration note and synctoken diagnostic scratch guide had drifted behind the v0.20 config model. Current migration guidance now lives in `docs/v0.20-migration.md` and the CloudKit synctoken reference remains in `docs/synctoken-reference.md`. ([#494])
 
 ### Fixed
 
@@ -112,6 +116,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#488]: https://github.com/rhoopr/kei/pull/488
 [#489]: https://github.com/rhoopr/kei/pull/489
 [#490]: https://github.com/rhoopr/kei/pull/490
+[#492]: https://github.com/rhoopr/kei/pull/492
+[#493]: https://github.com/rhoopr/kei/pull/493
+[#494]: https://github.com/rhoopr/kei/pull/494
+[#495]: https://github.com/rhoopr/kei/pull/495
+[#496]: https://github.com/rhoopr/kei/pull/496
 
 ---
 
@@ -260,7 +269,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0] - 2026-05-02
 
-Selection and folder-structure flag redesign. `--exclude-album` becomes `--album '!NAME'`. New `--smart-folder` and `--unfiled` per-category flags. `--library` now repeatable. Per-category `--folder-structure-{albums,smart-folders}` templates with their own defaults. Multi-library scope with `{library}` in any template. State DB schema migrates to v9 (per-zone primary key on `assets`, `asset_albums`, and `asset_people`) on first sync. Old shapes worked with deprecation warnings through v0.19 and were removed in v0.20. Full migration guide: [docs/v0.13-migration.md](docs/v0.13-migration.md). ([#215], [#288])
+Selection and folder-structure flag redesign. `--exclude-album` becomes `--album '!NAME'`. New `--smart-folder` and `--unfiled` per-category flags. `--library` now repeatable. Per-category `--folder-structure-{albums,smart-folders}` templates with their own defaults. Multi-library scope with `{library}` in any template. State DB schema migrates to v9 (per-zone primary key on `assets`, `asset_albums`, and `asset_people`) on first sync. Old shapes worked with deprecation warnings through v0.19 and were removed in v0.20. Current migration guide: [docs/v0.20-migration.md](docs/v0.20-migration.md). ([#215], [#288])
 
 ### Added
 
@@ -1304,8 +1313,8 @@ The following Python icloudpd features are not yet available. Links go to tracki
 
 ---
 
-[Unreleased]: https://github.com/rhoopr/kei/compare/v0.20.0...HEAD
-[0.20.0]: https://github.com/rhoopr/kei/compare/v0.14.2...v0.20.0
+[Unreleased]: https://github.com/rhoopr/kei/compare/main...HEAD
+[0.20.0]: https://github.com/rhoopr/kei/compare/v0.14.2...main
 [0.14.2]: https://github.com/rhoopr/kei/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/rhoopr/kei/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/rhoopr/kei/compare/v0.13.3...v0.14.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ You don't need to run auth tests for most changes. CI runs the offline suite (un
 
 ## License
 
-By contributing, you agree that your contributions are licensed under the [MIT License](LICENSE.md).
+By contributing, you agree that your contributions are licensed under the [MIT License](LICENSE).

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -4,4 +4,16 @@ There are no active warning windows. Removed flags, commands, env vars, and TOML
 
 ## v0.20.0
 
-The v0.20 cleanup removed the v0.13 compatibility aliases listed in [docs/v0.13-migration.md](docs/v0.13-migration.md).
+The v0.20 cleanup removed the v0.13-v0.19 compatibility aliases. Current
+migration guidance lives in [docs/v0.20-migration.md](docs/v0.20-migration.md).
+
+Removed examples include:
+
+- durable sync flags such as `--download-dir`, `--album`, `--smart-folder`,
+  `--library`, `--skip-videos`, `--threads`, and `--watch-with-interval`
+- durable sync env mirrors such as `KEI_DOWNLOAD_DIR`, `KEI_ALBUM`,
+  `KEI_LIBRARY`, `KEI_THREADS`, and `KEI_WATCH_WITH_INTERVAL`
+- old TOML aliases such as `[filters].album`, `[filters].exclude_albums`,
+  `[filters].library`, `[download].threads_num`, and `[metrics].port`
+- hidden command aliases such as `kei setup`, `kei retry-failed`, and
+  `kei reset-state`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 > Check [CHANGELOG.md](CHANGELOG.md) before updating.
 
 > [!IMPORTANT]
-> **v0.20 is a breaking config release.**
+> **v0.20 is the current release candidate and is a breaking config release.**
 >
 > The old "everything can be a CLI flag or `KEI_*` env var" model was replaced by a smaller source model:
 >
@@ -61,8 +61,8 @@
 ```sh
 brew install rhoopr/kei/kei             # Homebrew
 
-docker pull ghcr.io/rhoopr/kei:latest   # Docker tagged release
-docker pull ghcr.io/rhoopr/kei:0.20.0   # Docker pinned release
+docker pull ghcr.io/rhoopr/kei:latest   # last tagged release
+docker pull ghcr.io/rhoopr/kei:main     # v0.20 release candidate
 ```
 
 Pre-built binaries for macOS, Linux, and Windows are on the [Releases page](https://github.com/rhoopr/kei/releases). For Docker Compose, building from source, FreeBSD, and other install paths, see the [Install wiki page](https://github.com/rhoopr/kei/wiki/Install).
@@ -82,7 +82,9 @@ kei sync
 
 `kei config setup` writes a TOML config and can save your password in the OS
 keyring, or in an encrypted file when a keyring isn't available. You'll still
-approve 2FA on a trusted device the first time.
+approve 2FA on a trusted device the first time. The wizard defaults to all
+visible iCloud Photos libraries and adds `{library}` to unfiled paths when that
+keeps shared-library files separated.
 
 Minimal config:
 
@@ -106,6 +108,7 @@ Sync what matters:
 - Sync your full iCloud Photos library, selected albums, smart folders, shared libraries, or only recent media.
 - Keep unfiled photos and shared-library media organized without manual sorting.
 - Filter by media type, filename, date, and library when you only want part of the archive.
+- Explicit album and smart-folder filters are collection-scoped across visible libraries. That includes `Hidden` and `Recently Deleted` when you ask for them. Library selection still scopes unfiled passes.
 - Details: [Configuration](https://github.com/rhoopr/kei/wiki/Configuration)
 
 Run it your way:

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -1,6 +1,6 @@
 # Migrating from `icloudpd`
 
-> Last updated on 5-17-26 for v0.20.
+> Last updated on 5-25-26 for the v0.20 release candidate.
 
 This guide is for moving an existing
 [`icloud-photos-downloader`](https://github.com/icloud-photos-downloader/icloud_photos_downloader)
@@ -15,6 +15,9 @@ The short version:
 
 kei can't reuse Python's `~/.pyicloud` cookies, so the first run still needs a
 fresh Apple login and 2FA approval. Your local photo files can stay in place.
+
+During the release candidate, use the Docker `:main` image if you test v0.20 in
+containers. Use `:latest` or pin `:0.20.0` after the release tag is published.
 
 ## Step 1: import the existing tree
 
@@ -135,8 +138,12 @@ raw_policy = "as-is"
 
 ### Libraries and albums
 
-kei defaults to the primary iCloud Photos library. If you want shared libraries
-too, import with the same library selector that sync will read from TOML:
+The runtime default is the primary iCloud Photos library. The setup wizard
+defaults to all visible libraries and writes a `{library}` segment for unfiled
+paths when that avoids mixing primary and shared files.
+
+If you want shared libraries too, import with the same library selector that
+sync will read from TOML:
 
 ```sh
 kei import-existing --library all --config ~/.config/kei/config.toml
@@ -167,6 +174,11 @@ folder_structure_albums = "{library}/{album}/%Y/%m/%d"
 flags. It reads those selectors from `config.toml`, using the same defaults as
 sync: all user albums, no smart folders, and an unfiled pass. If you use a
 config file for sync selection, pass that same `--config` during import.
+
+Explicit album and smart-folder selectors are collection-scoped in v0.20. When
+`[filters].albums` or `[filters].smart_folders` is set, sync and
+`import-existing` look for those passes across every visible library. The
+`--library` import flag and `[filters].libraries` still scope unfiled photos.
 
 ## Step 2: sync
 
@@ -251,7 +263,7 @@ the same way.
 | `kei password set` | Store the password in the OS keyring or encrypted file backend. |
 | `--save-password` | Save the password after a successful auth. |
 | `[filters].libraries` | Select primary, shared, all, named, or excluded iCloud libraries. |
-| `[filters].smart_folders` | Sync Favorites, Screenshots, Hidden, Recently Deleted, and other Apple smart folders. |
+| `[filters].smart_folders` | Sync Favorites, Screenshots, Hidden, Recently Deleted, and other Apple smart folders across visible libraries when explicitly set. |
 | `[filters].unfiled = false` | Disable the separate pass for photos not in any user album. |
 | `[filters].filename_exclude` | Skip files by glob, such as `*.AAE` or `Screenshot*`. |
 | `[download].bandwidth_limit` | Cap total download throughput, for example `10M` or `1.5Mi`. |
@@ -282,7 +294,8 @@ v0.20 removed the remaining v0.13 compatibility aliases:
 
 ## Docker migration
 
-The official image is `ghcr.io/rhoopr/kei:latest`. It uses `/config` and
+During the release candidate, use `ghcr.io/rhoopr/kei:main`. After release, use
+`ghcr.io/rhoopr/kei:latest` or pin `ghcr.io/rhoopr/kei:0.20.0`. It uses `/config` and
 `/photos` volumes. The image runs `kei service run --config /config/config.toml`
 by default, with `KEI_DATA_DIR=/config` as container runtime glue. Set
 `[download].directory = "/photos"` in the config file. `service run` uses a
@@ -293,7 +306,7 @@ A minimal compose file:
 ```yaml
 services:
   kei:
-    image: ghcr.io/rhoopr/kei:latest
+    image: ghcr.io/rhoopr/kei:main
     container_name: kei
     restart: unless-stopped
     stop_grace_period: 30s
@@ -320,6 +333,11 @@ virtual malloc arenas even when their resident memory is small. The Docker
 image sets `MALLOC_ARENA_MAX=2`, and `kei install` writes the same setting into
 Linux systemd units. If you run kei from your own service manager and care
 about VSZ, set `MALLOC_ARENA_MAX=2` before `kei service run`.
+
+If the container exits with a v0.20 `/config/config.toml` error, it found old
+sync env vars such as `KEI_DOWNLOAD_DIR` but no mounted config file. Move those
+durable settings into `/config/config.toml` and keep env for secrets or runtime
+glue.
 
 For a one-shot import against an existing mounted tree:
 

--- a/docs/v0.20-migration.md
+++ b/docs/v0.20-migration.md
@@ -2,6 +2,10 @@
 
 v0.20 is kei's breaking config cleanup release.
 
+The current `main` branch and Docker `:main` image are the v0.20 release
+candidate. Use the tagged `:latest` or `:0.20.0` Docker images after the
+release tag is published.
+
 The rule is simple:
 
 - TOML is for settings you want to keep.
@@ -40,6 +44,25 @@ For a guided file, run:
 ```sh
 kei config setup
 ```
+
+The setup wizard defaults to all visible iCloud Photos libraries. When that
+would mix primary and shared-library unfiled files, it writes a `{library}` path
+segment for the unfiled template.
+
+## Upgrade failure hints
+
+v0.20 removed durable sync flags and env mirrors instead of accepting them with
+warnings. If an old command fails with `unexpected argument '--download-dir'` or
+another removed sync flag, move that setting into `config.toml`.
+
+If sync or import reports a missing `[download].directory` while old `KEI_*`
+sync env vars are still set, the error lists the ignored env names. Those env
+vars no longer configure sync. Keep env vars for secrets, config discovery, and
+runtime glue.
+
+Unknown TOML keys now include a v0.20 migration hint. This is usually an old
+pre-v0.20 key such as `[filters].album`, `[filters].library`,
+`[download].threads_num`, or `[metrics].port`.
 
 ## What changed
 
@@ -93,6 +116,15 @@ library name looks like a sentinel:
 [filters]
 albums = ["=all", "=none", "=!Drafts", "!Archive"]
 ```
+
+Explicit album and smart-folder selectors are collection-scoped. When
+`[filters].albums` or `[filters].smart_folders` is set, kei looks for those
+passes across every visible library. `[filters].libraries` still scopes unfiled
+photos and default library selection.
+
+`smart_folders = ["all"]` still excludes Apple's sensitive folders. Use
+`all-with-sensitive`, or name `Hidden` / `Recently Deleted` directly, to include
+them.
 
 ### Photos, Live Photos, RAW, and filenames
 
@@ -165,12 +197,15 @@ unset. Plain `kei sync` stays one-shot unless you set a watch interval.
 
 ## Docker migration
 
+During the release candidate, use `ghcr.io/rhoopr/kei:main`. After the release,
+use `ghcr.io/rhoopr/kei:latest` or pin `ghcr.io/rhoopr/kei:0.20.0`.
+
 The Docker image reads `/config/config.toml` by default:
 
 ```yaml
 services:
   kei:
-    image: ghcr.io/rhoopr/kei:latest
+    image: ghcr.io/rhoopr/kei:main
     container_name: kei
     restart: unless-stopped
     environment:
@@ -237,13 +272,18 @@ systemd unit. If you manage your own unit file, add:
 Environment=MALLOC_ARENA_MAX=2
 ```
 
+If a Docker container exits with `/config/config.toml is required for v0.20
+Docker sync settings`, it found removed sync env config such as
+`KEI_DOWNLOAD_DIR` but no mounted config file. Create `/config/config.toml`,
+move durable settings there, and leave only secrets or runtime glue in env.
+
 For one-shot commands, override the command:
 
 ```sh
 docker run --rm \
   -v "$PWD/config:/config" \
   -v "/path/to/photos:/photos" \
-  ghcr.io/rhoopr/kei:latest \
+  ghcr.io/rhoopr/kei:main \
   sync --config /config/config.toml --dry-run
 ```
 
@@ -263,4 +303,5 @@ These remain public because they are action or one-run controls:
 - `--skip-created-before`
 - `--skip-created-after`
 - subcommand action flags such as `reset --yes`, `uninstall --purge`,
-  `verify --checksums`, `import-existing --strict`, and service install flags
+  `verify --checksums`, `import-existing --library`, `import-existing --strict`,
+  and service install flags


### PR DESCRIPTION
## Summary
- Updated README and migration guides for the current v0.20 release-candidate state.
- Added the latest v0.20 PRs to the changelog, including collection-scoped smart folders, setup/listing guidance, Docker upgrade hints, and removed stale docs.
- Fixed stale user-facing doc links in DEPRECATED and CONTRIBUTING.

## Tests
- `cargo check`
- `cargo fmt --all --check`
- `cargo test --lib named_sensitive_smart_folders_widen_across_zones_unfiled_stays_selected`
- `cargo test --lib setup::tests::apply_library_scoped_templates_sets_library_safe_defaults_for_all_libraries -- --exact`
- `cargo test --lib commands::list::tests::format_libraries_primary_then_shared_with_labels -- --exact`
- `cargo run --quiet -- sync --help | rg -n "recent|download-dir|library|smart-folder|config"`
- `git diff --check`
