### PR TITLE
Add crash-safety regression tests for download finalization

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1497,8 +1497,9 @@ mod tests {
     use chrono::Utc;
     use rustc_hash::FxHashSet;
 
-    use crate::icloud::photos::PhotoAsset;
-    use crate::test_helpers::TestPhotoAsset;
+    use crate::icloud::photos::{PhotoAsset, PRIMARY_ZONE_NAME};
+    use crate::state::SqliteStateDb;
+    use crate::test_helpers::{TestAssetRecord, TestPhotoAsset};
     use crate::types::LivePhotoMode;
     use serde_json::json;
     use std::fs;
@@ -1517,6 +1518,52 @@ mod tests {
         let mut claimed_paths = FxHashMap::default();
         let mut dir_cache = paths::DirCache::new();
         filter_asset_to_tasks(asset, config, &mut claimed_paths, &mut dir_cache)
+    }
+
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_CHILD_ENV: &str = "KEI_POST_RENAME_PRE_STATE_SIGKILL_CHILD";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_DOWNLOAD_DIR_ENV: &str = "KEI_CRASH_HARNESS_DOWNLOAD_DIR";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_DB_ENV: &str = "KEI_CRASH_HARNESS_DB";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_PART_ENV: &str = "KEI_CRASH_HARNESS_PART";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_CHILD_TEST: &str =
+        "download::filter::tests::post_rename_pre_state_sigkill_child";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_ASSET_ID: &str = "ASSET_REAL_KILL";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_FILENAME: &str = "IMG_REAL_KILL.JPG";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_CHECKSUM: &str = "ck_real_kill";
+    #[cfg(unix)]
+    const POST_RENAME_PRE_STATE_PART_FILE: &str = "published-before-state.kei-tmp";
+
+    #[cfg(unix)]
+    fn post_rename_pre_state_crash_asset() -> PhotoAsset {
+        TestPhotoAsset::new(POST_RENAME_PRE_STATE_ASSET_ID)
+            .filename(POST_RENAME_PRE_STATE_FILENAME)
+            .orig_size(1000)
+            .orig_url("https://p01.icloud-content.com/real-kill")
+            .orig_checksum(POST_RENAME_PRE_STATE_CHECKSUM)
+            .build()
+    }
+
+    #[cfg(unix)]
+    fn post_rename_pre_state_config(download_dir: &std::path::Path) -> DownloadConfig {
+        let mut config = test_config();
+        config.directory = Arc::from(download_dir);
+        config
+    }
+
+    #[cfg(unix)]
+    fn post_rename_pre_state_final_path_for(download_dir: &std::path::Path) -> std::path::PathBuf {
+        let asset = post_rename_pre_state_crash_asset();
+        let config = post_rename_pre_state_config(download_dir);
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert_eq!(tasks.len(), 1);
+        tasks[0].download_path.clone()
     }
 
     fn plain_photo_asset() -> PhotoAsset {
@@ -5117,6 +5164,133 @@ mod tests {
              (file exists at {final_path:?} with matching size); \
              got tasks: {tasks_post:?}",
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_process_death_after_publish_before_mark_downloaded_recovers() {
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::Command;
+
+        let dir = TempDir::new().unwrap();
+        let download_dir = dir.path().join("download");
+        let db_path = dir.path().join("state.db");
+        let part_path = dir.path().join(POST_RENAME_PRE_STATE_PART_FILE);
+        let final_path = post_rename_pre_state_final_path_for(&download_dir);
+
+        let output = Command::new(std::env::current_exe().unwrap())
+            .arg("--ignored")
+            .arg("--exact")
+            .arg(POST_RENAME_PRE_STATE_CHILD_TEST)
+            .arg("--nocapture")
+            .env(POST_RENAME_PRE_STATE_CHILD_ENV, "1")
+            .env(POST_RENAME_PRE_STATE_DOWNLOAD_DIR_ENV, &download_dir)
+            .env(POST_RENAME_PRE_STATE_DB_ENV, &db_path)
+            .env(POST_RENAME_PRE_STATE_PART_ENV, &part_path)
+            .output()
+            .expect("spawn crash harness child");
+
+        assert_eq!(
+            output.status.signal(),
+            Some(libc::SIGKILL),
+            "child should die at the post-publish/pre-state-write kill point; \
+             status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            final_path.exists(),
+            "final media file must survive the killed child"
+        );
+        assert!(
+            !part_path.exists(),
+            "published temp file should be gone after final-file publish"
+        );
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let row = rt.block_on(async {
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            db.get_pending()
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|record| {
+                    &*record.library == PRIMARY_ZONE_NAME
+                        && &*record.id == POST_RENAME_PRE_STATE_ASSET_ID
+                        && record.version_size.as_str() == "original"
+                })
+                .expect("post-kill row should remain pending")
+        });
+        assert_eq!(
+            row.local_path, None,
+            "SIGKILL before mark_downloaded must not fabricate downloaded state"
+        );
+
+        let asset = post_rename_pre_state_crash_asset();
+        let config = post_rename_pre_state_config(&download_dir);
+        let tasks_post = filter_asset_fresh(&asset, &config);
+        assert!(
+            tasks_post.is_empty(),
+            "post-kill rerun must skip via on-disk detection even when the DB \
+             row is still pending; got tasks: {tasks_post:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "spawned by real_process_death_after_publish_before_mark_downloaded_recovers"]
+    fn post_rename_pre_state_sigkill_child() {
+        use std::path::PathBuf;
+
+        if std::env::var_os(POST_RENAME_PRE_STATE_CHILD_ENV).is_none() {
+            return;
+        }
+
+        let download_dir = PathBuf::from(
+            std::env::var_os(POST_RENAME_PRE_STATE_DOWNLOAD_DIR_ENV).expect("download dir env"),
+        );
+        let db_path =
+            PathBuf::from(std::env::var_os(POST_RENAME_PRE_STATE_DB_ENV).expect("db env"));
+        let part_path =
+            PathBuf::from(std::env::var_os(POST_RENAME_PRE_STATE_PART_ENV).expect("part env"));
+        let final_path = post_rename_pre_state_final_path_for(&download_dir);
+
+        if let Some(parent) = part_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&part_path, vec![0x42; 1000]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            let record = TestAssetRecord::new(POST_RENAME_PRE_STATE_ASSET_ID)
+                .filename(POST_RENAME_PRE_STATE_FILENAME)
+                .checksum(POST_RENAME_PRE_STATE_CHECKSUM)
+                .size(1000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            crate::download::file::rename_part_to_final(&part_path, &final_path)
+                .await
+                .unwrap();
+        });
+
+        // SAFETY: this child process is a dedicated crash harness. SIGKILL is
+        // the test subject: the parent asserts the final file survived while
+        // the DB row did not advance through mark_downloaded.
+        unsafe {
+            libc::raise(libc::SIGKILL);
+        }
+        std::process::exit(137);
     }
 
     // ── Gap: VideoOnly mode emits only MOV, no primary image ─────────

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1497,9 +1497,14 @@ mod tests {
     use chrono::Utc;
     use rustc_hash::FxHashSet;
 
-    use crate::icloud::photos::{PhotoAsset, PRIMARY_ZONE_NAME};
+    use crate::icloud::photos::PhotoAsset;
+    #[cfg(unix)]
+    use crate::icloud::photos::PRIMARY_ZONE_NAME;
+    #[cfg(unix)]
     use crate::state::SqliteStateDb;
-    use crate::test_helpers::{TestAssetRecord, TestPhotoAsset};
+    #[cfg(unix)]
+    use crate::test_helpers::TestAssetRecord;
+    use crate::test_helpers::TestPhotoAsset;
     use crate::types::LivePhotoMode;
     use serde_json::json;
     use std::fs;

--- a/src/icloud/photos/cloudkit.rs
+++ b/src/icloud/photos/cloudkit.rs
@@ -308,6 +308,21 @@ mod tests {
     }
 
     #[test]
+    fn changes_database_response_missing_zones_defaults_empty() {
+        let json = r#"{
+            "syncToken": "db-token-no-zones",
+            "moreComing": false
+        }"#;
+        let resp: ChangesDatabaseResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.sync_token, "db-token-no-zones");
+        assert!(!resp.more_coming);
+        assert!(
+            resp.zones.is_empty(),
+            "missing zones must parse as an empty changes list"
+        );
+    }
+
+    #[test]
     fn test_changed_zone_info() {
         let json = r#"{
             "zoneID": {"zoneName": "PrimarySync"},

--- a/src/password.rs
+++ b/src/password.rs
@@ -504,6 +504,16 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn run_password_command_rejects_non_utf8_stdout() {
+        let err = run_password_command("printf '\\377\\376'").unwrap_err();
+        assert!(
+            err.to_string().contains("not valid UTF-8"),
+            "expected invalid UTF-8 error; got: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn run_password_command_strips_newline() {
         assert_eq!(
             run_password_command("echo secret_value")

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -7090,6 +7090,20 @@ mod tests {
             Some("local_sha256"),
             "local_checksum should be stored"
         );
+        let conn = db.acquire_lock("verify download checksum").unwrap();
+        let download_checksum: Option<String> = conn
+            .query_row(
+                "SELECT download_checksum FROM assets \
+                 WHERE library = 'PrimarySync' AND id = 'DL_CK' AND version_size = 'original'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            download_checksum.as_deref(),
+            Some("pre_exif_sha256"),
+            "download_checksum should preserve the pre-EXIF downloaded bytes hash"
+        );
     }
 
     // ── v5 metadata round-trip ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added regression coverage for crash-safe download finalization, including a child process killed after the final file is published but before `mark_downloaded` runs.
- Covered invalid UTF-8 from password commands, missing CloudKit database `zones`, and persisted download checksum assertions.

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test password::tests::run_password_command_rejects_non_utf8_stdout`
- `cargo test icloud::photos::cloudkit::tests::changes_database_response_missing_zones_defaults_empty`
- `cargo test state::db::tests::mark_downloaded_stores_download_checksum`
- `cargo test download::filter::tests::real_process_death_after_publish_before_mark_downloaded_recovers`
- `cargo test`
- `cargo test -- --test-threads=1`
- `just gate`

Sandboxed `just gate` hit localhost bind restrictions; the unrestricted rerun passed.
