### PR TITLE
Simplify config resolver override path

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,8 +233,9 @@ pub struct SyncArgs {
     #[arg(long, conflicts_with = "dry_run")]
     pub retry_failed: bool,
 
-    /// Internal durable config overrides for tests and programmatic call
-    /// sites. Public CLI/env no longer expose these fields in v0.20.
+    /// Test-only durable config overrides used by unit tests that exercise
+    /// resolver internals without rebuilding TOML snippets.
+    #[cfg(test)]
     #[arg(skip)]
     pub(crate) config_overrides: crate::config::SyncConfigOverrides,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1033,6 +1033,16 @@ pub(crate) fn resolve_password_command(
         .or_else(|| toml_auth.and_then(|a| a.password_command.clone()))
 }
 
+#[cfg(test)]
+fn take_sync_config_overrides(sync: &mut crate::cli::SyncArgs) -> SyncConfigOverrides {
+    std::mem::take(&mut sync.config_overrides)
+}
+
+#[cfg(not(test))]
+fn take_sync_config_overrides(_sync: &mut crate::cli::SyncArgs) -> SyncConfigOverrides {
+    SyncConfigOverrides::default()
+}
+
 impl Config {
     /// Build a Config by merging CLI args with optional TOML config.
     /// Runtime CLI flags override TOML where they remain public. Durable sync
@@ -1040,12 +1050,13 @@ impl Config {
     pub fn build(
         globals: &GlobalArgs,
         pw: &crate::cli::PasswordArgs,
-        mut sync: crate::cli::SyncArgs,
+        sync: crate::cli::SyncArgs,
         toml: Option<&TomlConfig>,
     ) -> anyhow::Result<Self> {
-        let overrides = std::mem::take(&mut sync.config_overrides);
+        let mut sync = sync;
+        let overrides = take_sync_config_overrides(&mut sync);
         let friendly_request = toml.and_then(|t| t.ui.as_ref()).and_then(|u| u.friendly);
-        Self::build_inner(
+        Self::build_inner_impl(
             globals,
             pw,
             sync,
@@ -1057,6 +1068,25 @@ impl Config {
     }
 
     pub(crate) fn build_inner(
+        globals: &GlobalArgs,
+        pw: &crate::cli::PasswordArgs,
+        sync: crate::cli::SyncArgs,
+        toml: Option<&TomlConfig>,
+        personality_mode: crate::personality::Mode,
+        friendly_request: Option<bool>,
+    ) -> anyhow::Result<Self> {
+        Self::build_inner_impl(
+            globals,
+            pw,
+            sync,
+            SyncConfigOverrides::default(),
+            toml,
+            personality_mode,
+            friendly_request,
+        )
+    }
+
+    fn build_inner_impl(
         globals: &GlobalArgs,
         pw: &crate::cli::PasswordArgs,
         sync: crate::cli::SyncArgs,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -340,7 +340,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         globals,
         &pw,
         sync,
-        config::SyncConfigOverrides::default(),
         toml_config.as_ref(),
         personality_mode,
         friendly_request,


### PR DESCRIPTION
## Summary
- Made `SyncArgs::config_overrides` test-only so runtime CLI parsing no longer carries the durable override bag.
- Simplified config construction by routing `Config::build` through one internal implementation path and selecting overrides via a small test/non-test helper.
- Updated `sync_loop` to the new `Config::build_inner` signature (no explicit overrides argument).

## Tests
- `cargo check` (pass)
- `cargo test config --lib` (pass)
- `cargo fmt --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)
- `cargo test --test cli` (fails in sandbox: `wait-timeout` / `Operation not permitted`)
- `cargo test --test behavioral config -- --test-threads=1` (fails in sandbox: `wait-timeout` / `Operation not permitted`)
