### PR TITLE
Improve sync-token blocked diagnostics for token non-advance runs

### DIFF
--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -553,4 +553,50 @@ mod tests {
             "pagination_shortfall"
         );
     }
+
+    #[tokio::test]
+    async fn sync_token_blocked_diagnostics_serialize_to_report_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            sync_token_blocked: true,
+            sync_token_blocked_reason: Some("icloud_sync_token_missing"),
+            sync_token_blocked_source: Some("icloud"),
+            sync_token_blocked_explanation: Some(
+                "iCloud did not return a sync token for this full enumeration",
+            ),
+            sync_token_blocked_zone: Some("PrimarySync".to_string()),
+            sync_token_expected_receivers: Some(3),
+            sync_token_receivers_with_token: Some(0),
+            sync_token_receivers_missing: Some(3),
+            sync_token_receivers_blank: Some(0),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(0),
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 0, false).await;
+
+        let report_json = parse_json(&report_path);
+        let stats_json = &report_json["stats"];
+        assert_eq!(
+            stats_json["sync_token_blocked_reason"],
+            "icloud_sync_token_missing"
+        );
+        assert_eq!(stats_json["sync_token_blocked_source"], "icloud");
+        assert_eq!(
+            stats_json["sync_token_blocked_explanation"],
+            "iCloud did not return a sync token for this full enumeration"
+        );
+        assert_eq!(stats_json["sync_token_blocked_zone"], "PrimarySync");
+        assert_eq!(stats_json["sync_token_expected_receivers"], 3);
+        assert_eq!(stats_json["sync_token_receivers_with_token"], 0);
+        assert_eq!(stats_json["sync_token_receivers_missing"], 3);
+        assert_eq!(stats_json["sync_token_receivers_blank"], 0);
+        assert_eq!(stats_json["sync_token_receivers_dropped"], 0);
+        assert_eq!(stats_json["sync_token_unique_values"], 0);
+    }
 }

--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -380,6 +380,25 @@ mod tests {
         })
     }
 
+    fn reporter_with_db<'a>(
+        dir: &'a Path,
+        report_path: Option<&'a Path>,
+        notifier: &'a Notifier,
+        db: &'a state::SqliteStateDb,
+    ) -> CycleReporter<'a, state::SqliteStateDb> {
+        CycleReporter::new(CycleReporterConfig {
+            username: "reporter@example.com",
+            watch_mode: false,
+            report_path,
+            run_options: run_options(),
+            health_dir: dir,
+            personality_mode: Mode::Off,
+            state_db: Some(db),
+            metrics_handle: None,
+            notifier,
+        })
+    }
+
     fn parse_json(path: &Path) -> serde_json::Value {
         let contents = std::fs::read_to_string(path).unwrap();
         serde_json::from_str(&contents).unwrap()
@@ -426,6 +445,49 @@ mod tests {
         let report_json = parse_json(&report_path);
         assert_eq!(report_json["status"], "success");
         assert_eq!(report_json["stats"]["downloaded"], 2);
+    }
+
+    #[tokio::test]
+    async fn success_report_can_include_preexisting_failed_assets_sample() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let db = state::SqliteStateDb::open_in_memory().expect("open db");
+        let failed_record = state::AssetRecord::new_pending(
+            std::sync::Arc::from("PrimarySync"),
+            "FAILED_OLD".to_string(),
+            crate::state::VersionSizeKey::Original,
+            "checksum".to_string(),
+            "failed_old.jpg".to_string(),
+            chrono::Utc::now(),
+            None,
+            1_024,
+            crate::state::MediaType::Photo,
+        );
+        db.upsert_seen(&failed_record)
+            .await
+            .expect("upsert failed row");
+        db.mark_failed("PrimarySync", "FAILED_OLD", "original", "old failure")
+            .await
+            .expect("mark failed");
+        let reporter = reporter_with_db(dir.path(), Some(&report_path), &notifier, &db);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            downloaded: 1,
+            failed: 0,
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 0, false).await;
+
+        let report_json = parse_json(&report_path);
+        assert_eq!(report_json["status"], "success");
+        assert_eq!(report_json["stats"]["failed"], 0);
+        assert_eq!(report_json["failed_assets"][0]["id"], "FAILED_OLD");
+        assert_eq!(
+            report_json["failed_assets"][0]["error_message"],
+            "old failure"
+        );
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -190,6 +190,34 @@ pub struct SyncStats {
     /// Structured reason for `sync_token_blocked`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_blocked_reason: Option<&'static str>,
+    /// High-level owner attribution for `sync_token_blocked_reason`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_blocked_source: Option<&'static str>,
+    /// Human-readable explanation for why token advancement was blocked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_blocked_explanation: Option<&'static str>,
+    /// Zone name where token advancement was blocked. Set by the cycle owner
+    /// so report.json can identify the affected library directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_blocked_zone: Option<String>,
+    /// Number of token receivers expected from full-enumeration passes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_expected_receivers: Option<usize>,
+    /// Number of passes that produced a non-blank sync token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_receivers_with_token: Option<usize>,
+    /// Number of passes that completed but produced no sync token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_receivers_missing: Option<usize>,
+    /// Number of passes that produced a blank sync token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_receivers_blank: Option<usize>,
+    /// Number of sync token channels that dropped before reporting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_receivers_dropped: Option<usize>,
+    /// Number of unique non-blank sync token values observed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_token_unique_values: Option<usize>,
     pub elapsed_secs: f64,
     pub interrupted: bool,
     /// Number of tasks that observed at least one HTTP 429 / 503 response
@@ -242,6 +270,33 @@ impl SyncStats {
         if self.sync_token_blocked_reason.is_none() {
             self.sync_token_blocked_reason = other.sync_token_blocked_reason;
         }
+        if self.sync_token_blocked_source.is_none() {
+            self.sync_token_blocked_source = other.sync_token_blocked_source;
+        }
+        if self.sync_token_blocked_explanation.is_none() {
+            self.sync_token_blocked_explanation = other.sync_token_blocked_explanation;
+        }
+        if self.sync_token_blocked_zone.is_none() {
+            self.sync_token_blocked_zone = other.sync_token_blocked_zone.clone();
+        }
+        if self.sync_token_expected_receivers.is_none() {
+            self.sync_token_expected_receivers = other.sync_token_expected_receivers;
+        }
+        if self.sync_token_receivers_with_token.is_none() {
+            self.sync_token_receivers_with_token = other.sync_token_receivers_with_token;
+        }
+        if self.sync_token_receivers_missing.is_none() {
+            self.sync_token_receivers_missing = other.sync_token_receivers_missing;
+        }
+        if self.sync_token_receivers_blank.is_none() {
+            self.sync_token_receivers_blank = other.sync_token_receivers_blank;
+        }
+        if self.sync_token_receivers_dropped.is_none() {
+            self.sync_token_receivers_dropped = other.sync_token_receivers_dropped;
+        }
+        if self.sync_token_unique_values.is_none() {
+            self.sync_token_unique_values = other.sync_token_unique_values;
+        }
         self.elapsed_secs += other.elapsed_secs;
         self.interrupted = self.interrupted || other.interrupted;
         self.rate_limited += other.rate_limited;
@@ -253,6 +308,39 @@ impl SyncStats {
 
 const PAGINATION_SHORTFALL_TOLERANCE_PERCENT: u64 = 5;
 const PAGINATION_SHORTFALL_TOLERANCE_ABSOLUTE: u64 = 100;
+
+pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
+    match reason {
+        "kei_internal_token_receiver_dropped" => "kei",
+        "pagination_shortfall"
+        | "icloud_blank_sync_token"
+        | "icloud_sync_token_mismatch"
+        | "icloud_sync_token_missing" => "icloud",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
+    match reason {
+        "pagination_shortfall" => {
+            "enumeration counts did not line up safely, so kei blocked token advancement"
+        }
+        "icloud_sync_token_missing" => {
+            "iCloud did not return a sync token for this full enumeration"
+        }
+        "icloud_blank_sync_token" => {
+            "iCloud returned a blank sync token, which kei treated as unusable"
+        }
+        "icloud_sync_token_mismatch" => "iCloud returned conflicting sync tokens across passes",
+        "kei_internal_token_receiver_dropped" => {
+            "an internal token collection channel closed before completion"
+        }
+        "sync_token_unavailable" | "sync_token_missing" => {
+            "no usable sync token was available at the end of the cycle"
+        }
+        _ => "the sync token was unavailable for an unspecified reason",
+    }
+}
 
 /// Per-reason breakdown of skipped assets.
 #[derive(Debug, Default, Clone, serde::Serialize)]
@@ -2470,8 +2558,7 @@ async fn download_photos_full_with_token(
                         shortfall,
                         tolerance_percent = PAGINATION_SHORTFALL_TOLERANCE_PERCENT,
                         tolerance_assets = PAGINATION_SHORTFALL_TOLERANCE_ABSOLUTE,
-                        "Enumeration count shortfall observed, but within tolerance - \
-                         sync token will still advance"
+                        "Enumeration count shortfall observed, but within tolerance"
                     );
                     false
                 }
@@ -2505,18 +2592,81 @@ async fn download_photos_full_with_token(
     // intentionally stops before the full pass is drained, so advancing the
     // token would make older, unenumerated assets invisible to later
     // incremental syncs.
-    let sync_token = if config.recent.is_none()
+    let token_eligible = config.recent.is_none()
         && !controls.run_mode.only_print_filenames()
         && !pagination_undercount
-        && streaming_result.enumeration_errors == 0
-    {
+        && streaming_result.enumeration_errors == 0;
+    let mut token_block_reason: Option<&'static str> = None;
+    let mut token_expected_receivers: Option<usize> = None;
+    let mut token_receivers_with_token: Option<usize> = None;
+    let mut token_receivers_missing: Option<usize> = None;
+    let mut token_receivers_blank: Option<usize> = None;
+    let mut token_receivers_dropped: Option<usize> = None;
+    let mut token_unique_values: Option<usize> = None;
+    let sync_token = if token_eligible {
+        let expected_token_count = token_receivers.len();
+        token_expected_receivers = Some(expected_token_count);
         let mut tokens = Vec::new();
+        let mut missing_tokens = 0usize;
+        let mut blank_tokens = 0usize;
+        let mut dropped_receivers = 0usize;
         for rx in token_receivers {
-            if let Ok(Some(token)) = rx.await {
-                tokens.push(token);
+            match rx.await {
+                Ok(Some(token)) => {
+                    let trimmed = token.trim();
+                    if trimmed.is_empty() {
+                        blank_tokens += 1;
+                        continue;
+                    }
+                    tokens.push(trimmed.to_string());
+                }
+                Ok(None) => {
+                    missing_tokens += 1;
+                }
+                Err(_) => {
+                    dropped_receivers += 1;
+                }
             }
         }
-        unanimous_pass_sync_token(&tokens)
+        token_receivers_with_token = Some(tokens.len());
+        token_receivers_missing = Some(missing_tokens);
+        token_receivers_blank = Some(blank_tokens);
+        token_receivers_dropped = Some(dropped_receivers);
+        if blank_tokens > 0 {
+            tracing::warn!(
+                blank_tokens,
+                expected_token_count,
+                "Full enumeration returned blank syncToken values; blocking token advancement"
+            );
+        }
+        if dropped_receivers > 0 {
+            tracing::warn!(
+                dropped_receivers,
+                expected_token_count,
+                "Full enumeration syncToken receiver dropped before completion; blocking token advancement"
+            );
+        }
+        let unique_token_count = tokens
+            .iter()
+            .map(std::string::String::as_str)
+            .collect::<FxHashSet<_>>()
+            .len();
+        token_unique_values = Some(unique_token_count);
+        let resolved = unanimous_pass_sync_token(&tokens);
+        if resolved.is_none() {
+            token_block_reason = Some(if dropped_receivers > 0 {
+                "kei_internal_token_receiver_dropped"
+            } else if blank_tokens > 0 {
+                "icloud_blank_sync_token"
+            } else if unique_token_count > 1 {
+                "icloud_sync_token_mismatch"
+            } else if missing_tokens > 0 {
+                "icloud_sync_token_missing"
+            } else {
+                "sync_token_unavailable"
+            });
+        }
+        resolved
     } else {
         None
     };
@@ -2543,6 +2693,21 @@ async fn download_photos_full_with_token(
     if pagination_undercount {
         stats.sync_token_blocked = true;
         stats.sync_token_blocked_reason = Some("pagination_shortfall");
+        stats.sync_token_blocked_source = Some(sync_token_blocked_source("pagination_shortfall"));
+        stats.sync_token_blocked_explanation =
+            Some(sync_token_blocked_explanation("pagination_shortfall"));
+    } else if token_eligible && sync_token.is_none() {
+        let reason = token_block_reason.unwrap_or("sync_token_unavailable");
+        stats.sync_token_blocked = true;
+        stats.sync_token_blocked_reason = Some(reason);
+        stats.sync_token_blocked_source = Some(sync_token_blocked_source(reason));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(reason));
+        stats.sync_token_expected_receivers = token_expected_receivers;
+        stats.sync_token_receivers_with_token = token_receivers_with_token;
+        stats.sync_token_receivers_missing = token_receivers_missing;
+        stats.sync_token_receivers_blank = token_receivers_blank;
+        stats.sync_token_receivers_dropped = token_receivers_dropped;
+        stats.sync_token_unique_values = token_unique_values;
     }
 
     // Clear enumeration-in-progress markers when the producer reached the
@@ -2911,6 +3076,7 @@ async fn download_photos_incremental(
         photos_downloaded: pass_result.photos_downloaded,
         videos_downloaded: pass_result.videos_downloaded,
         recap: pass_result.recap.clone(),
+        ..SyncStats::default()
     };
     log_sync_summary(
         "\u{2500}\u{2500} Incremental Sync Summary \u{2500}\u{2500}",
@@ -3512,7 +3678,89 @@ mod tests {
             result.stats.sync_token_blocked_reason,
             Some("pagination_shortfall")
         );
+        assert_eq!(result.stats.sync_token_blocked_source, Some("icloud"));
+        assert_eq!(
+            result.stats.sync_token_blocked_explanation,
+            Some(sync_token_blocked_explanation("pagination_shortfall"))
+        );
+        assert_eq!(result.stats.sync_token_expected_receivers, None);
+        assert_eq!(result.stats.sync_token_receivers_with_token, None);
+        assert_eq!(result.stats.sync_token_receivers_missing, None);
+        assert_eq!(result.stats.sync_token_receivers_blank, None);
+        assert_eq!(result.stats.sync_token_receivers_dropped, None);
+        assert_eq!(result.stats.sync_token_unique_values, None);
         assert_eq!(result.sync_token, None, "token should stay blocked");
+    }
+
+    #[tokio::test]
+    async fn full_sync_blank_query_sync_token_blocks_advancement() {
+        let records = mock_photo_records_with_filename("MASTER_BLANK_TOKEN", "blank-token.jpg");
+        let session = MockPhotosFlow::new()
+            .album_count(1)
+            .query_page(records.clone(), Some(""))
+            .empty_query_page(Some(""))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 2;
+
+        // Seed the destination so the enumerated asset is skipped on-disk
+        // and this test isolates token-capture behavior.
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let pass_config = config.with_pass(&passes[0]);
+        let expected_path = filter::expected_paths_for(&asset, &pass_config)
+            .into_iter()
+            .next()
+            .expect("mock asset should have an expected path");
+        tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
+            .await
+            .expect("create parent dir");
+        tokio::fs::write(&expected_path.path, vec![0u8; 1024])
+            .await
+            .expect("seed existing file");
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("blank sync token should not error");
+
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "blank token should not force partial failure"
+        );
+        assert_eq!(result.stats.failed, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.pagination_shortfall_assets, 0);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some("icloud_sync_token_missing")
+        );
+        assert_eq!(result.stats.sync_token_blocked_source, Some("icloud"));
+        assert_eq!(
+            result.stats.sync_token_blocked_explanation,
+            Some(sync_token_blocked_explanation("icloud_sync_token_missing"))
+        );
+        assert_eq!(result.stats.sync_token_expected_receivers, Some(1));
+        assert_eq!(result.stats.sync_token_receivers_with_token, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_missing, Some(1));
+        assert_eq!(result.stats.sync_token_receivers_blank, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_dropped, Some(0));
+        assert_eq!(result.stats.sync_token_unique_values, Some(0));
+        assert_eq!(result.sync_token, None, "blank token must not be persisted");
     }
 
     #[test]
@@ -5224,6 +5472,17 @@ mod tests {
             pagination_shortfall_assets: 9,
             sync_token_blocked: true,
             sync_token_blocked_reason: Some("pagination_shortfall"),
+            sync_token_blocked_source: Some("icloud"),
+            sync_token_blocked_explanation: Some(sync_token_blocked_explanation(
+                "pagination_shortfall",
+            )),
+            sync_token_blocked_zone: Some("PrimarySync".to_string()),
+            sync_token_expected_receivers: Some(3),
+            sync_token_receivers_with_token: Some(2),
+            sync_token_receivers_missing: Some(1),
+            sync_token_receivers_blank: Some(0),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(1),
             elapsed_secs: 1.5,
             interrupted: false,
             rate_limited: 7,
@@ -5258,6 +5517,15 @@ mod tests {
             pagination_shortfall_assets: 11,
             sync_token_blocked: false,
             sync_token_blocked_reason: None,
+            sync_token_blocked_source: Some("kei"),
+            sync_token_blocked_explanation: Some("should not overwrite first"),
+            sync_token_blocked_zone: Some("SharedSync-abc".to_string()),
+            sync_token_expected_receivers: Some(9),
+            sync_token_receivers_with_token: Some(9),
+            sync_token_receivers_missing: Some(0),
+            sync_token_receivers_blank: Some(0),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(1),
             elapsed_secs: 0.75,
             interrupted: true,
             rate_limited: 3,
@@ -5288,6 +5556,18 @@ mod tests {
         );
         assert!(acc.sync_token_blocked, "sync_token_blocked must OR");
         assert_eq!(acc.sync_token_blocked_reason, Some("pagination_shortfall"));
+        assert_eq!(acc.sync_token_blocked_source, Some("icloud"));
+        assert_eq!(
+            acc.sync_token_blocked_explanation,
+            Some(sync_token_blocked_explanation("pagination_shortfall"))
+        );
+        assert_eq!(acc.sync_token_blocked_zone.as_deref(), Some("PrimarySync"));
+        assert_eq!(acc.sync_token_expected_receivers, Some(3));
+        assert_eq!(acc.sync_token_receivers_with_token, Some(2));
+        assert_eq!(acc.sync_token_receivers_missing, Some(1));
+        assert_eq!(acc.sync_token_receivers_blank, Some(0));
+        assert_eq!(acc.sync_token_receivers_dropped, Some(0));
+        assert_eq!(acc.sync_token_unique_values, Some(1));
         assert!(
             (acc.elapsed_secs - 2.25).abs() < 1e-9,
             "elapsed_secs must sum (got {})",

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3747,17 +3747,17 @@ mod tests {
         assert!(result.stats.sync_token_blocked);
         assert_eq!(
             result.stats.sync_token_blocked_reason,
-            Some("icloud_sync_token_missing")
+            Some("icloud_blank_sync_token")
         );
         assert_eq!(result.stats.sync_token_blocked_source, Some("icloud"));
         assert_eq!(
             result.stats.sync_token_blocked_explanation,
-            Some(sync_token_blocked_explanation("icloud_sync_token_missing"))
+            Some(sync_token_blocked_explanation("icloud_blank_sync_token"))
         );
         assert_eq!(result.stats.sync_token_expected_receivers, Some(1));
         assert_eq!(result.stats.sync_token_receivers_with_token, Some(0));
-        assert_eq!(result.stats.sync_token_receivers_missing, Some(1));
-        assert_eq!(result.stats.sync_token_receivers_blank, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_missing, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_blank, Some(1));
         assert_eq!(result.stats.sync_token_receivers_dropped, Some(0));
         assert_eq!(result.stats.sync_token_unique_values, Some(0));
         assert_eq!(result.sync_token, None, "blank token must not be persisted");
@@ -5598,6 +5598,84 @@ mod tests {
             3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13,
             "skip total must reflect summed breakdown"
         );
+    }
+
+    /// When multiple libraries block token advancement in one cycle, the
+    /// aggregated cycle stats preserve the first blocked diagnostic payload.
+    #[test]
+    fn sync_stats_accumulate_preserves_first_token_blocked_diagnostics() {
+        let first = SyncStats {
+            sync_token_blocked: true,
+            sync_token_blocked_reason: Some("icloud_blank_sync_token"),
+            sync_token_blocked_source: Some("icloud"),
+            sync_token_blocked_explanation: Some(sync_token_blocked_explanation(
+                "icloud_blank_sync_token",
+            )),
+            sync_token_blocked_zone: Some("PrimarySync".to_string()),
+            sync_token_expected_receivers: Some(2),
+            sync_token_receivers_with_token: Some(0),
+            sync_token_receivers_missing: Some(0),
+            sync_token_receivers_blank: Some(2),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(0),
+            ..SyncStats::default()
+        };
+        let second = SyncStats {
+            sync_token_blocked: true,
+            sync_token_blocked_reason: Some("icloud_sync_token_mismatch"),
+            sync_token_blocked_source: Some("icloud"),
+            sync_token_blocked_explanation: Some(sync_token_blocked_explanation(
+                "icloud_sync_token_mismatch",
+            )),
+            sync_token_blocked_zone: Some("SharedSync-XYZ".to_string()),
+            sync_token_expected_receivers: Some(3),
+            sync_token_receivers_with_token: Some(3),
+            sync_token_receivers_missing: Some(0),
+            sync_token_receivers_blank: Some(0),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(2),
+            ..SyncStats::default()
+        };
+
+        let mut acc = SyncStats::default();
+        acc.accumulate(&first);
+        acc.accumulate(&second);
+
+        assert!(acc.sync_token_blocked);
+        assert_eq!(
+            acc.sync_token_blocked_reason,
+            first.sync_token_blocked_reason
+        );
+        assert_eq!(
+            acc.sync_token_blocked_source,
+            first.sync_token_blocked_source
+        );
+        assert_eq!(
+            acc.sync_token_blocked_explanation,
+            first.sync_token_blocked_explanation
+        );
+        assert_eq!(acc.sync_token_blocked_zone, first.sync_token_blocked_zone);
+        assert_eq!(
+            acc.sync_token_expected_receivers,
+            first.sync_token_expected_receivers
+        );
+        assert_eq!(
+            acc.sync_token_receivers_with_token,
+            first.sync_token_receivers_with_token
+        );
+        assert_eq!(
+            acc.sync_token_receivers_missing,
+            first.sync_token_receivers_missing
+        );
+        assert_eq!(
+            acc.sync_token_receivers_blank,
+            first.sync_token_receivers_blank
+        );
+        assert_eq!(
+            acc.sync_token_receivers_dropped,
+            first.sync_token_receivers_dropped
+        );
+        assert_eq!(acc.sync_token_unique_values, first.sync_token_unique_values);
     }
 
     /// A transient `pass.album.len()` failure must not

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1994,6 +1994,7 @@ pub(super) async fn build_download_outcome(
             photos_downloaded: streaming_result.photos_downloaded,
             videos_downloaded: streaming_result.videos_downloaded,
             recap: streaming_result.recap.clone(),
+            ..super::SyncStats::default()
         };
         return Ok((
             DownloadOutcome::SessionExpired {
@@ -2082,6 +2083,7 @@ pub(super) async fn build_download_outcome(
             photos_downloaded: streaming_result.photos_downloaded,
             videos_downloaded: streaming_result.videos_downloaded,
             recap: streaming_result.recap.clone(),
+            ..super::SyncStats::default()
         };
         log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);
         return Ok((
@@ -2119,6 +2121,7 @@ pub(super) async fn build_download_outcome(
             photos_downloaded: streaming_result.photos_downloaded,
             videos_downloaded: streaming_result.videos_downloaded,
             recap: streaming_result.recap.clone(),
+            ..super::SyncStats::default()
         };
         log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);
         if state_write_failures > 0
@@ -2204,6 +2207,7 @@ pub(super) async fn build_download_outcome(
             photos_downloaded: streaming_result.photos_downloaded + pass_result.photos_downloaded,
             videos_downloaded: streaming_result.videos_downloaded + pass_result.videos_downloaded,
             recap: merged_recap,
+            ..super::SyncStats::default()
         };
         return Ok((
             DownloadOutcome::SessionExpired {
@@ -2252,6 +2256,7 @@ pub(super) async fn build_download_outcome(
         photos_downloaded: streaming_result.photos_downloaded + pass_result.photos_downloaded,
         videos_downloaded: streaming_result.videos_downloaded + pass_result.videos_downloaded,
         recap: merged_recap,
+        ..super::SyncStats::default()
     };
     maybe_warn_rate_limit_pressure(&stats);
     log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1218,8 +1218,19 @@ impl PhotoAlbum {
                 };
 
                 // Capture the zone-level syncToken from each page response.
-                if let Some(token) = &query.sync_token {
-                    last_sync_token = Some(token.clone());
+                // Treat blank tokens as missing so we never persist an
+                // unusable marker that forces the next cycle back to full.
+                if let Some(token) = query.sync_token.as_deref() {
+                    let trimmed = token.trim();
+                    if trimmed.is_empty() {
+                        tracing::warn!(
+                            album = %name,
+                            offset,
+                            "Fetcher response contained blank syncToken; treating as unavailable"
+                        );
+                    } else {
+                        last_sync_token = Some(trimmed.to_string());
+                    }
                 }
 
                 let records = query.records;
@@ -1920,6 +1931,30 @@ mod tests {
 
         let token = token_rx.await.expect("oneshot should not be dropped");
         assert_eq!(token, None, "no syncToken in responses means None");
+    }
+
+    #[tokio::test]
+    async fn test_photo_stream_with_token_blank_sync_token_treated_as_none() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .query_photo_page("master-1", Some(""))
+            .empty_query_page(Some(""))
+            .build();
+        let album = make_album_with_session(100, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, None, 1);
+        tokio::pin!(stream);
+
+        while let Some(result) = stream.next().await {
+            result.expect("photo asset should be Ok");
+        }
+
+        let token = token_rx.await.expect("oneshot should not be dropped");
+        assert_eq!(
+            token, None,
+            "blank syncToken must be treated as unavailable"
+        );
     }
 
     #[tokio::test]

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -549,6 +549,7 @@ impl PhotoAlbum {
             total_count,
             PhotoStreamProfile::FastEnumeration { concurrency },
             None,
+            false,
         );
         tokio::spawn(async move {
             let panicked = await_fetcher_handles(handles).await;
@@ -580,6 +581,7 @@ impl PhotoAlbum {
             limit,
             total_count,
             PhotoStreamProfile::FastEnumeration { concurrency },
+            false,
         )
     }
 
@@ -600,6 +602,7 @@ impl PhotoAlbum {
             PhotoStreamProfile::BackpressuredDownload {
                 download_concurrency,
             },
+            true,
         )
     }
 
@@ -608,9 +611,15 @@ impl PhotoAlbum {
         limit: Option<u32>,
         total_count: Option<u64>,
         profile: PhotoStreamProfile,
+        preserve_blank_sync_tokens_for_diagnostics: bool,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
         if self.has_cross_zone_hydration() {
-            return self.photo_stream_with_cross_zone_hydration(limit, total_count, profile);
+            return self.photo_stream_with_cross_zone_hydration(
+                limit,
+                total_count,
+                profile,
+                preserve_blank_sync_tokens_for_diagnostics,
+            );
         }
 
         let (token_tx, token_rx) = tokio::sync::oneshot::channel();
@@ -622,6 +631,7 @@ impl PhotoAlbum {
             total_count,
             profile,
             Some(fetcher_sync_tokens.clone()),
+            preserve_blank_sync_tokens_for_diagnostics,
         );
         let album_name = Arc::clone(&self.name);
 
@@ -651,11 +661,16 @@ impl PhotoAlbum {
         limit: Option<u32>,
         total_count: Option<u64>,
         profile: PhotoStreamProfile,
+        preserve_blank_sync_tokens_for_diagnostics: bool,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
         let (tx, rx) = mpsc::channel::<anyhow::Result<PhotoAsset>>(500);
         let (token_tx, token_rx) = tokio::sync::oneshot::channel();
-        let (base_stream, base_token_rx) =
-            self.photo_stream_with_token_inner_no_cross_zone(limit, total_count, profile);
+        let (base_stream, base_token_rx) = self.photo_stream_with_token_inner_no_cross_zone(
+            limit,
+            total_count,
+            profile,
+            preserve_blank_sync_tokens_for_diagnostics,
+        );
         let Some(container_id) = self.container_id.clone() else {
             let _ = token_tx.send(None);
             return (
@@ -786,6 +801,7 @@ impl PhotoAlbum {
         limit: Option<u32>,
         total_count: Option<u64>,
         profile: PhotoStreamProfile,
+        preserve_blank_sync_tokens_for_diagnostics: bool,
     ) -> (PhotoStream, tokio::sync::oneshot::Receiver<Option<String>>) {
         let (token_tx, token_rx) = tokio::sync::oneshot::channel();
         let fetcher_sync_tokens: Arc<tokio::sync::Mutex<Vec<String>>> =
@@ -796,6 +812,7 @@ impl PhotoAlbum {
             total_count,
             profile,
             Some(fetcher_sync_tokens.clone()),
+            preserve_blank_sync_tokens_for_diagnostics,
         );
         let album_name = Arc::clone(&self.name);
 
@@ -1095,6 +1112,7 @@ impl PhotoAlbum {
         total_count: Option<u64>,
         profile: PhotoStreamProfile,
         fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
+        preserve_blank_sync_tokens_for_diagnostics: bool,
     ) -> (PhotoStream, Vec<JoinHandle<()>>) {
         let plan = build_enumeration_plan(limit, total_count, self.page_size, profile);
         let (tx, rx) = mpsc::channel::<anyhow::Result<PhotoAsset>>(
@@ -1114,6 +1132,7 @@ impl PhotoAlbum {
                 range.limit,
                 fetcher_sync_tokens.clone(),
                 plan.page_size,
+                preserve_blank_sync_tokens_for_diagnostics,
             ));
         }
         // Drop our sender so channel closes when all fetchers finish.
@@ -1144,6 +1163,7 @@ impl PhotoAlbum {
         limit: Option<u32>,
         fetcher_sync_tokens: Option<Arc<tokio::sync::Mutex<Vec<String>>>>,
         page_size: usize,
+        preserve_blank_sync_tokens_for_diagnostics: bool,
     ) -> JoinHandle<()> {
         let session = self.session.clone_box();
         let service_endpoint = Arc::clone(&self.service_endpoint);
@@ -1158,6 +1178,7 @@ impl PhotoAlbum {
             let mut offset = start_offset;
             let mut total_sent: u64 = 0;
             let mut last_sync_token: Option<String> = None;
+            let mut saw_blank_sync_token = false;
             let mut pending_masters: FxHashMap<String, super::cloudkit::Record> =
                 FxHashMap::default();
             let mut consecutive_empty_pages: u32 = 0;
@@ -1223,6 +1244,7 @@ impl PhotoAlbum {
                 if let Some(token) = query.sync_token.as_deref() {
                     let trimmed = token.trim();
                     if trimmed.is_empty() {
+                        saw_blank_sync_token = true;
                         tracing::warn!(
                             album = %name,
                             offset,
@@ -1372,8 +1394,12 @@ impl PhotoAlbum {
                 }
             }
 
-            if let (Some(shared), Some(token)) = (&fetcher_sync_tokens, last_sync_token) {
-                shared.lock().await.push(token);
+            if let Some(shared) = &fetcher_sync_tokens {
+                if let Some(token) = last_sync_token {
+                    shared.lock().await.push(token);
+                } else if saw_blank_sync_token && preserve_blank_sync_tokens_for_diagnostics {
+                    shared.lock().await.push(String::new());
+                }
             }
         })
     }
@@ -2057,6 +2083,7 @@ mod tests {
             None,
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
 
         assert_eq!(
@@ -2834,6 +2861,7 @@ mod tests {
             Some(10),
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 
@@ -2856,6 +2884,7 @@ mod tests {
             Some(10),
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 
@@ -2907,6 +2936,7 @@ mod tests {
             None,
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 
@@ -2945,6 +2975,7 @@ mod tests {
             None,
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 
@@ -2985,6 +3016,7 @@ mod tests {
             None,
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 
@@ -3028,6 +3060,7 @@ mod tests {
             None,
             PhotoStreamProfile::FastEnumeration { concurrency: 1 },
             None,
+            false,
         );
         tokio::pin!(stream);
 

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -317,7 +317,7 @@ pub(crate) async fn run_cycle(
             Arc::from(lib_state.zone_name.as_str()),
         );
         let download_client = shared_session.read().await.download_client().clone();
-        let sync_result = download::download_photos_with_sync(
+        let mut sync_result = download::download_photos_with_sync(
             &download_client,
             &lib_state.plan.passes,
             download_config,
@@ -378,9 +378,45 @@ pub(crate) async fn run_cycle(
                 }
                 (None, _) => {
                     db_sync_token_advance_safe = false;
-                    tracing::debug!(
+                    let reason = sync_result
+                        .stats
+                        .sync_token_blocked_reason
+                        .unwrap_or("sync_token_missing");
+                    let source = sync_result
+                        .stats
+                        .sync_token_blocked_source
+                        .unwrap_or_else(|| download::sync_token_blocked_source(reason));
+                    let explanation = sync_result
+                        .stats
+                        .sync_token_blocked_explanation
+                        .as_ref()
+                        .copied()
+                        .unwrap_or_else(|| download::sync_token_blocked_explanation(reason));
+                    let observation = match (
+                        sync_result.stats.sync_token_expected_receivers,
+                        sync_result.stats.sync_token_receivers_with_token,
+                    ) {
+                        (Some(expected), Some(with_token)) => {
+                            let missing = sync_result.stats.sync_token_receivers_missing.unwrap_or(0);
+                            let blank = sync_result.stats.sync_token_receivers_blank.unwrap_or(0);
+                            let dropped = sync_result.stats.sync_token_receivers_dropped.unwrap_or(0);
+                            let unique = sync_result.stats.sync_token_unique_values.unwrap_or(0);
+                            format!(
+                                "Observed usable sync tokens on {with_token}/{expected} passes (missing: {missing}, blank: {blank}, dropped: {dropped}, unique values: {unique})"
+                            )
+                        }
+                        _ => "No per-pass sync token observation details were collected for this reason"
+                            .to_string(),
+                    };
+                    tracing::warn!(
                         zone = %lib_state.zone_name,
-                        "Sync token unavailable after successful sync"
+                        reason,
+                        source,
+                        explanation,
+                        observation,
+                        "Sync token did not advance after this successful sync. Here's why: {}. {}. Next cycle will run full enumeration",
+                        explanation,
+                        observation
                     );
                 }
             }
@@ -390,6 +426,12 @@ pub(crate) async fn run_cycle(
                 zone = %lib_state.zone_name,
                 "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
             );
+        }
+
+        if sync_result.stats.sync_token_blocked
+            && sync_result.stats.sync_token_blocked_zone.is_none()
+        {
+            sync_result.stats.sync_token_blocked_zone = Some(lib_state.zone_name.clone());
         }
 
         // Accumulate stats across libraries.

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -513,8 +513,8 @@ where
 {
     if is_retry_failed {
         if library_count == 1 {
-            tracing::debug!(
-                "Retry-failed requires full enumeration to find previously-failed assets"
+            tracing::info!(
+                "Retry-failed always runs full enumeration because incremental sync only returns new iCloud changes and can miss older failed assets"
             );
         }
         download::SyncMode::Full

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -3749,6 +3749,32 @@ mod tests {
         );
     }
 
+    /// Retry-failed should ignore a stored token for its own run, but it must
+    /// not clear that token. A subsequent normal sync should still use
+    /// incremental mode from the previously stored token.
+    #[tokio::test]
+    async fn determine_sync_mode_retry_failed_does_not_consume_or_clear_stored_token() {
+        let db = make_state_db();
+        let sync_token_key = "sync_token:PrimarySync";
+        db.set_metadata(sync_token_key, "stored-token-abc")
+            .await
+            .expect("set token");
+
+        let retry_mode =
+            determine_sync_mode(true, 1, Some(db.as_ref()), sync_token_key, "PrimarySync").await;
+        assert!(
+            matches!(retry_mode, download::SyncMode::Full),
+            "retry-failed must force Full, got {retry_mode:?}"
+        );
+
+        let normal_mode =
+            determine_sync_mode(false, 1, Some(db.as_ref()), sync_token_key, "PrimarySync").await;
+        assert!(
+            matches!(normal_mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "stored-token-abc"),
+            "normal sync should still use the stored token after retry-failed, got {normal_mode:?}"
+        );
+    }
+
     #[tokio::test]
     async fn determine_sync_mode_empty_stored_token_falls_back_to_full() {
         let db = make_state_db();


### PR DESCRIPTION
## Summary
- improves sync-token non-advance diagnostics with additive report fields: source, explanation, blocked zone, and per-pass token receiver counts
- upgrades the token-not-advanced path to a WARN with plain-language output: why token advancement was blocked and what kei observed
- adds a retry-failed notice at user log level: retry-failed always does full enumeration because incremental only returns new changes
- keeps token behavior fail-closed and makes blank token causes explicit in full-sync diagnostics (`icloud_blank_sync_token`)
- keeps the tolerated shortfall warning neutral: `Enumeration count shortfall observed, but within tolerance`
- adds coverage for key edge cases:
  - retry-failed ignores stored token but does not clear it for the next normal sync
  - full sync blank token classification and per-pass counters
  - multi-library stat accumulation keeps first blocked diagnostic payload
  - success report can still include preexisting failed-assets sample rows

## Context
Fixes #500.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test determine_sync_mode_retry_failed_with_token_returns_full`
- `cargo test determine_sync_mode_retry_failed_does_not_consume_or_clear_stored_token`
- `cargo test full_sync_blank_query_sync_token_blocks_advancement`
- `cargo test sync_stats_accumulate_preserves_first_token_blocked_diagnostics`
- `cargo test success_report_can_include_preexisting_failed_assets_sample`
- `cargo test test_photo_stream_with_token_blank_sync_token_treated_as_none`
