### PR TITLE
Add release regression smoke gate

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,6 +65,10 @@ full-test:
 full-test-history N="10":
     scripts/full-test/history.sh "{{N}}"
 
+# Fast offline v0.20 patch-release smoke for the May 27 regression set.
+release-smoke:
+    scripts/full-test/run_release_regression_smoke.sh
+
 # Test dispatcher: offline | fast | live | concurrency | state | docker | PATTERN.
 test MODE="":
     #!/usr/bin/env bash

--- a/scripts/full-test/run_release_regression_smoke.sh
+++ b/scripts/full-test/run_release_regression_smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Offline v0.20 regression smoke.
+#
+# This is the quick patch-release gate for the May 27, 2026 regression set:
+# token reuse, retry-state fallback, on-disk pending adoption, tolerated
+# pagination shortfalls, permissive valid-media validation, inactive pass
+# templates, and dotted config paths.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "run_release_regression_smoke: not in a git repo" >&2
+  exit 1
+}
+cd "$repo_root"
+
+echo "--- stored token decisions stay incremental ---"
+cargo test --lib sync_cycle::tests::determine_sync_mode_two_normal_syncs_reuse_stored_token
+
+echo "--- failed rows force full enumeration before normal sync ---"
+cargo test --lib download::tests::incremental_with_failed_rows_falls_back_to_full_enumeration
+
+echo "--- pending rows with existing files are adopted ---"
+cargo test --lib download::pipeline::tests::producer_adopts_pending_on_disk_skip_as_downloaded
+
+echo "--- tolerated pagination shortfalls remain warnings ---"
+cargo test --lib download::tests::classify_pagination_shortfall_issue_498_fixture_is_tolerated
+cargo test --lib download::tests::classify_pagination_shortfall_billimek_sharedsync_fixture_is_tolerated
+
+echo "--- valid JPEG bytes under .PNG are saved ---"
+cargo test --lib download::file::tests::attempt_download_promotes_valid_jpeg_with_png_extension_issue_507
+
+echo "--- inactive album and smart-folder templates do not force full enumeration ---"
+cargo test --lib download::tests::unfiled_only_incremental_ignores_inactive_album_path_templates
+
+echo "--- dotted config path handling ---"
+cargo test --lib config::tests::test_expand_tilde_with_injected_home_uses_path_join
+host=$(rustc -vV | awk '/^host:/ { print $2 }')
+if [[ "$host" == *windows* ]]; then
+  cargo test --lib config::tests::test_expand_tilde_windows_home_keeps_separator_before_dot_config
+else
+  echo "skipping cfg(windows) dotted path smoke on host $host"
+fi
+
+echo "release regression smoke passed"

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -4361,6 +4361,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incremental_with_failed_rows_falls_back_to_full_enumeration() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = crate::test_helpers::TestAssetRecord::new("FAILED_BEFORE_SYNC")
+            .filename("failed-before-sync.jpg")
+            .checksum("ck_failed_before_sync")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        db.mark_failed(
+            "PrimarySync",
+            "FAILED_BEFORE_SYNC",
+            "original",
+            "prior download failure",
+        )
+        .await
+        .expect("mark failed");
+
+        let session = MockPhotosFlow::new()
+            .album_count(0)
+            .empty_query_page(Some("zone-token-next"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("failed rows should fall back to full enumeration");
+
+        assert!(
+            result.full_enumeration_ran,
+            "normal sync with failed rows must not stay incremental"
+        );
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+    }
+
+    #[tokio::test]
     async fn incremental_sync_queries_zone_changes_once_per_library() {
         let calls = Arc::new(AtomicUsize::new(0));
         let session = changes_zone_session(

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -616,4 +616,28 @@ mod tests {
             &make_library_state(true),
         ));
     }
+
+    #[tokio::test]
+    async fn determine_sync_mode_two_normal_syncs_reuse_stored_token() {
+        let db = state::SqliteStateDb::open_in_memory().expect("state db");
+        let sync_token_key = sync_token_key("PrimarySync");
+        db.set_metadata(&sync_token_key, "stored-token-abc")
+            .await
+            .expect("set token");
+
+        for cycle in 1..=2 {
+            let mode =
+                determine_sync_mode(false, 1, Some(&db), &sync_token_key, "PrimarySync").await;
+            assert!(
+                matches!(mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "stored-token-abc"),
+                "normal sync cycle {cycle} should use the stored token, got {mode:?}"
+            );
+        }
+
+        assert_eq!(
+            db.get_metadata(&sync_token_key).await.expect("read token"),
+            Some("stored-token-abc".to_string()),
+            "mode selection must not consume or clear the stored token"
+        );
+    }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,6 +39,7 @@ tests/
 | `scripts/full-test/run_live_import_rehearsal.sh` | 1 | yes | `just full-test` |
 | `scripts/full-test/run_docker_puid_smoke.sh` | 1 | no | `just full-test` |
 | `scripts/full-test/run_release_archive_smoke.sh` | 1 | no | `just full-test` |
+| `scripts/full-test/run_release_regression_smoke.sh` | 8 | no | `just release-smoke` |
 | `.github/workflows/service-smoke.yml` | 3 (linux/macos/windows) | no | `just service-smoke` (linux/macOS) |
 
 Counts are approximate and drift as tests are added.
@@ -54,6 +55,7 @@ just test state       # shell: token + config-hash invariants
 just test docker      # shell: docker container scenarios
 just test PATTERN     # passes through to cargo test PATTERN
 just gate             # full pre-push gate (what CI runs)
+just release-smoke    # fast offline v0.20 hotfix regression smoke
 just full-test        # pre-release battery, including Docker and live smokes
 ```
 
@@ -182,6 +184,10 @@ happens:
 - **`scripts/full-test/run_release_archive_smoke.sh`** - packages the host
   release binary into a temp archive, extracts it, and runs basic CLI/config
   probes against the extracted binary.
+- **`scripts/full-test/run_release_regression_smoke.sh`** - fast offline
+  v0.20 hotfix gate. Run `just release-smoke` before any `v0.20.x` hotfix and
+  before release branches that touch sync tokens, retry state, download
+  validation, config paths, or reporting.
 - **`scripts/full-test/run_docker_puid_smoke.sh`** - offline Docker entrypoint
   checks for PUID/PGID drop, volume chown, root-default behavior, and invalid
   env rejection.


### PR DESCRIPTION
## Summary
- Added `just release-smoke` as a fast offline v0.20 hotfix gate.
- Added a regression smoke script that runs the May 27 regression set without live iCloud credentials.
- Added focused coverage for repeated stored-token decisions and failed-row fallback to full enumeration.
- Documented when to run the smoke gate in `tests/README.md`.

## Tests
- `cargo check`
- `just release-smoke` - passed; Windows-only dotted-path check skipped on Linux host.
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
