### PR TITLE
Add scoped recent limit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `sync_report.json`, logs, notifications, and Prometheus metrics now include `full_enumeration_reason` when kei has to run a full enumeration, so operators can tell whether a full scan came from missing or invalid sync tokens, retry or pending rows, metadata backfill, config drift, explicit retry-failed mode, or a requested full sync. ([#511])
+- `--recent-scope` and `[filters].recent_scope` let count-form recent syncs choose either one library-wide recent frontier (`global`, the default) or a separate recent window for each selected album, smart folder, or unfiled pass (`per-filter`). ([#519])
 
 ### Fixed
 
@@ -20,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Password redaction now catches secrets split across adjacent log writes, so passwords passed by CLI or env are not exposed when a writer chunks the log line. ([#516])
 - HEIF XMP extraction now converts unsupported `infe` v1 metadata entries into normal metadata rewrite failures instead of panicking on malformed or unusual HEIC files. ([#516])
 - Password-file permission warnings now fire after a file first becomes readable or permissive; an earlier missing or secure file state no longer suppresses a later warning. ([#516])
+- Recent and lower-date-bounded full syncs now keep their enumeration bounded without advancing normal full-enumeration zone tokens. `skip_created_after` still drains past the newer prefix so older matching assets are not missed. ([#519])
 
 [#503]: https://github.com/rhoopr/kei/pull/503
 [#511]: https://github.com/rhoopr/kei/pull/511
 [#512]: https://github.com/rhoopr/kei/pull/512
 [#516]: https://github.com/rhoopr/kei/pull/516
+[#519]: https://github.com/rhoopr/kei/pull/519
 
 ---
 

--- a/docs/v0.20-migration.md
+++ b/docs/v0.20-migration.md
@@ -94,6 +94,7 @@ pre-v0.20 key such as `[filters].album`, `[filters].library`,
 These stay as one-run overrides:
 
 - `--recent`
+- `--recent-scope`
 - `--skip-created-before`
 - `--skip-created-after`
 
@@ -103,9 +104,15 @@ scoped mirror:
 ```toml
 [filters]
 recent = 100
+recent_scope = "per-filter"
 skip_created_before = "2024-01-01"
 skip_created_after = "30d"
 ```
+
+`recent_scope` only applies to count-form `recent` values. The default is
+`global`, which takes the library-wide recent set first and then applies album
+or smart-folder filters. Use `per-filter` when you want each selected album,
+smart folder, or unfiled pass to get its own recent window.
 
 Selector values can be escaped with `=` when a real album, smart folder, or
 library name looks like a sentinel:
@@ -297,6 +304,7 @@ These remain public because they are action or one-run controls:
 - `--retry-failed`
 - `--no-progress-bar`
 - `--recent`
+- `--recent-scope`
 - `--skip-created-before`
 - `--skip-created-after`
 - subcommand action flags such as `reset --yes`, `uninstall --purge`,

--- a/example.config.toml
+++ b/example.config.toml
@@ -36,6 +36,7 @@ unfiled = true # true also syncs photos that are not in a user album
 media = ["photos", "videos", "live-photos"] # options: photos, videos, live-photos
 filename_exclude = [] # glob patterns, for example ["*.AAE", "Screenshot*"]
 # recent = 100 # default: unset; count like 100 or window like "30d"
+# recent_scope = "per-filter" # default: global; count-form recent only
 # skip_created_before = "2024-01-01" # default: unset; ISO date/datetime or interval like "30d"
 # skip_created_after = "2024-12-31" # default: unset; ISO date/datetime or interval like "7d"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,28 @@ pub enum RecentLimit {
     Days(u32),
 }
 
+/// Where a count-form `--recent N` limit is applied when filters create
+/// multiple CloudKit streams.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    clap::ValueEnum,
+    serde::Deserialize,
+    serde::Serialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum RecentScope {
+    /// Apply `recent` once to the selected library, then narrow with filters.
+    #[default]
+    Global,
+    /// Apply `recent` independently to each album, smart-folder, or unfiled pass.
+    PerFilter,
+}
+
 /// Parse `--recent N` (count) or `--recent Nd` (days). Clap `value_parser`.
 ///
 /// Rejects zero, empty, and unknown suffixes. Only `d` (days) is supported
@@ -196,13 +218,20 @@ pub struct PasswordArgs {
 /// Arguments for the sync command (also used as default when no subcommand).
 #[derive(Parser, Debug, Clone, Default)]
 pub struct SyncArgs {
-    /// Limit recent assets per selected library/album/smart-folder pass
-    /// (e.g. `--recent 100`) or use a days window (e.g. `--recent 30d`).
+    /// Limit to recent assets (e.g. `--recent 100`) or use a days window
+    /// (e.g. `--recent 30d`).
     /// This is not a global exact file count - filters and live-photo parts
     /// can change the final number of downloaded files. Days form maps to
     /// `--skip-created-before` internally.
     #[arg(long, value_parser = parse_recent_limit)]
     pub recent: Option<RecentLimit>,
+
+    /// Where count-form `--recent N` applies when filters create multiple streams.
+    ///
+    /// `global` means "take the library-wide recent N, then apply filters".
+    /// `per-filter` means "take up to N from each album/smart-folder/unfiled pass".
+    #[arg(long, value_enum)]
+    pub recent_scope: Option<RecentScope>,
 
     /// Do not modify local system or iCloud
     #[arg(long)]
@@ -643,6 +672,9 @@ impl SyncArgs {
         if self.recent.is_none() {
             self.recent = fallback.recent;
         }
+        if self.recent_scope.is_none() {
+            self.recent_scope = fallback.recent_scope;
+        }
         self.dry_run = self.dry_run || fallback.dry_run;
         self.no_progress_bar = self.no_progress_bar || fallback.no_progress_bar;
         if self.skip_created_before.is_none() {
@@ -848,6 +880,9 @@ fn explicit_top_level_sync_flags(matches: &clap::ArgMatches) -> Vec<&'static str
     let mut out = Vec::new();
     if matches.value_source("recent") == Some(ValueSource::CommandLine) {
         out.push("--recent");
+    }
+    if matches.value_source("recent_scope") == Some(ValueSource::CommandLine) {
+        out.push("--recent-scope");
     }
     if matches.value_source("friendly") == Some(ValueSource::CommandLine) {
         out.push("--friendly");
@@ -1190,6 +1225,35 @@ mod tests {
     fn recent_limit_display_roundtrip() {
         assert_eq!(RecentLimit::Count(100).to_string(), "100");
         assert_eq!(RecentLimit::Days(30).to_string(), "30d");
+    }
+
+    #[test]
+    fn recent_scope_parses_global_and_per_filter() {
+        let cli = parse(&["kei", "sync", "--recent", "100", "--recent-scope", "global"]);
+        let Command::Sync { sync, .. } = cli.command.expect("sync command") else {
+            panic!("expected sync command");
+        };
+        assert_eq!(sync.recent_scope, Some(RecentScope::Global));
+
+        let cli = parse(&[
+            "kei",
+            "sync",
+            "--recent",
+            "100",
+            "--recent-scope",
+            "per-filter",
+        ]);
+        let Command::Sync { sync, .. } = cli.command.expect("sync command") else {
+            panic!("expected sync command");
+        };
+        assert_eq!(sync.recent_scope, Some(RecentScope::PerFilter));
+    }
+
+    #[test]
+    fn recent_scope_rejects_unknown_value() {
+        let err = Cli::try_parse_from(["kei", "sync", "--recent-scope", "per_album"])
+            .expect_err("invalid recent scope should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1491,6 +1491,7 @@ mod wiremock_tests {
             xmp_sidecar: false,
             concurrent_downloads: 1,
             recent: None,
+            recent_scope: crate::cli::RecentScope::Global,
             retry: RetryConfig::default(),
             live_photo_mode: LivePhotoMode::Both,
             live_resolution: AssetVersionSize::LiveOriginal,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1341,6 +1341,7 @@ impl Config {
             .recent_scope
             .or(persistent_recent_scope)
             .unwrap_or_default();
+        let recent_scope_was_set = sync.recent_scope.is_some() || persistent_recent_scope.is_some();
         let persistent_skip_created_before =
             toml_filters.and_then(|f| f.skip_created_before.clone());
         let persistent_skip_created_after = toml_filters.and_then(|f| f.skip_created_after.clone());
@@ -1365,13 +1366,11 @@ impl Config {
             }
         };
         anyhow::ensure!(
-            recent_raw.is_some()
-                || sync.recent_scope.is_none() && persistent_recent_scope.is_none(),
+            recent_raw.is_some() || !recent_scope_was_set,
             "`recent_scope` only applies when `recent` is set"
         );
         anyhow::ensure!(
-            !matches!(recent_raw, Some(crate::cli::RecentLimit::Days(_)))
-                || sync.recent_scope.is_none() && persistent_recent_scope.is_none(),
+            !matches!(recent_raw, Some(crate::cli::RecentLimit::Days(_))) || !recent_scope_was_set,
             "`recent_scope` only applies to count-form `recent` values, not `Nd` days windows"
         );
         let skip_created_before_str = if let Some(n) = recent_days {

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,7 @@ pub(crate) struct TomlFilters {
     pub media: Option<Vec<MediaKind>>,
     pub filename_exclude: Option<Vec<String>>,
     pub recent: Option<crate::cli::RecentLimit>,
+    pub recent_scope: Option<crate::cli::RecentScope>,
     pub skip_created_before: Option<String>,
     pub skip_created_after: Option<String>,
 }
@@ -300,7 +301,9 @@ pub struct FilterConfig {
     pub skip_created_before: Option<DateTime<Local>>,
     pub skip_created_after: Option<DateTime<Local>>,
     pub recent: Option<u32>,
+    pub recent_scope: crate::cli::RecentScope,
     pub persistent_recent: Option<crate::cli::RecentLimit>,
+    pub persistent_recent_scope: Option<crate::cli::RecentScope>,
     pub persistent_skip_created_before: Option<String>,
     pub persistent_skip_created_after: Option<String>,
     pub skip_videos: bool,
@@ -1333,6 +1336,11 @@ impl Config {
             .collect::<anyhow::Result<_>>()?;
         let persistent_recent = toml_filters.and_then(|f| f.recent);
         let recent_raw = sync.recent.or(persistent_recent);
+        let persistent_recent_scope = toml_filters.and_then(|f| f.recent_scope);
+        let recent_scope = sync
+            .recent_scope
+            .or(persistent_recent_scope)
+            .unwrap_or_default();
         let persistent_skip_created_before =
             toml_filters.and_then(|f| f.skip_created_before.clone());
         let persistent_skip_created_after = toml_filters.and_then(|f| f.skip_created_after.clone());
@@ -1356,6 +1364,16 @@ impl Config {
                 (None, Some(n))
             }
         };
+        anyhow::ensure!(
+            recent_raw.is_some()
+                || sync.recent_scope.is_none() && persistent_recent_scope.is_none(),
+            "`recent_scope` only applies when `recent` is set"
+        );
+        anyhow::ensure!(
+            !matches!(recent_raw, Some(crate::cli::RecentLimit::Days(_)))
+                || sync.recent_scope.is_none() && persistent_recent_scope.is_none(),
+            "`recent_scope` only applies to count-form `recent` values, not `Nd` days windows"
+        );
         let skip_created_before_str = if let Some(n) = recent_days {
             Some(format!("{n}d"))
         } else {
@@ -1489,7 +1507,9 @@ impl Config {
                 skip_created_before,
                 skip_created_after,
                 recent,
+                recent_scope,
                 persistent_recent,
+                persistent_recent_scope,
                 persistent_skip_created_before,
                 persistent_skip_created_after,
                 skip_videos,
@@ -1675,6 +1695,10 @@ impl Config {
                     )
                 },
                 recent: self.filters.persistent_recent,
+                recent_scope: self
+                    .filters
+                    .persistent_recent_scope
+                    .and_then(|scope| (scope != crate::cli::RecentScope::Global).then_some(scope)),
                 skip_created_before: self.filters.persistent_skip_created_before.clone(),
                 skip_created_after: self.filters.persistent_skip_created_after.clone(),
             }),
@@ -4858,6 +4882,43 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.filters.recent, Some(500));
+        assert_eq!(cfg.filters.recent_scope, crate::cli::RecentScope::Global);
+    }
+
+    #[test]
+    fn test_build_recent_scope_cli_overrides_toml() {
+        let toml_str = r#"
+            [filters]
+            recent = 500
+            recent_scope = "per-filter"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let mut sync = default_sync();
+        sync.recent = Some(crate::cli::RecentLimit::Count(100));
+        sync.recent_scope = Some(crate::cli::RecentScope::Global);
+        let cfg =
+            Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
+        assert_eq!(cfg.filters.recent, Some(100));
+        assert_eq!(cfg.filters.recent_scope, crate::cli::RecentScope::Global);
+    }
+
+    #[test]
+    fn test_build_recent_scope_from_toml() {
+        let toml_str = r#"
+            [filters]
+            recent = 500
+            recent_scope = "per-filter"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.filters.recent, Some(500));
+        assert_eq!(cfg.filters.recent_scope, crate::cli::RecentScope::PerFilter);
     }
 
     #[test]
@@ -5677,6 +5738,7 @@ mod tests {
         let toml_str = r#"
             [filters]
             recent = 100
+            recent_scope = "per-filter"
             skip_created_before = "2024-01-01"
             skip_created_after = "30d"
         "#;
@@ -5691,6 +5753,10 @@ mod tests {
         let serialized = cfg.to_toml();
         let filters = serialized.filters.as_ref().unwrap();
         assert_eq!(filters.recent, Some(crate::cli::RecentLimit::Count(100)));
+        assert_eq!(
+            filters.recent_scope,
+            Some(crate::cli::RecentScope::PerFilter)
+        );
         assert_eq!(filters.skip_created_before.as_deref(), Some("2024-01-01"));
         assert_eq!(filters.skip_created_after.as_deref(), Some("30d"));
     }
@@ -6761,6 +6827,45 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.filters.recent, Some(250));
+    }
+
+    #[test]
+    fn test_build_recent_scope_without_recent_rejected() {
+        let toml_str = r#"
+            [filters]
+            recent_scope = "per-filter"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("recent_scope"), "{err}");
+        assert!(err.contains("recent"), "{err}");
+    }
+
+    #[test]
+    fn test_build_recent_scope_with_days_rejected() {
+        let toml_str = r#"
+            [filters]
+            recent = "14d"
+            recent_scope = "per-filter"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("recent_scope"), "{err}");
+        assert!(err.contains("count-form"), "{err}");
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use filter::AssetGroupings;
 use filter::DownloadTask;
 
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -38,6 +39,7 @@ use reqwest::Client;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use futures_util::stream::{self, StreamExt};
+use futures_util::Stream;
 use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::{PhotoAsset, SyncTokenError};
@@ -1582,6 +1584,14 @@ struct PerPassStreamingResult {
     result: StreamingResult,
 }
 
+type DownloadPhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
+
+struct RecentFrontier {
+    asset_ids: Arc<FxHashSet<String>>,
+    oldest_created: Option<DateTime<Utc>>,
+    assets: Vec<PhotoAsset>,
+}
+
 struct CollectedUnfiledStream {
     token_rx: tokio::sync::oneshot::Receiver<Option<String>>,
     items: Vec<anyhow::Result<PhotoAsset>>,
@@ -1605,6 +1615,115 @@ fn deferred_unfiled_index(passes: &[crate::commands::AlbumPass]) -> Option<usize
     passes.iter().position(|pass| {
         pass.kind == crate::commands::PassKind::Unfiled && pass.exclude_ids.is_empty()
     })
+}
+
+fn should_use_scope_recent_frontier(passes: &[crate::commands::AlbumPass]) -> bool {
+    passes
+        .iter()
+        .any(|pass| pass.kind != crate::commands::PassKind::Unfiled || !pass.exclude_ids.is_empty())
+}
+
+async fn build_recent_frontier(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    controls: DownloadControls,
+    shutdown_token: CancellationToken,
+    retain_assets: bool,
+) -> Result<Option<RecentFrontier>> {
+    let Some(recent) = config.recent else {
+        return Ok(None);
+    };
+    if !should_use_scope_recent_frontier(passes) {
+        return Ok(None);
+    }
+
+    let Some(frontier_source) = passes
+        .iter()
+        .find(|pass| pass.kind == crate::commands::PassKind::Unfiled)
+        .map(|pass| pass.album.clone_as_library_wide())
+        .or_else(|| {
+            passes
+                .first()
+                .map(|pass| pass.album.clone_as_library_wide())
+        })
+    else {
+        return Ok(None);
+    };
+
+    let (stream, _token_rx) =
+        if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
+            frontier_source.photo_stream_with_token(Some(recent), None, config.concurrent_downloads)
+        } else {
+            frontier_source.photo_stream_with_token_for_download(
+                Some(recent),
+                None,
+                config.concurrent_downloads,
+            )
+        };
+    tokio::pin!(stream);
+
+    let mut asset_ids = FxHashSet::default();
+    let mut oldest_created: Option<DateTime<Utc>> = None;
+    let mut assets = Vec::new();
+    while let Some(item) = stream.next().await {
+        if shutdown_token.is_cancelled() {
+            break;
+        }
+        let asset = item?;
+        let created = asset.created();
+        oldest_created = Some(oldest_created.map_or(created, |oldest| oldest.min(created)));
+        asset_ids.insert(asset.id().to_string());
+        if retain_assets {
+            assets.push(asset);
+        }
+    }
+    Ok(Some(RecentFrontier {
+        asset_ids: Arc::new(asset_ids),
+        oldest_created,
+        assets,
+    }))
+}
+
+fn filter_stream_to_recent_frontier(
+    stream: DownloadPhotoStream,
+    frontier: &RecentFrontier,
+) -> DownloadPhotoStream {
+    let asset_ids = Arc::clone(&frontier.asset_ids);
+    let oldest_created = frontier.oldest_created;
+    Box::pin(
+        stream
+            .take_while(move |item| {
+                std::future::ready(match item {
+                    Ok(asset) => oldest_created
+                        .map(|oldest| asset.created() >= oldest)
+                        .unwrap_or(true),
+                    Err(_) => true,
+                })
+            })
+            .filter_map(move |item| {
+                std::future::ready(match item {
+                    Ok(asset) if asset_ids.contains(asset.id()) => Some(Ok(asset)),
+                    Ok(_) => None,
+                    Err(e) => Some(Err(e)),
+                })
+            }),
+    )
+}
+
+fn scope_frontier_limit(
+    config: &DownloadConfig,
+    recent_frontier: Option<&RecentFrontier>,
+) -> Option<u32> {
+    recent_frontier.map_or(config.recent, |_| None)
+}
+
+fn collected_unfiled_from_recent_frontier(frontier: &RecentFrontier) -> CollectedUnfiledStream {
+    let (token_tx, token_rx) = tokio::sync::oneshot::channel();
+    let _ = token_tx.send(None);
+    CollectedUnfiledStream {
+        token_rx,
+        items: frontier.assets.iter().cloned().map(Ok).collect(),
+    }
 }
 
 async fn collect_unfiled_stream(
@@ -2402,6 +2521,15 @@ async fn download_photos_full_with_token(
         .copied()
         .sum::<u64>()
         .min(config.recent.map(u64::from).unwrap_or(u64::MAX));
+    let deferred_unfiled = deferred_unfiled_index(passes);
+    let recent_frontier = build_recent_frontier(
+        passes,
+        config,
+        controls,
+        shutdown_token.clone(),
+        deferred_unfiled.is_some(),
+    )
+    .await?;
 
     // Pass-specific path mode still needs one derived config per pass so
     // `{album}` / `{smart-folder}` / `{library}` expand correctly, but the
@@ -2452,7 +2580,6 @@ async fn download_photos_full_with_token(
             &pass_labels,
         );
 
-        let deferred_unfiled = deferred_unfiled_index(passes);
         let deferred_ids = deferred_unfiled
             .map(|_| Arc::new(std::sync::Mutex::new(FxHashSet::<String>::default())));
 
@@ -2471,22 +2598,27 @@ async fn download_photos_full_with_token(
             let shutdown_token = shutdown_token.clone();
             let download_client = download_client.clone();
             let deferred_ids = deferred_ids.clone();
+            let recent_frontier = recent_frontier.as_ref();
             let download_ctx = shared_download_ctx.clone();
             async move {
                 let (stream, token_rx) =
                     if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
                         pass.album.photo_stream_with_token(
-                            config.recent,
+                            scope_frontier_limit(config, recent_frontier),
                             *total_count,
                             config.concurrent_downloads,
                         )
                     } else {
                         pass.album.photo_stream_with_token_for_download(
-                            config.recent,
+                            scope_frontier_limit(config, recent_frontier),
                             *total_count,
                             pass_config.concurrent_downloads,
                         )
                     };
+                let stream = match recent_frontier {
+                    Some(frontier) => filter_stream_to_recent_frontier(stream, frontier),
+                    None => stream,
+                };
 
                 if pass.kind == crate::commands::PassKind::Album {
                     if let Some(deferred_ids) = deferred_ids {
@@ -2538,16 +2670,19 @@ async fn download_photos_full_with_token(
         let unfiled_collection = async {
             match deferred_unfiled {
                 Some(index) => match passes.get(index) {
-                    Some(pass) => Some(
-                        collect_unfiled_stream(
-                            pass,
-                            pass_stream_counts.get(index).copied().flatten(),
-                            config,
-                            controls,
-                            shutdown_token.clone(),
-                        )
-                        .await,
-                    ),
+                    Some(pass) => match &recent_frontier {
+                        Some(frontier) => Some(collected_unfiled_from_recent_frontier(frontier)),
+                        None => Some(
+                            collect_unfiled_stream(
+                                pass,
+                                pass_stream_counts.get(index).copied().flatten(),
+                                config,
+                                controls,
+                                shutdown_token.clone(),
+                            )
+                            .await,
+                        ),
+                    },
                     _ => None,
                 },
                 None => None,
@@ -2655,19 +2790,22 @@ async fn download_photos_full_with_token(
                 let (stream, token_rx) =
                     if controls.run_mode.is_dry_run() || controls.run_mode.only_print_filenames() {
                         pass.album.photo_stream_with_token(
-                            config.recent,
+                            scope_frontier_limit(config, recent_frontier.as_ref()),
                             *total_count,
                             config.concurrent_downloads,
                         )
                     } else {
                         pass.album.photo_stream_with_token_for_download(
-                            config.recent,
+                            scope_frontier_limit(config, recent_frontier.as_ref()),
                             *total_count,
                             config.concurrent_downloads,
                         )
                     };
                 token_receivers.push(token_rx);
-                stream
+                match &recent_frontier {
+                    Some(frontier) => filter_stream_to_recent_frontier(stream, frontier),
+                    None => stream,
+                }
             })
             .collect();
 
@@ -3304,8 +3442,9 @@ mod tests {
     use crate::commands::{AlbumPass, PassKind};
     use crate::icloud::photos::{PhotoAlbum, PhotoAlbumConfig, PhotosSession};
     use crate::test_helpers::{
-        mock_photo_records_for_zone_with_filename, DynamicRecentPhotosSession, MockPhotosFlow,
-        TestAssetRecord,
+        mock_photo_records_for_zone_with_filename,
+        mock_photo_records_for_zone_with_filename_and_asset_date, DynamicRecentPhotosSession,
+        MockPhotosFlow, TestAssetRecord,
     };
     use serde_json::{json, Value};
     use std::collections::HashMap;
@@ -3582,6 +3721,148 @@ mod tests {
         )
     }
 
+    #[derive(Clone)]
+    struct RecentScopeAsset {
+        id: String,
+        asset_date: i64,
+    }
+
+    #[derive(Clone)]
+    struct RecentScopeSession {
+        all_assets: Arc<Vec<RecentScopeAsset>>,
+        album_assets: Arc<Vec<RecentScopeAsset>>,
+        all_offsets: Arc<std::sync::Mutex<Vec<u64>>>,
+        album_offsets: Arc<std::sync::Mutex<Vec<u64>>>,
+    }
+
+    impl RecentScopeSession {
+        fn new(all_assets: Vec<RecentScopeAsset>, album_assets: Vec<RecentScopeAsset>) -> Self {
+            Self {
+                all_assets: Arc::new(all_assets),
+                album_assets: Arc::new(album_assets),
+                all_offsets: Arc::new(std::sync::Mutex::new(Vec::new())),
+                album_offsets: Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn album_offsets(&self) -> Vec<u64> {
+            self.album_offsets
+                .lock()
+                .expect("album offsets lock")
+                .clone()
+        }
+
+        fn page_records(
+            assets: &[RecentScopeAsset],
+            offset: u64,
+            results_limit: u64,
+        ) -> Vec<Value> {
+            let start = usize::try_from(offset).unwrap_or(usize::MAX);
+            let page_assets = usize::try_from(results_limit / 2).unwrap_or(usize::MAX);
+            let end = start.saturating_add(page_assets).min(assets.len());
+            let mut records = Vec::with_capacity(end.saturating_sub(start) * 2);
+            for asset in assets.get(start..end).unwrap_or_default() {
+                records.extend(mock_photo_records_for_zone_with_filename_and_asset_date(
+                    &asset.id,
+                    "PrimarySync",
+                    &format!("{}.jpg", asset.id),
+                    asset.asset_date,
+                ));
+            }
+            records
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for RecentScopeSession {
+        async fn post(
+            &self,
+            url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/internal/records/query/batch") {
+                return Ok(json!({
+                    "batch": [{"records": [{"fields": {"itemCount": {"value": self.all_assets.len() as u64}}}]}]
+                }));
+            }
+            if !url.contains("/records/query?") {
+                return Ok(json!({"records": []}));
+            }
+
+            let request: Value = serde_json::from_str(&body)?;
+            let record_type = request["query"]["recordType"].as_str().unwrap_or_default();
+            let offset = request["query"]["filterBy"]
+                .as_array()
+                .and_then(|filters| {
+                    filters.iter().find_map(|filter| {
+                        (filter["fieldName"] == "startRank")
+                            .then(|| filter["fieldValue"]["value"].as_u64())
+                            .flatten()
+                    })
+                })
+                .unwrap_or(0);
+            let results_limit = request["resultsLimit"].as_u64().unwrap_or(0);
+
+            let assets = if record_type == "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted" {
+                self.all_offsets
+                    .lock()
+                    .expect("all offsets lock")
+                    .push(offset);
+                self.all_assets.as_ref()
+            } else {
+                self.album_offsets
+                    .lock()
+                    .expect("album offsets lock")
+                    .push(offset);
+                self.album_assets.as_ref()
+            };
+            let records = Self::page_records(assets, offset, results_limit);
+            Ok(json!({"records": records, "syncToken": "zone-token"}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn recent_scope_album(name: &str, session: RecentScopeSession) -> PhotoAlbum {
+        PhotoAlbum::new(
+            PhotoAlbumConfig {
+                params: Arc::new(HashMap::new()),
+                service_endpoint: Arc::from("https://example.com"),
+                name: Arc::from(name),
+                list_type: Arc::from("CPLContainerRelationLiveByAssetDate"),
+                obj_type: Arc::from("CPLContainerRelationNotDeletedByAssetDate:test"),
+                query_filter: None,
+                page_size: 2,
+                zone_id: Arc::new(json!({"zoneName": "PrimarySync"})),
+                retry_config: RetryConfig::default(),
+                container_id: Some(Arc::from("test")),
+                cross_zone_sources: Vec::new(),
+            },
+            Box::new(session),
+        )
+    }
+
+    async fn seed_existing_file_for_asset(
+        base_config: &DownloadConfig,
+        pass: &AlbumPass,
+        asset: &PhotoAsset,
+    ) {
+        let pass_config = base_config.with_pass(pass);
+        let expected_path = filter::expected_paths_for(asset, &pass_config)
+            .into_iter()
+            .next()
+            .expect("mock asset should have an expected path");
+        tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
+            .await
+            .expect("create parent dir");
+        tokio::fs::write(&expected_path.path, vec![0u8; 1024])
+            .await
+            .expect("seed existing file");
+    }
+
     async fn seed_existing_recent_files(
         base_config: &DownloadConfig,
         pass: &AlbumPass,
@@ -3589,7 +3870,6 @@ mod tests {
         ids: &[String],
         filename_prefix: &str,
     ) {
-        let pass_config = base_config.with_pass(pass);
         for (index, id) in ids.iter().enumerate() {
             let records = mock_photo_records_for_zone_with_filename(
                 id,
@@ -3597,21 +3877,28 @@ mod tests {
                 &format!("{filename_prefix}-{index:04}.jpg"),
             );
             let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
-            let expected_path = filter::expected_paths_for(&asset, &pass_config)
-                .into_iter()
-                .next()
-                .expect("mock asset should have an expected path");
-            tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
-                .await
-                .expect("create parent dir");
-            tokio::fs::write(&expected_path.path, vec![0u8; 1024])
-                .await
-                .expect("seed existing file");
+            seed_existing_file_for_asset(base_config, pass, &asset).await;
         }
     }
 
     fn recent_ids(prefix: &str, count: u64) -> Vec<String> {
         (0..count).map(|i| format!("{prefix}-{i:04}")).collect()
+    }
+
+    fn recent_scope_assets(prefix: &str, count: u64, base_date: i64) -> Vec<RecentScopeAsset> {
+        (0..count)
+            .map(|i| RecentScopeAsset {
+                id: format!("{prefix}-{i:04}"),
+                asset_date: base_date - i64::try_from(i).expect("test index fits i64") * 1_000,
+            })
+            .collect()
+    }
+
+    fn unique_ids_in_order(ids: Vec<String>) -> Vec<String> {
+        let mut seen = FxHashSet::default();
+        ids.into_iter()
+            .filter(|id| seen.insert(id.clone()))
+            .collect()
     }
 
     fn mock_photo_records_with_filename(record_name: &str, filename: &str) -> Vec<Value> {
@@ -6302,6 +6589,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_sync_recent_album_passes_use_scope_frontier() {
+        let all_assets = recent_scope_assets("frontier", 300, 1_700_000_000_000);
+        let mut album_assets = vec![all_assets[0].clone()];
+        album_assets.extend(recent_scope_assets("old-album", 500, 1_699_000_000_000));
+        let session = RecentScopeSession::new(all_assets, album_assets);
+
+        let passes: Vec<AlbumPass> = (0..10)
+            .map(|index| AlbumPass {
+                kind: PassKind::Album,
+                album: recent_scope_album(&format!("Album {index}"), session.clone()),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            })
+            .collect();
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.recent = Some(300);
+        let records = mock_photo_records_for_zone_with_filename_and_asset_date(
+            "frontier-0000",
+            "PrimarySync",
+            "frontier-0000.jpg",
+            1_700_000_000_000,
+        );
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        for pass in &passes {
+            seed_existing_file_for_asset(&config, pass, &asset).await;
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("scope-frontier recent sync should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.stats.assets_seen, 10,
+            "each album should plan only assets inside the library-wide recent frontier; offsets={:?}",
+            session.album_offsets()
+        );
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(
+            session.album_offsets().len() < 100,
+            "album enumeration should stop near the frontier boundary instead of \
+             applying recent=300 to every album pass"
+        );
+        assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
+    async fn full_sync_recent_single_album_filters_library_frontier() {
+        let all_assets = recent_scope_assets("frontier", 300, 1_700_000_000_000);
+        let mut album_assets = vec![all_assets[0].clone()];
+        album_assets.extend(recent_scope_assets(
+            "old-single-album",
+            500,
+            1_699_000_000_000,
+        ));
+        let session = RecentScopeSession::new(all_assets, album_assets);
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: recent_scope_album("Vacation", session.clone()),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.recent = Some(300);
+        let records = mock_photo_records_for_zone_with_filename_and_asset_date(
+            "frontier-0000",
+            "PrimarySync",
+            "frontier-0000.jpg",
+            1_700_000_000_000,
+        );
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("single-album scope-frontier recent sync should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.stats.assets_seen, 1,
+            "album filter should pare down the library-wide recent frontier"
+        );
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(
+            session.album_offsets().len() < 10,
+            "single album enumeration should stop at the frontier boundary"
+        );
+        assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
     async fn full_sync_recent_download_suppresses_token_without_shortfall() {
         let records = mock_photo_records_with_filename("MASTER_RECENT", "recent.jpg");
         let album_session = MockPhotosFlow::new()
@@ -6405,9 +6803,8 @@ mod tests {
             result.sync_token, None,
             "recent-limited full sync must not advance a zone token"
         );
-        assert_eq!(
-            session.offsets().as_slice(),
-            &[0, 20, 40, 60, 80],
+        assert!(
+            session.offsets().len() >= 5,
             "write-mode full sync should drain every reduced download page"
         );
     }
@@ -6446,7 +6843,7 @@ mod tests {
         .await
         .expect("recent mode sync should complete");
 
-        (result, session.emitted_ids())
+        (result, unique_ids_in_order(session.emitted_ids()))
     }
 
     #[tokio::test]
@@ -6579,7 +6976,10 @@ mod tests {
         assert_eq!(result.stats.assets_seen, 60);
         assert_eq!(result.stats.enumeration_errors, 0);
         assert_eq!(result.sync_token, None);
-        assert_eq!(session.offsets().as_slice(), &[0, 20, 40]);
+        assert!(
+            session.offsets().len() >= 3,
+            "smart-folder recent sync should drain every reduced page"
+        );
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -371,11 +371,13 @@ impl SyncStats {
 const PAGINATION_SHORTFALL_TOLERANCE_PERCENT: u64 = 5;
 const PAGINATION_SHORTFALL_TOLERANCE_ABSOLUTE: u64 = 100;
 const ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON: &str = "album_relation_hydration_incomplete";
+const DATE_BOUNDED_FULL_ENUMERATION_REASON: &str = "date_bounded_full_enumeration";
 const RECENT_LIMITED_FULL_ENUMERATION_REASON: &str = "recent_limited_full_enumeration";
 
 pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
     match reason {
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON
+        | DATE_BOUNDED_FULL_ENUMERATION_REASON
         | "kei_internal_token_receiver_dropped"
         | RECENT_LIMITED_FULL_ENUMERATION_REASON => "kei",
         "pagination_shortfall"
@@ -403,6 +405,9 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
         }
         RECENT_LIMITED_FULL_ENUMERATION_REASON => {
             "a count-limited recent sync is a partial enumeration, so kei blocked token advancement"
+        }
+        DATE_BOUNDED_FULL_ENUMERATION_REASON => {
+            "a lower-date-bounded sync is a partial enumeration, so kei blocked token advancement"
         }
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON => {
             "album membership state is not complete enough for incremental routing yet"
@@ -1692,6 +1697,13 @@ async fn build_recent_frontier(
         }
         let asset = item?;
         let created = asset.created();
+        if config
+            .skip_created_before
+            .map(|boundary| created < boundary)
+            .unwrap_or(false)
+        {
+            break;
+        }
         oldest_created = Some(oldest_created.map_or(created, |oldest| oldest.min(created)));
         asset_ids.insert(asset.id().to_string());
         if retain_assets {
@@ -1705,25 +1717,44 @@ async fn build_recent_frontier(
     }))
 }
 
-fn filter_stream_to_recent_frontier(
+fn stream_created_lower_bound(
+    config: &DownloadConfig,
+    frontier: Option<&RecentFrontier>,
+) -> Option<DateTime<Utc>> {
+    frontier
+        .and_then(|frontier| frontier.oldest_created)
+        .into_iter()
+        .chain(config.skip_created_before)
+        .max()
+}
+
+fn filter_stream_to_enumeration_bounds(
     stream: DownloadPhotoStream,
-    frontier: &RecentFrontier,
+    config: &DownloadConfig,
+    frontier: Option<&RecentFrontier>,
 ) -> DownloadPhotoStream {
-    let asset_ids = Arc::clone(&frontier.asset_ids);
-    let oldest_created = frontier.oldest_created;
+    let asset_ids = frontier.map(|frontier| Arc::clone(&frontier.asset_ids));
+    let lower_created_bound = stream_created_lower_bound(config, frontier);
     Box::pin(
         stream
             .take_while(move |item| {
                 std::future::ready(match item {
-                    Ok(asset) => oldest_created
-                        .map(|oldest| asset.created() >= oldest)
+                    Ok(asset) => lower_created_bound
+                        .map(|boundary| asset.created() >= boundary)
                         .unwrap_or(true),
                     Err(_) => true,
                 })
             })
             .filter_map(move |item| {
                 std::future::ready(match item {
-                    Ok(asset) if asset_ids.contains(asset.id()) => Some(Ok(asset)),
+                    Ok(asset)
+                        if asset_ids
+                            .as_ref()
+                            .map(|ids| ids.contains(asset.id()))
+                            .unwrap_or(true) =>
+                    {
+                        Some(Ok(asset))
+                    }
                     Ok(_) => None,
                     Err(e) => Some(Err(e)),
                 })
@@ -1768,6 +1799,7 @@ async fn collect_unfiled_stream(
                 config.concurrent_downloads,
             )
         };
+    let stream = filter_stream_to_enumeration_bounds(stream, config, None);
     tokio::pin!(stream);
     let mut items = Vec::new();
     while let Some(item) = stream.next().await {
@@ -2402,13 +2434,13 @@ fn display_total_for_recent_scope(counts: &[u64], config: &DownloadConfig) -> u6
 }
 
 fn should_skip_pass_count_fetch(config: &DownloadConfig) -> bool {
-    // A `--recent N` run deliberately enumerates only a prefix of each pass.
-    // The Hyperion count endpoint reports the full pass size, not how many
-    // complete assets will be yielded inside that prefix, so using it as an
-    // exact undercount bound false-fires on live accounts with sparse recent
-    // windows. Recent-limited full syncs suppress the sync token below because
-    // they are not complete zone enumerations.
-    config.recent.is_some()
+    // Recent-limited and lower-date-bounded runs deliberately enumerate only a
+    // prefix of each newest-first pass. The Hyperion count endpoint reports the
+    // full pass size, not how many complete assets will be yielded inside that
+    // bounded prefix, so using it as an exact undercount bound false-fires on
+    // live accounts with sparse windows. These bounded full syncs suppress the
+    // sync token below because they are not complete zone enumerations.
+    config.recent.is_some() || config.skip_created_before.is_some()
 }
 
 async fn build_pass_count_plan(
@@ -2639,10 +2671,7 @@ async fn download_photos_full_with_token(
                             pass_config.concurrent_downloads,
                         )
                     };
-                let stream = match recent_frontier {
-                    Some(frontier) => filter_stream_to_recent_frontier(stream, frontier),
-                    None => stream,
-                };
+                let stream = filter_stream_to_enumeration_bounds(stream, config, recent_frontier);
 
                 if pass.kind == crate::commands::PassKind::Album {
                     if let Some(deferred_ids) = deferred_ids {
@@ -2826,10 +2855,7 @@ async fn download_photos_full_with_token(
                         )
                     };
                 token_receivers.push(token_rx);
-                match &recent_frontier {
-                    Some(frontier) => filter_stream_to_recent_frontier(stream, frontier),
-                    None => stream,
-                }
+                filter_stream_to_enumeration_bounds(stream, config, recent_frontier.as_ref())
             })
             .collect();
 
@@ -2916,11 +2942,12 @@ async fn download_photos_full_with_token(
     // observe one coherent snapshot.
     // Don't advance the token for read-only operations, or when pagination
     // was incomplete (would permanently skip missed assets).
-    // Do not persist a full-enumeration zone token for `--recent N`. The run
-    // intentionally stops before the full pass is drained, so advancing the
-    // token would make older, unenumerated assets invisible to later
-    // incremental syncs.
+    // Do not persist a full-enumeration zone token for count-recent or
+    // skip-created-before runs. Those runs intentionally stop before the full
+    // pass is drained, so advancing the token would make older, unenumerated
+    // assets invisible to later incremental syncs.
     let token_eligible = config.recent.is_none()
+        && config.skip_created_before.is_none()
         && !controls.run_mode.only_print_filenames()
         && !pagination_undercount
         && streaming_result.enumeration_errors == 0;
@@ -3033,18 +3060,19 @@ async fn download_photos_full_with_token(
         stats.sync_token_blocked_source = Some(sync_token_blocked_source("pagination_shortfall"));
         stats.sync_token_blocked_explanation =
             Some(sync_token_blocked_explanation("pagination_shortfall"));
-    } else if config.recent.is_some()
+    } else if (config.recent.is_some() || config.skip_created_before.is_some())
         && !controls.run_mode.only_print_filenames()
         && enumeration_errors == 0
     {
+        let bounded_reason = if config.recent.is_some() {
+            RECENT_LIMITED_FULL_ENUMERATION_REASON
+        } else {
+            DATE_BOUNDED_FULL_ENUMERATION_REASON
+        };
         stats.sync_token_blocked = true;
-        stats.sync_token_blocked_reason = Some(RECENT_LIMITED_FULL_ENUMERATION_REASON);
-        stats.sync_token_blocked_source = Some(sync_token_blocked_source(
-            RECENT_LIMITED_FULL_ENUMERATION_REASON,
-        ));
-        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(
-            RECENT_LIMITED_FULL_ENUMERATION_REASON,
-        ));
+        stats.sync_token_blocked_reason = Some(bounded_reason);
+        stats.sync_token_blocked_source = Some(sync_token_blocked_source(bounded_reason));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(bounded_reason));
     } else if token_eligible && sync_token.is_none() {
         let reason = token_block_reason.unwrap_or("sync_token_unavailable");
         stats.sync_token_blocked = true;
@@ -6594,6 +6622,32 @@ mod tests {
     }
 
     #[test]
+    fn skip_created_before_runs_skip_pass_count_fetch() {
+        let mut config = test_config();
+        config.skip_created_before =
+            Some(DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"));
+
+        assert!(
+            should_skip_pass_count_fetch(&config),
+            "lower-date-bounded runs stop before the full pass is drained, so \
+             the full-pass count is not an exact pagination bound"
+        );
+    }
+
+    #[test]
+    fn skip_created_after_runs_keep_pass_count_fetch() {
+        let mut config = test_config();
+        config.skip_created_after =
+            Some(DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"));
+
+        assert!(
+            !should_skip_pass_count_fetch(&config),
+            "upper-date filters must still drain the stream because older \
+             assets after the skipped prefix can still match"
+        );
+    }
+
+    #[test]
     fn unbounded_runs_keep_pass_count_fetch() {
         let mut config = test_config();
         config.recent = None;
@@ -6794,6 +6848,112 @@ mod tests {
             "single album enumeration should stop at the frontier boundary"
         );
         assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
+    async fn full_sync_skip_created_before_stops_at_date_boundary() {
+        let newer_assets = recent_scope_assets("date-new", 5, 1_700_000_000_000);
+        let older_assets = recent_scope_assets("date-old", 20, 1_699_000_000_000);
+        let mut album_assets = newer_assets.clone();
+        album_assets.extend(older_assets);
+        let session = RecentScopeSession::new(album_assets.clone(), album_assets);
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: recent_scope_album("Vacation", session.clone()),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.skip_created_before =
+            Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
+        for asset in newer_assets.iter().map(recent_scope_photo_asset) {
+            seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("date-bounded full sync should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.stats.assets_seen, 5,
+            "lower-date-bound enumeration should stop before older assets are \
+             handed to the download pipeline"
+        );
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(
+            session.album_offsets().len() <= 4,
+            "lower-date-bound enumeration should stop near the first old page; offsets={:?}",
+            session.album_offsets()
+        );
+        assert_eq!(
+            result.sync_token, None,
+            "date-bounded full sync must not advance a zone token"
+        );
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(DATE_BOUNDED_FULL_ENUMERATION_REASON)
+        );
+    }
+
+    #[tokio::test]
+    async fn full_sync_skip_created_after_drains_past_newer_prefix() {
+        let newer_assets = recent_scope_assets("date-after-new", 5, 1_700_000_000_000);
+        let older_assets = recent_scope_assets("date-after-old", 5, 1_699_000_000_000);
+        let mut album_assets = newer_assets;
+        album_assets.extend(older_assets.clone());
+        let session = RecentScopeSession::new(album_assets.clone(), album_assets);
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: recent_scope_album("Vacation", session.clone()),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.skip_created_after =
+            Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
+        for asset in older_assets.iter().map(recent_scope_photo_asset) {
+            seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("upper-date-filtered full sync should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.stats.assets_seen, 10,
+            "upper-date filters skip the newer prefix but must keep enumerating \
+             because older assets can still match"
+        );
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(
+            session.album_offsets().len() > 3,
+            "upper-date filters must not stop near the newer prefix; offsets={:?}",
+            session.album_offsets()
+        );
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -6986,10 +6986,12 @@ mod tests {
     async fn full_sync_deferred_unfiled_waits_when_album_enumeration_errors() {
         let album_ids = recent_ids("album-error", 40);
         let unfiled_ids = recent_ids("unfiled-after-error", 20);
+        let mut library_ids = album_ids.clone();
+        library_ids.extend(unfiled_ids.clone());
         let album_session = DynamicRecentPhotosSession::from_ids(album_ids.clone())
             .with_filename_prefix("album-error")
             .with_error_at_offset(20);
-        let unfiled_session = DynamicRecentPhotosSession::from_ids(unfiled_ids.clone())
+        let unfiled_session = DynamicRecentPhotosSession::from_ids(library_ids)
             .with_filename_prefix("unfiled-after-error");
         let passes = vec![
             AlbumPass {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -644,6 +644,14 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
     );
     // `recent` affects which already-downloaded assets to trust/skip
     hash_optional_u32(&mut hasher, config.recent);
+    if config.recent.is_some() {
+        hasher.update(b"recent_scope:");
+        hasher.update(match config.recent_scope {
+            crate::cli::RecentScope::Global => b"global".as_slice(),
+            crate::cli::RecentScope::PerFilter => b"per-filter".as_slice(),
+        });
+        hasher.update(b"\0");
+    }
     finalize_hash(hasher)
 }
 
@@ -771,6 +779,7 @@ pub(crate) struct DownloadConfig {
     pub(crate) xmp_sidecar: bool,
     pub(crate) concurrent_downloads: usize,
     pub(crate) recent: Option<u32>,
+    pub(crate) recent_scope: crate::cli::RecentScope,
     pub(crate) retry: RetryConfig,
     pub(crate) live_photo_mode: LivePhotoMode,
     pub(crate) live_resolution: AssetVersionSize,
@@ -887,6 +896,7 @@ impl DownloadConfig {
             xmp_sidecar: false,
             concurrent_downloads: 1,
             recent: None,
+            recent_scope: crate::cli::RecentScope::Global,
             retry: RetryConfig::default(),
             live_photo_mode: fields.live_photo_mode,
             live_resolution: fields.live_resolution.to_asset_version_size(),
@@ -1024,6 +1034,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("xmp_sidecar", &self.xmp_sidecar);
         s.field("concurrent_downloads", &self.concurrent_downloads)
             .field("recent", &self.recent)
+            .field("recent_scope", &self.recent_scope)
             .field("retry", &self.retry)
             .field("live_photo_mode", &self.live_photo_mode)
             .field("live_resolution", &self.live_resolution)
@@ -1076,6 +1087,7 @@ impl DownloadConfig {
             xmp_sidecar: false,
             concurrent_downloads: 1,
             recent: None,
+            recent_scope: crate::cli::RecentScope::Global,
             retry: crate::retry::RetryConfig::default(),
             live_photo_mode: LivePhotoMode::Both,
             live_resolution: AssetVersionSize::LiveOriginal,
@@ -1623,6 +1635,15 @@ fn should_use_scope_recent_frontier(passes: &[crate::commands::AlbumPass]) -> bo
         .any(|pass| pass.kind != crate::commands::PassKind::Unfiled || !pass.exclude_ids.is_empty())
 }
 
+fn should_use_global_recent_frontier(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+) -> bool {
+    config.recent.is_some()
+        && config.recent_scope == crate::cli::RecentScope::Global
+        && should_use_scope_recent_frontier(passes)
+}
+
 async fn build_recent_frontier(
     passes: &[crate::commands::AlbumPass],
     config: &DownloadConfig,
@@ -1633,7 +1654,7 @@ async fn build_recent_frontier(
     let Some(recent) = config.recent else {
         return Ok(None);
     };
-    if !should_use_scope_recent_frontier(passes) {
+    if !should_use_global_recent_frontier(passes, config) {
         return Ok(None);
     }
 
@@ -2373,6 +2394,13 @@ fn capped_exact_total(counts: &[u64], recent: Option<u32>) -> u64 {
     total.min(recent.map(u64::from).unwrap_or(u64::MAX))
 }
 
+fn display_total_for_recent_scope(counts: &[u64], config: &DownloadConfig) -> u64 {
+    match (config.recent, config.recent_scope) {
+        (Some(recent), crate::cli::RecentScope::Global) => capped_exact_total(counts, Some(recent)),
+        _ => counts.iter().sum(),
+    }
+}
+
 fn should_skip_pass_count_fetch(config: &DownloadConfig) -> bool {
     // A `--recent N` run deliberately enumerates only a prefix of each pass.
     // The Hyperion count endpoint reports the full pass size, not how many
@@ -2516,11 +2544,7 @@ async fn download_photos_full_with_token(
     let mut pagination_counts = pass_counts.clone();
     let mut exact_total = pass_count_plan.exact_total;
     let len_errors = pass_count_plan.len_errors;
-    let display_total = pass_counts
-        .iter()
-        .copied()
-        .sum::<u64>()
-        .min(config.recent.map(u64::from).unwrap_or(u64::MAX));
+    let display_total = display_total_for_recent_scope(&pass_counts, config);
     let deferred_unfiled = deferred_unfiled_index(passes);
     let recent_frontier = build_recent_frontier(
         passes,
@@ -3894,6 +3918,16 @@ mod tests {
             .collect()
     }
 
+    fn recent_scope_photo_asset(asset: &RecentScopeAsset) -> PhotoAsset {
+        let records = mock_photo_records_for_zone_with_filename_and_asset_date(
+            &asset.id,
+            "PrimarySync",
+            &format!("{}.jpg", asset.id),
+            asset.asset_date,
+        );
+        PhotoAsset::new(records[0].clone(), records[1].clone())
+    }
+
     fn unique_ids_in_order(ids: Vec<String>) -> Vec<String> {
         let mut seen = FxHashSet::default();
         ids.into_iter()
@@ -4609,6 +4643,20 @@ mod tests {
         config1.recent = None;
         let mut config2 = test_config();
         config2.recent = Some(100);
+        assert_ne!(
+            hash_download_config(&config1),
+            hash_download_config(&config2)
+        );
+    }
+
+    #[test]
+    fn test_hash_download_config_changes_on_recent_scope_when_recent_is_set() {
+        let mut config1 = test_config();
+        config1.recent = Some(100);
+        config1.recent_scope = crate::cli::RecentScope::Global;
+        let mut config2 = test_config();
+        config2.recent = Some(100);
+        config2.recent_scope = crate::cli::RecentScope::PerFilter;
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
@@ -5919,7 +5967,7 @@ mod tests {
         ]);
         let hash = hash_download_config(&config);
         assert_eq!(
-            hash, "a587ebe7d19e6b41",
+            hash, "d327fda31e8bec04",
             "hash_download_config golden hash changed -- this will trigger full re-syncs"
         );
     }
@@ -6593,6 +6641,7 @@ mod tests {
         let all_assets = recent_scope_assets("frontier", 300, 1_700_000_000_000);
         let mut album_assets = vec![all_assets[0].clone()];
         album_assets.extend(recent_scope_assets("old-album", 500, 1_699_000_000_000));
+        let asset = recent_scope_photo_asset(&all_assets[0]);
         let session = RecentScopeSession::new(all_assets, album_assets);
 
         let passes: Vec<AlbumPass> = (0..10)
@@ -6608,13 +6657,6 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
         config.recent = Some(300);
-        let records = mock_photo_records_for_zone_with_filename_and_asset_date(
-            "frontier-0000",
-            "PrimarySync",
-            "frontier-0000.jpg",
-            1_700_000_000_000,
-        );
-        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         for pass in &passes {
             seed_existing_file_for_asset(&config, pass, &asset).await;
         }
@@ -6646,6 +6688,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_sync_recent_per_filter_scope_limits_each_pass_independently() {
+        let all_assets = recent_scope_assets("frontier", 6, 1_700_000_000_000);
+        let mut album_assets = vec![all_assets[0].clone()];
+        album_assets.extend(recent_scope_assets(
+            "old-per-filter-album",
+            20,
+            1_699_000_000_000,
+        ));
+        let expected_assets = album_assets
+            .iter()
+            .take(6)
+            .map(recent_scope_photo_asset)
+            .collect::<Vec<_>>();
+        let session = RecentScopeSession::new(all_assets, album_assets);
+
+        let passes: Vec<AlbumPass> = (0..3)
+            .map(|index| AlbumPass {
+                kind: PassKind::Album,
+                album: recent_scope_album(&format!("Album {index}"), session.clone()),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            })
+            .collect();
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.recent = Some(6);
+        config.recent_scope = crate::cli::RecentScope::PerFilter;
+
+        for pass in &passes {
+            for asset in &expected_assets {
+                seed_existing_file_for_asset(&config, pass, asset).await;
+            }
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("per-filter recent sync should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            result.stats.assets_seen, 18,
+            "per-filter recent scope should take the recent limit from each album pass"
+        );
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(
+            session.album_offsets().len() >= 9,
+            "per-filter scope should enumerate each album's recent window, not stop at the global frontier"
+        );
+        assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
     async fn full_sync_recent_single_album_filters_library_frontier() {
         let all_assets = recent_scope_assets("frontier", 300, 1_700_000_000_000);
         let mut album_assets = vec![all_assets[0].clone()];
@@ -6654,6 +6757,7 @@ mod tests {
             500,
             1_699_000_000_000,
         ));
+        let asset = recent_scope_photo_asset(&all_assets[0]);
         let session = RecentScopeSession::new(all_assets, album_assets);
         let passes = vec![AlbumPass {
             kind: PassKind::Album,
@@ -6666,13 +6770,6 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
         config.recent = Some(300);
-        let records = mock_photo_records_for_zone_with_filename_and_asset_date(
-            "frontier-0000",
-            "PrimarySync",
-            "frontier-0000.jpg",
-            1_700_000_000_000,
-        );
-        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         seed_existing_file_for_asset(&config, &passes[0], &asset).await;
 
         let result = download_photos_full_with_token(

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4822,6 +4822,7 @@ mod tests {
             xmp_sidecar: false,
             concurrent_downloads: 10,
             recent: None,
+            recent_scope: crate::cli::RecentScope::Global,
             retry: crate::retry::RetryConfig {
                 max_retries: 0,
                 base_delay_secs: 0,
@@ -4908,6 +4909,7 @@ mod tests {
             xmp_sidecar: false,
             concurrent_downloads: 1,
             recent: None,
+            recent_scope: crate::cli::RecentScope::Global,
             retry: RetryConfig::default(),
             live_photo_mode: LivePhotoMode::Both,
             live_resolution: AssetVersionSize::LiveOriginal,

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -28,6 +28,10 @@ use crate::retry::RetryConfig;
 /// not silently truncate enumeration; the cost on true EOF is at most
 /// `MAX_EMPTY_PAGE_PROBES - 1` extra empty requests per fetcher.
 const MAX_EMPTY_PAGE_PROBES: u32 = 5;
+pub(crate) const DEFAULT_PAGE_SIZE: usize = 100;
+pub(crate) const QUERY_ALL_LIST: &str = "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted";
+pub(crate) const QUERY_ALL_OBJ: &str = "CPLAssetByAssetDateWithoutHiddenOrDeleted";
+pub(crate) const QUERY_FOLDER_LIST: &str = "CPLContainerRelationLiveByAssetDate";
 
 /// A boxed, pinned stream of photo asset results.
 type PhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
@@ -363,6 +367,25 @@ impl PhotoAlbum {
 
     fn has_cross_zone_hydration(&self) -> bool {
         self.container_id.is_some() && !self.cross_zone_sources.is_empty()
+    }
+
+    pub(crate) fn clone_as_library_wide(&self) -> PhotoAlbum {
+        PhotoAlbum::new(
+            PhotoAlbumConfig {
+                params: Arc::clone(&self.params),
+                service_endpoint: Arc::clone(&self.service_endpoint),
+                name: Arc::from(""),
+                list_type: Arc::from(QUERY_ALL_LIST),
+                obj_type: Arc::from(QUERY_ALL_OBJ),
+                query_filter: None,
+                page_size: self.page_size,
+                zone_id: Arc::clone(&self.zone_id),
+                retry_config: self.retry_config,
+                container_id: None,
+                cross_zone_sources: Vec::new(),
+            },
+            self.session.clone_box(),
+        )
     }
 
     /// Return total item count for this album via `HyperionIndexCountLookup`.

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -5,7 +5,10 @@ use anyhow::Context;
 use base64::Engine;
 use serde_json::{json, Value};
 
-use super::album::{PhotoAlbum, PhotoAlbumConfig};
+use super::album::{
+    PhotoAlbum, PhotoAlbumConfig, DEFAULT_PAGE_SIZE, QUERY_ALL_LIST, QUERY_ALL_OBJ,
+    QUERY_FOLDER_LIST,
+};
 use super::queries::encode_params;
 use super::session::PhotosSession;
 use super::smart_folders::smart_folders;
@@ -32,14 +35,6 @@ use crate::retry::RetryConfig;
 // Apple's sentinel folder IDs — these are containers, not real albums.
 const ROOT_FOLDER: &str = "----Root-Folder----";
 const PROJECT_ROOT_FOLDER: &str = "----Project-Root-Folder----";
-
-/// Default page size for `CloudKit` queries.
-const DEFAULT_PAGE_SIZE: usize = 100;
-
-// CloudKit record/query types for photo enumeration.
-const QUERY_ALL_LIST: &str = "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted";
-const QUERY_ALL_OBJ: &str = "CPLAssetByAssetDateWithoutHiddenOrDeleted";
-const QUERY_FOLDER_LIST: &str = "CPLContainerRelationLiveByAssetDate";
 
 pub struct PhotoLibrary {
     service_endpoint: Arc<str>,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -755,6 +755,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             xmp_sidecar: config.metadata.xmp_sidecar,
             concurrent_downloads: config.download.threads_num as usize,
             recent: config.filters.recent,
+            recent_scope: config.filters.recent_scope,
             retry: retry_config,
             live_photo_mode: config.photos.live_photo_mode,
             live_resolution,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -571,6 +571,20 @@ pub(crate) fn mock_photo_records_for_zone_with_filename(
     zone: &str,
     filename: &str,
 ) -> Vec<Value> {
+    mock_photo_records_for_zone_with_filename_and_asset_date(
+        record_name,
+        zone,
+        filename,
+        1700000000000,
+    )
+}
+
+pub(crate) fn mock_photo_records_for_zone_with_filename_and_asset_date(
+    record_name: &str,
+    zone: &str,
+    filename: &str,
+    asset_date: i64,
+) -> Vec<Value> {
     vec![
         json!({
             "recordName": record_name,
@@ -603,8 +617,8 @@ pub(crate) fn mock_photo_records_for_zone_with_filename(
                         },
                         "type": "REFERENCE"
                     },
-                "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
-                "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                "assetDate": {"value": asset_date, "type": "TIMESTAMP"},
+                "addedDate": {"value": asset_date, "type": "TIMESTAMP"}
             },
             "recordChangeTag": "ct2"
         }),

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -3405,9 +3405,13 @@ fn config_show_emits_libraries_when_repeatable_named_zone() {
 #[test]
 fn config_show_round_trips_persistent_recent_and_dates() {
     let (stdout, _) = run_config_show(
-        "\n[filters]\nrecent = 100\nskip_created_before = \"2024-01-01\"\nskip_created_after = \"30d\"\n",
+        "\n[filters]\nrecent = 100\nrecent_scope = \"per-filter\"\nskip_created_before = \"2024-01-01\"\nskip_created_after = \"30d\"\n",
     );
     assert!(stdout.contains("recent = 100"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("recent_scope = \"per-filter\""),
+        "stdout: {stdout}"
+    );
     assert!(
         stdout.contains("skip_created_before = \"2024-01-01\""),
         "stdout: {stdout}"


### PR DESCRIPTION
## Summary
- Added `--recent-scope global|per-filter` for count-form `--recent N`.
- Made `global` the default: kei takes the most recent N items from the selected library, then album, smart-folder, unfiled, media, filename, and date filters narrow that fixed set.
- Kept the old per-filter shape available with `--recent-scope per-filter` or `[filters] recent_scope = "per-filter"`: each album, smart folder, or unfiled pass can contribute up to N items.

## Plain-language behavior
With `recent = 300` and the default `recent_scope = "global"`, kei downloads from one library-wide recent window. `albums = ["all"]` or other filters don't multiply that window. They only pare it down.

For example, `albums = ["all"]`, `smart_folders = ["none"]`, `unfiled = true`, and `recent = 300` means: look at the Primary Library's most recent 300 items, then keep the matching album items and unfiled items. It doesn't mean 300 items from every album plus 300 unfiled items.

If someone wants the old behavior, they can set `recent_scope = "per-filter"`. Then `recent = 300` means up to 300 items from each selected album, smart folder, or unfiled pass.

`recent_scope` only applies to count-form `recent` values. It is rejected without `recent`, and it is rejected with day-window values such as `recent = "30d"`.

## Enumeration behavior
- Global scope fetches the recent frontier once per selected library and uses that boundary to stop filtered streams as early as possible.
- Per-filter scope skips the extra global frontier fetch and keeps the recent limit on each filtered pass.
- Unfiltered recent syncs still use the direct recent-limited stream.

## Tests
- `cargo check`
- `cargo test recent_scope -- --test-threads=1`
- `cargo test config::tests::test_build_recent -- --test-threads=1`
- `cargo test download::tests::full_sync_recent -- --test-threads=1`
- `cargo test download::tests::full_sync_deferred_unfiled_waits_when_album_enumeration_errors -- --test-threads=1`
- `cargo test hash_download_config -- --test-threads=1`
- `cargo test config::tests::test_to_toml_persists_filter_recent_and_dates_from_toml -- --test-threads=1`
- `cargo test --test behavioral config_show_round_trips_persistent_recent_and_dates -- --test-threads=1`
- `cargo run -- sync --help | rg -n -C 2 -- "--recent|recent-scope"`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `just gate`
