### PR TITLE
Force full sync on path config drift

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -91,6 +91,7 @@ pub enum FullEnumerationReason {
     PathTemplateRequiresFullEnumeration,
     AlbumRelationHydrationIncomplete,
     EnumConfigHashDrift,
+    DownloadConfigHashDrift,
     ExplicitRetryFailed,
     #[allow(
         dead_code,
@@ -110,6 +111,7 @@ impl FullEnumerationReason {
             Self::PathTemplateRequiresFullEnumeration => "path_template_requires_full_enumeration",
             Self::AlbumRelationHydrationIncomplete => ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON,
             Self::EnumConfigHashDrift => "enum_config_hash_drift",
+            Self::DownloadConfigHashDrift => "download_config_hash_drift",
             Self::ExplicitRetryFailed => "explicit_retry_failed",
             Self::TokenBlockedPreviously => "token_blocked_previously",
             Self::OtherStaticReason => "other_static_reason",
@@ -572,6 +574,7 @@ fn finalize_hash(hasher: sha2::Sha256) -> String {
 /// of trusting paths derived under older code.
 const PATH_DERIVATION_HASH_VERSION: u8 = 2;
 const ENUMERATION_SAFETY_HASH_VERSION: u8 = 2;
+pub(crate) const DOWNLOAD_CONFIG_HASH_KEY: &str = "config_hash";
 
 /// Fields shared between [`hash_download_config`] and [`compute_config_hash`]
 /// that affect path resolution and asset eligibility.

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1246,7 +1246,10 @@ where
     // under the new filter settings.
     if let Some(db) = &state_db {
         let config_hash = super::hash_download_config(config);
-        let stored_hash = db.get_metadata("config_hash").await.unwrap_or(None);
+        let stored_hash = db
+            .get_metadata(super::DOWNLOAD_CONFIG_HASH_KEY)
+            .await
+            .unwrap_or(None);
         if stored_hash.as_deref() != Some(&config_hash) {
             if stored_hash.is_some() {
                 tracing::info!("Download config changed since last sync, verifying all files");
@@ -1263,7 +1266,10 @@ where
                     _ => {}
                 }
             }
-            if let Err(e) = db.set_metadata("config_hash", &config_hash).await {
+            if let Err(e) = db
+                .set_metadata(super::DOWNLOAD_CONFIG_HASH_KEY, &config_hash)
+                .await
+            {
                 tracing::warn!(error = %e, "Failed to persist config_hash");
             }
         }

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -161,6 +161,25 @@ impl EnumConfigHashOutcome {
     }
 }
 
+/// State of the path-affecting download config hash before a cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DownloadConfigHashOutcome {
+    Unchanged,
+    Changed,
+    ReadFailed,
+    TokenPurgeFailed,
+}
+
+impl DownloadConfigHashOutcome {
+    const fn must_force_full_sync(self) -> bool {
+        !matches!(self, Self::Unchanged)
+    }
+
+    const fn token_purge_failed(self) -> bool {
+        matches!(self, Self::TokenPurgeFailed)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SyncModeDecision {
     pub(crate) mode: download::SyncMode,
@@ -214,6 +233,46 @@ where
     outcome
 }
 
+/// Check the path-affecting download config hash.
+///
+/// This hash does not prove CloudKit cursor safety. It proves local
+/// path/state trust: after a directory or filename-template change, an
+/// incremental `/changes/zone` cycle would only see new deltas and could miss
+/// already-known assets that must be written to the new local paths.
+pub(crate) async fn check_download_config_hash_for_cycle<D>(
+    db: &D,
+    current_hash: &str,
+) -> DownloadConfigHashOutcome
+where
+    D: state::SyncTokenStore + ?Sized,
+{
+    match db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY).await {
+        Ok(Some(stored)) if stored == current_hash => DownloadConfigHashOutcome::Unchanged,
+        Ok(None) => DownloadConfigHashOutcome::Unchanged,
+        Ok(Some(_stored)) => match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
+            Ok(n) if n > 0 => {
+                tracing::debug!(
+                    cleared = n,
+                    "Cleared sync tokens after download config hash drift"
+                );
+                DownloadConfigHashOutcome::Changed
+            }
+            Ok(_) => DownloadConfigHashOutcome::Changed,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to clear sync tokens after download config hash drift"
+                );
+                DownloadConfigHashOutcome::TokenPurgeFailed
+            }
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to read download config_hash");
+            DownloadConfigHashOutcome::ReadFailed
+        }
+    }
+}
+
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
 pub(crate) async fn run_cycle(
     library_states: &[&LibraryState],
@@ -245,6 +304,7 @@ pub(crate) async fn run_cycle(
     }
     let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
     let mut force_full_for_config_hash = false;
+    let mut force_full_for_download_config_hash = false;
 
     // Check if token-unsafe eligibility config changed since last sync. If
     // so, clear sync tokens and force full enumeration for this cycle -- the
@@ -272,6 +332,28 @@ pub(crate) async fn run_cycle(
         }
     }
 
+    // A path-affecting config drift does not make the CloudKit token itself
+    // unsafe, but it does make an incremental cycle insufficient: with no
+    // changed assets, `/changes/zone` would never re-plan already-known media
+    // into the new directory/template. Detect that before choosing
+    // incremental mode and force a full reconciliation for this cycle.
+    if !config.runtime.dry_run {
+        if let (Some(db), Some(first_library)) = (state_db, library_states.first()) {
+            let probe_config = build_download_config(
+                download::SyncMode::Full,
+                Arc::new(rustc_hash::FxHashSet::default()),
+                Arc::new(download::AssetGroupings::default()),
+                Arc::from(first_library.zone_name.as_str()),
+            );
+            let download_config_hash = download::hash_download_config(&probe_config);
+            let outcome = check_download_config_hash_for_cycle(db, &download_config_hash).await;
+            force_full_for_download_config_hash = outcome.must_force_full_sync();
+            if outcome.token_purge_failed() {
+                db_sync_token_advance_safe = false;
+            }
+        }
+    }
+
     for lib_state in library_states {
         if shutdown_token.is_cancelled() {
             break;
@@ -287,6 +369,17 @@ pub(crate) async fn run_cycle(
                 zone = %lib_state.zone_name,
                 full_enumeration_reason = reason.as_str(),
                 "Forcing full sync because config-hash validation invalidated stored sync tokens"
+            );
+            SyncModeDecision {
+                mode: download::SyncMode::Full,
+                full_enumeration_reason: Some(reason),
+            }
+        } else if force_full_for_download_config_hash {
+            let reason = download::FullEnumerationReason::DownloadConfigHashDrift;
+            tracing::debug!(
+                zone = %lib_state.zone_name,
+                full_enumeration_reason = reason.as_str(),
+                "Forcing full sync because download config hash drift requires local path reconciliation"
             );
             SyncModeDecision {
                 mode: download::SyncMode::Full,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -31,9 +31,9 @@ use crate::sync_cycle::{run_cycle, sync_token_key as make_sync_token_key, Librar
 
 #[cfg(test)]
 use crate::sync_cycle::{
-    check_and_persist_enum_config_hash, determine_sync_mode, should_store_sync_token,
-    should_store_sync_token_for_cycle, CycleResult, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY,
-    SYNC_TOKEN_PREFIX,
+    check_and_persist_enum_config_hash, check_download_config_hash_for_cycle, determine_sync_mode,
+    should_store_sync_token, should_store_sync_token_for_cycle, CycleResult,
+    DownloadConfigHashOutcome, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY, SYNC_TOKEN_PREFIX,
 };
 
 #[cfg(all(test, feature = "xmp"))]
@@ -4704,13 +4704,12 @@ mod tests {
             result.stats.full_enumeration_reason,
             Some(download::FullEnumerationReason::EnumConfigHashDrift)
         );
-        assert_eq!(
+        let observed_modes = observed_modes.lock().expect("recorded modes lock").clone();
+        assert!(
             observed_modes
-                .lock()
-                .expect("recorded modes lock")
-                .as_slice(),
-            &[download::SyncMode::Full],
-            "config drift must not trust a surviving old incremental token in this cycle"
+                .iter()
+                .all(|mode| matches!(mode, download::SyncMode::Full)),
+            "config drift must not trust a surviving old incremental token in this cycle: {observed_modes:?}"
         );
         assert!(
             !result.db_sync_token_advance_safe,
@@ -4733,6 +4732,78 @@ mod tests {
                 .as_deref(),
             Some("zone-tok-new"),
             "the forced full pass should still refresh the selected zone token after success"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_download_config_hash_drift_forces_full_reconciliation() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let old_download_dir = tempfile::tempdir().expect("old download tempdir");
+        let new_download_dir = tempfile::tempdir().expect("new download tempdir");
+
+        let old_build_download_config =
+            make_run_cycle_download_config_builder(old_download_dir.path(), Arc::clone(&db));
+        let old_download_config = old_build_download_config(
+            download::SyncMode::Full,
+            Arc::new(rustc_hash::FxHashSet::default()),
+            Arc::new(download::AssetGroupings::default()),
+            Arc::from("PrimarySync"),
+        );
+        let old_hash = download::hash_download_config(&old_download_config);
+        db.set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, &old_hash)
+            .await
+            .expect("seed old download hash");
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            &format!("{SYNC_TOKEN_PREFIX}PrimarySync"),
+            make_empty_full_album("zone-tok-new"),
+        );
+        let states = vec![&lib_state];
+        let observed_modes = Arc::new(std::sync::Mutex::new(Vec::<download::SyncMode>::new()));
+        let build_download_config = make_recording_run_cycle_download_config_builder(
+            new_download_dir.path(),
+            Arc::clone(&db),
+            Arc::clone(&observed_modes),
+        );
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::DownloadConfigHashDrift)
+        );
+        let observed_modes = observed_modes.lock().expect("recorded modes lock").clone();
+        assert!(
+            observed_modes
+                .iter()
+                .all(|mode| matches!(mode, download::SyncMode::Full)),
+            "path drift must not run an empty incremental pass against the old cursor: {observed_modes:?}"
+        );
+        assert_eq!(
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-new"),
+            "the forced full pass should refresh the selected zone token after success"
         );
     }
 
@@ -5366,6 +5437,35 @@ mod tests {
                 .unwrap()
                 .as_deref(),
             Some("tok-keep"),
+        );
+    }
+
+    #[tokio::test]
+    async fn download_config_hash_drift_clears_token() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, "old-download-hash")
+            .await
+            .expect("seed old path hash");
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "tok-keep")
+            .await
+            .expect("seed token");
+
+        let outcome = check_download_config_hash_for_cycle(&db, "current-download-hash").await;
+
+        assert_eq!(outcome, DownloadConfigHashOutcome::Changed);
+        assert_eq!(
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
+                .await
+                .unwrap(),
+            None,
+            "path hash drift cannot leave an old incremental cursor in place"
+        );
+        assert_eq!(
+            db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .unwrap(),
+            Some("old-download-hash".to_string()),
+            "the download pipeline owns persisting the path hash once reconciliation starts"
         );
     }
 


### PR DESCRIPTION
## Summary
- Force a full reconciliation when the path-affecting download config hash changes before an incremental sync.
- Clear stored zone tokens for that drift so already-known assets get planned into the new download directory or filename template.
- Add regression coverage for config-hash drift and report the full-enumeration reason as `download_config_hash_drift`.

## Tests
- `cargo check`
- `cargo test sync_loop::tests:: -- --test-threads=1`
- `cargo test download::tests:: -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `KEI_TEST_ALBUM=kei-test ICLOUD_TEST_COOKIE_DIR=/home/robhooper/git/kei/.test-cookies cargo test --test sync -- --ignored --test-threads=1`
- `just gate`
