### PR TITLE
Fix live import rehearsal album seeding

### DIFF
--- a/scripts/full-test/run_live_import_rehearsal.sh
+++ b/scripts/full-test/run_live_import_rehearsal.sh
@@ -70,16 +70,20 @@ run_and_show() {
   shift
   local out="$work/$name.out"
   local err="$work/$name.err"
+  set +e
   "$@" >"$out" 2>"$err"
+  local rc=$?
+  set -e
   echo "--- $name stderr tail ---"
   tail -30 "$err"
   echo "--- $name stdout tail ---"
   tail -30 "$out"
+  return "$rc"
 }
 
-echo "--- seed sync ($album, recent 10) ---"
+echo "--- seed sync ($album, recent 10 per filter) ---"
 run_and_show seed-sync \
-  "$binary" sync --recent 10 --no-progress-bar --config "$sync_config"
+  "$binary" sync --recent 10 --recent-scope per-filter --no-progress-bar --config "$sync_config"
 
 file_count=$(find "$photos" -type f | wc -l | tr -d ' ')
 echo "seed_files=$file_count"

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -138,3 +138,25 @@ fn live_import_smoke_uses_toml_directory() {
         "live smoke download scratch should follow full-test's TMPDIR"
     );
 }
+
+#[test]
+fn live_import_rehearsal_seeds_album_with_per_filter_recent_scope() {
+    let rehearsal = repo_file("scripts/full-test/run_live_import_rehearsal.sh");
+
+    assert!(
+        rehearsal.contains("sync --recent 10 --recent-scope per-filter --no-progress-bar"),
+        "live import rehearsal must seed from the selected album's recent window, not the global library frontier"
+    );
+    assert!(
+        rehearsal.contains("set +e\n  \"$@\" >\"$out\" 2>\"$err\"\n  local rc=$?\n  set -e"),
+        "live import rehearsal must print command tails before propagating a failed command"
+    );
+    assert!(
+        rehearsal.contains("import-existing --dry-run --recent 10 --force-empty --no-progress-bar"),
+        "live import rehearsal dry-run should keep import-existing bounded to the same recent count"
+    );
+    assert!(
+        rehearsal.contains("import-existing --recent 10 --force-empty --no-progress-bar"),
+        "live import rehearsal real import should keep import-existing bounded to the same recent count"
+    );
+}


### PR DESCRIPTION
## Summary
- Seed the live import rehearsal with `--recent-scope per-filter` so the selected test album contributes files even when the account-wide newest assets are elsewhere.
- Keep the rehearsal's captured stdout/stderr visible when a child command fails.
- Add branch static coverage for the rehearsal command shape.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test branch_static`
- `scripts/full-test/run_live_import_rehearsal.sh`
- `just gate`
