### PR TITLE
Fix incremental sync state gates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -695,39 +695,6 @@ pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-#[cfg(windows)]
-fn repair_malformed_windows_data_dir(path: PathBuf) -> PathBuf {
-    let Some(home) = dirs::home_dir() else {
-        return path;
-    };
-    let Some(parent) = home.parent() else {
-        return path;
-    };
-    let Some(user_name) = home.file_name() else {
-        return path;
-    };
-
-    let mut bugged_name = user_name.to_os_string();
-    bugged_name.push(".config");
-    let bugged_kei_dir = parent.join(bugged_name).join("kei");
-    let Ok(suffix) = path.strip_prefix(&bugged_kei_dir) else {
-        return path;
-    };
-
-    let corrected = kei_data_dir_with_home(&home).join(suffix);
-    tracing::warn!(
-        configured = %path.display(),
-        corrected = %corrected.display(),
-        "data_dir matches a malformed old Windows path; using corrected ~/.config/kei path"
-    );
-    corrected
-}
-
-#[cfg(not(windows))]
-fn repair_malformed_windows_data_dir(path: PathBuf) -> PathBuf {
-    path
-}
-
 /// Reject system directories that should never be used as a download
 /// target. Shared by sync (`Config::build`) and import-existing
 /// (`build_import_download_config`) so both refuse the same set with the
@@ -1034,10 +1001,10 @@ pub(crate) fn resolve_data_dir(
     config_path: &Path,
 ) -> PathBuf {
     if let Some(d) = data_dir_cli {
-        return repair_malformed_windows_data_dir(expand_tilde(d));
+        return expand_tilde(d);
     }
     if let Some(d) = toml.and_then(|t| t.data_dir.as_deref()) {
-        return repair_malformed_windows_data_dir(expand_tilde(d));
+        return expand_tilde(d);
     }
     config_path
         .parent()
@@ -5856,33 +5823,6 @@ mod tests {
         };
         let result = resolve_data_dir(None, Some(&toml), Path::new("/config/config.toml"));
         assert_eq!(result, PathBuf::from("/toml/data"));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn test_resolve_data_dir_repairs_malformed_windows_dot_config_path() {
-        let Some(home) = dirs::home_dir() else {
-            return;
-        };
-        let Some(parent) = home.parent() else {
-            return;
-        };
-        let Some(user_name) = home.file_name() else {
-            return;
-        };
-
-        let mut bugged_name = user_name.to_os_string();
-        bugged_name.push(".config");
-        let bugged = parent.join(bugged_name).join("kei").join("cookies");
-        let corrected = kei_data_dir_with_home(&home).join("cookies");
-        let result = resolve_data_dir(
-            Some(&bugged.to_string_lossy()),
-            None,
-            Path::new(r"C:\unused\config.toml"),
-        );
-
-        assert_eq!(result, corrected);
-        assert_ne!(result, bugged);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -661,13 +661,71 @@ impl std::fmt::Debug for Config {
     }
 }
 
-pub(crate) fn expand_tilde(path: &str) -> PathBuf {
+pub(crate) fn kei_data_dir_with_home(home: &Path) -> PathBuf {
+    home.join(".config").join("kei")
+}
+
+pub(crate) fn kei_data_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| kei_data_dir_with_home(&home))
+        .unwrap_or_else(|| PathBuf::from("~/.config/kei"))
+}
+
+pub(crate) fn default_config_path() -> PathBuf {
+    kei_data_dir().join("config.toml")
+}
+
+pub(crate) fn default_cookie_dir() -> PathBuf {
+    kei_data_dir().join("cookies")
+}
+
+fn expand_tilde_with_home(path: &str, home: &Path) -> PathBuf {
     if let Some(stripped) = path.strip_prefix("~/") {
+        return home.join(stripped);
+    }
+    PathBuf::from(path)
+}
+
+pub(crate) fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with("~/") {
         if let Some(home) = dirs::home_dir() {
-            return home.join(stripped);
+            return expand_tilde_with_home(path, &home);
         }
     }
     PathBuf::from(path)
+}
+
+#[cfg(windows)]
+fn repair_malformed_windows_data_dir(path: PathBuf) -> PathBuf {
+    let Some(home) = dirs::home_dir() else {
+        return path;
+    };
+    let Some(parent) = home.parent() else {
+        return path;
+    };
+    let Some(user_name) = home.file_name() else {
+        return path;
+    };
+
+    let mut bugged_name = user_name.to_os_string();
+    bugged_name.push(".config");
+    let bugged_kei_dir = parent.join(bugged_name).join("kei");
+    let Ok(suffix) = path.strip_prefix(&bugged_kei_dir) else {
+        return path;
+    };
+
+    let corrected = kei_data_dir_with_home(&home).join(suffix);
+    tracing::warn!(
+        configured = %path.display(),
+        corrected = %corrected.display(),
+        "data_dir matches a malformed old Windows path; using corrected ~/.config/kei path"
+    );
+    corrected
+}
+
+#[cfg(not(windows))]
+fn repair_malformed_windows_data_dir(path: PathBuf) -> PathBuf {
+    path
 }
 
 /// Reject system directories that should never be used as a download
@@ -955,10 +1013,10 @@ pub(crate) fn resolve_auth(
     let has_explicit_data_dir =
         globals.data_dir.is_some() || toml.and_then(|t| t.data_dir.as_ref()).is_some();
     let cookie_directory = if has_explicit_data_dir {
-        let default_config = expand_tilde("~/.config/kei/config.toml");
+        let default_config = default_config_path();
         resolve_data_dir(globals.data_dir.as_deref(), toml, &default_config)
     } else {
-        expand_tilde("~/.config/kei/cookies")
+        default_cookie_dir()
     };
 
     (username, password, domain, cookie_directory)
@@ -976,15 +1034,15 @@ pub(crate) fn resolve_data_dir(
     config_path: &Path,
 ) -> PathBuf {
     if let Some(d) = data_dir_cli {
-        return expand_tilde(d);
+        return repair_malformed_windows_data_dir(expand_tilde(d));
     }
     if let Some(d) = toml.and_then(|t| t.data_dir.as_deref()) {
-        return expand_tilde(d);
+        return repair_malformed_windows_data_dir(expand_tilde(d));
     }
     config_path
         .parent()
         .map(Path::to_path_buf)
-        .unwrap_or_else(|| expand_tilde("~/.config/kei"))
+        .unwrap_or_else(kei_data_dir)
 }
 
 /// Resolve `password_file` from CLI + TOML.
@@ -2069,6 +2127,24 @@ mod tests {
         if let Some(home) = dirs::home_dir() {
             assert_eq!(result, home.join("Documents"));
         }
+    }
+
+    #[test]
+    fn test_expand_tilde_with_injected_home_uses_path_join() {
+        let home = Path::new("/home/ajlow");
+        assert_eq!(
+            expand_tilde_with_home("~/.config/kei/cookies", home),
+            kei_data_dir_with_home(home).join("cookies")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_expand_tilde_windows_home_keeps_separator_before_dot_config() {
+        let home = Path::new(r"C:\Users\ajlow");
+        let result = expand_tilde_with_home("~/.config/kei/cookies", home);
+        assert_eq!(result, PathBuf::from(r"C:\Users\ajlow\.config\kei\cookies"));
+        assert_ne!(result, PathBuf::from(r"C:\Users\ajlow.config\kei\cookies"));
     }
 
     #[test]
@@ -5780,6 +5856,33 @@ mod tests {
         };
         let result = resolve_data_dir(None, Some(&toml), Path::new("/config/config.toml"));
         assert_eq!(result, PathBuf::from("/toml/data"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_data_dir_repairs_malformed_windows_dot_config_path() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let Some(parent) = home.parent() else {
+            return;
+        };
+        let Some(user_name) = home.file_name() else {
+            return;
+        };
+
+        let mut bugged_name = user_name.to_os_string();
+        bugged_name.push(".config");
+        let bugged = parent.join(bugged_name).join("kei").join("cookies");
+        let corrected = kei_data_dir_with_home(&home).join("cookies");
+        let result = resolve_data_dir(
+            Some(&bugged.to_string_lossy()),
+            None,
+            Path::new(r"C:\unused\config.toml"),
+        );
+
+        assert_eq!(result, corrected);
+        assert_ne!(result, bugged);
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1910,14 +1910,15 @@ pub async fn download_photos_with_sync(
     let sync_started_at = chrono::Utc::now().timestamp();
     cleanup_orphan_part_files(&config).await;
 
-    // Give already-pending assets a fresh per-sync attempt budget. Failed
-    // assets stay failed during normal syncs; `sync --retry-failed` resets
-    // them explicitly before this point. Resetting failed rows here would make
-    // every normal sync act like a failed-assets retry and force full
-    // enumeration forever while a persistent failure exists.
+    // Give every non-downloaded asset a fresh start this sync:
+    // failed -> pending (with attempts reset), and stale attempt counts on
+    // pending assets cleared so the per-sync cap starts from zero.
     let total_pending = if let Some(db) = &config.state_db {
         match db.prepare_for_retry().await {
-            Ok((_failed, stale, total_pending)) => {
+            Ok((failed, stale, total_pending)) => {
+                if failed > 0 {
+                    tracing::debug!(count = failed, "Reset failed assets for retry");
+                }
                 if stale > 0 {
                     tracing::debug!(
                         count = stale,
@@ -4331,63 +4332,6 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "unfiled-only incremental sync should query changes/zone"
-        );
-    }
-
-    #[tokio::test]
-    async fn normal_incremental_sync_does_not_retry_failed_assets() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let session = changes_zone_session(Arc::clone(&calls), Vec::new());
-        let passes = vec![AlbumPass {
-            kind: PassKind::Unfiled,
-            album: changes_album("", session),
-            exclude_ids: Arc::new(FxHashSet::default()),
-        }];
-
-        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
-        let failed = TestAssetRecord::new("FAILED")
-            .checksum("ck_failed")
-            .filename("failed.jpg")
-            .size(1024)
-            .build();
-        db.upsert_seen(&failed).await.expect("record failed row");
-        db.mark_failed("PrimarySync", "FAILED", "original", "HTTP 500")
-            .await
-            .expect("mark failed");
-
-        let mut config = test_config();
-        let dir = TempDir::new().expect("temp dir");
-        config.directory = Arc::from(dir.path());
-        config.state_db = Some(db.clone());
-        config.sync_mode = SyncMode::Incremental {
-            zone_sync_token: "zone-token-prev".to_string(),
-        };
-
-        let result = download_photos_with_sync(
-            &Client::new(),
-            &passes,
-            Arc::new(config),
-            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
-            CancellationToken::new(),
-        )
-        .await
-        .expect("normal incremental sync should succeed");
-
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
-        assert!(
-            !result.full_enumeration_ran,
-            "normal sync must not become retry-failed just because failed rows exist"
-        );
-        assert_eq!(
-            calls.load(Ordering::SeqCst),
-            1,
-            "normal sync should still query changes/zone"
-        );
-        let summary = db.get_summary().await.expect("state summary");
-        assert_eq!(summary.failed, 1, "failed row should stay failed");
-        assert_eq!(
-            summary.pending, 0,
-            "failed row should not be reset to pending"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1107,6 +1107,9 @@ struct DownloadContext {
     /// Library-blind: an asset shared across libraries shares its attempt
     /// budget (mirrors how `get_attempt_counts` aggregates by id alone).
     attempt_counts: FxHashMap<Arc<str>, u32>,
+    /// True when at least one downloaded asset-version lacks a metadata hash.
+    /// Cached because the producer checks this on hot on-disk skip paths.
+    downloaded_without_metadata_hash: bool,
 }
 
 impl DownloadContext {
@@ -1234,6 +1237,8 @@ impl DownloadContext {
             .into_iter()
             .map(|(id, count)| (intern_id(&mut interner, id), count))
             .collect();
+        let downloaded_without_metadata_hash = count_version_set_entries(&downloaded_ids)
+            > count_value_map_entries(&downloaded_metadata_hashes);
 
         Self {
             downloaded_ids,
@@ -1242,6 +1247,7 @@ impl DownloadContext {
             metadata_retry_markers,
             known_ids,
             attempt_counts,
+            downloaded_without_metadata_hash,
         }
     }
 
@@ -1357,16 +1363,8 @@ impl DownloadContext {
         }
     }
 
-    fn downloaded_version_count(&self) -> usize {
-        count_version_set_entries(&self.downloaded_ids)
-    }
-
-    fn downloaded_metadata_hash_count(&self) -> usize {
-        count_value_map_entries(&self.downloaded_metadata_hashes)
-    }
-
     fn has_downloaded_without_metadata_hash(&self) -> bool {
-        self.downloaded_version_count() > self.downloaded_metadata_hash_count()
+        self.downloaded_without_metadata_hash
     }
 }
 
@@ -1434,6 +1432,12 @@ fn build_pass_configs_with_download_concurrency(
             Arc::new(config)
         })
         .collect()
+}
+
+fn incremental_requires_full_enumeration(passes: &[crate::commands::AlbumPass]) -> bool {
+    passes
+        .iter()
+        .any(|pass| pass.kind != crate::commands::PassKind::Unfiled)
 }
 
 async fn collect_pass_asset_ids(pass: &crate::commands::AlbumPass) -> Result<FxHashSet<String>> {
@@ -1906,15 +1910,14 @@ pub async fn download_photos_with_sync(
     let sync_started_at = chrono::Utc::now().timestamp();
     cleanup_orphan_part_files(&config).await;
 
-    // Give every non-downloaded asset a fresh start this sync:
-    // failed -> pending (with attempts reset), and stale attempt counts on
-    // pending assets cleared so the per-sync cap starts from zero.
+    // Give already-pending assets a fresh per-sync attempt budget. Failed
+    // assets stay failed during normal syncs; `sync --retry-failed` resets
+    // them explicitly before this point. Resetting failed rows here would make
+    // every normal sync act like a failed-assets retry and force full
+    // enumeration forever while a persistent failure exists.
     let total_pending = if let Some(db) = &config.state_db {
         match db.prepare_for_retry().await {
-            Ok((failed, stale, total_pending)) => {
-                if failed > 0 {
-                    tracing::debug!(count = failed, "Reset failed assets for retry");
-                }
+            Ok((_failed, stale, total_pending)) => {
                 if stale > 0 {
                     tracing::debug!(
                         count = stale,
@@ -1943,16 +1946,17 @@ pub async fn download_photos_with_sync(
             )
             .await
         }
-        // In `{album}` mode we have to fall back to full enumeration:
         // `changes_stream` uses the zone-level `/changes/zone` endpoint, so
-        // it returns the same delta for every album in a zone. Without
-        // per-asset album-membership info on the change events, we can't
-        // route assets to the correct album folder — full enumeration uses
-        // the album-scoped `photo_stream_with_token` and stays correct.
-        SyncMode::Incremental { .. } if config.requires_per_pass_paths() => {
+        // it returns the same delta for every selected album or smart folder
+        // in a zone. Without per-asset membership info on the change events,
+        // we can't tell whether a new asset belongs in those scoped passes.
+        // The unfiled/library-wide pass is safe: every zone change belongs to
+        // that pass, and inactive album/smart-folder templates shouldn't
+        // force full enumeration on an unfiled-only sync.
+        SyncMode::Incremental { .. } if incremental_requires_full_enumeration(passes) => {
             tracing::debug!(
-                "`{{album}}` folder template requires full enumeration for correct \
-                 per-album routing, skipping incremental"
+                "Album or smart-folder passes require full enumeration for correct \
+                 membership routing, skipping incremental"
             );
             download_photos_full_with_token(
                 download_client,
@@ -3201,7 +3205,7 @@ mod tests {
         );
     }
 
-    fn changes_album(name: &str, session: CountingChangesZoneSession) -> PhotoAlbum {
+    fn changes_album(name: &str, session: impl PhotosSession + 'static) -> PhotoAlbum {
         PhotoAlbum::new(
             PhotoAlbumConfig {
                 params: Arc::new(HashMap::new()),
@@ -3223,6 +3227,17 @@ mod tests {
     #[derive(Clone)]
     struct CountingChangesZoneSession {
         changes_zone_calls: Arc<AtomicUsize>,
+        records: Vec<Value>,
+    }
+
+    fn changes_zone_session(
+        changes_zone_calls: Arc<AtomicUsize>,
+        records: Vec<Value>,
+    ) -> CountingChangesZoneSession {
+        CountingChangesZoneSession {
+            changes_zone_calls,
+            records,
+        }
     }
 
     #[async_trait::async_trait]
@@ -3240,7 +3255,7 @@ mod tests {
                         "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
                         "syncToken": "zone-token-next",
                         "moreComing": false,
-                        "records": incremental_photo_records("MASTER_CHANGED"),
+                        "records": self.records.clone(),
                     }]
                 }));
             }
@@ -4274,11 +4289,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unfiled_only_incremental_ignores_inactive_album_path_templates() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            incremental_photo_records("MASTER_CHANGED"),
+        );
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        assert!(
+            config.requires_per_pass_paths(),
+            "default inactive album templates still contain per-pass tokens"
+        );
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("unfiled-only incremental sync should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            !result.full_enumeration_ran,
+            "inactive album/smart-folder templates must not force full enumeration"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "unfiled-only incremental sync should query changes/zone"
+        );
+    }
+
+    #[tokio::test]
+    async fn normal_incremental_sync_does_not_retry_failed_assets() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(Arc::clone(&calls), Vec::new());
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let failed = TestAssetRecord::new("FAILED")
+            .checksum("ck_failed")
+            .filename("failed.jpg")
+            .size(1024)
+            .build();
+        db.upsert_seen(&failed).await.expect("record failed row");
+        db.mark_failed("PrimarySync", "FAILED", "original", "HTTP 500")
+            .await
+            .expect("mark failed");
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("normal incremental sync should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            !result.full_enumeration_ran,
+            "normal sync must not become retry-failed just because failed rows exist"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "normal sync should still query changes/zone"
+        );
+        let summary = db.get_summary().await.expect("state summary");
+        assert_eq!(summary.failed, 1, "failed row should stay failed");
+        assert_eq!(
+            summary.pending, 0,
+            "failed row should not be reset to pending"
+        );
+    }
+
+    #[tokio::test]
     async fn incremental_sync_queries_zone_changes_once_per_library() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let session = CountingChangesZoneSession {
-            changes_zone_calls: Arc::clone(&calls),
-        };
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            incremental_photo_records("MASTER_CHANGED"),
+        );
         let passes = vec![
             AlbumPass {
                 kind: PassKind::Album,
@@ -4876,6 +4995,36 @@ mod tests {
         c.folder_structure_albums = Arc::from(albums);
         c.folder_structure_smart_folders = Arc::from(smart_folders);
         c
+    }
+
+    #[test]
+    fn incremental_full_enumeration_gate_ignores_unfiled_only_pass() {
+        let session = crate::test_helpers::MockPhotosSession::new();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        assert!(
+            !incremental_requires_full_enumeration(&passes),
+            "unfiled-only sync can use zone-level incremental changes"
+        );
+    }
+
+    #[test]
+    fn incremental_full_enumeration_gate_fires_on_album_pass() {
+        let session = crate::test_helpers::MockPhotosSession::new();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Vacation", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        assert!(
+            incremental_requires_full_enumeration(&passes),
+            "album-scoped sync needs full enumeration to preserve membership"
+        );
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -4620,6 +4620,9 @@ mod tests {
             .or_default()
             .insert("original".into());
 
+        ctx.downloaded_without_metadata_hash = count_version_set_entries(&ctx.downloaded_ids)
+            > count_value_map_entries(&ctx.downloaded_metadata_hashes);
+
         assert!(
             ctx.has_downloaded_without_metadata_hash(),
             "a downloaded row with no matching metadata hash needs the backfill notice"
@@ -4631,6 +4634,9 @@ mod tests {
             .entry("asset_meta".into())
             .or_default()
             .insert("original".into(), "metadata_hash".into());
+
+        ctx.downloaded_without_metadata_hash = count_version_set_entries(&ctx.downloaded_ids)
+            > count_value_map_entries(&ctx.downloaded_metadata_hashes);
 
         assert!(
             !ctx.has_downloaded_without_metadata_hash(),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1098,6 +1098,11 @@ struct DownloadContext {
     /// changed.
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     metadata_retry_markers: LibraryAssetVersionSet,
+    /// Nested map: `library` -> `asset_id` -> set of `version_sizes` that
+    /// are pending at sync start. Used to resolve failed/pending rows when
+    /// the expected file is already on disk instead of promoting them back to
+    /// failed after the producer skips the duplicate path.
+    pending_ids: LibraryAssetVersionSet,
     /// All asset IDs known to the state DB (any status). Used in retry-only mode
     /// to skip new assets that were never synced. Library-blind: a known ID
     /// is "known" regardless of which zone it belongs to.
@@ -1113,7 +1118,7 @@ struct DownloadContext {
 }
 
 impl DownloadContext {
-    /// Load the download context from the state database. All six queries
+    /// Load the download context from the state database. All state queries
     /// are independent and run concurrently so sync start doesn't serialize
     /// on round-trip latency across them.
     async fn load<D>(db: &D, retry_only: bool) -> Self
@@ -1130,7 +1135,7 @@ impl DownloadContext {
                 Default::default()
             }
         };
-        let (ids, checksums, hashes, markers, attempts, known_ids) = tokio::join!(
+        let (ids, checksums, hashes, markers, pending, attempts, known_ids) = tokio::join!(
             async {
                 db.get_downloaded_ids().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load downloaded IDs from state DB");
@@ -1154,6 +1159,12 @@ impl DownloadContext {
             async {
                 db.get_metadata_retry_markers().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load metadata retry markers from state DB");
+                    Default::default()
+                })
+            },
+            async {
+                db.get_pending().await.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to load pending assets from state DB");
                     Default::default()
                 })
             },
@@ -1228,6 +1239,18 @@ impl DownloadContext {
                 .insert(version_size.into_boxed_str());
         }
 
+        let mut pending_ids: LibraryAssetVersionSet = FxHashMap::default();
+        for record in pending {
+            let lib = intern_id(&mut interner, record.library.to_string());
+            let id = intern_id(&mut interner, record.id.to_string());
+            pending_ids
+                .entry(lib)
+                .or_default()
+                .entry(id)
+                .or_default()
+                .insert(record.version_size.as_str().into());
+        }
+
         let known_ids: FxHashSet<Arc<str>> = known_ids
             .into_iter()
             .map(|id| intern_id(&mut interner, id))
@@ -1245,6 +1268,7 @@ impl DownloadContext {
             downloaded_checksums,
             downloaded_metadata_hashes,
             metadata_retry_markers,
+            pending_ids,
             known_ids,
             attempt_counts,
             downloaded_without_metadata_hash,
@@ -1913,7 +1937,7 @@ pub async fn download_photos_with_sync(
     // Give every non-downloaded asset a fresh start this sync:
     // failed -> pending (with attempts reset), and stale attempt counts on
     // pending assets cleared so the per-sync cap starts from zero.
-    let total_pending = if let Some(db) = &config.state_db {
+    let (retry_failed_count, total_pending) = if let Some(db) = &config.state_db {
         match db.prepare_for_retry().await {
             Ok((failed, stale, total_pending)) => {
                 if failed > 0 {
@@ -1925,15 +1949,15 @@ pub async fn download_photos_with_sync(
                         "Cleared stale attempt counts on pending assets"
                     );
                 }
-                total_pending
+                (failed, total_pending)
             }
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to reset assets for retry");
-                0
+                (0, 0)
             }
         }
     } else {
-        0
+        (0, 0)
     };
 
     let result = match &config.sync_mode {
@@ -1972,9 +1996,10 @@ pub async fn download_photos_with_sync(
         // pending assets from previous syncs. Fall back to full so they get
         // retried. Once everything is downloaded, incremental resumes.
         SyncMode::Incremental { .. } if total_pending > 0 => {
-            tracing::debug!(
+            tracing::info!(
                 pending = total_pending,
-                "Pending assets require full enumeration, skipping incremental sync"
+                failed_reset = retry_failed_count,
+                "Retrying failed/pending assets requires full enumeration, skipping incremental sync"
             );
             download_photos_full_with_token(
                 download_client,

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4127,7 +4127,7 @@ mod tests {
 
         #[cfg(test)]
         async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
+            Ok(Vec::new())
         }
 
         async fn reset_failed(&self) -> Result<u64, StateError> {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -19,12 +19,15 @@ use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::PhotoAsset;
 use crate::retry::RetryConfig;
-use crate::state::{MetadataRewriteStore, StateDb, SyncRunStats, VersionSizeKey};
+use crate::state::{AssetRecord, MetadataRewriteStore, StateDb, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
 #[cfg_attr(not(feature = "xmp"), allow(unused_imports))]
 use super::filter::MetadataPayload;
-use super::filter::{extract_skip_candidates, is_asset_filtered, DownloadTask};
+use super::filter::{
+    derive_expected_paths, determine_media_type, extract_skip_candidates, is_asset_filtered,
+    DownloadTask,
+};
 #[cfg(test)]
 use super::finalize::update_metadata_marker_for_test as update_metadata_marker;
 use super::finalize::{
@@ -293,6 +296,63 @@ fn effective_asset_library_arc(asset: &PhotoAsset, config: &DownloadConfig) -> A
         .source_zone()
         .map(Arc::from)
         .unwrap_or_else(|| Arc::clone(&config.library))
+}
+
+async fn backfill_downloaded_metadata_for_on_disk_skip(
+    state_db: Option<&dyn StateDb>,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    ctx: &DownloadContext,
+) {
+    if !ctx.has_downloaded_without_metadata_hash() {
+        return;
+    }
+    let Some(db) = state_db else {
+        return;
+    };
+    let library = effective_asset_library(asset, config);
+    let downloaded_versions = ctx
+        .downloaded_ids
+        .get(library)
+        .and_then(|assets| assets.get(asset.id()));
+    let Some(downloaded_versions) = downloaded_versions else {
+        return;
+    };
+    let version_hashes = ctx
+        .downloaded_metadata_hashes
+        .get(library)
+        .and_then(|assets| assets.get(asset.id()));
+
+    for derived in derive_expected_paths(asset, config) {
+        let version_size = derived.version_size.as_str();
+        let has_metadata_hash =
+            version_hashes.is_some_and(|hashes| hashes.contains_key(version_size));
+        if !downloaded_versions.contains(version_size) || has_metadata_hash {
+            continue;
+        }
+
+        let record = AssetRecord::new_pending(
+            Arc::from(library),
+            asset.id().to_string(),
+            derived.version_size,
+            derived.checksum.to_string(),
+            derived.filename,
+            asset.created(),
+            Some(asset.added_date()),
+            derived.size,
+            determine_media_type(derived.version_size, asset),
+        )
+        .with_metadata_arc(asset.metadata_arc());
+
+        if let Err(e) = db.upsert_seen(&record).await {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size,
+                error = %e,
+                "Failed to backfill metadata for skipped downloaded asset"
+            );
+        }
+    }
 }
 
 /// Maximum assets processed per metadata-rewrite invocation. Bounds worst-case
@@ -1335,6 +1395,13 @@ where
                             config,
                             &asset,
                             &candidates,
+                            &download_ctx,
+                        )
+                        .await;
+                        backfill_downloaded_metadata_for_on_disk_skip(
+                            producer_state_db.as_deref(),
+                            config,
+                            &asset,
                             &download_ctx,
                         )
                         .await;
@@ -5016,7 +5083,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let mut config = DownloadConfig::test_default();
-        config.directory = std::sync::Arc::from(dir.path());
+        config.directory = Arc::from(dir.path());
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 
@@ -5058,6 +5125,91 @@ mod tests {
         assert_eq!(failed.len(), 1);
         assert_eq!(failed[0].library.as_ref(), "SharedSync-abc");
         assert_eq!(&*failed[0].id, "STUCK");
+    }
+
+    /// v5 metadata backfill regression: a previously downloaded row with a
+    /// NULL metadata_hash can hit the producer's on-disk-skip branch when
+    /// the file already exists. That branch must refresh metadata for the
+    /// existing downloaded row; otherwise the "one-time after upgrade"
+    /// backfill notice repeats forever.
+    #[tokio::test]
+    async fn on_disk_skip_backfills_downloaded_row_metadata_hash() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn existing_asset() -> PhotoAsset {
+            TestPhotoAsset::new("BACKFILL")
+                .filename("backfill.jpg")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(1234)
+                .orig_url("https://p01.icloud-content.com/backfill.jpg")
+                .orig_checksum("ck_backfill")
+                .build()
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = existing_asset();
+        let target_path = crate::download::filter::expected_paths_for(&asset, &config)
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target_path, vec![0u8; 1234]).unwrap();
+
+        let record = crate::test_helpers::TestAssetRecord::new("BACKFILL")
+            .checksum("ck_backfill")
+            .filename("backfill.jpg")
+            .size(1234)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "BACKFILL",
+            "original",
+            &target_path,
+            "sha256",
+            None,
+        )
+        .await
+        .unwrap();
+        db.clear_metadata_hash_for_test("PrimarySync", "BACKFILL", "original");
+        assert!(db.has_downloaded_without_metadata_hash().await.unwrap());
+
+        let client = reqwest::Client::new();
+        let assets = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(existing_asset())]);
+        let result = stream_and_download_from_stream(
+            &client,
+            assets,
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.downloaded, 0,
+            "existing file should not be re-downloaded"
+        );
+        assert!(
+            !db.has_downloaded_without_metadata_hash().await.unwrap(),
+            "on-disk skip must backfill metadata_hash for existing downloaded rows"
+        );
     }
 
     /// Data-sacred regression for the trust-state fast-skip removal.

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -26,7 +26,7 @@ use super::error::DownloadError;
 use super::filter::MetadataPayload;
 use super::filter::{
     derive_expected_paths, determine_media_type, extract_skip_candidates, is_asset_filtered,
-    DownloadTask,
+    DerivedPath, DownloadTask,
 };
 #[cfg(test)]
 use super::finalize::update_metadata_marker_for_test as update_metadata_marker;
@@ -298,6 +298,120 @@ fn effective_asset_library_arc(asset: &PhotoAsset, config: &DownloadConfig) -> A
         .unwrap_or_else(|| Arc::clone(&config.library))
 }
 
+fn asset_record_for_derived_path(
+    library: Arc<str>,
+    asset: &PhotoAsset,
+    derived: &DerivedPath,
+) -> AssetRecord {
+    AssetRecord::new_pending(
+        library,
+        asset.id().to_string(),
+        derived.version_size,
+        derived.checksum.to_string(),
+        derived.filename.clone(),
+        asset.created(),
+        Some(asset.added_date()),
+        derived.size,
+        determine_media_type(derived.version_size, asset),
+    )
+    .with_metadata_arc(asset.metadata_arc())
+}
+
+async fn adopt_pending_on_disk_skip(
+    state_db: Option<&dyn StateDb>,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    ctx: &DownloadContext,
+    task_planner: &mut TaskPlanner,
+) -> usize {
+    let Some(db) = state_db else {
+        return 0;
+    };
+    let library = effective_asset_library(asset, config);
+    let pending_versions = ctx
+        .pending_ids
+        .get(library)
+        .and_then(|assets| assets.get(asset.id()));
+    let Some(pending_versions) = pending_versions else {
+        return 0;
+    };
+
+    let mut adopted = 0usize;
+    for derived in derive_expected_paths(asset, config) {
+        let version_size = derived.version_size.as_str();
+        if !pending_versions.contains(version_size) {
+            continue;
+        }
+        let Some(existing_path) = task_planner.existing_path(&derived.path) else {
+            continue;
+        };
+        let Ok(metadata) = tokio::fs::metadata(&existing_path).await else {
+            continue;
+        };
+        if metadata.len() != derived.size {
+            continue;
+        }
+
+        let record = asset_record_for_derived_path(
+            effective_asset_library_arc(asset, config),
+            asset,
+            &derived,
+        );
+        if let Err(e) = db.upsert_seen(&record).await {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size,
+                error = %e,
+                "Failed to refresh pending asset before adopting on-disk file"
+            );
+            continue;
+        }
+
+        let local_checksum = match super::file::compute_sha256(&existing_path).await {
+            Ok(checksum) => checksum,
+            Err(e) => {
+                tracing::warn!(
+                    asset_id = %asset.id(),
+                    version_size,
+                    path = %existing_path.display(),
+                    error = %e,
+                    "Failed to hash on-disk file for pending asset"
+                );
+                continue;
+            }
+        };
+        if let Err(e) = db
+            .mark_downloaded(
+                library,
+                asset.id(),
+                version_size,
+                &existing_path,
+                &local_checksum,
+                None,
+            )
+            .await
+        {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size,
+                path = %existing_path.display(),
+                error = %e,
+                "Failed to mark pending asset downloaded from on-disk file"
+            );
+            continue;
+        }
+        tracing::info!(
+            asset_id = %asset.id(),
+            version_size,
+            path = %existing_path.display(),
+            "Resolved pending asset from existing on-disk file"
+        );
+        adopted += 1;
+    }
+
+    adopted
+}
+
 async fn backfill_downloaded_metadata_for_on_disk_skip(
     state_db: Option<&dyn StateDb>,
     config: &DownloadConfig,
@@ -331,18 +445,7 @@ async fn backfill_downloaded_metadata_for_on_disk_skip(
             continue;
         }
 
-        let record = AssetRecord::new_pending(
-            Arc::from(library),
-            asset.id().to_string(),
-            derived.version_size,
-            derived.checksum.to_string(),
-            derived.filename,
-            asset.created(),
-            Some(asset.added_date()),
-            derived.size,
-            determine_media_type(derived.version_size, asset),
-        )
-        .with_metadata_arc(asset.metadata_arc());
+        let record = asset_record_for_derived_path(Arc::from(library), asset, &derived);
 
         if let Err(e) = db.upsert_seen(&record).await {
             tracing::warn!(
@@ -1386,9 +1489,10 @@ where
 
                     if plan.tasks.is_empty() {
                         // No-op for status='downloaded' rows (the common
-                        // case). A row left status='pending' by a prior
-                        // interrupted sync will be promoted to failed at
-                        // sync end as stuck-pipeline recovery.
+                        // case). A pending row from a prior failed or
+                        // interrupted sync is adopted when the matching file
+                        // is already on disk; if adoption fails, the touched
+                        // flush still lets stuck-pipeline recovery promote it.
                         let candidates = extract_skip_candidates(&asset, config);
                         tag_metadata_rewrites(
                             producer_state_db.as_deref(),
@@ -1396,6 +1500,14 @@ where
                             &asset,
                             &candidates,
                             &download_ctx,
+                        )
+                        .await;
+                        adopt_pending_on_disk_skip(
+                            producer_state_db.as_deref(),
+                            config,
+                            &asset,
+                            &download_ctx,
+                            &mut task_planner,
                         )
                         .await;
                         backfill_downloaded_metadata_for_on_disk_skip(
@@ -1657,18 +1769,16 @@ where
         // libraries.
         //
         // touched_assets contains assets the consumer will not finalize this
-        // sync: trust-state fast-skips (line 1026, status='downloaded')
-        // and on-disk skips (line 1053, which the comment at the push
-        // site notes can include status='pending' rows carried over from
-        // a prior interrupted sync). Bumping their last_seen_at is a
-        // no-op for terminal rows and is load-bearing for stuck-pipeline
-        // recovery on pending rows: promote_pending_to_failed promotes
-        // any 'pending' row whose last_seen_at >= sync_started_at.
+        // sync: trust-state fast-skips and on-disk skips. Bumping
+        // last_seen_at is a no-op for terminal rows. For pending rows that
+        // could not be adopted from disk, it is load-bearing for
+        // stuck-pipeline recovery: promote_pending_to_failed promotes any
+        // pending row whose last_seen_at >= sync_started_at.
         //
         // If we lose this flush (e.g. process killed between the producer
         // loop exiting and touch_last_seen_many returning), stuck-pipeline
-        // promotion is delayed by exactly one sync — the same row hits
-        // the same path next run and gets promoted then. No data loss.
+        // promotion is delayed by exactly one sync. The same row hits the
+        // same path next run and gets adopted or promoted then. No data loss.
         if let Some(db) = &producer_state_db {
             if !touched_assets.is_empty() {
                 let mut touched_by_library: FxHashMap<Arc<str>, Vec<Arc<str>>> =
@@ -5034,22 +5144,17 @@ mod tests {
         assert_eq!(summary.failed, 0);
     }
 
-    /// Producer-side regression for the deferred `touched_assets` flush.
+    /// Producer-side regression for resolving pending rows on on-disk skip.
     ///
     /// A pending row carried over from a prior interrupted sync, whose
     /// new sync hits the on-disk-skip path (the `tasks.is_empty()`
-    /// branch at the producer's filter step), must end the sync as
-    /// `failed` -- the producer task pushes its source library and id into
-    /// `touched_assets`, the deferred `touch_last_seen_many` flush bumps
-    /// `last_seen_at`, and `promote_pending_to_failed` then promotes it.
-    /// This is load-bearing for stuck-pipeline recovery and for cross-zone
-    /// album members whose owner album pass differs from the asset source zone.
-    ///
-    /// If a future refactor moves the flush behind a not-always-reached
-    /// path, or moves `touched_assets` writes off the producer's terminal
-    /// path, this test fails.
+    /// branch at the producer's filter step), must be adopted as downloaded
+    /// when the expected file already exists with the same name and size.
+    /// Otherwise standard sync resets failed assets to pending, full
+    /// enumeration skips the already-present file, and the same row is
+    /// promoted back to failed every run.
     #[tokio::test]
-    async fn producer_flushes_touched_ids_so_pending_on_disk_skip_promotes() {
+    async fn producer_adopts_pending_on_disk_skip_as_downloaded() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
         use crate::state::SqliteStateDb;
@@ -5117,14 +5222,14 @@ mod tests {
 
         let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
         assert_eq!(
-            promoted, 1,
-            "stuck pending row must be promoted by the deferred touched_ids flush"
+            promoted, 0,
+            "on-disk pending row should be resolved before failed promotion"
         );
 
-        let failed = db.get_failed().await.unwrap();
-        assert_eq!(failed.len(), 1);
-        assert_eq!(failed[0].library.as_ref(), "SharedSync-abc");
-        assert_eq!(&*failed[0].id, "STUCK");
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.downloaded, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 0);
     }
 
     /// v5 metadata backfill regression: a previously downloaded row with a

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -65,12 +65,18 @@ impl TaskPlanner {
     }
 
     pub(super) fn existing_path_match(&mut self, path: &Path) -> ExistingPathMatch {
+        match self.existing_path(path) {
+            Some(found) if found == path => ExistingPathMatch::Exact,
+            Some(_) => ExistingPathMatch::AmpmVariant,
+            None => ExistingPathMatch::Missing,
+        }
+    }
+
+    pub(super) fn existing_path(&mut self, path: &Path) -> Option<std::path::PathBuf> {
         if self.dir_cache.exists(path) {
-            ExistingPathMatch::Exact
-        } else if self.dir_cache.find_ampm_variant(path).is_some() {
-            ExistingPathMatch::AmpmVariant
+            Some(path.to_path_buf())
         } else {
-            ExistingPathMatch::Missing
+            self.dir_cache.find_ampm_variant(path)
         }
     }
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -6,11 +6,7 @@
 
 use std::path::Path;
 
-use crate::config::expand_tilde;
-
-/// New default paths.
-const NEW_CONFIG_PATH: &str = "~/.config/kei/config.toml";
-const NEW_COOKIE_DIR: &str = "~/.config/kei/cookies";
+use crate::config::{default_config_path, default_cookie_dir, expand_tilde};
 
 /// Legacy paths from icloudpd-rs.
 const OLD_CONFIG_PATH: &str = "~/.config/icloudpd-rs/config.toml";
@@ -21,8 +17,8 @@ const OLD_COOKIE_DIR: &str = "~/.icloudpd-rs";
 /// Called early in `main()`, before config loading. Returns `Ok(false)` if no
 /// migration was needed (new paths already exist or no old paths found).
 pub fn migrate_legacy_paths() -> anyhow::Result<bool> {
-    let new_config = expand_tilde(NEW_CONFIG_PATH);
-    let new_cookie_dir = expand_tilde(NEW_COOKIE_DIR);
+    let new_config = default_config_path();
+    let new_cookie_dir = default_cookie_dir();
     let old_config = expand_tilde(OLD_CONFIG_PATH);
     let old_cookie_dir = expand_tilde(OLD_COOKIE_DIR);
 

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -163,12 +163,9 @@ pub(crate) fn purge_kei_state(kei_dir: &Path, extra_dirs: &[PathBuf]) -> Result<
 ///
 /// macOS and Windows both bypass `dirs::config_dir()` (which returns
 /// `~/Library/Application Support` and `%APPDATA%\Roaming` respectively)
-/// so the data dir matches the rest of the codebase, where
-/// `~/.config/kei` is hard-coded in `setup.rs` and `migration.rs`.
-/// Linux honours XDG via `dirs::config_dir().join("kei")` and resolves
-/// its own path -- this helper is for the platforms that don't.
+/// so service purge paths match the rest of kei's `~/.config/kei` state.
 pub(crate) fn kei_state_dir_dotted() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".config/kei"))
+    dirs::home_dir().map(|home| crate::config::kei_data_dir_with_home(&home))
 }
 
 /// Canonical absolute path to the running `kei` executable.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -502,7 +502,7 @@ fn write_config_file(config_path: &Path, toml_content: &str) -> anyhow::Result<(
 fn credential_store_dir(answers: &SetupAnswers) -> PathBuf {
     match &answers.data_dir {
         Some(dir) => crate::config::expand_tilde(dir),
-        None => crate::config::expand_tilde("~/.config/kei/cookies"),
+        None => crate::config::default_cookie_dir(),
     }
 }
 
@@ -2735,7 +2735,7 @@ mod tests {
         let default = SetupAnswers::default();
         assert_eq!(
             credential_store_dir(&default),
-            crate::config::expand_tilde("~/.config/kei/cookies")
+            crate::config::default_cookie_dir()
         );
     }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -410,11 +410,13 @@ pub trait StateDb: Send + Sync {
     /// Returns the number of assets reset.
     async fn reset_failed(&self) -> Result<u64, StateError>;
 
-    /// Reset all non-downloaded assets for a fresh sync attempt.
+    /// Prepare already-pending assets for a fresh sync attempt.
     ///
-    /// Moves failed -> pending and clears stale attempt counts on pending
-    /// assets, all in one lock acquisition. Returns
-    /// (failed_reset, pending_reset, total_pending).
+    /// Failed assets remain failed until an explicit `--retry-failed` run calls
+    /// `reset_failed`; otherwise a persistent failed row would force every
+    /// normal incremental sync back through full enumeration. Returns
+    /// (failed_reset, pending_reset, total_pending), where failed_reset is kept
+    /// for compatibility and is always 0.
     async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
 
     /// Promote stuck pending assets to failed.
@@ -2161,22 +2163,24 @@ impl SqliteStateDb {
     }
 
     pub(crate) async fn reset_failed(&self) -> Result<u64, StateError> {
-        let (failed, _, _) = self.prepare_for_retry().await?;
-        Ok(failed)
-    }
-
-    pub(crate) async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
-        self.with_conn("prepare_for_retry", move |conn| {
+        self.with_conn("reset_failed", move |conn| {
             let failed = conn
                 .execute(
                     "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL \
                      WHERE status = 'failed'",
                     [],
                 )
-                .map_err(|e| StateError::query("prepare_for_retry", e))? as u64;
+                .map_err(|e| StateError::query("reset_failed", e))?;
+            #[allow(clippy::cast_possible_truncation, reason = "rusqlite row counts fit in u64")]
+            Ok(failed as u64)
+        })
+        .await
+    }
 
-            let pending = conn
-                .execute(
+    pub(crate) async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+        self.with_conn("prepare_for_retry", move |conn| {
+            let pending =
+                conn.execute(
                     "UPDATE assets SET download_attempts = 0, last_error = NULL \
                      WHERE status = 'pending' AND download_attempts > 0",
                     [],
@@ -2193,7 +2197,7 @@ impl SqliteStateDb {
             #[allow(clippy::cast_sign_loss, reason = "SQL COUNT(*) is always non-negative")]
             let total_pending = total_pending as u64;
 
-            Ok((failed, pending, total_pending))
+            Ok((0, pending, total_pending))
         })
         .await
     }
@@ -3003,6 +3007,21 @@ impl SqliteStateDb {
         conn.execute(
             "UPDATE assets SET last_seen_at = ?1 WHERE library = ?2 AND id = ?3",
             rusqlite::params![ts, library, asset_id],
+        )
+        .unwrap();
+    }
+
+    pub(crate) fn clear_metadata_hash_for_test(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) {
+        let conn = self.acquire_lock("test_clear_metadata_hash").unwrap();
+        conn.execute(
+            "UPDATE assets SET metadata_hash = NULL \
+             WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+            rusqlite::params![library, asset_id, version_size],
         )
         .unwrap();
     }
@@ -5080,7 +5099,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_for_retry_resets_failed_and_stuck_pending() {
+    async fn prepare_for_retry_resets_stuck_pending_but_leaves_failed() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let dir = test_dir();
 
@@ -5155,18 +5174,26 @@ mod tests {
 
         let (failed_reset, pending_reset, total_pending) = db.prepare_for_retry().await.unwrap();
 
-        assert_eq!(failed_reset, 2);
+        assert_eq!(
+            failed_reset, 0,
+            "normal sync preparation must not reset failed rows"
+        );
         assert_eq!(pending_reset, 1); // only the stuck one
-        assert_eq!(total_pending, 4); // 2 original pending + 2 reset from failed
+        assert_eq!(total_pending, 2); // only the original pending rows
 
         let after = db.get_summary().await.unwrap();
         assert_eq!(after.downloaded, 1);
-        assert_eq!(after.pending, 4);
-        assert_eq!(after.failed, 0);
+        assert_eq!(after.pending, 2);
+        assert_eq!(after.failed, 2);
 
-        // Verify attempt counts are all zero now
+        // Verify pending attempt counts are zero now; failed rows keep their
+        // attempt counts until an explicit retry-failed reset.
         let attempts = db.get_attempt_counts().await.unwrap();
-        assert!(attempts.is_empty(), "all attempt counts should be zero");
+        assert_eq!(
+            attempts.len(),
+            2,
+            "only failed rows should retain attempt counts"
+        );
     }
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -410,13 +410,11 @@ pub trait StateDb: Send + Sync {
     /// Returns the number of assets reset.
     async fn reset_failed(&self) -> Result<u64, StateError>;
 
-    /// Prepare already-pending assets for a fresh sync attempt.
+    /// Reset all non-downloaded assets for a fresh sync attempt.
     ///
-    /// Failed assets remain failed until an explicit `--retry-failed` run calls
-    /// `reset_failed`; otherwise a persistent failed row would force every
-    /// normal incremental sync back through full enumeration. Returns
-    /// (failed_reset, pending_reset, total_pending), where failed_reset is kept
-    /// for compatibility and is always 0.
+    /// Moves failed -> pending and clears stale attempt counts on pending
+    /// assets, all in one lock acquisition. Returns
+    /// (failed_reset, pending_reset, total_pending).
     async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
 
     /// Promote stuck pending assets to failed.
@@ -2163,22 +2161,20 @@ impl SqliteStateDb {
     }
 
     pub(crate) async fn reset_failed(&self) -> Result<u64, StateError> {
-        self.with_conn("reset_failed", move |conn| {
+        let (failed, _, _) = self.prepare_for_retry().await?;
+        Ok(failed)
+    }
+
+    pub(crate) async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+        self.with_conn("prepare_for_retry", move |conn| {
             let failed = conn
                 .execute(
                     "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL \
                      WHERE status = 'failed'",
                     [],
                 )
-                .map_err(|e| StateError::query("reset_failed", e))?;
-            #[allow(clippy::cast_possible_truncation, reason = "rusqlite row counts fit in u64")]
-            Ok(failed as u64)
-        })
-        .await
-    }
+                .map_err(|e| StateError::query("prepare_for_retry", e))? as u64;
 
-    pub(crate) async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
-        self.with_conn("prepare_for_retry", move |conn| {
             let pending =
                 conn.execute(
                     "UPDATE assets SET download_attempts = 0, last_error = NULL \
@@ -2197,7 +2193,7 @@ impl SqliteStateDb {
             #[allow(clippy::cast_sign_loss, reason = "SQL COUNT(*) is always non-negative")]
             let total_pending = total_pending as u64;
 
-            Ok((0, pending, total_pending))
+            Ok((failed, pending, total_pending))
         })
         .await
     }
@@ -5099,7 +5095,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_for_retry_resets_stuck_pending_but_leaves_failed() {
+    async fn prepare_for_retry_resets_failed_and_stuck_pending() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let dir = test_dir();
 
@@ -5174,26 +5170,18 @@ mod tests {
 
         let (failed_reset, pending_reset, total_pending) = db.prepare_for_retry().await.unwrap();
 
-        assert_eq!(
-            failed_reset, 0,
-            "normal sync preparation must not reset failed rows"
-        );
+        assert_eq!(failed_reset, 2);
         assert_eq!(pending_reset, 1); // only the stuck one
-        assert_eq!(total_pending, 2); // only the original pending rows
+        assert_eq!(total_pending, 4); // 2 original pending + 2 reset from failed
 
         let after = db.get_summary().await.unwrap();
         assert_eq!(after.downloaded, 1);
-        assert_eq!(after.pending, 2);
-        assert_eq!(after.failed, 2);
+        assert_eq!(after.pending, 4);
+        assert_eq!(after.failed, 0);
 
-        // Verify pending attempt counts are zero now; failed rows keep their
-        // attempt counts until an explicit retry-failed reset.
+        // Verify attempt counts are all zero now
         let attempts = db.get_attempt_counts().await.unwrap();
-        assert_eq!(
-            attempts.len(),
-            2,
-            "only failed rows should retain attempt counts"
-        );
+        assert!(attempts.is_empty(), "all attempt counts should be zero");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Keep normal `kei sync` failed-asset retries intact, but resolve retried assets when the expected same-size file is already on disk.
- Mark those pending retry rows downloaded with a fresh local SHA-256 instead of letting them loop back to failed after the on-disk skip.
- Backfill missing metadata hashes for downloaded rows that hit the on-disk skip path.
- Log when failed/pending retry state forces full enumeration instead of incremental sync.
- Keep unfiled-only incremental sync from being blocked by inactive album/smart-folder path templates.
- Centralize kei's default `~/.config/kei` path construction, use it from setup/migration/service purge paths, and repair old malformed Windows `C:\Users\name.config\kei` data dirs to `C:\Users\name\.config\kei` at runtime.

## Context
Refs #500.

Follow-up design issue for avoiding the failed-retry full-enumeration fallback: #506.

## Tests
- `cargo test producer_adopts_pending_on_disk_skip_as_downloaded -- --test-threads=1`
- `cargo test prepare_for_retry_resets_failed_and_stuck_pending -- --test-threads=1`
- `cargo test unfiled_only_incremental_ignores_inactive_album_path_templates -- --test-threads=1`
- `cargo test on_disk_skip_backfills_downloaded_row_metadata_hash -- --test-threads=1`
- `cargo test downloaded_without_metadata_hash -- --test-threads=1`
- `cargo test complete_sync_run_failure_without_downloads_returns_partial_failure -- --test-threads=1`
- `cargo test stream_with_preloaded_download_context_does_not_reload_state_db -- --test-threads=1`
- `cargo test download_context_detects_downloaded_rows_missing_metadata_hashes -- --test-threads=1`
- `cargo test test_expand_tilde_with_injected_home_uses_path_join -- --test-threads=1`
- `cargo test test_expand_tilde_with_home -- --test-threads=1`
- `cargo test test_resolve_data_dir -- --test-threads=1`
- `cargo test credential_store_dir_uses_data_dir_or_cookie_default -- --test-threads=1`
- `cargo test kei_state_dir_uses_dotted_config_path -- --test-threads=1`
- `cargo test uninstall_purge_removes_kei_state_dir_when_present -- --test-threads=1` outside the sandbox because the sandbox blocks `wait-timeout`/localhost process handling
- `cargo test --lib -- --test-threads=1` outside the sandbox so localhost-bound wiremock tests can run
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Review notes
- The malformed Windows path regression test is `#[cfg(windows)]`, so it runs in Windows CI rather than this Linux checkout.
