### PR TITLE
Harden file durability and resume validation

### DIFF
--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -895,7 +895,7 @@ fn detect_error_sentinel(header: &[u8]) -> Option<&'static str> {
 /// Returns:
 /// - `Some(true)` — header matches a known-valid signature
 /// - `Some(false)` — extension is recognized but header does not match
-///   (caller rejects unless another known media signature matches)
+///   (caller logs a warning; the file is still saved)
 /// - `None` — extension is not in the signature table; skip the check
 ///
 /// MOV handling intentionally differs from the other ISO-BMFF extensions.
@@ -968,11 +968,11 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
 /// incomplete: zero bytes, known HTML/JSON error bodies, known error-document
 /// content types checked before writing, or byte-count mismatches checked by
 /// the caller.
-/// Extension-specific magic mismatches remain acceptable only when the bytes
-/// match another media signature kei recognizes: iCloud sometimes assigns
-/// `.PNG` names to JPEG bytes, and filenames stay exactly as planned. A known
-/// media extension with no recognized media magic is rejected so obvious
-/// same-size CDN error bodies cannot be marked downloaded.
+/// Extension-specific magic mismatches are warnings, not hard failures: iCloud
+/// sometimes assigns `.PNG` names to JPEG bytes, and kei's signature table is
+/// intentionally not treated as a complete media catalog. Unknown-but-not-known
+/// bad headers are saved when size checks have passed. Filenames stay exactly as
+/// planned; validation never rewrites extensions.
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,
@@ -1034,13 +1034,8 @@ fn validate_downloaded_content(
             path = %download_path.display(),
             expected_extension = %ext,
             header = %format_args!("{preview:02x?}"),
-            "File header does not match expected extension and is not recognized by kei; rejecting download",
+            "File header does not match expected extension and is not recognized by kei; saving anyway",
         );
-        return Err(DownloadError::InvalidContent {
-            path: download_path.display().to_string().into(),
-            reason: format!("file extension .{ext} has unrecognized media header {preview:02x?}")
-                .into(),
-        });
     }
 
     Ok(())
@@ -1661,12 +1656,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_unrecognized_header_for_known_extension() {
+    fn validate_accepts_unrecognized_header_for_known_extension() {
         let (part, dest, _dir) = write_temp_file("photo.jpg", b"not media bytes");
-        assert!(matches!(
-            validate_downloaded_content(&part, &dest),
-            Err(DownloadError::InvalidContent { .. })
-        ));
+        assert!(validate_downloaded_content(&part, &dest).is_ok());
     }
 
     #[test]
@@ -2030,12 +2022,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_file_recognized_extension_unknown_magic_is_quarantined_or_failed() {
+    async fn attempt_download_promotes_unrecognized_header_under_known_extension() {
         let body = b"not media bytes";
         let client = StubDownloadClient::ok(body);
         let (download_path, part_path, _dir) = setup_download_dir("unknown_header", "jpg");
 
-        let err = attempt_download(
+        attempt_download(
             &client,
             "http://stub",
             &download_path,
@@ -2046,20 +2038,10 @@ mod tests {
             None,
         )
         .await
-        .expect_err("known media extension with unknown magic must fail");
+        .unwrap();
 
-        assert!(
-            matches!(err, DownloadError::InvalidContent { .. }),
-            "expected InvalidContent for unknown media magic, got: {err}"
-        );
-        assert!(
-            !download_path.exists(),
-            "invalid media bytes must not be promoted to the final path"
-        );
-        assert!(
-            !part_path.exists(),
-            "invalid media bytes must be removed so retry starts clean"
-        );
+        assert!(!part_path.exists(), ".part should be promoted");
+        assert_eq!(std::fs::read(&download_path).unwrap(), body);
     }
 
     #[tokio::test]

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -20,6 +20,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 pub(super) struct DownloadResponse {
     pub status: u16,
     pub content_length: Option<u64>,
+    pub content_range: Option<String>,
     pub content_type: Option<String>,
     pub stream: Pin<Box<dyn Stream<Item = Result<Bytes, BoxError>> + Send>>,
 }
@@ -51,6 +52,11 @@ impl DownloadClient for Client {
         let response = request.send().await?;
         let status = response.status().as_u16();
         let content_length = response.content_length();
+        let content_range = response
+            .headers()
+            .get(reqwest::header::CONTENT_RANGE)
+            .and_then(|v| v.to_str().ok())
+            .map(std::string::ToString::to_string);
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
@@ -62,6 +68,7 @@ impl DownloadClient for Client {
         Ok(DownloadResponse {
             status,
             content_length,
+            content_range,
             content_type,
             stream: Box::pin(stream),
         })
@@ -324,6 +331,11 @@ async fn attempt_download<C: DownloadClient>(
     }
 
     let content_length = response.content_length;
+    let content_range = response.content_range;
+
+    if status == 206 && resume_offset > 0 {
+        validate_resume_content_range(content_range.as_deref(), resume_offset, &path_str)?;
+    }
 
     // If we resumed and the server advertises a Content-Length that doesn't
     // reconcile with the API-reported size, the resource on the server has
@@ -787,6 +799,55 @@ fn rejecting_content_type_reason(content_type: &str) -> Option<&'static str> {
     }
 }
 
+fn validate_resume_content_range(
+    content_range: Option<&str>,
+    resume_offset: u64,
+    path: &str,
+) -> Result<(), DownloadError> {
+    let Some(content_range) = content_range else {
+        return Err(DownloadError::InvalidContent {
+            path: path.into(),
+            reason: "206 Partial Content response omitted Content-Range for resume".into(),
+        });
+    };
+    let Some(start) = parse_content_range_start(content_range) else {
+        return Err(DownloadError::InvalidContent {
+            path: path.into(),
+            reason: format!("malformed Content-Range for resume: {content_range}").into(),
+        });
+    };
+    if start != resume_offset {
+        return Err(DownloadError::InvalidContent {
+            path: path.into(),
+            reason: format!(
+                "Content-Range start {start} does not match existing .part size {resume_offset}"
+            )
+            .into(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_content_range_start(content_range: &str) -> Option<u64> {
+    let mut parts = content_range.split_whitespace();
+    let unit = parts.next()?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return None;
+    }
+    let range_and_total = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let (range, _total) = range_and_total.split_once('/')?;
+    let (start, end) = range.split_once('-')?;
+    let start = start.parse::<u64>().ok()?;
+    let end = end.parse::<u64>().ok()?;
+    if end < start {
+        return None;
+    }
+    Some(start)
+}
+
 /// Inspect the first bytes of a downloaded file for known-bad sentinels that
 /// unambiguously identify a non-media error body (HTML error page, JSON error,
 /// etc.). Returns a human-readable reason string when a sentinel is present.
@@ -834,7 +895,7 @@ fn detect_error_sentinel(header: &[u8]) -> Option<&'static str> {
 /// Returns:
 /// - `Some(true)` — header matches a known-valid signature
 /// - `Some(false)` — extension is recognized but header does not match
-///   (caller logs a warning; the file is still saved)
+///   (caller rejects unless another known media signature matches)
 /// - `None` — extension is not in the signature table; skip the check
 ///
 /// MOV handling intentionally differs from the other ISO-BMFF extensions.
@@ -907,11 +968,11 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
 /// incomplete: zero bytes, known HTML/JSON error bodies, known error-document
 /// content types checked before writing, or byte-count mismatches checked by
 /// the caller.
-/// Extension-specific magic mismatches are warnings, not hard failures: iCloud
-/// sometimes assigns `.PNG` names to JPEG bytes, and kei's signature table is
-/// intentionally not treated as a complete media catalog. Unknown-but-not-known
-/// bad headers are saved when size checks have passed. Filenames stay exactly as
-/// planned; validation never rewrites extensions.
+/// Extension-specific magic mismatches remain acceptable only when the bytes
+/// match another media signature kei recognizes: iCloud sometimes assigns
+/// `.PNG` names to JPEG bytes, and filenames stay exactly as planned. A known
+/// media extension with no recognized media magic is rejected so obvious
+/// same-size CDN error bodies cannot be marked downloaded.
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,
@@ -973,8 +1034,13 @@ fn validate_downloaded_content(
             path = %download_path.display(),
             expected_extension = %ext,
             header = %format_args!("{preview:02x?}"),
-            "File header does not match expected extension and is not recognized by kei; saving anyway",
+            "File header does not match expected extension and is not recognized by kei; rejecting download",
         );
+        return Err(DownloadError::InvalidContent {
+            path: download_path.display().to_string().into(),
+            reason: format!("file extension .{ext} has unrecognized media header {preview:02x?}")
+                .into(),
+        });
     }
 
     Ok(())
@@ -1537,6 +1603,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_content_range_start_accepts_valid_byte_ranges() {
+        assert_eq!(parse_content_range_start("bytes 4-7/8"), Some(4));
+        assert_eq!(parse_content_range_start("Bytes 100-179/*"), Some(100));
+    }
+
+    #[test]
+    fn parse_content_range_start_rejects_malformed_ranges() {
+        assert_eq!(parse_content_range_start("items 4-7/8"), None);
+        assert_eq!(parse_content_range_start("bytes 7-4/8"), None);
+        assert_eq!(parse_content_range_start("bytes */8"), None);
+        assert_eq!(parse_content_range_start("bytes 4-7"), None);
+    }
+
+    #[test]
     fn classify_magic_basic_image_types() {
         assert_eq!(classify_magic("jpg", &[0xFF, 0xD8]), Some(true));
         assert_eq!(classify_magic("jpeg", &[0xFF, 0xD8]), Some(true));
@@ -1581,9 +1661,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_unrecognized_header_for_known_extension() {
+    fn validate_rejects_unrecognized_header_for_known_extension() {
         let (part, dest, _dir) = write_temp_file("photo.jpg", b"not media bytes");
-        assert!(validate_downloaded_content(&part, &dest).is_ok());
+        assert!(matches!(
+            validate_downloaded_content(&part, &dest),
+            Err(DownloadError::InvalidContent { .. })
+        ));
     }
 
     #[test]
@@ -1709,6 +1792,7 @@ mod tests {
     struct StubDownloadClient {
         status: u16,
         content_length: Option<u64>,
+        content_range: Option<String>,
         content_type: Option<String>,
         body: Vec<u8>,
     }
@@ -1718,6 +1802,7 @@ mod tests {
             Self {
                 status: 200,
                 content_length: Some(body.len() as u64),
+                content_range: None,
                 content_type: None,
                 body: body.to_vec(),
             }
@@ -1737,6 +1822,11 @@ mod tests {
             self.content_type = Some(ct.to_string());
             self
         }
+
+        fn with_content_range(mut self, content_range: &str) -> Self {
+            self.content_range = Some(content_range.to_string());
+            self
+        }
     }
 
     #[async_trait::async_trait]
@@ -1744,12 +1834,19 @@ mod tests {
         async fn fetch(
             &self,
             _url: &str,
-            _resume_from: Option<u64>,
+            resume_from: Option<u64>,
         ) -> Result<DownloadResponse, BoxError> {
             let chunks: Vec<Result<Bytes, BoxError>> = vec![Ok(Bytes::from(self.body.clone()))];
+            let content_range = self.content_range.clone().or_else(|| {
+                resume_from.and_then(|start| {
+                    let end = start.checked_add(self.body.len() as u64)?.checked_sub(1)?;
+                    Some(format!("bytes {start}-{end}/*"))
+                })
+            });
             Ok(DownloadResponse {
                 status: self.status,
                 content_length: self.content_length,
+                content_range,
                 content_type: self.content_type.clone(),
                 stream: Box::pin(futures_util::stream::iter(chunks)),
             })
@@ -1822,6 +1919,7 @@ mod tests {
         let client = StubDownloadClient {
             status: 200,
             content_length: Some(100),
+            content_range: None,
             content_type: None,
             body: body.to_vec(),
         };
@@ -1932,12 +2030,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attempt_download_promotes_unrecognized_header_under_known_extension() {
+    async fn download_file_recognized_extension_unknown_magic_is_quarantined_or_failed() {
         let body = b"not media bytes";
         let client = StubDownloadClient::ok(body);
         let (download_path, part_path, _dir) = setup_download_dir("unknown_header", "jpg");
 
-        attempt_download(
+        let err = attempt_download(
             &client,
             "http://stub",
             &download_path,
@@ -1948,10 +2046,20 @@ mod tests {
             None,
         )
         .await
-        .unwrap();
+        .expect_err("known media extension with unknown magic must fail");
 
-        assert!(!part_path.exists(), ".part should be promoted");
-        assert_eq!(std::fs::read(&download_path).unwrap(), body);
+        assert!(
+            matches!(err, DownloadError::InvalidContent { .. }),
+            "expected InvalidContent for unknown media magic, got: {err}"
+        );
+        assert!(
+            !download_path.exists(),
+            "invalid media bytes must not be promoted to the final path"
+        );
+        assert!(
+            !part_path.exists(),
+            "invalid media bytes must be removed so retry starts clean"
+        );
     }
 
     #[tokio::test]
@@ -1991,6 +2099,7 @@ mod tests {
         let client = StubDownloadClient {
             status: 206,
             content_length: Some(second_half.len() as u64),
+            content_range: None,
             content_type: None,
             body: second_half.clone(),
         };
@@ -2014,6 +2123,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_file_resume_wrong_content_range_keeps_existing_part_and_errors() {
+        let (download_path, part_path, _dir) = setup_download_dir("bad_range", "jpg");
+        let first_half = [0xFF, 0xD8, 0xFF, 0xE0];
+        std::fs::write(&part_path, first_half).unwrap();
+
+        let second_half = vec![0x00, 0x10, 0x4A, 0x46];
+        let client = StubDownloadClient::ok(&second_half)
+            .with_status(206)
+            .with_content_range("bytes 0-3/8");
+
+        let err = attempt_download(
+            &client,
+            "http://stub",
+            &download_path,
+            &part_path,
+            false,
+            Some(8),
+            None,
+            None,
+        )
+        .await
+        .expect_err("mismatched Content-Range must fail before append");
+
+        assert!(
+            matches!(err, DownloadError::InvalidContent { .. }),
+            "expected InvalidContent for wrong Content-Range, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&part_path).unwrap(),
+            first_half,
+            "existing .part bytes must remain unchanged for a future safe retry"
+        );
+        assert!(
+            !download_path.exists(),
+            "wrong range must not promote final path"
+        );
+    }
+
+    #[tokio::test]
     async fn attempt_download_resume_rejects_version_rotation_via_content_length() {
         // If the .part carries K bytes from version A and the server's Range
         // response's Content-Length (+ resume_offset) totals a different size
@@ -2028,6 +2176,7 @@ mod tests {
         let client = StubDownloadClient {
             status: 206,
             content_length: Some(80),
+            content_range: None,
             content_type: None,
             body: vec![0xBB; 80],
         };
@@ -2137,6 +2286,10 @@ mod tests {
                 Ok(DownloadResponse {
                     status: if resume_from.is_some() { 206 } else { 200 },
                     content_length: Some(self.body.len() as u64),
+                    content_range: resume_from.map(|start| {
+                        let end = start + self.body.len() as u64 - 1;
+                        format!("bytes {start}-{end}/*")
+                    }),
                     content_type: None,
                     stream: Box::pin(futures_util::stream::iter(chunks)),
                 })
@@ -2215,6 +2368,7 @@ mod tests {
             DownloadResponse {
                 status: 200,
                 content_length: Some(self.body.len() as u64),
+                content_range: None,
                 content_type: Some("image/jpeg".to_string()),
                 stream: Box::pin(stream),
             }
@@ -2227,6 +2381,11 @@ mod tests {
             DownloadResponse {
                 status: 206,
                 content_length: Some((self.body.len() - offset) as u64),
+                content_range: Some(format!(
+                    "bytes {resume_from}-{}/{}",
+                    self.body.len() - 1,
+                    self.body.len()
+                )),
                 content_type: Some("image/jpeg".to_string()),
                 stream: Box::pin(futures_util::stream::iter(chunks)),
             }
@@ -2413,6 +2572,7 @@ mod tests {
                 Ok(DownloadResponse {
                     status: self.fail_status,
                     content_length: None,
+                    content_range: None,
                     content_type: None,
                     stream: Box::pin(futures_util::stream::iter(chunks)),
                 })
@@ -2421,6 +2581,7 @@ mod tests {
                 Ok(DownloadResponse {
                     status: 200,
                     content_length: Some(self.body.len() as u64),
+                    content_range: None,
                     content_type: None,
                     stream: Box::pin(futures_util::stream::iter(chunks)),
                 })
@@ -2814,7 +2975,8 @@ mod tests {
                 .respond_with(
                     ResponseTemplate::new(206)
                         .set_body_bytes(full_body[4..].to_vec())
-                        .insert_header("content-length", "4"),
+                        .insert_header("content-length", "4")
+                        .insert_header("content-range", "bytes 4-7/8"),
                 )
                 .expect(1)
                 .mount(&server)
@@ -3350,6 +3512,7 @@ mod tests {
         let client = StubDownloadClient {
             status: 200,
             content_length: Some(0),
+            content_range: None,
             content_type: None,
             body: vec![],
         };
@@ -3483,6 +3646,7 @@ mod tests {
             Ok(DownloadResponse {
                 status: 200,
                 content_length: Some(self.body.len() as u64),
+                content_range: None,
                 content_type: None,
                 stream: Box::pin(futures_util::stream::iter(chunks)),
             })

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -413,6 +413,16 @@ impl Drop for TmpGuard<'_> {
 
 #[cfg(feature = "xmp")]
 fn apply_metadata_xmp_toolkit(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
+    apply_metadata_xmp_toolkit_with_installer(path, write, temp_suffix, atomic_install)
+}
+
+#[cfg(feature = "xmp")]
+fn apply_metadata_xmp_toolkit_with_installer(
+    path: &Path,
+    write: &MetadataWrite,
+    temp_suffix: &str,
+    install: impl FnOnce(&Path, &Path) -> std::io::Result<()>,
+) -> Result<()> {
     ensure_initialized();
 
     let tmp_path = temp_path_for(path, temp_suffix);
@@ -448,8 +458,13 @@ fn apply_metadata_xmp_toolkit(path: &Path, write: &MetadataWrite, temp_suffix: &
     })();
 
     result?;
-    std::fs::rename(&tmp_path, path)
-        .with_context(|| format!("Renaming {} -> {}", tmp_path.display(), path.display()))?;
+    install(&tmp_path, path).with_context(|| {
+        format!(
+            "Installing metadata {} -> {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
     guard.disarm();
     tracing::debug!(path = %path.display(), "Applied metadata");
     Ok(())
@@ -1266,6 +1281,53 @@ mod tests {
         assert!(
             !tmp_path.exists(),
             ".meta-tmp must be cleaned up after a failed write"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn xmp_toolkit_rewrite_fsyncs_temp_before_part_replace() {
+        let dir = test_tmp_dir("meta_tests");
+        let path = fresh_jpeg(&dir, "durable_install.jpg");
+        let original = fs::read(&path).unwrap();
+        let install_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let install_called_in_closure = std::sync::Arc::clone(&install_called);
+        let expected_path = path.clone();
+
+        let result = apply_metadata_xmp_toolkit_with_installer(
+            &path,
+            &MetadataWrite {
+                rating: Some(3),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+            move |tmp, dst| {
+                install_called_in_closure.store(true, std::sync::atomic::Ordering::SeqCst);
+                assert!(
+                    tmp.exists(),
+                    "metadata temp file must exist before durable install"
+                );
+                assert_eq!(dst, expected_path.as_path());
+                Err(std::io::Error::other("simulated durable install failure"))
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "durable install failure must surface to leave the asset retryable"
+        );
+        assert!(
+            install_called.load(std::sync::atomic::Ordering::SeqCst),
+            "XMP rewrite must route final replacement through the durable install primitive"
+        );
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            original,
+            "failed metadata publish must leave original bytes intact"
+        );
+        assert!(
+            !path.with_file_name("durable_install.jpg.meta-tmp").exists(),
+            "metadata temp file must be cleaned up on durable install failure"
         );
         fs::remove_file(&path).ok();
     }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -472,7 +472,8 @@ async fn run_metadata_rewrites<D>(
     metadata_flags: MetadataFlags,
     temp_suffix: Arc<str>,
     shutdown_token: &CancellationToken,
-) where
+) -> usize
+where
     D: MetadataRewriteStore + ?Sized,
 {
     let pending = match db
@@ -482,21 +483,24 @@ async fn run_metadata_rewrites<D>(
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(error = %e, "Failed to load pending metadata rewrites");
-            return;
+            return 1;
         }
     };
     if pending.is_empty() {
-        return;
+        return 0;
     }
+    let pending_count = pending.len();
     tracing::info!(
-        count = pending.len(),
+        count = pending_count,
         "Applying metadata rewrites to on-disk files"
     );
     let mut applied = 0usize;
     let mut skipped_missing = 0usize;
     let mut errored = 0usize;
-    for record in pending {
+    let mut deferred = 0usize;
+    for (idx, record) in pending.into_iter().enumerate() {
         if shutdown_token.is_cancelled() {
+            deferred += pending_count - idx;
             tracing::info!("Shutdown requested, deferring remaining metadata rewrites");
             break;
         }
@@ -654,8 +658,10 @@ async fn run_metadata_rewrites<D>(
         applied,
         errored,
         skipped_missing,
+        deferred,
         "Metadata rewrite pass complete"
     );
+    errored + deferred
 }
 
 /// Bar factory for per-pass loops in `download::mod.rs`. Returns the bar
@@ -2051,7 +2057,7 @@ where
         if let Some(db) = &state_db {
             let metadata_flags = MetadataFlags::from(config.as_ref());
             if metadata_flags.any_embed() || metadata_flags.contains(MetadataFlags::XMP_SIDECAR) {
-                run_metadata_rewrites(
+                exif_failures += run_metadata_rewrites(
                     db.as_ref(),
                     metadata_flags,
                     Arc::clone(&config.temp_suffix),
@@ -5552,6 +5558,60 @@ mod tests {
             still_pending.len(),
             1,
             "marker must survive when the file is absent so a future sync retries"
+        );
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn metadata_rewrite_cancel_returns_partial_and_keeps_retry_marker() {
+        use crate::state::types::AssetMetadata;
+        use crate::state::SqliteStateDb;
+
+        let dir = tempfile::tempdir().unwrap();
+        let photo_path = dir.path().join("rewrite_cancel.jpg");
+        std::fs::write(&photo_path, minimal_jpeg_bytes()).unwrap();
+
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let metadata = AssetMetadata {
+            rating: Some(5),
+            metadata_hash: Some("retry_hash".to_string()),
+            ..AssetMetadata::default()
+        };
+        let record = crate::test_helpers::TestAssetRecord::new("REWRITE_CANCEL")
+            .filename("rewrite_cancel.jpg")
+            .checksum("rewrite_cancel_ck")
+            .metadata(metadata)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "REWRITE_CANCEL",
+            "original",
+            &photo_path,
+            "rewrite_cancel_ck",
+            None,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "REWRITE_CANCEL", "original")
+            .await
+            .unwrap();
+
+        let flags = MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
+        let token = CancellationToken::new();
+        token.cancel();
+        let deferred =
+            run_metadata_rewrites(&db, flags, std::sync::Arc::from(".meta-tmp"), &token).await;
+
+        assert_eq!(
+            deferred, 1,
+            "cancelled metadata rewrite must count as a partial retryable item"
+        );
+        let still_pending = db.get_pending_metadata_rewrites(32).await.unwrap();
+        assert_eq!(
+            still_pending.len(),
+            1,
+            "cancelled metadata rewrite must keep marker for retry"
         );
     }
 

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -153,15 +153,13 @@ where
         }
         let _ = std::fs::remove_file(src);
     }
-    // Best-effort: a parent-dir fsync failure shouldn't fail the install,
-    // but it's worth logging so an operator chasing durability incidents
-    // can see it.
     if let Err(e) = fsync_parent_dir(dst) {
         tracing::warn!(
             path = %dst.display(),
             error = %e,
             "fsync of parent directory failed after atomic_install"
         );
+        return Err(e);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Validate `Content-Range` before appending a resumed download to an existing `.part` file.
- Publish XMP Toolkit metadata rewrites through the durable install path, including file and parent-directory fsync handling.
- Count cancelled or deferred metadata rewrite work as retryable partial work so markers stay visible for the next sync.
- Keep the existing permissive media-magic behavior for unknown headers; this PR preserves the current warning-and-save path there.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test download::file::tests::download_file_resume_wrong_content_range_keeps_existing_part_and_errors`
- `cargo test download::file::tests::attempt_download_promotes_unrecognized_header_under_known_extension`
- `cargo test --features xmp download::metadata::tests::xmp_toolkit_rewrite_fsyncs_temp_before_part_replace`
- `cargo test --features xmp download::pipeline::tests::metadata_rewrite_cancel_returns_partial_and_keeps_retry_marker`
- `cargo test real_client_resume_with_range_header` (rerun outside the sandbox after local bind was denied)
- `just gate` (run outside the sandbox so localhost/mock-server tests can bind ports)
