### PR TITLE
Report sync-token observations even when not blocked

### DIFF
--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -404,6 +404,26 @@ mod tests {
         serde_json::from_str(&contents).unwrap()
     }
 
+    fn assert_sync_token_observation_fields(
+        stats_json: &serde_json::Value,
+        expected_receivers: usize,
+        with_token: usize,
+        missing: usize,
+        blank: usize,
+        dropped: usize,
+        unique: usize,
+    ) {
+        assert_eq!(
+            stats_json["sync_token_expected_receivers"],
+            expected_receivers
+        );
+        assert_eq!(stats_json["sync_token_receivers_with_token"], with_token);
+        assert_eq!(stats_json["sync_token_receivers_missing"], missing);
+        assert_eq!(stats_json["sync_token_receivers_blank"], blank);
+        assert_eq!(stats_json["sync_token_receivers_dropped"], dropped);
+        assert_eq!(stats_json["sync_token_unique_values"], unique);
+    }
+
     async fn report_cycle(
         reporter: &CycleReporter<'_, state::SqliteStateDb>,
         health: &mut HealthStatus,
@@ -654,11 +674,36 @@ mod tests {
             "iCloud did not return a sync token for this full enumeration"
         );
         assert_eq!(stats_json["sync_token_blocked_zone"], "PrimarySync");
-        assert_eq!(stats_json["sync_token_expected_receivers"], 3);
-        assert_eq!(stats_json["sync_token_receivers_with_token"], 0);
-        assert_eq!(stats_json["sync_token_receivers_missing"], 3);
-        assert_eq!(stats_json["sync_token_receivers_blank"], 0);
-        assert_eq!(stats_json["sync_token_receivers_dropped"], 0);
-        assert_eq!(stats_json["sync_token_unique_values"], 0);
+        assert_sync_token_observation_fields(stats_json, 3, 0, 3, 0, 0, 0);
+    }
+
+    #[tokio::test]
+    async fn sync_token_observation_fields_serialize_even_when_not_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let report_path = dir.path().join("sync_report.json");
+        let notifier = Notifier::new(None);
+        let reporter = reporter(dir.path(), Some(&report_path), &notifier);
+        let mut health = HealthStatus::new();
+        let stats = SyncStats {
+            sync_token_blocked: false,
+            sync_token_expected_receivers: Some(2),
+            sync_token_receivers_with_token: Some(2),
+            sync_token_receivers_missing: Some(0),
+            sync_token_receivers_blank: Some(0),
+            sync_token_receivers_dropped: Some(0),
+            sync_token_unique_values: Some(1),
+            ..SyncStats::default()
+        };
+
+        report_cycle(&reporter, &mut health, &stats, 0, false).await;
+
+        let report_json = parse_json(&report_path);
+        let stats_json = &report_json["stats"];
+        assert_eq!(stats_json["sync_token_blocked"], false);
+        assert_sync_token_observation_fields(stats_json, 2, 2, 0, 0, 0, 1);
+        assert!(
+            stats_json["sync_token_blocked_reason"].is_null(),
+            "reason should stay absent when sync token was not blocked"
+        );
     }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -201,21 +201,33 @@ pub struct SyncStats {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_blocked_zone: Option<String>,
     /// Number of token receivers expected from full-enumeration passes.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_expected_receivers: Option<usize>,
     /// Number of passes that produced a non-blank sync token.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_receivers_with_token: Option<usize>,
     /// Number of passes that completed but produced no sync token.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_receivers_missing: Option<usize>,
     /// Number of passes that produced a blank sync token.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_receivers_blank: Option<usize>,
     /// Number of sync token channels that dropped before reporting.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_receivers_dropped: Option<usize>,
     /// Number of unique non-blank sync token values observed.
+    /// Emitted whenever token receiver telemetry was collected, even if
+    /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_unique_values: Option<usize>,
     pub elapsed_secs: f64,
@@ -2690,6 +2702,14 @@ async fn download_photos_full_with_token(
     .await?;
     stats.pagination_shortfall_warnings = pagination_shortfall_warnings;
     stats.pagination_shortfall_assets = pagination_shortfall_assets;
+    if token_eligible {
+        stats.sync_token_expected_receivers = token_expected_receivers;
+        stats.sync_token_receivers_with_token = token_receivers_with_token;
+        stats.sync_token_receivers_missing = token_receivers_missing;
+        stats.sync_token_receivers_blank = token_receivers_blank;
+        stats.sync_token_receivers_dropped = token_receivers_dropped;
+        stats.sync_token_unique_values = token_unique_values;
+    }
     if pagination_undercount {
         stats.sync_token_blocked = true;
         stats.sync_token_blocked_reason = Some("pagination_shortfall");
@@ -2702,12 +2722,6 @@ async fn download_photos_full_with_token(
         stats.sync_token_blocked_reason = Some(reason);
         stats.sync_token_blocked_source = Some(sync_token_blocked_source(reason));
         stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(reason));
-        stats.sync_token_expected_receivers = token_expected_receivers;
-        stats.sync_token_receivers_with_token = token_receivers_with_token;
-        stats.sync_token_receivers_missing = token_receivers_missing;
-        stats.sync_token_receivers_blank = token_receivers_blank;
-        stats.sync_token_receivers_dropped = token_receivers_dropped;
-        stats.sync_token_unique_values = token_unique_values;
     }
 
     // Clear enumeration-in-progress markers when the producer reached the
@@ -3615,6 +3629,13 @@ mod tests {
             Some("zone-token"),
             "clean write-mode enumeration should still advance the agreed sync token"
         );
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.stats.sync_token_expected_receivers, Some(2));
+        assert_eq!(result.stats.sync_token_receivers_with_token, Some(2));
+        assert_eq!(result.stats.sync_token_receivers_missing, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_blank, Some(0));
+        assert_eq!(result.stats.sync_token_receivers_dropped, Some(0));
+        assert_eq!(result.stats.sync_token_unique_values, Some(1));
         assert!(
             matches!(result.outcome, DownloadOutcome::Success),
             "filtered duplicate should not make the write-mode run partial"


### PR DESCRIPTION
## Summary
- Populate sync token receiver observation fields whenever token telemetry is collected, even when `sync_token_blocked` is false.
- Keep blocked-only reason/source/explanation fields tied to true blocked cases.
- Add tests for non-blocked token observation serialization in both download and cycle reporter paths.

## Context
- Refs #500.

## Tests
- `cargo check`
- `cargo test sync_token_observation_fields_serialize_even_when_not_blocked`
- `cargo test full_sync_deferred_unfiled_write_mode_exclusion_does_not_count_as_shortfall`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`