### PR TITLE
Fix metadata-mutated file redownloads

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use filter::determine_media_type;
 pub(crate) use filter::AssetGroupings;
 use filter::DownloadTask;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -1208,6 +1208,11 @@ type LibraryAssetVersionSet = FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashSet<
 type LibraryAssetVersionValueMap =
     FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, Box<str>>>>;
 
+/// `library -> asset_id -> (version_size -> local_path)`. Used to confirm
+/// state-backed skips still point at the currently configured path.
+type LibraryAssetVersionPathMap =
+    FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, PathBuf>>>;
+
 #[derive(Debug, Default)]
 struct DownloadContext {
     /// Nested map: `library` -> `asset_id` -> set of `version_sizes` that
@@ -1218,6 +1223,10 @@ struct DownloadContext {
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> checksum).
     /// Used to detect checksum changes (CloudKit asset updated) without DB queries.
     downloaded_checksums: LibraryAssetVersionValueMap,
+    /// Nested map: `library` -> `asset_id` -> (`version_size` -> local_path).
+    /// Used to validate path-aware filesystem skips after state says the
+    /// remote bytes are unchanged.
+    downloaded_local_paths: LibraryAssetVersionPathMap,
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> metadata_hash).
     /// Used to detect metadata-only changes (favorite toggle, keywords, GPS
     /// edit, etc.) when file bytes are unchanged but CloudKit has newer
@@ -1267,7 +1276,7 @@ impl DownloadContext {
                 Default::default()
             }
         };
-        let (ids, checksums, hashes, markers, pending, attempts, known_ids) = tokio::join!(
+        let (ids, checksums, paths, hashes, markers, pending, attempts, known_ids) = tokio::join!(
             async {
                 db.get_downloaded_ids().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load downloaded IDs from state DB");
@@ -1277,6 +1286,12 @@ impl DownloadContext {
             async {
                 db.get_downloaded_checksums().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load checksums from state DB");
+                    Default::default()
+                })
+            },
+            async {
+                db.get_downloaded_local_paths().await.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to load downloaded local paths from state DB");
                     Default::default()
                 })
             },
@@ -1344,6 +1359,18 @@ impl DownloadContext {
                 .insert(version_size.into_boxed_str(), checksum.into_boxed_str());
         }
 
+        let mut downloaded_local_paths: LibraryAssetVersionPathMap = FxHashMap::default();
+        for ((library, asset_id, version_size), path) in paths {
+            let lib = intern_id(&mut interner, library);
+            let id = intern_id(&mut interner, asset_id);
+            downloaded_local_paths
+                .entry(lib)
+                .or_default()
+                .entry(id)
+                .or_default()
+                .insert(version_size.into_boxed_str(), path);
+        }
+
         let mut downloaded_metadata_hashes: LibraryAssetVersionValueMap = FxHashMap::default();
         for ((library, asset_id, version_size), metadata_hash) in hashes {
             let lib = intern_id(&mut interner, library);
@@ -1398,6 +1425,7 @@ impl DownloadContext {
         Self {
             downloaded_ids,
             downloaded_checksums,
+            downloaded_local_paths,
             downloaded_metadata_hashes,
             metadata_retry_markers,
             pending_ids,
@@ -1517,6 +1545,19 @@ impl DownloadContext {
         } else {
             None
         }
+    }
+
+    fn downloaded_local_path(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: VersionSizeKey,
+    ) -> Option<&Path> {
+        self.downloaded_local_paths
+            .get(library)
+            .and_then(|m| m.get(asset_id))
+            .and_then(|versions| versions.get(version_size.as_str()))
+            .map(PathBuf::as_path)
     }
 
     fn has_downloaded_without_metadata_hash(&self) -> bool {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -412,6 +412,46 @@ async fn adopt_pending_on_disk_skip(
     adopted
 }
 
+fn state_confirmed_current_path_exists(
+    ctx: &DownloadContext,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    task: &DownloadTask,
+    task_planner: &mut TaskPlanner,
+) -> Option<PathBuf> {
+    let stored_path =
+        ctx.downloaded_local_path(&task.library, &task.asset_id, task.version_size)?;
+
+    for derived in derive_expected_paths(asset, config) {
+        if derived.version_size != task.version_size {
+            continue;
+        }
+        let Some(existing_path) = task_planner.existing_path(&derived.path) else {
+            continue;
+        };
+        if existing_path == stored_path {
+            return Some(existing_path);
+        }
+    }
+
+    None
+}
+
+async fn record_seen_for_forwarded_task(
+    db: &dyn StateDb,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    task: &DownloadTask,
+) {
+    if let Err(e) = planner::upsert_seen_for_task(db, config, asset, task).await {
+        tracing::warn!(
+            asset_id = %task.asset_id,
+            error = %e,
+            "Failed to record asset"
+        );
+    }
+}
+
 async fn backfill_downloaded_metadata_for_on_disk_skip(
     state_db: Option<&dyn StateDb>,
     config: &DownloadConfig,
@@ -1555,20 +1595,6 @@ where
                             }
 
                             if let Some(db) = &producer_state_db {
-                                if let Err(e) = planner::upsert_seen_for_task(
-                                    db.as_ref(),
-                                    config,
-                                    &asset,
-                                    &task,
-                                )
-                                .await
-                                {
-                                    tracing::warn!(
-                                        asset_id = %task.asset_id,
-                                        error = %e,
-                                        "Failed to record asset"
-                                    );
-                                }
                                 // Per-album config (set when {album} is in folder_structure)
                                 // carries the album name so we can record membership.
                                 // In merged-stream mode album is unknown at this point;
@@ -1599,6 +1625,13 @@ where
                                 ) {
                                     Some(true) => {
                                         disposition = disposition.max(AssetDisposition::Forwarded);
+                                        record_seen_for_forwarded_task(
+                                            db.as_ref(),
+                                            config,
+                                            &asset,
+                                            &task,
+                                        )
+                                        .await;
                                         let size = task.size;
                                         if task_tx.send(task).await.is_err() {
                                             return skips;
@@ -1614,43 +1647,70 @@ where
                                             "Skipping (state confirms no download needed)"
                                         );
                                     }
-                                    None => match task_planner
-                                        .existing_path_match(&task.download_path)
-                                    {
-                                        ExistingPathMatch::Exact => {
+                                    None => {
+                                        if let Some(existing_path) =
+                                            state_confirmed_current_path_exists(
+                                                &download_ctx,
+                                                config,
+                                                &asset,
+                                                &task,
+                                                &mut task_planner,
+                                            )
+                                        {
                                             disposition = disposition.max(AssetDisposition::OnDisk);
                                             tracing::debug!(
                                                 asset_id = %task.asset_id,
-                                                path = %task.download_path.display(),
-                                                "Skipping (already downloaded)"
+                                                path = %existing_path.display(),
+                                                "Skipping (state path exists on disk)"
                                             );
+                                            continue;
                                         }
-                                        ExistingPathMatch::AmpmVariant => {
-                                            disposition =
-                                                disposition.max(AssetDisposition::AmpmVariant);
-                                            tracing::debug!(
-                                                asset_id = %task.asset_id,
-                                                path = %task.download_path.display(),
-                                                "Skipping (AM/PM variant exists on disk)"
-                                            );
-                                        }
-                                        ExistingPathMatch::Missing => {
-                                            tracing::debug!(
-                                                asset_id = %task.asset_id,
-                                                path = %task.download_path.display(),
-                                                "File missing, will re-download"
-                                            );
-                                            disposition =
-                                                disposition.max(AssetDisposition::Forwarded);
-                                            let size = task.size;
-                                            if task_tx.send(task).await.is_err() {
-                                                return skips;
+
+                                        match task_planner.existing_path_match(&task.download_path)
+                                        {
+                                            ExistingPathMatch::Exact => {
+                                                disposition =
+                                                    disposition.max(AssetDisposition::OnDisk);
+                                                tracing::debug!(
+                                                    asset_id = %task.asset_id,
+                                                    path = %task.download_path.display(),
+                                                    "Skipping (already downloaded)"
+                                                );
                                             }
-                                            if forecast_check(size) {
-                                                return skips;
+                                            ExistingPathMatch::AmpmVariant => {
+                                                disposition =
+                                                    disposition.max(AssetDisposition::AmpmVariant);
+                                                tracing::debug!(
+                                                    asset_id = %task.asset_id,
+                                                    path = %task.download_path.display(),
+                                                    "Skipping (AM/PM variant exists on disk)"
+                                                );
+                                            }
+                                            ExistingPathMatch::Missing => {
+                                                tracing::debug!(
+                                                    asset_id = %task.asset_id,
+                                                    path = %task.download_path.display(),
+                                                    "File missing, will re-download"
+                                                );
+                                                disposition =
+                                                    disposition.max(AssetDisposition::Forwarded);
+                                                record_seen_for_forwarded_task(
+                                                    db.as_ref(),
+                                                    config,
+                                                    &asset,
+                                                    &task,
+                                                )
+                                                .await;
+                                                let size = task.size;
+                                                if task_tx.send(task).await.is_err() {
+                                                    return skips;
+                                                }
+                                                if forecast_check(size) {
+                                                    return skips;
+                                                }
                                             }
                                         }
-                                    },
+                                    }
                                 }
                             } else {
                                 disposition = disposition.max(AssetDisposition::Forwarded);
@@ -5404,6 +5464,99 @@ mod tests {
             "deleted file must be forwarded for re-download (which fails against the dead URL)"
         );
         assert_eq!(&*failed[0].id, "DELETED");
+    }
+
+    /// Metadata embedding can legitimately change the local byte size after
+    /// the downloaded bytes were verified. A later sync must use the DB row's
+    /// asset identity and recorded path to skip that current-path file instead
+    /// of treating it as a same-name/different-size collision and downloading
+    /// a `-<size>` duplicate.
+    #[tokio::test]
+    async fn metadata_mutated_downloaded_file_is_not_size_dedup_redownloaded() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn asset() -> PhotoAsset {
+            TestPhotoAsset::new("METADATA_MUTATED")
+                .filename("IMG_4123.JPG")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(1234)
+                // Allowlisted CDN host so a regression reaches the download
+                // phase; the non-base64 checksum then fails locally without
+                // doing network I/O.
+                .orig_url("https://p01.icloud-content.com/IMG_4123.JPG")
+                .orig_checksum("ck_metadata_mutated")
+                .build()
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let existing_asset = asset();
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let target_path = crate::download::paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &existing_asset.created().with_timezone(&chrono::Local),
+            "IMG_4123.JPG",
+            None,
+        );
+        fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+        fs::write(&target_path, vec![0u8; 1500]).unwrap();
+
+        let record = crate::test_helpers::TestAssetRecord::new("METADATA_MUTATED")
+            .checksum("ck_metadata_mutated")
+            .filename("IMG_4123.JPG")
+            .size(1234)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "METADATA_MUTATED",
+            "original",
+            &target_path,
+            "local_checksum_after_metadata_write",
+            Some("download_checksum_before_metadata_write"),
+        )
+        .await
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let stream1 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset())]);
+        let result = stream_and_download_from_stream(
+            &client,
+            stream1,
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(result.downloaded, 0, "asset must not be re-downloaded");
+        assert!(
+            result.failed.is_empty(),
+            "state-backed current path should skip before the dead URL reaches the download phase"
+        );
+        assert!(
+            !target_path.with_file_name("IMG_4123-1234.JPG").exists(),
+            "sync must not create a size-dedup duplicate"
+        );
+        let failed = db.get_failed().await.unwrap();
+        assert!(
+            failed.is_empty(),
+            "metadata-mutated downloaded file should remain downloaded, not failed"
+        );
     }
 
     // ── run_metadata_rewrites end-to-end ───────────────────────────────────

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -123,6 +123,11 @@ pub trait DownloadStateStore: Send + Sync {
     async fn get_downloaded_checksums(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError>;
+    async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        Ok(HashMap::new())
+    }
     async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError>;
     async fn touch_last_seen_many(
         &self,
@@ -634,6 +639,18 @@ pub trait StateDb: Send + Sync {
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError>;
 
+    /// Get downloaded asset IDs with their recorded local paths.
+    ///
+    /// Returns a map of (library, id, `version_size`) -> `local_path` for
+    /// downloaded assets. Used to confirm that a state-backed skip still points
+    /// at the current configured destination before skipping size-mismatched
+    /// files that may have been changed by metadata embedding.
+    async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        Ok(HashMap::new())
+    }
+
     /// Get per-asset maximum download attempt counts for failed assets.
     ///
     /// Returns a map of asset_id -> max(download_attempts).
@@ -1114,6 +1131,12 @@ where
         DownloadStateStore::get_downloaded_checksums(self).await
     }
 
+    async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        DownloadStateStore::get_downloaded_local_paths(self).await
+    }
+
     async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
         DownloadStateStore::get_attempt_counts(self).await
     }
@@ -1490,6 +1513,12 @@ impl DownloadStateStore for dyn StateDb + '_ {
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
         StateDb::get_downloaded_checksums(self).await
+    }
+
+    async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        StateDb::get_downloaded_local_paths(self).await
     }
 
     async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
@@ -3006,6 +3035,52 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        self.with_conn("get_downloaded_local_paths", move |conn| {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM assets \
+                     WHERE status = 'downloaded' AND local_path IS NOT NULL",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| StateError::query("get_downloaded_local_paths", e))?;
+            let count = usize::try_from(count).unwrap_or(0);
+
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT library, id, version_size, local_path FROM assets \
+                     WHERE status = 'downloaded' AND local_path IS NOT NULL",
+                )
+                .map_err(|e| StateError::query("get_downloaded_local_paths", e))?;
+
+            let mut paths = HashMap::with_capacity(count);
+            let rows = stmt
+                .query_map([], |row| {
+                    let local_path: String = row.get(3)?;
+                    Ok((
+                        (
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                        ),
+                        PathBuf::from(local_path),
+                    ))
+                })
+                .map_err(|e| StateError::query("get_downloaded_local_paths", e))?;
+            for row in rows {
+                let (key, val) =
+                    row.map_err(|e| StateError::query("get_downloaded_local_paths", e))?;
+                paths.insert(key, val);
+            }
+
+            Ok(paths)
+        })
+        .await
+    }
+
     pub(crate) async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
         self.with_conn("get_attempt_counts", move |conn| {
             let mut stmt = conn
@@ -3897,6 +3972,12 @@ impl DownloadStateStore for SqliteStateDb {
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
         SqliteStateDb::get_downloaded_checksums(self).await
+    }
+
+    async fn get_downloaded_local_paths(
+        &self,
+    ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
+        SqliteStateDb::get_downloaded_local_paths(self).await
     }
 
     async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {


### PR DESCRIPTION
## Summary
- Fixes #553 by skipping a downloaded asset when the DB records the current destination path and the remote checksum still matches.
- Keeps metadata-mutated files from being mistaken for same-name/different-size collisions after EXIF/XMP writes change the local byte size.
- Keeps deleted-file recovery and true size-collision dedupe behavior intact.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test metadata_mutated_downloaded_file_is_not_size_dedup_redownloaded --lib`
- `cargo test deleted_downloaded_file_is_forwarded_not_state_skipped --lib`
- `cargo test filter_two_assets_same_path_different_size_second_deduped --lib`
- `cargo test mark_downloaded_stores_download_checksum --lib`
- `cargo test download::filter::tests:: --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `just gate`

## A/B checks
- Main fails the new issue 553 regression test as expected.
- This branch passes the issue 553 regression test.
- Main and this branch both pass the guard tests above.
- Main and this branch both pass live ignored metadata checks for `sync_set_exif_datetime_embeds_date`, `sync_embed_xmp_writes_xmp_packet`, and `sync_xmp_sidecar_writes_sidecar_file`.
