### PR TITLE
Explain full enumeration reasons

### DIFF
--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -539,6 +539,9 @@ mod tests {
                         crate::download::sync_token_blocked_explanation("pagination_shortfall"),
                     ),
                     sync_token_blocked_zone: Some("PrimarySync".to_string()),
+                    full_enumeration_reason: Some(
+                        crate::download::FullEnumerationReason::RetryFailedRows,
+                    ),
                     ..SyncStats::default()
                 },
                 failed_count: 0,
@@ -556,6 +559,7 @@ mod tests {
                     "kei_sync_enumeration_errors_total 0",
                     "kei_sync_pagination_shortfall_warnings_total 1",
                     "kei_sync_token_blocked_cycles_total 1",
+                    "kei_sync_full_enumeration_reason_total{reason=\"retry_failed_rows\"} 1",
                 ],
             },
             OutcomeCase {
@@ -716,6 +720,20 @@ mod tests {
                 assert!(
                     report_json["stats"]["sync_token_blocked_reason"].is_null(),
                     "{} JSON token-blocked reason should be absent",
+                    case.name
+                );
+            }
+            if let Some(reason) = case.stats.full_enumeration_reason {
+                assert_eq!(
+                    report_json["stats"]["full_enumeration_reason"],
+                    reason.as_str(),
+                    "{} JSON full-enumeration reason",
+                    case.name
+                );
+            } else {
+                assert!(
+                    report_json["stats"]["full_enumeration_reason"].is_null(),
+                    "{} JSON full-enumeration reason should be absent",
                     case.name
                 );
             }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -73,6 +73,41 @@ pub enum SyncMode {
     },
 }
 
+/// Bounded reason vocabulary for full enumeration runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FullEnumerationReason {
+    NoStoredToken,
+    RetryFailedRows,
+    PendingRows,
+    MetadataBackfill,
+    PathTemplateRequiresFullEnumeration,
+    EnumConfigHashDrift,
+    ExplicitRetryFailed,
+    #[allow(
+        dead_code,
+        reason = "reserved report vocabulary for a future durable token-blocked marker"
+    )]
+    TokenBlockedPreviously,
+    OtherStaticReason,
+}
+
+impl FullEnumerationReason {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::NoStoredToken => "no_stored_token",
+            Self::RetryFailedRows => "retry_failed_rows",
+            Self::PendingRows => "pending_rows",
+            Self::MetadataBackfill => "metadata_backfill",
+            Self::PathTemplateRequiresFullEnumeration => "path_template_requires_full_enumeration",
+            Self::EnumConfigHashDrift => "enum_config_hash_drift",
+            Self::ExplicitRetryFailed => "explicit_retry_failed",
+            Self::TokenBlockedPreviously => "token_blocked_previously",
+            Self::OtherStaticReason => "other_static_reason",
+        }
+    }
+}
+
 /// One-shot runtime behavior for a sync pass.
 ///
 /// Kept outside [`DownloadConfig`] so path/filter/download decisions do not
@@ -196,6 +231,10 @@ pub struct SyncStats {
     /// Human-readable explanation for why token advancement was blocked.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_blocked_explanation: Option<&'static str>,
+    /// Bounded reason explaining why this run used full enumeration instead
+    /// of incremental sync.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_enumeration_reason: Option<FullEnumerationReason>,
     /// Zone name where token advancement was blocked. Set by the cycle owner
     /// so report.json can identify the affected library directly.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -287,6 +326,9 @@ impl SyncStats {
         }
         if self.sync_token_blocked_explanation.is_none() {
             self.sync_token_blocked_explanation = other.sync_token_blocked_explanation;
+        }
+        if self.full_enumeration_reason.is_none() {
+            self.full_enumeration_reason = other.full_enumeration_reason;
         }
         if self.sync_token_blocked_zone.is_none() {
             self.sync_token_blocked_zone = other.sync_token_blocked_zone.clone();
@@ -1924,6 +1966,43 @@ async fn cleanup_orphan_part_files(config: &DownloadConfig) {
     }
 }
 
+async fn has_metadata_backfill_work(config: &DownloadConfig) -> bool {
+    let Some(db) = &config.state_db else {
+        return false;
+    };
+    match db.has_downloaded_without_metadata_hash().await {
+        Ok(needs_backfill) => needs_backfill,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to check metadata backfill state before incremental sync"
+            );
+            false
+        }
+    }
+}
+
+fn set_full_enumeration_reason(result: &mut SyncResult, reason: FullEnumerationReason) {
+    if result.full_enumeration_ran && result.stats.full_enumeration_reason.is_none() {
+        result.stats.full_enumeration_reason = Some(reason);
+    }
+}
+
+async fn download_photos_full_with_reason(
+    download_client: &Client,
+    passes: &[crate::commands::AlbumPass],
+    config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
+    shutdown_token: CancellationToken,
+    reason: FullEnumerationReason,
+) -> Result<SyncResult> {
+    let mut result =
+        download_photos_full_with_token(download_client, passes, config, controls, shutdown_token)
+            .await?;
+    set_full_enumeration_reason(&mut result, reason);
+    Ok(result)
+}
+
 pub async fn download_photos_with_sync(
     download_client: &Client,
     passes: &[crate::commands::AlbumPass],
@@ -1979,16 +2058,19 @@ pub async fn download_photos_with_sync(
         // that pass, and inactive album/smart-folder templates shouldn't
         // force full enumeration on an unfiled-only sync.
         SyncMode::Incremental { .. } if incremental_requires_full_enumeration(passes) => {
+            let reason = FullEnumerationReason::PathTemplateRequiresFullEnumeration;
             tracing::debug!(
+                full_enumeration_reason = reason.as_str(),
                 "Album or smart-folder passes require full enumeration for correct \
                  membership routing, skipping incremental"
             );
-            download_photos_full_with_token(
+            download_photos_full_with_reason(
                 download_client,
                 passes,
                 &config,
                 controls,
                 shutdown_token.clone(),
+                reason,
             )
             .await
         }
@@ -1996,17 +2078,40 @@ pub async fn download_photos_with_sync(
         // pending assets from previous syncs. Fall back to full so they get
         // retried. Once everything is downloaded, incremental resumes.
         SyncMode::Incremental { .. } if total_pending > 0 => {
+            let reason = if retry_failed_count > 0 {
+                FullEnumerationReason::RetryFailedRows
+            } else {
+                FullEnumerationReason::PendingRows
+            };
             tracing::info!(
                 pending = total_pending,
                 failed_reset = retry_failed_count,
+                full_enumeration_reason = reason.as_str(),
                 "Retrying failed/pending assets requires full enumeration, skipping incremental sync"
             );
-            download_photos_full_with_token(
+            download_photos_full_with_reason(
                 download_client,
                 passes,
                 &config,
                 controls,
                 shutdown_token.clone(),
+                reason,
+            )
+            .await
+        }
+        SyncMode::Incremental { .. } if has_metadata_backfill_work(&config).await => {
+            let reason = FullEnumerationReason::MetadataBackfill;
+            tracing::info!(
+                full_enumeration_reason = reason.as_str(),
+                "Metadata backfill requires full enumeration, skipping incremental sync"
+            );
+            download_photos_full_with_reason(
+                download_client,
+                passes,
+                &config,
+                controls,
+                shutdown_token.clone(),
+                reason,
             )
             .await
         }
@@ -2042,16 +2147,19 @@ pub async fn download_photos_with_sync(
                         });
 
                     if is_token_error || !is_transient {
+                        let reason = FullEnumerationReason::OtherStaticReason;
                         tracing::warn!(
                             error = %e,
+                            full_enumeration_reason = reason.as_str(),
                             "Incremental sync failed, falling back to full enumeration"
                         );
-                        download_photos_full_with_token(
+                        download_photos_full_with_reason(
                             download_client,
                             passes,
                             &config,
                             controls,
                             shutdown_token.clone(),
+                            reason,
                         )
                         .await
                     } else {
@@ -4361,6 +4469,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn album_incremental_records_path_template_full_enumeration_reason() {
+        let session = MockPhotosFlow::new()
+            .album_count(0)
+            .empty_query_page(Some("zone-token-next"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Vacation", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("album incremental should fall back to full enumeration");
+
+        assert!(result.full_enumeration_ran);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(FullEnumerationReason::PathTemplateRequiresFullEnumeration)
+        );
+    }
+
+    #[tokio::test]
     async fn incremental_with_failed_rows_falls_back_to_full_enumeration() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = crate::test_helpers::TestAssetRecord::new("FAILED_BEFORE_SYNC")
@@ -4410,7 +4554,117 @@ mod tests {
             result.full_enumeration_ran,
             "normal sync with failed rows must not stay incremental"
         );
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(FullEnumerationReason::RetryFailedRows)
+        );
         assert!(matches!(result.outcome, DownloadOutcome::Success));
+    }
+
+    #[tokio::test]
+    async fn incremental_with_pending_rows_records_pending_full_enumeration_reason() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = crate::test_helpers::TestAssetRecord::new("PENDING_BEFORE_SYNC")
+            .filename("pending-before-sync.jpg")
+            .checksum("ck_pending_before_sync")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let session = MockPhotosFlow::new()
+            .album_count(0)
+            .empty_query_page(Some("zone-token-next"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("pending rows should fall back to full enumeration");
+
+        assert!(result.full_enumeration_ran);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(FullEnumerationReason::PendingRows)
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_with_metadata_backfill_records_full_enumeration_reason() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let record = crate::test_helpers::TestAssetRecord::new("BACKFILL_BEFORE_SYNC")
+            .filename("backfill-before-sync.jpg")
+            .checksum("ck_backfill_before_sync")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        let path = dir.path().join("backfill-before-sync.jpg");
+        tokio::fs::write(&path, vec![0u8; 1024])
+            .await
+            .expect("write local file");
+        db.mark_downloaded(
+            "PrimarySync",
+            "BACKFILL_BEFORE_SYNC",
+            "original",
+            &path,
+            "local_hash",
+            None,
+        )
+        .await
+        .expect("mark downloaded");
+        db.clear_metadata_hash_for_test("PrimarySync", "BACKFILL_BEFORE_SYNC", "original");
+        assert!(db.has_downloaded_without_metadata_hash().await.unwrap());
+
+        let session = MockPhotosFlow::new()
+            .album_count(0)
+            .empty_query_page(Some("zone-token-next"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("metadata backfill should fall back to full enumeration");
+
+        assert!(result.full_enumeration_ran);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(FullEnumerationReason::MetadataBackfill)
+        );
     }
 
     #[tokio::test]
@@ -5681,6 +5935,7 @@ mod tests {
             sync_token_receivers_blank: Some(0),
             sync_token_receivers_dropped: Some(0),
             sync_token_unique_values: Some(1),
+            full_enumeration_reason: Some(FullEnumerationReason::RetryFailedRows),
             elapsed_secs: 1.5,
             interrupted: false,
             rate_limited: 7,
@@ -5724,6 +5979,7 @@ mod tests {
             sync_token_receivers_blank: Some(0),
             sync_token_receivers_dropped: Some(0),
             sync_token_unique_values: Some(1),
+            full_enumeration_reason: Some(FullEnumerationReason::PendingRows),
             elapsed_secs: 0.75,
             interrupted: true,
             rate_limited: 3,
@@ -5766,6 +6022,10 @@ mod tests {
         assert_eq!(acc.sync_token_receivers_blank, Some(0));
         assert_eq!(acc.sync_token_receivers_dropped, Some(0));
         assert_eq!(acc.sync_token_unique_values, Some(1));
+        assert_eq!(
+            acc.full_enumeration_reason,
+            Some(FullEnumerationReason::RetryFailedRows)
+        );
         assert!(
             (acc.elapsed_secs - 2.25).abs() < 1e-9,
             "elapsed_secs must sum (got {})",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,6 +62,12 @@ struct SkipLabels {
     reason: &'static str,
 }
 
+/// Label set for the `kei_sync_full_enumeration_reason_total` counter family.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
+struct FullEnumerationLabels {
+    reason: &'static str,
+}
+
 /// Label set for the `kei_db_assets_total` and `kei_db_assets_size_bytes` gauge families.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
 struct StatusLabels {
@@ -104,6 +110,7 @@ pub(crate) struct MetricsHandle {
     pagination_shortfall_warnings: Counter,
     pagination_shortfall_assets: Counter,
     sync_token_blocked_cycles: Counter,
+    full_enumeration_reasons: Family<FullEnumerationLabels, Counter>,
     session_expirations: Counter,
     cycle_duration_seconds: Gauge<f64, AtomicU64>,
     consecutive_failures: Gauge,
@@ -205,6 +212,13 @@ impl MetricsHandle {
             sync_token_blocked_cycles.clone(),
         );
 
+        let full_enumeration_reasons: Family<FullEnumerationLabels, Counter> = Family::default();
+        registry.register(
+            "kei_sync_full_enumeration_reason",
+            "Total number of full-enumeration sync cycles, by bounded reason",
+            full_enumeration_reasons.clone(),
+        );
+
         let session_expirations = Counter::default();
         registry.register(
             "kei_sync_session_expirations",
@@ -303,6 +317,7 @@ impl MetricsHandle {
             pagination_shortfall_warnings,
             pagination_shortfall_assets,
             sync_token_blocked_cycles,
+            full_enumeration_reasons,
             session_expirations,
             cycle_duration_seconds,
             consecutive_failures,
@@ -337,6 +352,13 @@ impl MetricsHandle {
             .inc_by(stats.pagination_shortfall_assets);
         if stats.sync_token_blocked {
             self.sync_token_blocked_cycles.inc();
+        }
+        if let Some(reason) = stats.full_enumeration_reason {
+            self.full_enumeration_reasons
+                .get_or_create(&FullEnumerationLabels {
+                    reason: reason.as_str(),
+                })
+                .inc();
         }
 
         if stats.interrupted {
@@ -712,6 +734,26 @@ mod tests {
         );
         assert!(
             output.contains("kei_sync_token_blocked_cycles_total 1"),
+            "output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_enumeration_reason_counter_uses_bounded_label() {
+        let handle = MetricsHandle::new(None);
+        let stats = SyncStats {
+            full_enumeration_reason: Some(
+                crate::download::FullEnumerationReason::PathTemplateRequiresFullEnumeration,
+            ),
+            ..SyncStats::default()
+        };
+        handle.update(&stats, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains(
+                "kei_sync_full_enumeration_reason_total{reason=\"path_template_requires_full_enumeration\"} 1"
+            ),
             "output:\n{output}"
         );
     }

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -161,6 +161,12 @@ impl EnumConfigHashOutcome {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SyncModeDecision {
+    pub(crate) mode: download::SyncMode,
+    pub(crate) full_enumeration_reason: Option<download::FullEnumerationReason>,
+}
+
 /// Compare the current download-config hash against the one stored in
 /// the state DB and react to drift. Storage failures are logged at warn
 /// and swallowed, but the new hash is never persisted unless stale sync
@@ -275,14 +281,19 @@ pub(crate) async fn run_cycle(
         // retry-failed must always use full enumeration: incremental
         // sync only returns NEW iCloud changes, missing previously-
         // failed assets that were already enumerated but not downloaded.
-        let sync_mode = if force_full_for_config_hash {
+        let sync_mode_decision = if force_full_for_config_hash {
+            let reason = download::FullEnumerationReason::EnumConfigHashDrift;
             tracing::debug!(
                 zone = %lib_state.zone_name,
+                full_enumeration_reason = reason.as_str(),
                 "Forcing full sync because config-hash validation invalidated stored sync tokens"
             );
-            download::SyncMode::Full
+            SyncModeDecision {
+                mode: download::SyncMode::Full,
+                full_enumeration_reason: Some(reason),
+            }
         } else {
-            determine_sync_mode(
+            determine_sync_mode_decision(
                 is_retry_failed,
                 library_states.len(),
                 state_db,
@@ -291,12 +302,22 @@ pub(crate) async fn run_cycle(
             )
             .await
         };
+        let sync_mode = sync_mode_decision.mode;
 
         let sync_mode_label = match &sync_mode {
             download::SyncMode::Full => "full",
             download::SyncMode::Incremental { .. } => "incremental",
         };
-        tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
+        if let Some(reason) = sync_mode_decision.full_enumeration_reason {
+            tracing::info!(
+                sync_mode = sync_mode_label,
+                zone = %lib_state.zone_name,
+                full_enumeration_reason = reason.as_str(),
+                "Starting full-enumeration sync cycle"
+            );
+        } else {
+            tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
+        }
 
         // Skip the DB scan entirely when nothing downstream will read it.
         #[cfg(feature = "xmp")]
@@ -325,6 +346,10 @@ pub(crate) async fn run_cycle(
             shutdown_token.clone(),
         )
         .await?;
+
+        if sync_result.full_enumeration_ran && sync_result.stats.full_enumeration_reason.is_none() {
+            sync_result.stats.full_enumeration_reason = sync_mode_decision.full_enumeration_reason;
+        }
 
         let library_completed_without_errors =
             matches!(&sync_result.outcome, download::DownloadOutcome::Success)
@@ -501,6 +526,73 @@ where
 }
 
 /// Determine the sync mode for a library: full enumeration or incremental.
+pub(crate) async fn determine_sync_mode_decision<D>(
+    is_retry_failed: bool,
+    library_count: usize,
+    state_db: Option<&D>,
+    sync_token_key: &str,
+    zone_name: &str,
+) -> SyncModeDecision
+where
+    D: state::SyncTokenStore + ?Sized,
+{
+    if is_retry_failed {
+        let reason = download::FullEnumerationReason::ExplicitRetryFailed;
+        if library_count == 1 {
+            tracing::info!(
+                full_enumeration_reason = reason.as_str(),
+                "Retry-failed always runs full enumeration because incremental sync only returns new iCloud changes and can miss older failed assets"
+            );
+        }
+        SyncModeDecision {
+            mode: download::SyncMode::Full,
+            full_enumeration_reason: Some(reason),
+        }
+    } else if let Some(db) = state_db {
+        match db.get_metadata(sync_token_key).await {
+            Ok(Some(ref token)) if !token.is_empty() => {
+                tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
+                SyncModeDecision {
+                    mode: download::SyncMode::Incremental {
+                        zone_sync_token: token.clone(),
+                    },
+                    full_enumeration_reason: None,
+                }
+            }
+            Ok(_) => {
+                let reason = download::FullEnumerationReason::NoStoredToken;
+                tracing::debug!(
+                    zone = %zone_name,
+                    full_enumeration_reason = reason.as_str(),
+                    "No sync token found, performing full enumeration"
+                );
+                SyncModeDecision {
+                    mode: download::SyncMode::Full,
+                    full_enumeration_reason: Some(reason),
+                }
+            }
+            Err(e) => {
+                let reason = download::FullEnumerationReason::OtherStaticReason;
+                tracing::warn!(
+                    error = %e,
+                    full_enumeration_reason = reason.as_str(),
+                    "Failed to load sync token, falling back to full enumeration"
+                );
+                SyncModeDecision {
+                    mode: download::SyncMode::Full,
+                    full_enumeration_reason: Some(reason),
+                }
+            }
+        }
+    } else {
+        SyncModeDecision {
+            mode: download::SyncMode::Full,
+            full_enumeration_reason: Some(download::FullEnumerationReason::NoStoredToken),
+        }
+    }
+}
+
+#[cfg(test)]
 pub(crate) async fn determine_sync_mode<D>(
     is_retry_failed: bool,
     library_count: usize,
@@ -511,33 +603,15 @@ pub(crate) async fn determine_sync_mode<D>(
 where
     D: state::SyncTokenStore + ?Sized,
 {
-    if is_retry_failed {
-        if library_count == 1 {
-            tracing::info!(
-                "Retry-failed always runs full enumeration because incremental sync only returns new iCloud changes and can miss older failed assets"
-            );
-        }
-        download::SyncMode::Full
-    } else if let Some(db) = state_db {
-        match db.get_metadata(sync_token_key).await {
-            Ok(Some(ref token)) if !token.is_empty() => {
-                tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
-                download::SyncMode::Incremental {
-                    zone_sync_token: token.clone(),
-                }
-            }
-            Ok(_) => {
-                tracing::debug!(zone = %zone_name, "No sync token found, performing full enumeration");
-                download::SyncMode::Full
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to load sync token, falling back to full enumeration");
-                download::SyncMode::Full
-            }
-        }
-    } else {
-        download::SyncMode::Full
-    }
+    determine_sync_mode_decision(
+        is_retry_failed,
+        library_count,
+        state_db,
+        sync_token_key,
+        zone_name,
+    )
+    .await
+    .mode
 }
 
 #[cfg(test)]
@@ -638,6 +712,34 @@ mod tests {
             db.get_metadata(&sync_token_key).await.expect("read token"),
             Some("stored-token-abc".to_string()),
             "mode selection must not consume or clear the stored token"
+        );
+    }
+
+    #[tokio::test]
+    async fn determine_sync_mode_decision_records_explicit_full_reasons() {
+        let db = state::SqliteStateDb::open_in_memory().expect("state db");
+        let sync_token_key = sync_token_key("PrimarySync");
+        db.set_metadata(&sync_token_key, "stored-token-abc")
+            .await
+            .expect("set token");
+
+        let retry =
+            determine_sync_mode_decision(true, 1, Some(&db), &sync_token_key, "PrimarySync").await;
+        assert!(matches!(retry.mode, download::SyncMode::Full));
+        assert_eq!(
+            retry.full_enumeration_reason,
+            Some(download::FullEnumerationReason::ExplicitRetryFailed)
+        );
+
+        db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX)
+            .await
+            .expect("clear token");
+        let no_token =
+            determine_sync_mode_decision(false, 1, Some(&db), &sync_token_key, "PrimarySync").await;
+        assert!(matches!(no_token.mode, download::SyncMode::Full));
+        assert_eq!(
+            no_token.full_enumeration_reason,
+            Some(download::FullEnumerationReason::NoStoredToken)
         );
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4700,6 +4700,10 @@ mod tests {
 
         assert_eq!(result.failed_count, 0);
         assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::EnumConfigHashDrift)
+        );
+        assert_eq!(
             observed_modes
                 .lock()
                 .expect("recorded modes lock")
@@ -4887,6 +4891,10 @@ mod tests {
 
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::NoStoredToken)
+        );
         assert!(
             logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "completed full sync with zero assets should be visible in normal logs"
@@ -4908,6 +4916,10 @@ mod tests {
 
         assert_eq!(result.failed_count, 0);
         assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::ExplicitRetryFailed)
+        );
         assert!(
             !logs_contain(ZERO_ASSET_WARNING_PREFIX),
             "retry-failed no-op cycles must stay quiet"


### PR DESCRIPTION
## Summary
- Added a bounded `full_enumeration_reason` field to sync stats and `sync_report.json` so full re-enumerations explain why they happened.
- Threaded reasons through sync-mode selection, retry/pending fallbacks, metadata backfill, enum-config hash drift, logs, and Prometheus metrics.
- Added regression coverage for the known full-enumeration reasons and the cross-surface report/metrics serialization.

## Tests
- `cargo check`
- `cargo test determine_sync_mode`
- `cargo test full_enumeration`
- `cargo test sync_token` - passed outside sandbox after `wait-timeout` hit `Operation not permitted` in sandbox
- `cargo test metrics` - passed outside sandbox after localhost bind hit `Operation not permitted` in sandbox
- `cargo test sync_report`
- `cargo test notification`
- `cargo test outcome`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
