### PR TITLE
Fix deferred unfiled URL expiry and hash drift

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1877,12 +1877,6 @@ fn open_photo_stream_for_controls(
 struct RecentFrontier {
     asset_ids: Arc<FxHashSet<String>>,
     oldest_created: Option<DateTime<Utc>>,
-    assets: Vec<PhotoAsset>,
-}
-
-struct CollectedUnfiledStream {
-    token_rx: tokio::sync::oneshot::Receiver<Option<String>>,
-    items: Vec<anyhow::Result<PhotoAsset>>,
 }
 
 struct FullPassStreamOptions {
@@ -2065,7 +2059,6 @@ async fn build_recent_frontier(
     config: &DownloadConfig,
     controls: DownloadControls,
     shutdown_token: CancellationToken,
-    retain_assets: bool,
 ) -> Result<Option<RecentFrontier>> {
     let Some(recent) = config.recent else {
         return Ok(None);
@@ -2099,7 +2092,6 @@ async fn build_recent_frontier(
 
     let mut asset_ids = FxHashSet::default();
     let mut oldest_created: Option<DateTime<Utc>> = None;
-    let mut assets = Vec::new();
     while let Some(item) = stream.next().await {
         if shutdown_token.is_cancelled() {
             break;
@@ -2115,14 +2107,10 @@ async fn build_recent_frontier(
         }
         oldest_created = Some(oldest_created.map_or(created, |oldest| oldest.min(created)));
         asset_ids.insert(asset.id().to_string());
-        if retain_assets {
-            assets.push(asset);
-        }
     }
     Ok(Some(RecentFrontier {
         asset_ids: Arc::new(asset_ids),
         oldest_created,
-        assets,
     }))
 }
 
@@ -2176,42 +2164,6 @@ fn scope_frontier_limit(
     recent_frontier: Option<&RecentFrontier>,
 ) -> Option<u32> {
     recent_frontier.map_or(config.recent, |_| None)
-}
-
-fn collected_unfiled_from_recent_frontier(frontier: &RecentFrontier) -> CollectedUnfiledStream {
-    let (token_tx, token_rx) = tokio::sync::oneshot::channel();
-    let _ = token_tx.send(None);
-    CollectedUnfiledStream {
-        token_rx,
-        items: frontier.assets.iter().cloned().map(Ok).collect(),
-    }
-}
-
-async fn collect_unfiled_stream(
-    pass: &crate::commands::AlbumPass,
-    stream_total_count: Option<u64>,
-    config: &DownloadConfig,
-    controls: DownloadControls,
-    shutdown_token: CancellationToken,
-) -> CollectedUnfiledStream {
-    let (stream, token_rx) = open_photo_stream_for_controls(
-        &pass.album,
-        config.recent,
-        stream_total_count,
-        config.concurrent_downloads,
-        config.concurrent_downloads,
-        controls,
-    );
-    let stream = filter_stream_to_enumeration_bounds(stream, config, None);
-    tokio::pin!(stream);
-    let mut items = Vec::new();
-    while let Some(item) = stream.next().await {
-        if shutdown_token.is_cancelled() {
-            break;
-        }
-        items.push(item);
-    }
-    CollectedUnfiledStream { token_rx, items }
 }
 
 async fn run_full_pass_stream<S>(
@@ -3267,14 +3219,8 @@ async fn download_photos_full_with_token(
     let len_errors = pass_count_plan.len_errors;
     let display_total = display_total_for_recent_scope(&pass_counts, config);
     let deferred_unfiled = deferred_unfiled_index(passes);
-    let recent_frontier = build_recent_frontier(
-        passes,
-        config,
-        controls,
-        shutdown_token.clone(),
-        deferred_unfiled.is_some(),
-    )
-    .await?;
+    let recent_frontier =
+        build_recent_frontier(passes, config, controls, shutdown_token.clone()).await?;
 
     // Pass-specific path mode still needs one derived config per pass so
     // `{album}` / `{smart-folder}` / `{library}` expand correctly, but the
@@ -3339,7 +3285,7 @@ async fn download_photos_full_with_token(
                     Some(*index) != deferred_unfiled
                 }),
         )
-        .map(|((((index, pass), &count), total_count), pass_config)| {
+        .map(|((((_index, pass), &count), total_count), pass_config)| {
             let shutdown_token = shutdown_token.clone();
             let download_client = download_client.clone();
             let deferred_ids = deferred_ids.clone();
@@ -3394,7 +3340,6 @@ async fn download_photos_full_with_token(
                     }
                 }
 
-                let _ = index;
                 run_full_pass_stream(
                     download_client,
                     stream,
@@ -3415,30 +3360,7 @@ async fn download_photos_full_with_token(
         .buffer_unordered(pass_parallelism)
         .collect::<Vec<Result<PerPassStreamingResult>>>();
 
-        let unfiled_collection = async {
-            match deferred_unfiled {
-                Some(index) => match passes.get(index) {
-                    Some(pass) => match &recent_frontier {
-                        Some(frontier) => Some(collected_unfiled_from_recent_frontier(frontier)),
-                        None => Some(
-                            collect_unfiled_stream(
-                                pass,
-                                pass_stream_counts.get(index).copied().flatten(),
-                                config,
-                                controls,
-                                shutdown_token.clone(),
-                            )
-                            .await,
-                        ),
-                    },
-                    _ => None,
-                },
-                None => None,
-            }
-        };
-
-        let (pass_results, unfiled_collection) =
-            tokio::join!(non_unfiled_results, unfiled_collection);
+        let pass_results = non_unfiled_results.await;
 
         let mut token_receivers = Vec::with_capacity(passes.len());
         let mut deferred_exclusions_complete = true;
@@ -3466,35 +3388,42 @@ async fn download_photos_full_with_token(
             merge_streaming_result(&mut combined_result, result);
         }
 
-        if let (Some(index), Some(collected)) = (deferred_unfiled, unfiled_collection) {
+        if let Some(index) = deferred_unfiled {
             if deferred_exclusions_complete {
                 let excluded_ids = deferred_ids
                     .as_ref()
                     .and_then(|ids| ids.lock().ok().map(|guard| guard.clone()))
                     .unwrap_or_default();
-                let filtered = collected.items.into_iter().filter(move |item| {
-                    item.as_ref()
-                        .map_or(true, |asset| !excluded_ids.contains(asset.id()))
-                });
-                if let Some(pass_config) = pass_configs.get(index).cloned() {
-                    let filtered_items = filtered.collect::<Vec<_>>();
-                    let filtered_count = filtered_items
-                        .iter()
-                        .filter(|item| item.is_ok())
-                        .count()
-                        .try_into()
-                        .unwrap_or(u64::MAX);
-                    if let Some(slot) = pagination_counts.get_mut(index) {
-                        *slot = filtered_count;
-                    }
+                if let (Some(pass), Some(pass_config)) =
+                    (passes.get(index), pass_configs.get(index).cloned())
+                {
+                    let (stream, token_rx) = open_photo_stream_for_controls(
+                        &pass.album,
+                        scope_frontier_limit(config, recent_frontier.as_ref()),
+                        pass_stream_counts.get(index).copied().flatten(),
+                        config.concurrent_downloads,
+                        pass_config.concurrent_downloads,
+                        controls,
+                    );
+                    let stream = filter_stream_to_enumeration_bounds(
+                        stream,
+                        config,
+                        recent_frontier.as_ref(),
+                    )
+                    .filter(move |item| {
+                        let keep = item
+                            .as_ref()
+                            .map_or(true, |asset| !excluded_ids.contains(asset.id()));
+                        std::future::ready(keep)
+                    });
                     let pass_result = run_full_pass_stream(
                         download_client.clone(),
-                        stream::iter(filtered_items),
-                        collected.token_rx,
+                        stream,
+                        token_rx,
                         pass_config,
                         FullPassStreamOptions {
                             controls,
-                            count: filtered_count,
+                            count: pass_counts.get(index).copied().unwrap_or(0),
                             kind: crate::commands::PassKind::Unfiled,
                             shutdown_token: shutdown_token.clone(),
                             download_ctx: shared_download_ctx.clone(),
@@ -3502,6 +3431,10 @@ async fn download_photos_full_with_token(
                         },
                     )
                     .await?;
+                    let filtered_count = pass_result.result.assets_seen;
+                    if let Some(slot) = pagination_counts.get_mut(index) {
+                        *slot = filtered_count;
+                    }
                     let downloaded_u64 =
                         u64::try_from(pass_result.result.downloaded).unwrap_or(u64::MAX);
                     divider.mark_done(
@@ -3515,7 +3448,6 @@ async fn download_photos_full_with_token(
                 }
             } else {
                 combined_result.enumeration_complete = false;
-                token_receivers.push(collected.token_rx);
             }
         }
         divider.finish();
@@ -4393,7 +4325,7 @@ mod tests {
     };
     use serde_json::{json, Value};
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tempfile::TempDir;
     use tokio::time::Duration;
 
@@ -4878,6 +4810,89 @@ mod tests {
         )
     }
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum DeferredOrderKind {
+        Album,
+        Unfiled,
+    }
+
+    #[derive(Clone)]
+    struct DeferredOrderSession {
+        kind: DeferredOrderKind,
+        album_done: Arc<AtomicBool>,
+        unfiled_started_too_early: Arc<AtomicBool>,
+        record_name: Arc<str>,
+    }
+
+    impl DeferredOrderSession {
+        fn new_pair() -> (Self, Self) {
+            let album_done = Arc::new(AtomicBool::new(false));
+            let unfiled_started_too_early = Arc::new(AtomicBool::new(false));
+            (
+                Self {
+                    kind: DeferredOrderKind::Album,
+                    album_done: Arc::clone(&album_done),
+                    unfiled_started_too_early: Arc::clone(&unfiled_started_too_early),
+                    record_name: Arc::from("ORDER_ALBUM"),
+                },
+                Self {
+                    kind: DeferredOrderKind::Unfiled,
+                    album_done,
+                    unfiled_started_too_early,
+                    record_name: Arc::from("ORDER_UNFILED"),
+                },
+            )
+        }
+
+        fn unfiled_started_too_early(&self) -> bool {
+            self.unfiled_started_too_early.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for DeferredOrderSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/internal/records/query/batch") {
+                return Ok(json!({
+                    "batch": [{"records": [{"fields": {"itemCount": {"value": 1}}}]}]
+                }));
+            }
+
+            if url.contains("/records/query?") {
+                match self.kind {
+                    DeferredOrderKind::Album => {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        self.album_done.store(true, Ordering::SeqCst);
+                    }
+                    DeferredOrderKind::Unfiled => {
+                        if !self.album_done.load(Ordering::SeqCst) {
+                            self.unfiled_started_too_early.store(true, Ordering::SeqCst);
+                        }
+                    }
+                }
+                return Ok(json!({
+                    "records": mock_photo_records_for_zone_with_filename(
+                        &self.record_name,
+                        "PrimarySync",
+                        &format!("{}.jpg", self.record_name),
+                    ),
+                    "syncToken": "zone-token",
+                }));
+            }
+
+            Ok(json!({"records": []}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
     fn mock_album(name: &str, session: crate::test_helpers::MockPhotosSession) -> PhotoAlbum {
         album_with_session("PrimarySync", name, Box::new(session))
     }
@@ -5193,6 +5208,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_sync_threads_one_keeps_pass_streams_serial() {
+        let session = ConcurrentRecordsSession::new(Duration::from_millis(25));
+        let passes = vec![
+            AlbumPass {
+                kind: PassKind::Album,
+                album: probe_album("album_a", session.clone()),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+            AlbumPass {
+                kind: PassKind::Album,
+                album: probe_album("album_b", session.clone()),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+        ];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::dry_run_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("dry-run full sync should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            session.max_in_flight(),
+            1,
+            "threads=1 should prevent multi-pass enumeration from consuming multiple cores at once"
+        );
+    }
+
+    #[tokio::test]
     async fn full_sync_deferred_unfiled_excludes_album_members() {
         let album_session = MockPhotosFlow::new()
             .album_count(1)
@@ -5311,6 +5365,58 @@ mod tests {
         assert!(
             matches!(result.outcome, DownloadOutcome::Success),
             "filtered duplicate should not make the write-mode run partial"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_sync_deferred_unfiled_opens_stream_after_album_passes_finish() {
+        let (album_session, unfiled_session) = DeferredOrderSession::new_pair();
+        let unfiled_probe = unfiled_session.clone();
+        let passes = vec![
+            AlbumPass {
+                kind: PassKind::Album,
+                album: album_with_session("PrimarySync", "Vacation", Box::new(album_session)),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+            AlbumPass {
+                kind: PassKind::Unfiled,
+                album: album_with_session("PrimarySync", "", Box::new(unfiled_session)),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            },
+        ];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 2;
+        for (pass, record_name) in [(&passes[0], "ORDER_ALBUM"), (&passes[1], "ORDER_UNFILED")] {
+            let records = mock_photo_records_for_zone_with_filename(
+                record_name,
+                "PrimarySync",
+                &format!("{record_name}.jpg"),
+            );
+            let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+            seed_existing_file_for_asset(&config, pass, &asset).await;
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("write-mode full sync should succeed");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            !unfiled_probe.unfiled_started_too_early(),
+            "deferred unfiled must not enumerate URL-bearing assets while album passes are still running"
+        );
+        assert_eq!(
+            result.stats.assets_seen, 2,
+            "album and unfiled assets should both be processed after exclusions are known"
         );
     }
 
@@ -9195,8 +9301,8 @@ mod tests {
         assert_eq!(result.sync_token, None);
         assert_eq!(
             unfiled_session.emitted_ids().len(),
-            60,
-            "deferred unfiled collection should still drain its recent stream"
+            120,
+            "recent deferred unfiled should build the global frontier and then re-open a fresh stream for download URLs"
         );
     }
 
@@ -9305,10 +9411,6 @@ mod tests {
             "unfiled assets must not be processed when album exclusions are incomplete"
         );
         assert_eq!(result.sync_token, None);
-        assert!(
-            !unfiled_session.emitted_ids().is_empty(),
-            "the deferred unfiled stream may be collected concurrently"
-        );
     }
 
     #[test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1241,40 +1241,6 @@ where
         None => preload_download_context(config).await,
     };
 
-    // On flag drift, clear stored sync tokens so the next cycle falls back
-    // to full enumeration and picks up assets the old token would miss
-    // under the new filter settings.
-    if let Some(db) = &state_db {
-        let config_hash = super::hash_download_config(config);
-        let stored_hash = db
-            .get_metadata(super::DOWNLOAD_CONFIG_HASH_KEY)
-            .await
-            .unwrap_or(None);
-        if stored_hash.as_deref() != Some(&config_hash) {
-            if stored_hash.is_some() {
-                tracing::info!("Download config changed since last sync, verifying all files");
-                // Clear stored sync tokens so the next cycle/run falls back to
-                // full enumeration, picking up assets that the old incremental
-                // token would have missed under the new filter settings.
-                match db.delete_metadata_by_prefix("sync_token:").await {
-                    Ok(n) if n > 0 => {
-                        tracing::debug!(cleared = n, "Cleared stale sync tokens");
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Failed to clear sync tokens");
-                    }
-                    _ => {}
-                }
-            }
-            if let Err(e) = db
-                .set_metadata(super::DOWNLOAD_CONFIG_HASH_KEY, &config_hash)
-                .await
-            {
-                tracing::warn!(error = %e, "Failed to persist config_hash");
-            }
-        }
-    }
-
     // Start sync run tracking
     let sync_run_id = if let Some(db) = &state_db {
         match db.start_sync_run().await {
@@ -2202,6 +2168,8 @@ pub(super) async fn build_download_outcome(
             tracing::info!("── Dry Run Summary ──");
             tracing::info!("  0 files would be downloaded");
             tracing::info!(destination = %config.directory.display(), "  destination");
+        } else if streaming_result.url_expired_abort {
+            tracing::warn!("Download batch aborted because signed iCloud URLs expired");
         } else {
             tracing::info!("No new photos to download");
         }
@@ -5648,6 +5616,29 @@ mod tests {
         assert!(
             stats.interrupted,
             "expired URL aborts must not look like clean syncs"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_url_abort_with_zero_downloads_is_not_success() {
+        use crate::download::DownloadOutcome;
+
+        let streaming_result = StreamingResult {
+            url_expired_abort: true,
+            ..StreamingResult::default()
+        };
+        let (outcome, stats) =
+            build_zero_download_outcome(streaming_result, DownloadControls::download_hidden())
+                .await;
+
+        assert!(
+            matches!(outcome, DownloadOutcome::PartialFailure { failed_count: 1 }),
+            "expired CDN URL before any success must not be reported as a clean no-op, got {outcome:?}"
+        );
+        assert_eq!(stats.downloaded, 0);
+        assert!(
+            stats.interrupted,
+            "expired URL aborts must be visible as interrupted even with zero downloads"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,7 +863,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         },
         Command::Sync { password, sync, .. } => (sync.retry_failed, password, sync),
     };
-    sync_loop::run_sync(
+    Box::pin(sync_loop::run_sync(
         &globals,
         sync_loop::SyncArgs {
             is_one_shot,
@@ -877,7 +877,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             personality_mode,
             friendly_request,
         },
-    )
+    ))
     .await
 }
 

--- a/src/service/run.rs
+++ b/src/service/run.rs
@@ -36,5 +36,5 @@ pub(crate) async fn run(globals: &config::GlobalArgs, args: sync_loop::SyncArgs)
     }
 
     #[cfg(not(target_os = "windows"))]
-    sync_loop::run_sync(globals, args).await
+    Box::pin(sync_loop::run_sync(globals, args)).await
 }

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -248,24 +248,44 @@ where
 {
     match db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY).await {
         Ok(Some(stored)) if stored == current_hash => DownloadConfigHashOutcome::Unchanged,
-        Ok(None) => DownloadConfigHashOutcome::Unchanged,
-        Ok(Some(_stored)) => match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
-            Ok(n) if n > 0 => {
-                tracing::debug!(
-                    cleared = n,
-                    "Cleared sync tokens after download config hash drift"
-                );
-                DownloadConfigHashOutcome::Changed
+        Ok(None) => {
+            if let Err(e) = db
+                .set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, current_hash)
+                .await
+            {
+                tracing::warn!(error = %e, "Failed to persist download config_hash");
+                return DownloadConfigHashOutcome::ReadFailed;
             }
-            Ok(_) => DownloadConfigHashOutcome::Changed,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to clear sync tokens after download config hash drift"
-                );
-                DownloadConfigHashOutcome::TokenPurgeFailed
+            DownloadConfigHashOutcome::Unchanged
+        }
+        Ok(Some(_stored)) => {
+            tracing::info!("Download config changed since last sync, verifying all files");
+            match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
+                Ok(n) => {
+                    if n > 0 {
+                        tracing::debug!(
+                            cleared = n,
+                            "Cleared sync tokens after download config hash drift"
+                        );
+                    }
+                    if let Err(e) = db
+                        .set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, current_hash)
+                        .await
+                    {
+                        tracing::warn!(error = %e, "Failed to persist download config_hash");
+                        return DownloadConfigHashOutcome::TokenPurgeFailed;
+                    }
+                    DownloadConfigHashOutcome::Changed
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to clear sync tokens after download config hash drift"
+                    );
+                    DownloadConfigHashOutcome::TokenPurgeFailed
+                }
             }
-        },
+        }
         Err(e) => {
             tracing::warn!(error = %e, "Failed to read download config_hash");
             DownloadConfigHashOutcome::ReadFailed

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -2768,11 +2768,19 @@ mod tests {
         zone: &str,
         session: crate::test_helpers::MockPhotosSession,
     ) -> crate::icloud::photos::PhotoAlbum {
-        make_full_album_with_boxed_session(zone, Box::new(session))
+        make_named_full_album_with_boxed_session(zone, "TestAlbum", Box::new(session))
     }
 
     fn make_full_album_with_boxed_session(
         zone: &str,
+        session: Box<dyn crate::icloud::photos::PhotosSession>,
+    ) -> crate::icloud::photos::PhotoAlbum {
+        make_named_full_album_with_boxed_session(zone, "TestAlbum", session)
+    }
+
+    fn make_named_full_album_with_boxed_session(
+        zone: &str,
+        name: &str,
         session: Box<dyn crate::icloud::photos::PhotosSession>,
     ) -> crate::icloud::photos::PhotoAlbum {
         use serde_json::json;
@@ -2780,7 +2788,7 @@ mod tests {
             crate::icloud::photos::PhotoAlbumConfig {
                 params: Arc::new(std::collections::HashMap::new()),
                 service_endpoint: Arc::from("https://example.com"),
-                name: Arc::from("TestAlbum"),
+                name: Arc::from(name),
                 list_type: Arc::from("CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"),
                 obj_type: Arc::from("CPLAssetByAssetDateWithoutHiddenOrDeleted"),
                 query_filter: None,
@@ -2794,6 +2802,22 @@ mod tests {
         )
     }
 
+    fn make_named_empty_full_album(
+        zone: &str,
+        name: &str,
+        zone_sync_token: &str,
+    ) -> crate::icloud::photos::PhotoAlbum {
+        make_named_full_album_with_boxed_session(
+            zone,
+            name,
+            Box::new(
+                crate::test_helpers::MockPhotosSession::new()
+                    .ok(album_count_response(0))
+                    .ok(serde_json::json!({"records": [], "syncToken": zone_sync_token})),
+            ),
+        )
+    }
+
     fn make_empty_full_album(zone_sync_token: &str) -> crate::icloud::photos::PhotoAlbum {
         make_empty_full_album_for_zone("PrimarySync", zone_sync_token)
     }
@@ -2802,12 +2826,7 @@ mod tests {
         zone: &str,
         zone_sync_token: &str,
     ) -> crate::icloud::photos::PhotoAlbum {
-        make_full_album_with_session(
-            zone,
-            crate::test_helpers::MockPhotosSession::new()
-                .ok(album_count_response(0))
-                .ok(serde_json::json!({"records": [], "syncToken": zone_sync_token})),
-        )
+        make_named_empty_full_album(zone, "TestAlbum", zone_sync_token)
     }
 
     fn make_one_photo_full_album_for_zone(
@@ -2843,25 +2862,41 @@ mod tests {
         sync_token_key: &str,
         album: crate::icloud::photos::PhotoAlbum,
     ) -> LibraryState {
+        make_run_cycle_library_state_with_passes(
+            zone,
+            sync_token_key,
+            vec![crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Unfiled,
+                album,
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            }],
+        )
+    }
+
+    fn make_run_cycle_library_state_with_passes(
+        zone: &str,
+        sync_token_key: &str,
+        passes: Vec<crate::commands::AlbumPass>,
+    ) -> LibraryState {
         LibraryState {
             library: crate::icloud::photos::PhotoLibrary::new_stub_with_zone(
                 Box::new(crate::test_helpers::MockPhotosSession::new()),
                 zone,
             ),
             pass_scope: PassScope {
-                include_albums: false,
-                include_smart_folders: false,
-                include_unfiled: true,
+                include_albums: passes
+                    .iter()
+                    .any(|pass| pass.kind == crate::commands::PassKind::Album),
+                include_smart_folders: passes
+                    .iter()
+                    .any(|pass| pass.kind == crate::commands::PassKind::SmartFolder),
+                include_unfiled: passes
+                    .iter()
+                    .any(|pass| pass.kind == crate::commands::PassKind::Unfiled),
             },
             zone_name: zone.to_string(),
             sync_token_key: sync_token_key.to_string(),
-            plan: crate::commands::AlbumPlan {
-                passes: vec![crate::commands::AlbumPass {
-                    kind: crate::commands::PassKind::Unfiled,
-                    album,
-                    exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
-                }],
-            },
+            plan: crate::commands::AlbumPlan { passes },
             plan_is_stale: false,
             plan_needs_refresh: false,
             cross_zone_libraries: Vec::new(),
@@ -4808,6 +4843,185 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_cycle_multi_pass_persists_base_download_config_hash() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let passes = vec![
+            crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Album,
+                album: make_named_empty_full_album("PrimarySync", "Vacation", "zone-tok"),
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            },
+            crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Album,
+                album: make_named_empty_full_album("PrimarySync", "Family", "zone-tok"),
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            },
+            crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Unfiled,
+                album: make_named_empty_full_album("PrimarySync", "", "zone-tok"),
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            },
+        ];
+        let lib_state = make_run_cycle_library_state_with_passes(
+            "PrimarySync",
+            &format!("{SYNC_TOKEN_PREFIX}PrimarySync"),
+            passes.clone(),
+        );
+        let options = RunCycleDownloadConfigOptions {
+            per_pass_paths: true,
+            ..RunCycleDownloadConfigOptions::default()
+        };
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            options,
+        );
+        let base_config = build_download_config(
+            download::SyncMode::Full,
+            Arc::new(rustc_hash::FxHashSet::default()),
+            Arc::new(download::AssetGroupings::default()),
+            Arc::from("PrimarySync"),
+        );
+        let base_hash = download::hash_download_config(&base_config);
+        let pass_hashes: Vec<String> = passes
+            .iter()
+            .map(|pass| download::hash_download_config(&base_config.with_pass(pass)))
+            .collect();
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("multi-pass cycle should complete");
+
+        assert_eq!(result.failed_count, 0);
+        let stored_hash = db
+            .get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
+            .await
+            .expect("read stored download hash")
+            .expect("download hash should be persisted");
+        assert_eq!(
+            stored_hash, base_hash,
+            "global download config hash must be the base run-level hash"
+        );
+        assert!(
+            pass_hashes.iter().take(2).all(|hash| hash != &stored_hash),
+            "album-expanded folder templates must not overwrite the global hash: {pass_hashes:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_multi_pass_second_cycle_is_not_download_config_hash_drift() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let options = RunCycleDownloadConfigOptions {
+            per_pass_paths: true,
+            ..RunCycleDownloadConfigOptions::default()
+        };
+        let first_state = make_run_cycle_library_state_with_passes(
+            "PrimarySync",
+            &format!("{SYNC_TOKEN_PREFIX}PrimarySync"),
+            vec![
+                crate::commands::AlbumPass {
+                    kind: crate::commands::PassKind::Album,
+                    album: make_named_empty_full_album("PrimarySync", "Vacation", "zone-tok-1"),
+                    exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+                },
+                crate::commands::AlbumPass {
+                    kind: crate::commands::PassKind::Unfiled,
+                    album: make_named_empty_full_album("PrimarySync", "", "zone-tok-1"),
+                    exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+                },
+            ],
+        );
+        let first_builder = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            options,
+        );
+        let first_result = run_cycle(
+            &[&first_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &first_builder,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("first multi-pass cycle should complete");
+        assert_eq!(first_result.failed_count, 0);
+
+        let second_state = make_run_cycle_library_state_with_passes(
+            "PrimarySync",
+            &format!("{SYNC_TOKEN_PREFIX}PrimarySync"),
+            vec![crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Unfiled,
+                album: make_empty_full_album("zone-tok-2"),
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            }],
+        );
+        let observed_modes = Arc::new(std::sync::Mutex::new(Vec::<download::SyncMode>::new()));
+        let base_builder = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            options,
+        );
+        let second_builder = {
+            let observed_modes = Arc::clone(&observed_modes);
+            move |sync_mode: download::SyncMode,
+                  exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>,
+                  asset_groupings: Arc<download::AssetGroupings>,
+                  library: Arc<str>| {
+                observed_modes
+                    .lock()
+                    .expect("recorded modes lock")
+                    .push(sync_mode.clone());
+                base_builder(sync_mode, exclude_asset_ids, asset_groupings, library)
+            }
+        };
+        let second_result = run_cycle(
+            &[&second_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &second_builder,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("second cycle should complete");
+
+        assert_ne!(
+            second_result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::DownloadConfigHashDrift),
+            "pass-expanded hash from first run must not force path-drift reconciliation"
+        );
+        assert!(
+            observed_modes
+                .lock()
+                .expect("recorded modes lock")
+                .iter()
+                .any(|mode| matches!(mode, download::SyncMode::Incremental { .. })),
+            "unchanged config with a stored token should reach the incremental decision path"
+        );
+    }
+
+    #[tokio::test]
     async fn run_cycle_interrupted_incremental_download_blocks_sync_token_advance() {
         let config = make_run_cycle_config();
         let inner = make_state_db();
@@ -5464,8 +5678,36 @@ mod tests {
             db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
                 .await
                 .unwrap(),
-            Some("old-download-hash".to_string()),
-            "the download pipeline owns persisting the path hash once reconciliation starts"
+            Some("current-download-hash".to_string()),
+            "the cycle owner must persist the stable run-level path hash"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_config_hash_initial_persists_current_hash() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "tok-keep")
+            .await
+            .expect("seed token");
+
+        let outcome = check_download_config_hash_for_cycle(&db, "current-download-hash").await;
+
+        assert_eq!(outcome, DownloadConfigHashOutcome::Unchanged);
+        assert_eq!(
+            db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("current-download-hash"),
+            "first observation should persist the stable run-level path hash"
+        );
+        assert_eq!(
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("tok-keep"),
+            "initial hash persistence must not purge existing tokens"
         );
     }
 

--- a/tests/shell/state-machine.sh
+++ b/tests/shell/state-machine.sh
@@ -146,33 +146,38 @@ fi
 
 # ── 7. Simulated missing file: full re-enum re-downloads it ─────────────
 #
-# Two-stage check, each starting from a delete-from-state-and-disk seed
-# so each sync mode is exercised on a genuinely-missing file. Doing both
-# from a single delete would mask the second mode -- the first sync
-# would re-download the file, leaving the second a no-op.
+# Two-stage check from one delete-from-state-and-disk seed. Incremental
+# sync only sees new iCloud deltas, so it should not rediscover a local
+# state/disk deletion on its own. A forced full re-enumeration must
+# rediscover and re-download the file.
 echo ""
 echo "=== 7. Missing file detection ==="
-delete_and_sync() {
-    local mode_flag="$1"
-    local label="$2"
-    local f path out clean dl
+delete_one_downloaded_file() {
+    local f path
     f=$(kei_db_query "SELECT filename FROM assets WHERE status='downloaded' LIMIT 1")
     path=$(kei_db_query "SELECT local_path FROM assets WHERE filename = '$f' LIMIT 1")
     kei_db_exec "DELETE FROM assets WHERE filename = '$f'"
     rm -f "$path"
     echo "  Deleted from state + disk: $f"
-    out=$(kei_sync "$DIR" $mode_flag)
+}
+sync_and_count_downloads() {
+    local label="$1"
+    local out clean dl
+    out=$(kei_sync "$DIR")
     echo "$out" | grep -E "incremental|change|download|[Cc]ompleted"
-    echo "$out" | grep -qE "[Cc]ompleted in"; kei_check "$label completed without error"
+    echo "$out" | grep -qE "No new photos|[Cc]ompleted"; kei_check "$label completed without error"
     clean=$(echo "$out" | sed 's/\x1b\[[0-9;]*m//g')
     dl=$(echo "$clean" | grep -oE '[0-9]+ downloaded,' | head -1 | grep -oE '^[0-9]+')
     dl="${dl:-0}"
-    echo "  $label re-downloaded: $dl"
-    [ "$dl" -ge 1 ]; kei_check "$label finds missing file"
+    echo "  $label downloads: $dl"
+    DL_RESULT="$dl"
 }
-delete_and_sync "" "incremental"
+delete_one_downloaded_file
+sync_and_count_downloads "incremental"
+[ "$DL_RESULT" -eq 0 ]; kei_check "incremental leaves non-delta local drift for full reconcile"
 KEI_DATA_DIR="$COOKIES" "$KEI" reset sync-token --yes >/dev/null
-delete_and_sync "" "full re-enum"
+sync_and_count_downloads "full re-enum"
+[ "$DL_RESULT" -ge 1 ]; kei_check "full re-enum finds missing file"
 
 # ── 8. --dry-run preserves token ─────────────────────────────────────────
 echo ""

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -145,6 +145,15 @@ fn config_for_download_dir(
     common::write_toml_config(data_dir, "sync-live", &body)
 }
 
+fn reset_sync_tokens(cookie_dir: &std::path::Path) {
+    common::cmd()
+        .env("KEI_DATA_DIR", cookie_dir)
+        .args(["reset", "sync-token", "--yes"])
+        .timeout(Duration::from_secs(10))
+        .assert()
+        .success();
+}
+
 // ── Metadata (no downloads) ─────────────────────────────────────────────
 
 #[test]
@@ -1784,8 +1793,8 @@ fn sync_report_json_writes_valid_schema() {
 // ── Download integrity ──────────────────────────────────────────────────
 
 /// Data-sacred invariant: if the user (or `rm -rf` accident) deletes a synced
-/// file, the next sync must restore it. A silent skip here would mean kei
-/// "loses" the file permanently.
+/// file, a full reconciliation must restore it. A silent skip here would mean
+/// kei "loses" the file permanently.
 #[test]
 #[ignore]
 fn sync_recovers_deleted_file() {
@@ -1812,7 +1821,12 @@ fn sync_recovers_deleted_file() {
         std::fs::remove_file(&victim).expect("delete victim");
         assert!(!victim.exists(), "victim deleted");
 
-        // Re-sync: full enumeration so the filter can notice the missing file.
+        // Re-sync with a full enumeration so the filter can notice the
+        // missing file. A normal incremental sync only receives new iCloud
+        // deltas, so local disk drift must be tested with the cursor reset.
+        reset_sync_tokens(&cookie_dir);
+
+        // Full enumeration can notice the missing file.
         // Captured output is included in the assertion below so an intermittent
         // skip-where-recovery-was-expected leaves a usable trail (data-sacred
         // invariant: a silent skip here means kei "loses" the file).
@@ -1838,10 +1852,10 @@ fn sync_recovers_deleted_file() {
 }
 
 /// Data-sacred invariant: a truncated file left on disk (e.g. from a crashed
-/// write) must not mask the real photo. The default `name-size-dedup-with-suffix`
-/// policy preserves the existing file untouched and downloads the real photo
-/// alongside with a size suffix in the filename. Either way, the correctly-sized
-/// photo bytes must end up on disk.
+/// write) must not mask the real photo during full reconciliation. The default
+/// `name-size-dedup-with-suffix` policy preserves the existing file untouched
+/// and downloads the real photo alongside with a size suffix in the filename.
+/// Either way, the correctly-sized photo bytes must end up on disk.
 #[test]
 #[ignore]
 fn sync_truncated_file_does_not_cause_data_loss() {
@@ -1871,6 +1885,11 @@ fn sync_truncated_file_does_not_cause_data_loss() {
             .set_len(0)
             .expect("set_len 0");
         assert_eq!(std::fs::metadata(&victim).unwrap().len(), 0);
+
+        // Re-sync with a full enumeration so path planning compares the
+        // truncated local file with iCloud's expected size. A normal
+        // incremental sync only receives new iCloud deltas.
+        reset_sync_tokens(&cookie_dir);
 
         // Captured output is included in the assertion below so an
         // intermittent skip-where-recovery-was-expected leaves a usable


### PR DESCRIPTION
## Summary
- Reopen deferred unfiled full-sync streams only after album passes finish, so signed iCloud URLs are fetched closer to download time instead of buffered behind album enumeration.
- Move path-affecting download config hash ownership to the cycle boundary and persist the run-level hash, preventing per-pass album templates from forcing repeated "verifying all files" runs.
- Add coverage for deferred unfiled ordering, `threads=1` pass serialization, hash persistence, unchanged second cycles, expired URL zero-download outcomes, and live full-reconciliation expectations.

## Context
Closes #537.
Closes #538.
Related to #536.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test download::tests --lib`
- `cargo test sync_loop::tests --lib`
- `cargo test download::pipeline::tests --lib`
- `cargo test --test sync --no-run`
- `ICLOUD_TEST_COOKIE_DIR=/home/robhooper/git/kei/.test-cookies KEI_TEST_ALBUM=kei-test cargo test --test sync sync_recovers_deleted_file -- --ignored --test-threads=1`
- `ICLOUD_TEST_COOKIE_DIR=/home/robhooper/git/kei/.test-cookies KEI_TEST_ALBUM=kei-test cargo test --test sync sync_truncated_file_does_not_cause_data_loss -- --ignored --test-threads=1`
- `bash -n tests/shell/state-machine.sh`
- `set -a; source .env; set +a; tests/shell/state-machine.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate`
