### PR TITLE
Assert Docker allocator default in full-test

### DIFF
--- a/scripts/full-test/run_docker_puid_smoke.sh
+++ b/scripts/full-test/run_docker_puid_smoke.sh
@@ -46,6 +46,14 @@ if [[ "$puid_out" != "$expected" ]]; then
   exit 1
 fi
 
+echo "--- allocator env default ---"
+arena_out=$(docker run --rm \
+  "$image" sh -c 'printf "%s" "${MALLOC_ARENA_MAX:-}"' 2>&1)
+if [[ "$arena_out" != "2" ]]; then
+  echo "run_docker_puid_smoke: expected MALLOC_ARENA_MAX=2, got '$arena_out'" >&2
+  exit 1
+fi
+
 echo "--- default root mode ---"
 root_out=$(docker run --rm \
   --entrypoint /usr/local/bin/entrypoint.sh \

--- a/tests/README.md
+++ b/tests/README.md
@@ -189,8 +189,8 @@ happens:
   before release branches that touch sync tokens, retry state, download
   validation, config paths, or reporting.
 - **`scripts/full-test/run_docker_puid_smoke.sh`** - offline Docker entrypoint
-  checks for PUID/PGID drop, volume chown, root-default behavior, and invalid
-  env rejection.
+  checks for PUID/PGID drop, volume chown, `MALLOC_ARENA_MAX=2`, root-default
+  behavior, and invalid env rejection.
 - **`scripts/full-test/run_live_import_rehearsal.sh`** - live mini rehearsal
   for v0.20's TOML-first import path: seed a tiny real tree, import it into a
   fresh DB, and verify a repeat dry-run stays matched.


### PR DESCRIPTION
## Summary
- Added an offline Docker smoke assertion for `MALLOC_ARENA_MAX=2`.
- Updated the test catalog so the Docker PUID smoke lists the allocator env check.

## Context
Closes #475.

## Tests
- `bash -n scripts/full-test/run_docker_puid_smoke.sh`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just docker build`
- `scripts/full-test/run_docker_puid_smoke.sh`
