### PR TITLE
Apply album relation deltas during incremental sync

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -4591,6 +4591,9 @@ mod tests {
             record_type: Some("CPLAsset".into()),
             reason: ChangeReason::Created,
             asset: Some(modified_asset),
+            album: None,
+            relation: None,
+            token_unsafe_reason: None,
         };
 
         // Simulate the incremental filtering: Created reason + asset present

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -374,7 +374,7 @@ const PAGINATION_SHORTFALL_TOLERANCE_ABSOLUTE: u64 = 100;
 const ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON: &str = "album_relation_hydration_incomplete";
 const DATE_BOUNDED_FULL_ENUMERATION_REASON: &str = "date_bounded_full_enumeration";
 const RECENT_LIMITED_FULL_ENUMERATION_REASON: &str = "recent_limited_full_enumeration";
-const UNPARSEABLE_RELATION_DELTA_REASON: &str = "unparseable_relation_delta";
+const UNPARSABLE_RELATION_DELTA_REASON: &str = "unparsable_relation_delta";
 const UNKNOWN_ALBUM_RELATION_CONTAINER_REASON: &str = "unknown_album_relation_container";
 const ALBUM_DELTA_STATE_WRITE_FAILED_REASON: &str = "album_delta_state_write_failed";
 
@@ -389,7 +389,7 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
         | "icloud_blank_sync_token"
         | "icloud_sync_token_mismatch"
         | "icloud_sync_token_missing"
-        | UNPARSEABLE_RELATION_DELTA_REASON
+        | UNPARSABLE_RELATION_DELTA_REASON
         | UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => "icloud",
         _ => "unknown",
     }
@@ -419,7 +419,7 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON => {
             "album membership state is not complete enough for incremental routing yet"
         }
-        UNPARSEABLE_RELATION_DELTA_REASON => {
+        UNPARSABLE_RELATION_DELTA_REASON => {
             "iCloud returned an album relation delta kei could not parse safely"
         }
         UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => {
@@ -4044,7 +4044,7 @@ mod tests {
         })
     }
 
-    fn unparseable_relation_delete_record() -> Value {
+    fn unparsable_relation_delete_record() -> Value {
         json!({
             "recordName": "not-a-relation-delta",
             "recordType": "CPLContainerRelation",
@@ -5806,11 +5806,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unparseable_relation_delete_blocks_incremental_token() {
+    async fn unparsable_relation_delete_blocks_incremental_token() {
         let calls = Arc::new(AtomicUsize::new(0));
         let session = changes_zone_session(
             Arc::clone(&calls),
-            vec![unparseable_relation_delete_record()],
+            vec![unparsable_relation_delete_record()],
         );
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
@@ -5828,14 +5828,14 @@ mod tests {
             CancellationToken::new(),
         )
         .await
-        .expect("unparseable relation delete should not fall back to full here");
+        .expect("unparsable relation delete should not fall back to full here");
 
         assert!(matches!(result.outcome, DownloadOutcome::Success));
         assert_eq!(result.sync_token, None);
         assert!(result.stats.sync_token_blocked);
         assert_eq!(
             result.stats.sync_token_blocked_reason,
-            Some(UNPARSEABLE_RELATION_DELTA_REASON)
+            Some(UNPARSABLE_RELATION_DELTA_REASON)
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -374,17 +374,23 @@ const PAGINATION_SHORTFALL_TOLERANCE_ABSOLUTE: u64 = 100;
 const ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON: &str = "album_relation_hydration_incomplete";
 const DATE_BOUNDED_FULL_ENUMERATION_REASON: &str = "date_bounded_full_enumeration";
 const RECENT_LIMITED_FULL_ENUMERATION_REASON: &str = "recent_limited_full_enumeration";
+const UNPARSEABLE_RELATION_DELTA_REASON: &str = "unparseable_relation_delta";
+const UNKNOWN_ALBUM_RELATION_CONTAINER_REASON: &str = "unknown_album_relation_container";
+const ALBUM_DELTA_STATE_WRITE_FAILED_REASON: &str = "album_delta_state_write_failed";
 
 pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
     match reason {
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON
+        | ALBUM_DELTA_STATE_WRITE_FAILED_REASON
         | DATE_BOUNDED_FULL_ENUMERATION_REASON
         | "kei_internal_token_receiver_dropped"
         | RECENT_LIMITED_FULL_ENUMERATION_REASON => "kei",
         "pagination_shortfall"
         | "icloud_blank_sync_token"
         | "icloud_sync_token_mismatch"
-        | "icloud_sync_token_missing" => "icloud",
+        | "icloud_sync_token_missing"
+        | UNPARSEABLE_RELATION_DELTA_REASON
+        | UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => "icloud",
         _ => "unknown",
     }
 }
@@ -413,6 +419,13 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON => {
             "album membership state is not complete enough for incremental routing yet"
         }
+        UNPARSEABLE_RELATION_DELTA_REASON => {
+            "iCloud returned an album relation delta kei could not parse safely"
+        }
+        UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => {
+            "an album relation referenced a container kei has not mapped yet"
+        }
+        ALBUM_DELTA_STATE_WRITE_FAILED_REASON => "kei could not persist album delta state safely",
         "sync_token_unavailable" | "sync_token_missing" => {
             "no usable sync token was available at the end of the cycle"
         }
@@ -2353,6 +2366,15 @@ fn set_full_enumeration_reason(result: &mut SyncResult, reason: FullEnumerationR
     }
 }
 
+fn block_sync_token_for_incremental_delta(stats: &mut SyncStats, reason: &'static str) {
+    if stats.sync_token_blocked_reason.is_none() {
+        stats.sync_token_blocked_reason = Some(reason);
+        stats.sync_token_blocked_source = Some(sync_token_blocked_source(reason));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(reason));
+    }
+    stats.sync_token_blocked = true;
+}
+
 async fn download_photos_full_with_reason(
     download_client: &Client,
     passes: &[crate::commands::AlbumPass],
@@ -3303,6 +3325,7 @@ async fn download_photos_incremental(
     // that prevents assets already in some user album from downloading
     // twice) can be applied downstream.
     let mut downloadable_assets: Vec<(PhotoAsset, usize)> = Vec::new();
+    let mut change_events = Vec::new();
     let mut sync_token: Option<String> = None;
     let mut created_count = 0u64;
     let mut soft_deleted_count = 0u64;
@@ -3324,73 +3347,211 @@ async fn download_photos_incremental(
             }
             let event = result?;
             total_events += 1;
-            match event.reason {
-                ChangeReason::Created => {
-                    created_count += 1;
-                    if let Some(asset) = event.asset {
-                        for pass_index in 0..passes.len() {
-                            downloadable_assets.push((asset.clone(), pass_index));
-                        }
-                    }
-                }
-                ChangeReason::SoftDeleted => {
-                    soft_deleted_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping soft-deleted record");
-                    if let Some(db) = &config.state_db {
-                        let deleted_at = event.asset.as_ref().and_then(|a| a.metadata().deleted_at);
-                        if let Err(e) = db
-                            .mark_soft_deleted(&config.library, &event.record_name, deleted_at)
-                            .await
-                        {
-                            tracing::warn!(
-                                record_name = %event.record_name,
-                                error = %e,
-                                "Failed to record soft-delete in state DB"
-                            );
-                        }
-                    }
-                }
-                ChangeReason::HardDeleted => {
-                    hard_deleted_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hard-deleted record");
-                    // CloudKit returns no fields for hard-deleted records, so we
-                    // can't tell master from asset. Treat as soft-delete in DB
-                    // (sets is_deleted=1) — the row stays put so history and
-                    // local_path remain queryable.
-                    if let Some(db) = &config.state_db {
-                        if let Err(e) = db
-                            .mark_soft_deleted(&config.library, &event.record_name, None)
-                            .await
-                        {
-                            tracing::warn!(
-                                record_name = %event.record_name,
-                                error = %e,
-                                "Failed to record hard-delete in state DB"
-                            );
-                        }
-                    }
-                }
-                ChangeReason::Hidden => {
-                    hidden_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hidden record");
-                    if let Some(db) = &config.state_db {
-                        if let Err(e) = db
-                            .mark_hidden_at_source(&config.library, &event.record_name)
-                            .await
-                        {
-                            tracing::warn!(
-                                record_name = %event.record_name,
-                                error = %e,
-                                "Failed to record hidden state in state DB"
-                            );
-                        }
-                    }
-                }
-            }
+            change_events.push(event);
         }
 
         if let Ok(token) = token_rx.await {
             sync_token = Some(token);
+        }
+    }
+
+    let mut token_unsafe_reason: Option<&'static str> = None;
+    let mut asset_to_master: FxHashMap<&str, &str> = FxHashMap::default();
+    for event in &change_events {
+        if let Some(asset) = &event.asset {
+            asset_to_master.insert(asset.asset_record_name(), asset.id());
+        }
+    }
+    let planned_album_containers: FxHashMap<&str, &str> = passes
+        .iter()
+        .filter(|pass| pass.kind == crate::commands::PassKind::Album)
+        .filter_map(|pass| {
+            pass.album
+                .container_id()
+                .map(|container_id| (container_id, pass.album.name.as_ref()))
+        })
+        .collect();
+    let mut ensured_planned_containers: FxHashSet<&str> = FxHashSet::default();
+
+    if let Some(db) = &config.state_db {
+        for event in &change_events {
+            let Some(album) = &event.album else {
+                continue;
+            };
+            let result = if album.is_deleted {
+                if let Err(e) = db
+                    .mark_album_container_deleted(&config.library, &album.container_id)
+                    .await
+                {
+                    Err(e)
+                } else {
+                    db.invalidate_album_membership_snapshot(&config.library, &album.container_id)
+                        .await
+                }
+            } else {
+                db.upsert_album_container(
+                    &config.library,
+                    &album.container_id,
+                    &album.album_name,
+                    "album",
+                )
+                .await
+            };
+            if let Err(e) = result {
+                tracing::warn!(
+                    container_id = %album.container_id,
+                    error = %e,
+                    "Failed to apply album container delta"
+                );
+                token_unsafe_reason.get_or_insert(ALBUM_DELTA_STATE_WRITE_FAILED_REASON);
+            }
+        }
+
+        for event in &change_events {
+            let Some(relation) = &event.relation else {
+                continue;
+            };
+            if let Some(album_name) = planned_album_containers.get(relation.container_id.as_ref()) {
+                let container_id = relation.container_id.as_ref();
+                if !ensured_planned_containers.contains(container_id) {
+                    match db
+                        .upsert_album_container(
+                            &config.library,
+                            &relation.container_id,
+                            album_name,
+                            "album",
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            ensured_planned_containers.insert(container_id);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                container_id = %relation.container_id,
+                                error = %e,
+                                "Failed to upsert planned album container for relation delta"
+                            );
+                            token_unsafe_reason
+                                .get_or_insert(ALBUM_DELTA_STATE_WRITE_FAILED_REASON);
+                        }
+                    }
+                }
+            }
+
+            let container_known = if relation.is_deleted {
+                db.mark_album_membership_deleted(
+                    &config.library,
+                    &relation.container_id,
+                    &relation.asset_record_name,
+                )
+                .await
+            } else {
+                db.upsert_album_membership_delta(
+                    &config.library,
+                    &relation.container_id,
+                    &relation.asset_record_name,
+                    asset_to_master
+                        .get(relation.asset_record_name.as_ref())
+                        .copied(),
+                    "icloud",
+                )
+                .await
+            };
+
+            match container_known {
+                Ok(true) => {}
+                Ok(false) => {
+                    tracing::warn!(
+                        container_id = %relation.container_id,
+                        asset_record_name = %relation.asset_record_name,
+                        "Album relation delta referenced an unknown album container"
+                    );
+                    token_unsafe_reason.get_or_insert(UNKNOWN_ALBUM_RELATION_CONTAINER_REASON);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        container_id = %relation.container_id,
+                        asset_record_name = %relation.asset_record_name,
+                        error = %e,
+                        "Failed to apply album relation delta"
+                    );
+                    token_unsafe_reason.get_or_insert(ALBUM_DELTA_STATE_WRITE_FAILED_REASON);
+                }
+            }
+        }
+    }
+
+    for event in &change_events {
+        if let Some(reason) = event.token_unsafe_reason {
+            token_unsafe_reason.get_or_insert(reason);
+        }
+        if event.album.is_some() || event.relation.is_some() || event.token_unsafe_reason.is_some()
+        {
+            continue;
+        }
+        match event.reason {
+            ChangeReason::Created => {
+                created_count += 1;
+                if let Some(asset) = &event.asset {
+                    for pass_index in 0..passes.len() {
+                        downloadable_assets.push((asset.clone(), pass_index));
+                    }
+                }
+            }
+            ChangeReason::SoftDeleted => {
+                soft_deleted_count += 1;
+                tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping soft-deleted record");
+                if let Some(db) = &config.state_db {
+                    let deleted_at = event.asset.as_ref().and_then(|a| a.metadata().deleted_at);
+                    if let Err(e) = db
+                        .mark_soft_deleted(&config.library, &event.record_name, deleted_at)
+                        .await
+                    {
+                        tracing::warn!(
+                            record_name = %event.record_name,
+                            error = %e,
+                            "Failed to record soft-delete in state DB"
+                        );
+                    }
+                }
+            }
+            ChangeReason::HardDeleted => {
+                hard_deleted_count += 1;
+                tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hard-deleted record");
+                // CloudKit returns no fields for hard-deleted photo records, so we
+                // can't tell master from asset. Treat as soft-delete in DB
+                // (sets is_deleted=1) - the row stays put so history and
+                // local_path remain queryable.
+                if let Some(db) = &config.state_db {
+                    if let Err(e) = db
+                        .mark_soft_deleted(&config.library, &event.record_name, None)
+                        .await
+                    {
+                        tracing::warn!(
+                            record_name = %event.record_name,
+                            error = %e,
+                            "Failed to record hard-delete in state DB"
+                        );
+                    }
+                }
+            }
+            ChangeReason::Hidden => {
+                hidden_count += 1;
+                tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hidden record");
+                if let Some(db) = &config.state_db {
+                    if let Err(e) = db
+                        .mark_hidden_at_source(&config.library, &event.record_name)
+                        .await
+                    {
+                        tracing::warn!(
+                            record_name = %event.record_name,
+                            error = %e,
+                            "Failed to record hidden state in state DB"
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -3403,16 +3564,19 @@ async fn download_photos_incremental(
     );
 
     if downloadable_assets.is_empty() {
-        let stats = SyncStats {
+        let mut stats = SyncStats {
             elapsed_secs: started.elapsed().as_secs_f64(),
             interrupted: shutdown_token.is_cancelled(),
             ..SyncStats::default()
         };
+        if let Some(reason) = token_unsafe_reason {
+            block_sync_token_for_incremental_delta(&mut stats, reason);
+        }
         tracing::info!("No new photos to download from incremental sync");
         tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
         return Ok(SyncResult {
             outcome: DownloadOutcome::Success,
-            sync_token,
+            sync_token: (!stats.sync_token_blocked).then_some(sync_token).flatten(),
             stats,
             full_enumeration_ran: false,
         });
@@ -3519,13 +3683,16 @@ async fn download_photos_incremental(
     }
 
     if tasks.is_empty() {
-        let stats = SyncStats {
+        let mut stats = SyncStats {
             skipped: skip_breakdown,
             enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
             interrupted: shutdown_token.is_cancelled(),
             ..SyncStats::default()
         };
+        if let Some(reason) = token_unsafe_reason {
+            block_sync_token_for_incremental_delta(&mut stats, reason);
+        }
         tracing::info!("All incremental assets already downloaded or filtered");
         tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
         let outcome = if enumeration_errors > 0 {
@@ -3537,7 +3704,9 @@ async fn download_photos_incremental(
         };
         return Ok(SyncResult {
             outcome,
-            sync_token: (enumeration_errors == 0).then_some(sync_token).flatten(),
+            sync_token: (enumeration_errors == 0 && !stats.sync_token_blocked)
+                .then_some(sync_token)
+                .flatten(),
             stats,
             full_enumeration_ran: false,
         });
@@ -3551,12 +3720,15 @@ async fn download_photos_incremental(
         for task in &tasks {
             println!("{}", task.download_path.display());
         }
-        let stats = SyncStats {
+        let mut stats = SyncStats {
             skipped: skip_breakdown,
             enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
             ..SyncStats::default()
         };
+        if let Some(reason) = token_unsafe_reason {
+            block_sync_token_for_incremental_delta(&mut stats, reason);
+        }
         // Don't advance the sync token — this is a read-only operation.
         return Ok(SyncResult {
             outcome: if enumeration_errors > 0 {
@@ -3604,7 +3776,7 @@ async fn download_photos_incremental(
         }
     }
 
-    let stats = SyncStats {
+    let mut stats = SyncStats {
         assets_seen: 0, // incremental doesn't have total library count
         downloaded: succeeded,
         failed,
@@ -3628,6 +3800,9 @@ async fn download_photos_incremental(
         recap: pass_result.recap.clone(),
         ..SyncStats::default()
     };
+    if let Some(reason) = token_unsafe_reason {
+        block_sync_token_for_incremental_delta(&mut stats, reason);
+    }
     log_sync_summary(
         "\u{2500}\u{2500} Incremental Sync Summary \u{2500}\u{2500}",
         &stats,
@@ -3638,7 +3813,7 @@ async fn download_photos_incremental(
             outcome: DownloadOutcome::SessionExpired {
                 auth_error_count: pass_result.auth_errors,
             },
-            sync_token,
+            sync_token: (!stats.sync_token_blocked).then_some(sync_token).flatten(),
             stats,
             full_enumeration_ran: false,
         });
@@ -3661,7 +3836,9 @@ async fn download_photos_incremental(
 
     Ok(SyncResult {
         outcome,
-        sync_token: (enumeration_errors == 0).then_some(sync_token).flatten(),
+        sync_token: (enumeration_errors == 0 && !stats.sync_token_blocked)
+            .then_some(sync_token)
+            .flatten(),
         stats,
         full_enumeration_ran: false,
     })
@@ -3836,6 +4013,43 @@ mod tests {
                 }
             }),
         ]
+    }
+
+    fn album_delta_record(container_id: &str, album_name: &str) -> Value {
+        json!({
+            "recordName": container_id,
+            "recordType": "CPLAlbum",
+            "fields": {
+                "albumName": {"value": album_name}
+            }
+        })
+    }
+
+    fn relation_delta_record(container_id: &str, asset_record_name: &str) -> Value {
+        json!({
+            "recordName": format!("{asset_record_name}-IN-{container_id}"),
+            "recordType": "CPLContainerRelation",
+            "fields": {
+                "containerId": {"value": container_id},
+                "itemId": {"value": asset_record_name}
+            }
+        })
+    }
+
+    fn relation_delete_record(container_id: &str, asset_record_name: &str) -> Value {
+        json!({
+            "recordName": format!("{asset_record_name}-IN-{container_id}"),
+            "recordType": "CPLContainerRelation",
+            "deleted": true
+        })
+    }
+
+    fn unparseable_relation_delete_record() -> Value {
+        json!({
+            "recordName": "not-a-relation-delta",
+            "recordType": "CPLContainerRelation",
+            "deleted": true
+        })
     }
 
     #[derive(Clone)]
@@ -5495,6 +5709,133 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "changes/zone is zone-scoped; querying once per pass repeats the same delta"
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_relation_add_writes_membership_after_album_delta() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            vec![
+                relation_delta_record("container-a", "asset-record-a"),
+                album_delta_record("container-a", "Vacation"),
+            ],
+        );
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(db.clone());
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::Download, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("incremental relation delta should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        let memberships = db
+            .get_live_album_memberships_for_asset("PrimarySync", "asset-record-a")
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(memberships[0].container_id, "container-a");
+    }
+
+    #[tokio::test]
+    async fn incremental_relation_delete_marks_membership_deleted() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        db.upsert_album_container("PrimarySync", "container-a", "Vacation", "album")
+            .await
+            .unwrap();
+        db.upsert_album_membership_delta(
+            "PrimarySync",
+            "container-a",
+            "asset-record-a",
+            Some("master-a"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            vec![relation_delete_record("container-a", "asset-record-a")],
+        );
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: album_with_session_and_container(
+                "PrimarySync",
+                "Vacation",
+                Some("container-a"),
+                Box::new(session),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(db.clone());
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::Download, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("incremental relation delete should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        let memberships = db
+            .get_live_album_memberships_for_asset("PrimarySync", "asset-record-a")
+            .await
+            .unwrap();
+        assert!(memberships.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unparseable_relation_delete_blocks_incremental_token() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            vec![unparseable_relation_delete_record()],
+        );
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let config = Arc::new(test_config());
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &config,
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::Download, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("unparseable relation delete should not fall back to full here");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token, None);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(UNPARSEABLE_RELATION_DELTA_REASON)
         );
     }
 

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -675,7 +675,7 @@ fn parse_relation_delta(record: &Record, reason: ChangeReason) -> ChangeEvent {
                 Some("CPLContainerRelation".into()),
                 reason,
             );
-            event.token_unsafe_reason = Some("unparseable_relation_delta");
+            event.token_unsafe_reason = Some("unparsable_relation_delta");
             event
         }
     }
@@ -1567,7 +1567,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_unparseable_hard_deleted_relation_is_token_unsafe() {
+    fn test_buffer_unparsable_hard_deleted_relation_is_token_unsafe() {
         let mut buffer = DeltaRecordBuffer::new();
         let relation_delete = Record {
             record_name: "not-a-relation-name".to_string(),
@@ -1581,7 +1581,7 @@ mod tests {
         assert_eq!(events[0].relation, None);
         assert_eq!(
             events[0].token_unsafe_reason,
-            Some("unparseable_relation_delta")
+            Some("unparsable_relation_delta")
         );
     }
 

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -42,6 +42,43 @@ pub struct ChangeEvent {
     /// The photo asset, if this is a CPLMaster+CPLAsset pair that was successfully paired.
     /// None for hard-deletes, non-photo record types, or unpaired records.
     pub asset: Option<PhotoAsset>,
+    /// Album container metadata delta from `/changes/zone`.
+    pub album: Option<AlbumContainerDelta>,
+    /// Album relation delta from `/changes/zone`.
+    pub relation: Option<AlbumRelationDelta>,
+    /// A delta record that was understood well enough to make the cycle
+    /// token-unsafe, but not well enough to apply safely.
+    pub token_unsafe_reason: Option<&'static str>,
+}
+
+impl ChangeEvent {
+    fn new(record_name: Box<str>, record_type: Option<Box<str>>, reason: ChangeReason) -> Self {
+        Self {
+            record_name,
+            record_type,
+            reason,
+            asset: None,
+            album: None,
+            relation: None,
+            token_unsafe_reason: None,
+        }
+    }
+}
+
+/// Album container metadata carried by `CPLAlbum` change records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlbumContainerDelta {
+    pub container_id: Box<str>,
+    pub album_name: Box<str>,
+    pub is_deleted: bool,
+}
+
+/// Album membership relation carried by `CPLContainerRelation` change records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlbumRelationDelta {
+    pub container_id: Box<str>,
+    pub asset_record_name: Box<str>,
+    pub is_deleted: bool,
 }
 
 /// A photo or video asset from iCloud.
@@ -570,6 +607,80 @@ fn extract_master_ref(fields: &Value) -> Option<String> {
         .map(std::string::ToString::to_string)
 }
 
+fn field_value_str<'a>(fields: &'a Value, name: &str) -> Option<&'a str> {
+    fields
+        .get(name)
+        .and_then(|field| field.get("value"))
+        .and_then(Value::as_str)
+}
+
+fn parse_album_delta(record: &Record, reason: ChangeReason) -> ChangeEvent {
+    let is_deleted = matches!(
+        reason,
+        ChangeReason::HardDeleted | ChangeReason::SoftDeleted
+    );
+    let album_name = enc::decode_string(&record.fields, "albumNameEnc")
+        .or_else(|| field_value_str(&record.fields, "albumName").map(ToOwned::to_owned))
+        .unwrap_or_else(|| record.record_name.clone());
+    let mut event = ChangeEvent::new(
+        record.record_name.clone().into_boxed_str(),
+        Some(record.record_type.clone().into_boxed_str()),
+        reason,
+    );
+    event.album = Some(AlbumContainerDelta {
+        container_id: record.record_name.clone().into_boxed_str(),
+        album_name: crate::download::paths::sanitize_path_component(&album_name).into_boxed_str(),
+        is_deleted,
+    });
+    event
+}
+
+fn parse_relation_record_name(record_name: &str) -> Option<(&str, &str)> {
+    record_name
+        .rsplit_once("-IN-")
+        .filter(|(asset, container)| !asset.is_empty() && !container.is_empty())
+}
+
+fn parse_relation_delta(record: &Record, reason: ChangeReason) -> ChangeEvent {
+    let is_deleted = matches!(
+        reason,
+        ChangeReason::HardDeleted | ChangeReason::SoftDeleted
+    );
+    let parsed = if is_deleted {
+        parse_relation_record_name(&record.record_name)
+            .map(|(asset, container)| (container.to_owned(), asset.to_owned()))
+    } else {
+        field_value_str(&record.fields, "containerId")
+            .zip(field_value_str(&record.fields, "itemId"))
+            .map(|(container, item)| (container.to_owned(), item.to_owned()))
+    };
+
+    match parsed {
+        Some((container_id, asset_record_name)) => {
+            let mut event = ChangeEvent::new(
+                record.record_name.clone().into_boxed_str(),
+                Some("CPLContainerRelation".into()),
+                reason,
+            );
+            event.relation = Some(AlbumRelationDelta {
+                container_id: container_id.into_boxed_str(),
+                asset_record_name: asset_record_name.into_boxed_str(),
+                is_deleted,
+            });
+            event
+        }
+        None => {
+            let mut event = ChangeEvent::new(
+                record.record_name.clone().into_boxed_str(),
+                Some("CPLContainerRelation".into()),
+                reason,
+            );
+            event.token_unsafe_reason = Some("unparseable_relation_delta");
+            event
+        }
+    }
+}
+
 /// Buffers `CPLMaster` and `CPLAsset` records from `changes/zone` responses
 /// and pairs them into `ChangeEvent`s when both halves are available.
 ///
@@ -599,14 +710,25 @@ impl DeltaRecordBuffer {
 
             match reason {
                 ChangeReason::HardDeleted => {
+                    if record.record_type == "CPLContainerRelation" {
+                        events.push(parse_relation_delta(&record, reason));
+                        continue;
+                    }
+                    if record.record_type == "CPLAlbum" {
+                        events.push(parse_album_delta(&record, reason));
+                        continue;
+                    }
+                    if parse_relation_record_name(&record.record_name).is_some() {
+                        events.push(parse_relation_delta(&record, reason));
+                        continue;
+                    }
                     // Hard-deleted: no fields, can't tell if master or asset.
                     // Emit immediately as-is.
-                    events.push(ChangeEvent {
-                        record_name: record.record_name.into_boxed_str(),
-                        record_type: None,
+                    events.push(ChangeEvent::new(
+                        record.record_name.into_boxed_str(),
+                        None,
                         reason,
-                        asset: None,
-                    });
+                    ));
                 }
                 _ => match record.record_type.as_str() {
                     "CPLMaster" => {
@@ -631,13 +753,18 @@ impl DeltaRecordBuffer {
                             }
                         } else {
                             // CPLAsset with no masterRef -- metadata-only change
-                            events.push(ChangeEvent {
-                                record_name: record.record_name.into_boxed_str(),
-                                record_type: Some("CPLAsset".into()),
+                            events.push(ChangeEvent::new(
+                                record.record_name.into_boxed_str(),
+                                Some("CPLAsset".into()),
                                 reason,
-                                asset: None,
-                            });
+                            ));
                         }
+                    }
+                    "CPLAlbum" => {
+                        events.push(parse_album_delta(&record, reason));
+                    }
+                    "CPLContainerRelation" => {
+                        events.push(parse_relation_delta(&record, reason));
                     }
                     _ => {
                         // Non-photo record types (CPLAlbum, CPLContainerRelation, etc.)
@@ -657,22 +784,20 @@ impl DeltaRecordBuffer {
 
         for (name, record) in self.pending_masters.drain() {
             let reason = classify_change_reason(&record);
-            events.push(ChangeEvent {
-                record_name: name.into_boxed_str(),
-                record_type: Some("CPLMaster".into()),
+            events.push(ChangeEvent::new(
+                name.into_boxed_str(),
+                Some("CPLMaster".into()),
                 reason,
-                asset: None,
-            });
+            ));
         }
 
         for (_master_ref, record) in self.pending_assets.drain() {
             let reason = classify_change_reason(&record);
-            events.push(ChangeEvent {
-                record_name: record.record_name.into_boxed_str(),
-                record_type: Some("CPLAsset".into()),
+            events.push(ChangeEvent::new(
+                record.record_name.into_boxed_str(),
+                Some("CPLAsset".into()),
                 reason,
-                asset: None,
-            });
+            ));
         }
 
         events
@@ -710,12 +835,9 @@ impl DeltaRecordBuffer {
         // capacity slack that .clone().into_boxed_str() would drag along.
         let master_name: Box<str> = Box::from(master_record.record_name.as_str());
         let asset = PhotoAsset::from_records(master_record, &asset_record);
-        events.push(ChangeEvent {
-            record_name: master_name,
-            record_type: Some("CPLMaster".into()),
-            reason,
-            asset: Some(asset),
-        });
+        let mut event = ChangeEvent::new(master_name, Some("CPLMaster".into()), reason);
+        event.asset = Some(asset);
+        events.push(event);
     }
 }
 
@@ -1372,7 +1494,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_non_photo_records_skipped() {
+    fn test_buffer_emits_photo_album_and_relation_records() {
         let mut buffer = DeltaRecordBuffer::new();
 
         let album_record = Record {
@@ -1381,19 +1503,86 @@ mod tests {
             fields: json!({"albumName": {"value": "Vacation"}}),
             deleted: None,
         };
-        let container_record = Record {
-            record_name: "CR_1".to_string(),
+        let relation_record = Record {
+            record_name: "ASSET_1-IN-ALBUM_1".to_string(),
             record_type: "CPLContainerRelation".to_string(),
-            fields: json!({}),
+            fields: json!({
+                "containerId": {"value": "ALBUM_1"},
+                "itemId": {"value": "ASSET_1"}
+            }),
             deleted: None,
         };
 
-        let events = buffer.process_records(vec![album_record, container_record]);
-        assert!(events.is_empty(), "non-photo records should be skipped");
+        let events = buffer.process_records(vec![
+            make_master_record("M1"),
+            make_asset_record("A1", "M1"),
+            album_record,
+            relation_record,
+        ]);
+        assert_eq!(events.len(), 3);
+        assert!(events[0].asset.is_some());
+        assert_eq!(
+            events[1].album,
+            Some(AlbumContainerDelta {
+                container_id: "ALBUM_1".into(),
+                album_name: "Vacation".into(),
+                is_deleted: false,
+            })
+        );
+        assert_eq!(
+            events[2].relation,
+            Some(AlbumRelationDelta {
+                container_id: "ALBUM_1".into(),
+                asset_record_name: "ASSET_1".into(),
+                is_deleted: false,
+            })
+        );
 
-        // Flush should also be empty since non-photo records are not buffered
+        // Flush should still be empty since album/relation records are not buffered.
         let flushed = buffer.flush();
         assert!(flushed.is_empty());
+    }
+
+    #[test]
+    fn test_buffer_hard_deleted_relation_parses_record_name() {
+        let mut buffer = DeltaRecordBuffer::new();
+        let relation_delete = Record {
+            record_name: "ASSET_1-IN-ALBUM_1".to_string(),
+            record_type: "CPLContainerRelation".to_string(),
+            fields: json!({}),
+            deleted: Some(true),
+        };
+
+        let events = buffer.process_records(vec![relation_delete]);
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].relation,
+            Some(AlbumRelationDelta {
+                container_id: "ALBUM_1".into(),
+                asset_record_name: "ASSET_1".into(),
+                is_deleted: true,
+            })
+        );
+        assert_eq!(events[0].token_unsafe_reason, None);
+    }
+
+    #[test]
+    fn test_buffer_unparseable_hard_deleted_relation_is_token_unsafe() {
+        let mut buffer = DeltaRecordBuffer::new();
+        let relation_delete = Record {
+            record_name: "not-a-relation-name".to_string(),
+            record_type: "CPLContainerRelation".to_string(),
+            fields: json!({}),
+            deleted: Some(true),
+        };
+
+        let events = buffer.process_records(vec![relation_delete]);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].relation, None);
+        assert_eq!(
+            events[0].token_unsafe_reason,
+            Some("unparseable_relation_delta")
+        );
     }
 
     #[test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, Transaction};
 
 use super::error::StateError;
 use super::schema;
@@ -28,6 +28,23 @@ fn unsupported_album_membership_api(operation: &'static str) -> StateError {
         operation,
         detail: "album membership snapshots are not implemented by this state store".into(),
     }
+}
+
+fn album_container_known_tx(
+    tx: &Transaction<'_>,
+    library: &str,
+    container_id: &str,
+    operation: &'static str,
+) -> Result<bool, StateError> {
+    tx.query_row(
+        "SELECT 1 FROM album_containers \
+         WHERE library = ?1 AND container_id = ?2",
+        rusqlite::params![library, container_id],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+    .map_err(|e| StateError::query(operation, e))
 }
 
 /// Snapshot of an already-imported asset, returned by
@@ -244,6 +261,38 @@ pub trait MembershipStore: Send + Sync {
     ) -> Result<(), StateError> {
         Err(unsupported_album_membership_api(
             "add_album_membership_to_snapshot",
+        ))
+    }
+
+    /// Add or refresh an album relation learned from `/changes/zone`.
+    ///
+    /// Returns whether the relation's album container was already known when
+    /// the row was applied.
+    async fn upsert_album_membership_delta(
+        &self,
+        _library: &str,
+        _container_id: &str,
+        _asset_record_name: &str,
+        _master_record_name: Option<&str>,
+        _source: &str,
+    ) -> Result<bool, StateError> {
+        Err(unsupported_album_membership_api(
+            "upsert_album_membership_delta",
+        ))
+    }
+
+    /// Mark an album relation deleted from `/changes/zone`.
+    ///
+    /// Returns whether the relation's album container was already known when
+    /// the tombstone was applied.
+    async fn mark_album_membership_deleted(
+        &self,
+        _library: &str,
+        _container_id: &str,
+        _asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        Err(unsupported_album_membership_api(
+            "mark_album_membership_deleted",
         ))
     }
     async fn complete_album_membership_snapshot(
@@ -682,6 +731,38 @@ pub trait StateDb: Send + Sync {
         ))
     }
 
+    /// Add or refresh an album relation learned from `/changes/zone`.
+    ///
+    /// Returns whether the relation's album container was already known when
+    /// the row was applied.
+    async fn upsert_album_membership_delta(
+        &self,
+        _library: &str,
+        _container_id: &str,
+        _asset_record_name: &str,
+        _master_record_name: Option<&str>,
+        _source: &str,
+    ) -> Result<bool, StateError> {
+        Err(unsupported_album_membership_api(
+            "upsert_album_membership_delta",
+        ))
+    }
+
+    /// Mark an album relation deleted from `/changes/zone`.
+    ///
+    /// Returns whether the relation's album container was already known when
+    /// the tombstone was applied.
+    async fn mark_album_membership_deleted(
+        &self,
+        _library: &str,
+        _container_id: &str,
+        _asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        Err(unsupported_album_membership_api(
+            "mark_album_membership_deleted",
+        ))
+    }
+
     /// Complete a membership snapshot and mark rows absent from it deleted.
     async fn complete_album_membership_snapshot(
         &self,
@@ -1096,6 +1177,40 @@ where
             asset_record_name,
             master_record_name,
             source,
+        )
+        .await
+    }
+
+    async fn upsert_album_membership_delta(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+        master_record_name: Option<&str>,
+        source: &str,
+    ) -> Result<bool, StateError> {
+        MembershipStore::upsert_album_membership_delta(
+            self,
+            library,
+            container_id,
+            asset_record_name,
+            master_record_name,
+            source,
+        )
+        .await
+    }
+
+    async fn mark_album_membership_deleted(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        MembershipStore::mark_album_membership_deleted(
+            self,
+            library,
+            container_id,
+            asset_record_name,
         )
         .await
     }
@@ -1530,6 +1645,34 @@ impl MembershipStore for dyn StateDb + '_ {
             source,
         )
         .await
+    }
+
+    async fn upsert_album_membership_delta(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+        master_record_name: Option<&str>,
+        source: &str,
+    ) -> Result<bool, StateError> {
+        StateDb::upsert_album_membership_delta(
+            self,
+            library,
+            container_id,
+            asset_record_name,
+            master_record_name,
+            source,
+        )
+        .await
+    }
+
+    async fn mark_album_membership_deleted(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        StateDb::mark_album_membership_deleted(self, library, container_id, asset_record_name).await
     }
 
     async fn complete_album_membership_snapshot(
@@ -3119,6 +3262,91 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn upsert_album_membership_delta(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+        master_record_name: Option<&str>,
+        source: &str,
+    ) -> Result<bool, StateError> {
+        let library = library.to_owned();
+        let container_id = container_id.to_owned();
+        let asset_record_name = asset_record_name.to_owned();
+        let master_record_name = master_record_name.map(ToOwned::to_owned);
+        let source = source.to_owned();
+        self.with_conn_mut("upsert_album_membership_delta", move |conn| {
+            let now = Utc::now().timestamp();
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("upsert_album_membership_delta::begin", e))?;
+            let container_known = album_container_known_tx(
+                &tx,
+                &library,
+                &container_id,
+                "upsert_album_membership_delta::container",
+            )?;
+            tx.execute(
+                "INSERT INTO asset_album_memberships \
+                    (library, asset_record_name, master_record_name, container_id, generation, \
+                     is_deleted, source, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, 0, 0, ?5, ?6) \
+                 ON CONFLICT(library, asset_record_name, container_id) DO UPDATE SET \
+                    master_record_name = COALESCE(excluded.master_record_name, asset_album_memberships.master_record_name), \
+                    is_deleted = 0, \
+                    source = excluded.source, \
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    &library,
+                    &asset_record_name,
+                    master_record_name.as_deref(),
+                    &container_id,
+                    &source,
+                    now
+                ],
+            )
+            .map_err(|e| StateError::query("upsert_album_membership_delta::upsert", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("upsert_album_membership_delta::commit", e))?;
+            Ok(container_known)
+        })
+        .await
+    }
+
+    pub(crate) async fn mark_album_membership_deleted(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        let library = library.to_owned();
+        let container_id = container_id.to_owned();
+        let asset_record_name = asset_record_name.to_owned();
+        self.with_conn_mut("mark_album_membership_deleted", move |conn| {
+            let now = Utc::now().timestamp();
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("mark_album_membership_deleted::begin", e))?;
+            let container_known = album_container_known_tx(
+                &tx,
+                &library,
+                &container_id,
+                "mark_album_membership_deleted::container",
+            )?;
+            tx.execute(
+                "UPDATE asset_album_memberships \
+                 SET is_deleted = 1, updated_at = ?1 \
+                 WHERE library = ?2 AND container_id = ?3 AND asset_record_name = ?4",
+                rusqlite::params![now, &library, &container_id, &asset_record_name],
+            )
+            .map_err(|e| StateError::query("mark_album_membership_deleted::update", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("mark_album_membership_deleted::commit", e))?;
+            Ok(container_known)
+        })
+        .await
+    }
+
     pub(crate) async fn complete_album_membership_snapshot(
         &self,
         library: &str,
@@ -3811,6 +4039,35 @@ impl MembershipStore for SqliteStateDb {
             source,
         )
         .await
+    }
+
+    async fn upsert_album_membership_delta(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+        master_record_name: Option<&str>,
+        source: &str,
+    ) -> Result<bool, StateError> {
+        SqliteStateDb::upsert_album_membership_delta(
+            self,
+            library,
+            container_id,
+            asset_record_name,
+            master_record_name,
+            source,
+        )
+        .await
+    }
+
+    async fn mark_album_membership_deleted(
+        &self,
+        library: &str,
+        container_id: &str,
+        asset_record_name: &str,
+    ) -> Result<bool, StateError> {
+        SqliteStateDb::mark_album_membership_deleted(self, library, container_id, asset_record_name)
+            .await
     }
 
     async fn complete_album_membership_snapshot(
@@ -7293,6 +7550,86 @@ mod tests {
         assert_eq!(
             shared[0].master_record_name.as_deref(),
             Some("master-shared")
+        );
+    }
+
+    #[tokio::test]
+    async fn album_relation_delta_add_and_delete_update_live_membership() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.upsert_album_container("PrimarySync", "container-a", "Vacation", "album")
+            .await
+            .unwrap();
+
+        let known = db
+            .upsert_album_membership_delta(
+                "PrimarySync",
+                "container-a",
+                "asset-record-a",
+                Some("master-a"),
+                "icloud",
+            )
+            .await
+            .unwrap();
+        assert!(known, "selected album container should be known");
+        let live = db
+            .get_live_album_memberships_for_asset("PrimarySync", "asset-record-a")
+            .await
+            .unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].master_record_name.as_deref(), Some("master-a"));
+
+        let known = db
+            .mark_album_membership_deleted("PrimarySync", "container-a", "asset-record-a")
+            .await
+            .unwrap();
+        assert!(known, "delete should still know the album container");
+        let live = db
+            .get_live_album_memberships_for_asset("PrimarySync", "asset-record-a")
+            .await
+            .unwrap();
+        assert!(live.is_empty(), "relation delete must hide live membership");
+    }
+
+    #[tokio::test]
+    async fn album_delta_delete_invalidates_snapshot() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.upsert_album_container("PrimarySync", "container-a", "Vacation", "album")
+            .await
+            .unwrap();
+        let generation = db
+            .start_album_membership_snapshot("PrimarySync", "container-a", None)
+            .await
+            .unwrap();
+        db.add_album_membership_to_snapshot(
+            "PrimarySync",
+            "container-a",
+            generation,
+            "asset-record-a",
+            Some("master-a"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        db.complete_album_membership_snapshot("PrimarySync", "container-a", generation)
+            .await
+            .unwrap();
+        assert!(db
+            .selected_album_containers_have_complete_snapshots("PrimarySync", &["container-a"])
+            .await
+            .unwrap());
+
+        db.mark_album_container_deleted("PrimarySync", "container-a")
+            .await
+            .unwrap();
+        db.invalidate_album_membership_snapshot("PrimarySync", "container-a")
+            .await
+            .unwrap();
+
+        assert!(
+            !db.selected_album_containers_have_complete_snapshots("PrimarySync", &["container-a"])
+                .await
+                .unwrap(),
+            "deleted album containers must not remain trusted"
         );
     }
 


### PR DESCRIPTION
## Summary
- Applies `CPLAlbum` and `CPLContainerRelation` records from incremental `changes/zone` responses.
- Records album membership adds and deletes in the state DB without waiting for a full album pass.
- Blocks sync-token advancement when an album relation delta is unknown, unparseable, or not safely persisted.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test test_buffer_ --lib`
- `cargo test incremental_relation --lib`
- `cargo test album_relation_delta --lib`
- `cargo test album_delta_delete_invalidates_snapshot --lib`
- `cargo test unparsable_relation_delete_blocks_incremental_token --lib`
- `cargo test --lib` - passed outside sandbox; sandbox run failed on localhost bind restrictions from wiremock and metrics tests.

