### PR TITLE
Disable embedded HEIC/HEIF/AVIF metadata rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Embedded metadata writes now skip HEIC/HEIF/AVIF files with a warning instead of using the mp4-atom rewrite path that could corrupt Apple HEIC item graphs. JPEG/TIFF embedded writes and XMP sidecars still run. ([#552])
+
+[#552]: https://github.com/rhoopr/kei/issues/552
+
 ---
 
 ## [0.21.1] - 2026-06-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 [features]
 # XMP metadata embedding + sidecar writing. Default-on; build with
 # `--no-default-features` on platforms where Adobe's vendored C++ XMP
-# Toolkit does not compile (notably FreeBSD — see #256). Disabling drops XMP
-# embedding, sidecars, and HEIC container edits; native JPEG/TIFF EXIF writes
+# Toolkit does not compile (notably FreeBSD - see #256). Disabling drops XMP
+# embedding and sidecars; native JPEG/TIFF EXIF writes
 # remain available through little_exif.
 default = ["xmp"]
 xmp = ["dep:xmp_toolkit"]
@@ -92,8 +92,8 @@ console = "0.16"
 
 # XMP metadata via Adobe's XMP Toolkit (vendored C++ source).
 # Handles JPEG, PNG, TIFF, MP4, MOV, PSD, PDF, and more via XMPFiles.
-# Does NOT handle HEIC — the bundled XMPFiles has no HEIF handler, so HEIC
-# embedded XMP is handled separately via libheif-rs.
+# Does NOT handle HEIC - the bundled XMPFiles has no HEIF handler. Embedded
+# HEIC writes are temporarily skipped while the replacement writer is spiked.
 # Optional (behind the `xmp` feature, default-on) so platforms without a
 # working C++ toolchain for the vendored sources can opt out. See #256.
 xmp_toolkit = { version = "1", optional = true }
@@ -102,14 +102,15 @@ xmp_toolkit = { version = "1", optional = true }
 # disable the default `xmp` feature.
 little_exif = "0.6"
 
-# ISO-BMFF (MP4 / HEIF / HEIC) atom parsing + encoding. HEIC's XMP packet
-# lives in a `mime`-type item inside the `meta` box; mp4-atom gives us the
-# box primitives to surgically insert it without decoding image data.
+# ISO-BMFF (MP4 / HEIF / HEIC) atom parsing. HEIC's XMP packet lives in a
+# `mime`-type item inside the `meta` box; mp4-atom is currently used for
+# reading existing packets and for test-only fixtures while embedded HEIC
+# writes are disabled.
 #
 # Pinned because kei depends on specific HEIF fixes included in 0.11.0:
 #   - #123  `uri ` infe-item support for iOS 17+ HEICs (kei #274)
-#   - #153  colr cursor advance for `prof` / `rICC` ICC profiles, fixing
-#           metadata embed on HDR HEICs (kei #269, #276)
+#   - #153  colr cursor advance for `prof` / `rICC` ICC profiles, covering
+#           HDR HEIC parser fixtures (kei #269, #276)
 #   - #157  bound `Vec::with_capacity` in `parse_vorbis_comment` / `Avcc`,
 #           fixes the fuzz-found OOM (upstream #154)
 #   - #161  drops mp4-atom's unmaintained `paste` dep in favor of `pastey`

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -1,22 +1,20 @@
-//! ISO-BMFF atom surgery for inserting XMP into HEIC / HEIF / AVIF files.
+//! ISO-BMFF helpers for reading XMP from HEIC / HEIF / AVIF files.
 //!
-//! Adobe's XMP Toolkit has no HEIF handler, so the HEIC write path edits the
-//! container directly via [`mp4_atom`]. The goal is narrow: add (or replace)
-//! an XMP `mime` item inside the `meta` box without touching the encoded
-//! image bytes in `mdat` — invariant 2.
+//! Adobe's XMP Toolkit has no HEIF handler, so kei reads HEIF item metadata
+//! directly via [`mp4_atom`]. Embedded HEIC writes are temporarily disabled
+//! because the previous mp4-atom-backed writer could lossy-round-trip Apple
+//! item graphs.
 //!
-//! Strategy: append the XMP payload as a new trailing `mdat`, record it in
-//! `iinf` + `iloc` with `construction_method = 0` (file-absolute offsets),
-//! and remap every other `iloc` entry so the existing image data stays
-//! byte-for-byte identical in its new location after `meta` grows.
+//! The old insertion code remains compiled for unit tests so existing parser
+//! fixtures can still seed XMP packets while the replacement writer is spiked.
 
+#[cfg(test)]
 use std::io::Write;
 use std::path::Path;
 
-use mp4_atom::{
-    Any, Atom, Buf, DecodeMaybe, Encode, FourCC, Header, Iinf, Iloc, ItemInfoEntry, ItemLocation,
-    ItemLocationExtent, Mdat, Meta,
-};
+#[cfg(test)]
+use mp4_atom::{Any, Encode, ItemInfoEntry, ItemLocation, ItemLocationExtent, Mdat, Meta};
+use mp4_atom::{Atom, Buf, DecodeMaybe, FourCC, Header, Iinf, Iloc};
 
 /// Typed failures from the HEIC writer. Each variant names the precise mode
 /// so call-site logging and any future fall-back logic can distinguish
@@ -28,6 +26,7 @@ use mp4_atom::{
 /// while kei adds the byte offset / atom kind context.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum HeifError {
+    #[cfg(test)]
     #[error("ISO-BMFF decode failed at byte offset {offset}/{total}: {source}")]
     Decode {
         offset: u64,
@@ -36,6 +35,7 @@ pub(crate) enum HeifError {
         source: mp4_atom::Error,
     },
 
+    #[cfg(test)]
     #[error("Unparsable trailing bytes at offset {offset}/{total} (file likely truncated)")]
     UnparsableTail { offset: u64, total: u64 },
 
@@ -46,9 +46,11 @@ pub(crate) enum HeifError {
         source: mp4_atom::Error,
     },
 
+    #[cfg(test)]
     #[error("HEIC has no `meta` box at the top level ({input_len} bytes scanned)")]
     MissingMeta { input_len: usize },
 
+    #[cfg(test)]
     #[error("Failed to re-encode `{kind}` atom: {source}")]
     Encode {
         kind: FourCC,
@@ -359,6 +361,7 @@ fn iinf_entry_count(body: &[u8], version: u8) -> Option<u32> {
 /// Writing to a `Write` (typically `BufWriter<File>`) rather than returning
 /// a `Vec<u8>` eliminates one full-file-sized allocation on the metadata-
 /// embed path — meaningful for large ProRAW HEICs under high concurrency.
+#[cfg(test)]
 #[allow(
     clippy::indexing_slicing,
     reason = "meta_idx comes from .position() over atoms; new_mdat_idx is atoms.len() - 1 \
@@ -549,6 +552,7 @@ pub(crate) fn insert_xmp<W: Write>(
 /// Criteria: an iinf entry flagged as `mime` + `application/rdf+xml`, its
 /// iloc entry references a range that lies entirely within a single trailing
 /// mdat atom, and no other iloc entry references into that atom.
+#[cfg(test)]
 #[allow(
     clippy::indexing_slicing,
     reason = "meta_idx is caller-validated and idx comes from atoms.iter().enumerate() \
@@ -625,6 +629,7 @@ fn locate_stale_kei_mdat(
 /// Byte size of an atom's box header (the length field + 4-byte kind code).
 /// mp4-atom always emits a 32-bit-length header for atoms that fit — large
 /// mdats (>4GB) would use a 16-byte header, but kei isn't going to hit that.
+#[cfg(test)]
 fn header_size_of(_atom: &Any) -> u64 {
     8
 }
@@ -632,6 +637,7 @@ fn header_size_of(_atom: &Any) -> u64 {
 /// Return a vector where entry `i` is the byte offset at which atom `i` will
 /// sit in the re-serialized output (i.e. the running sum of preceding atom
 /// sizes).
+#[cfg(test)]
 fn running_offsets(atoms: &[Any]) -> Vec<u64> {
     let mut offsets = Vec::with_capacity(atoms.len());
     let mut running = 0u64;
@@ -646,6 +652,7 @@ fn running_offsets(atoms: &[Any]) -> Vec<u64> {
 /// offset" to "new file offset", using the per-atom old_start/old_end/new_start
 /// table. An offset that falls within `[old_start, old_end)` is rebased onto
 /// `new_start` with the same intra-atom position.
+#[cfg(test)]
 fn remap_file_offsets(iloc: &mut Iloc, ranges: &[(u64, u64, u64)]) {
     for loc in &mut iloc.item_locations {
         if loc.construction_method != 0 {
@@ -665,6 +672,7 @@ fn remap_file_offsets(iloc: &mut Iloc, ranges: &[(u64, u64, u64)]) {
     }
 }
 
+#[cfg(test)]
 fn remap_point(file_offset: u64, ranges: &[(u64, u64, u64)]) -> Option<u64> {
     for &(old_start, old_end, new_start) in ranges {
         if file_offset >= old_start && file_offset < old_end {
@@ -674,6 +682,7 @@ fn remap_point(file_offset: u64, ranges: &[(u64, u64, u64)]) -> Option<u64> {
     None
 }
 
+#[cfg(test)]
 fn encoded_size(atom: &Any) -> u64 {
     let mut sink = Vec::new();
     if let Err(e) = atom.encode(&mut sink) {
@@ -686,6 +695,7 @@ fn encoded_size(atom: &Any) -> u64 {
     sink.len() as u64
 }
 
+#[cfg(test)]
 fn remove_existing_xmp_items(meta: &mut Meta) -> Vec<u32> {
     let mut removed = Vec::new();
     if let Some(iinf) = meta.get_mut::<Iinf>() {
@@ -703,6 +713,7 @@ fn remove_existing_xmp_items(meta: &mut Meta) -> Vec<u32> {
     removed
 }
 
+#[cfg(test)]
 fn next_free_item_id(meta: &Meta) -> u32 {
     meta.get::<Iinf>()
         .map(|iinf| {
@@ -716,6 +727,7 @@ fn next_free_item_id(meta: &Meta) -> u32 {
         .unwrap_or(1)
 }
 
+#[cfg(test)]
 fn push_iinf_entry(meta: &mut Meta, entry: ItemInfoEntry) {
     match meta.get_mut::<Iinf>() {
         Some(iinf) => iinf.item_infos.push(entry),
@@ -725,6 +737,7 @@ fn push_iinf_entry(meta: &mut Meta, entry: ItemInfoEntry) {
     }
 }
 
+#[cfg(test)]
 fn push_iloc_entry(meta: &mut Meta, loc: ItemLocation) {
     match meta.get_mut::<Iloc>() {
         Some(iloc) => iloc.item_locations.push(loc),

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -42,6 +42,8 @@ const KEI_XMP_PREFIX: &str = "kei";
 
 #[cfg(feature = "xmp")]
 static INIT: Once = Once::new();
+#[cfg(feature = "xmp")]
+static HEIF_EMBED_DISABLED_WARNING: Once = Once::new();
 
 #[cfg(feature = "xmp")]
 fn ensure_initialized() {
@@ -222,9 +224,13 @@ impl MetadataWrite {
     }
 }
 
-/// Write the requested metadata into the file, using XMP Toolkit/HEIF packet
-/// rewriting in default builds and native EXIF for JPEG/TIFF in no-`xmp`
-/// builds.
+/// Write the requested metadata into the file, using XMP Toolkit in default
+/// builds and native EXIF for JPEG/TIFF in no-`xmp` builds.
+///
+/// HEIF-family embedded writes are intentionally disabled. The previous
+/// mp4-atom-backed rewrite path could corrupt Apple HEIC item graphs by
+/// re-encoding metadata boxes lossy, so HEIC/HEIF/AVIF inputs are left
+/// unchanged after emitting a warning. Sidecar writes remain available.
 ///
 /// Atomic: we copy the input to a sibling temp file named with `temp_suffix`,
 /// patch it in place, then rename over the target. A crash mid-write leaves the
@@ -247,10 +253,24 @@ pub(crate) fn apply_metadata(path: &Path, write: &MetadataWrite, temp_suffix: &s
     }
     #[cfg(feature = "xmp")]
     if is_heif_file(path) {
-        apply_metadata_heif(path, write, temp_suffix)
+        skip_heif_embed_write(path);
+        Ok(())
     } else {
         apply_metadata_xmp_toolkit(path, write, temp_suffix)
     }
+}
+
+#[cfg(feature = "xmp")]
+fn skip_heif_embed_write(path: &Path) {
+    HEIF_EMBED_DISABLED_WARNING.call_once(|| {
+        tracing::warn!(
+            path = %path.display(),
+            "Embedded HEIC/HEIF/AVIF metadata writes are temporarily disabled because the previous \
+             HEIF rewrite path can corrupt Apple HEIC item graphs; leaving HEIC/HEIF/AVIF files \
+             unchanged. Enable xmp_sidecar for HEIC metadata export until the embedded writer \
+             is replaced."
+        );
+    });
 }
 
 /// Read the first 12 bytes of `path` and dispatch to [`heif::is_heif_content`].
@@ -687,75 +707,6 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
     Ok(())
 }
 
-/// HEIC write path: read any existing XMP, apply our fields on top, and
-/// insert the resulting packet as a MIME item inside the HEIC's `meta` box.
-/// Operates on file bytes directly via ISO-BMFF atom editing so the encoded
-/// image data in `mdat` stays byte-for-byte identical — invariant 2.
-#[cfg(feature = "xmp")]
-fn apply_metadata_heif(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
-    ensure_initialized();
-
-    let input = std::fs::read(path)
-        .with_context(|| format!("Reading {} for HEIC update", path.display()))?;
-
-    // Preserve any XMP the file already carries (e.g. Apple Live Photo or
-    // depth markers) by parsing it into the XmpMeta we mutate. Use the
-    // strict variant so a structurally-broken iinf/iloc surfaces as an
-    // error instead of silently stripping pre-existing XMP — the failure
-    // then propagates to record_metadata_write_failure so the asset
-    // re-drives metadata on the next sync. If the XMP packet itself is
-    // malformed UTF-8 / RDF, fall back to an empty packet (string-level
-    // failure isn't structural).
-    let existing_xmp_bytes = heif::extract_xmp_strict(&input)
-        .with_context(|| format!("Reading existing XMP from {}", path.display()))?;
-    let mut meta = existing_xmp_bytes
-        .as_deref()
-        .and_then(|bytes| std::str::from_utf8(bytes).ok())
-        .and_then(|s| s.parse::<XmpMeta>().ok())
-        .unwrap_or_else(|| XmpMeta::new().unwrap_or_default());
-    apply_to_xmp(&mut meta, write)?;
-    let xmp_bytes = meta.to_string().into_bytes();
-
-    let tmp_path = temp_path_for(path, temp_suffix);
-
-    // Stream the rewrite straight to disk and keep the descriptor open
-    // through the post-rewrite validation: the old Vec<u8> output from
-    // insert_xmp was one full-file-sized copy we didn't need, and
-    // reusing the same fd for the magic-byte probe (below) avoids a
-    // second `open()` and the race with whatever interleaves with it.
-    // `read(true)` is required because `File::create` opens write-only.
-    let validate_guard = TmpGuard::new(&tmp_path);
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(&tmp_path)
-        .with_context(|| format!("Creating {}", tmp_path.display()))?;
-    let mut writer = std::io::BufWriter::new(file);
-    heif::insert_xmp(&input, &xmp_bytes, &mut writer)
-        .with_context(|| format!("Inserting XMP into HEIC {}", path.display()))?;
-    let mut file = writer
-        .into_inner()
-        .with_context(|| format!("Flushing patched HEIC to {}", tmp_path.display()))?;
-    file.sync_all()
-        .with_context(|| format!("fsync for {}", tmp_path.display()))?;
-
-    // MS-6: Defense-in-depth — read the first 12 bytes back and confirm
-    // the rewritten file still starts with a HEIF `ftyp` brand before
-    // atomic-renaming over the user's data. Catches any future
-    // insert_xmp regression that produces non-HEIF output (corrupted
-    // ftyp, wrong magic, truncated header) before the corrupt file
-    // becomes visible.
-    validate_heif_post_rewrite(&mut file, &tmp_path)?;
-    drop(file);
-    std::fs::rename(&tmp_path, path)
-        .with_context(|| format!("Renaming {} -> {}", tmp_path.display(), path.display()))?;
-    validate_guard.disarm();
-    tracing::debug!(path = %path.display(), "Applied HEIC metadata");
-    Ok(())
-}
-
 /// Read the first 12 bytes of `file` and verify it starts with an
 /// ISO-BMFF `ftyp` box whose major brand is in the HEIF family. Used as
 /// a sanity check between `insert_xmp` and the atomic rename so a
@@ -763,6 +714,7 @@ fn apply_metadata_heif(path: &Path, write: &MetadataWrite, temp_suffix: &str) ->
 /// rewrite handle (seeks back to 0) to avoid reopening `tmp_path`
 /// immediately after `sync_all`; the path is only used for diagnostics.
 #[cfg(feature = "xmp")]
+#[cfg(test)]
 fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Result<()> {
     use std::io::{Read, Seek, SeekFrom};
     file.seek(SeekFrom::Start(0))
@@ -787,6 +739,7 @@ fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Resu
 /// packet bytes directly.
 #[cfg(all(test, feature = "xmp"))]
 fn build_xmp_packet(write: &MetadataWrite) -> Result<Vec<u8>> {
+    ensure_initialized();
     let mut meta = XmpMeta::new().context("creating XmpMeta")?;
     apply_to_xmp(&mut meta, write)?;
     Ok(meta.to_string().into_bytes())
@@ -1418,6 +1371,14 @@ mod tests {
         bytes
     }
 
+    fn write_seeded_heic(dir: &Path, name: &str, seed: &MetadataWrite) -> PathBuf {
+        fs::create_dir_all(dir).unwrap();
+        let path = dir.join(name);
+        let seed_xmp = build_xmp_packet(seed).expect("seed XMP packet");
+        fs::write(&path, heic_with_xmp_packet(&seed_xmp)).unwrap();
+        path
+    }
+
     fn heif_ftyp_without_meta() -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&24u32.to_be_bytes());
@@ -1429,11 +1390,25 @@ mod tests {
         bytes
     }
 
+    fn assert_heif_embed_skip_preserves(path: &Path, write: &MetadataWrite) {
+        let original = fs::read(path).unwrap();
+        apply_metadata_with_default_suffix(path, write).expect("HEIC metadata skip should succeed");
+        assert_eq!(
+            fs::read(path).unwrap(),
+            original,
+            "skipped HEIC metadata write must leave media bytes unchanged"
+        );
+        assert!(
+            !temp_path_for(path, ".meta-tmp").exists(),
+            "skipped HEIC metadata write must not leave a metadata temp file behind"
+        );
+    }
+
     #[test]
     fn apply_metadata_heic_rating_and_title() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "rating.heic");
-        apply_metadata_with_default_suffix(
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 rating: Some(5),
@@ -1441,22 +1416,15 @@ mod tests {
                 keywords: vec!["beach".into()],
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC metadata write");
-
-        let xmp = extract_xmp_from_heic(&fs::read(&path).unwrap()).expect("XMP missing");
-        let s = std::str::from_utf8(&xmp).unwrap();
-        assert!(s.contains("xmp:Rating"), "XMP missing rating");
-        assert!(s.contains("Vacation"), "XMP missing title");
-        assert!(s.contains("beach"), "XMP missing keyword");
+        );
         fs::remove_file(&path).ok();
     }
 
     #[test]
-    fn apply_metadata_heic_gps_roundtrips() {
+    fn apply_metadata_heic_gps_skip_leaves_file_unchanged() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "gps.heic");
-        apply_metadata_with_default_suffix(
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 gps: Some(GpsCoords {
@@ -1466,16 +1434,7 @@ mod tests {
                 }),
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC metadata write");
-
-        let xmp = extract_xmp_from_heic(&fs::read(&path).unwrap()).expect("no XMP item");
-        let s = std::str::from_utf8(&xmp).unwrap();
-        assert!(s.contains("GPSLatitude"));
-        assert!(s.contains('N'), "latitude ref missing");
-        assert!(s.contains("GPSLongitude"));
-        assert!(s.contains('W'), "longitude ref missing");
-        assert!(s.contains("GPSAltitude"));
+        );
         fs::remove_file(&path).ok();
     }
 
@@ -1483,93 +1442,68 @@ mod tests {
     fn apply_metadata_heic_preserves_image_data() {
         let dir = test_tmp_dir("meta_heic_tests");
         let path = fresh_heic(&dir, "preserve.heic");
-        let original_bytes = SAMPLE_HEIC.to_vec();
-        apply_metadata_with_default_suffix(
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 rating: Some(3),
                 ..MetadataWrite::default()
             },
-        )
-        .unwrap();
-
-        let new_bytes = fs::read(&path).unwrap();
-        // XMP was appended, so the file grew by roughly packet size + box overhead.
-        assert!(
-            new_bytes.len() > original_bytes.len(),
-            "file should grow after XMP write"
-        );
-        assert!(
-            new_bytes.len() < original_bytes.len() + 16_384,
-            "HEIC file grew unexpectedly by {} bytes",
-            new_bytes.len() - original_bytes.len()
-        );
-
-        // The encoded image bytes in mdat must be byte-for-byte identical —
-        // invariant 2. Locate mdat in both buffers and compare.
-        let orig_mdat = find_mdat_bytes(&original_bytes).expect("original mdat");
-        let new_mdat = find_mdat_bytes(&new_bytes).expect("new mdat");
-        assert_eq!(
-            orig_mdat, new_mdat,
-            "mdat image data must not change across metadata writes"
         );
 
         fs::remove_file(&path).ok();
     }
 
-    /// Second write should preserve fields written by the first — confirms
-    /// the HEIC path reads existing XMP before mutating, so we don't drop
-    /// e.g. Apple's existing XMP markers when adding kei-specific fields.
+    /// Skipped HEIC writes must preserve pre-existing XMP byte-for-byte. The
+    /// temporary mitigation is safer than a lossy rewrite: kei does not add new
+    /// embedded fields, but it also does not drop Apple's existing metadata.
     #[test]
-    fn apply_metadata_heic_preserves_existing_xmp_on_rewrite() {
+    fn apply_metadata_heic_preserves_existing_xmp_on_skip() {
         let dir = test_tmp_dir("meta_heic_tests");
-        let path = fresh_heic(&dir, "preserve_xmp.heic");
-        apply_metadata_with_default_suffix(
-            &path,
+        let path = write_seeded_heic(
+            &dir,
+            "preserve_xmp.heic",
             &MetadataWrite {
                 title: Some("First".into()),
                 ..MetadataWrite::default()
             },
-        )
-        .unwrap();
-        apply_metadata_with_default_suffix(
+        );
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 rating: Some(4),
                 ..MetadataWrite::default()
             },
-        )
-        .unwrap();
+        );
 
-        let xmp = extract_xmp_from_heic(&fs::read(&path).unwrap()).expect("XMP missing");
+        let rewritten = fs::read(&path).unwrap();
+        let xmp = extract_xmp_from_heic(&rewritten).expect("XMP missing");
         let s = std::str::from_utf8(&xmp).unwrap();
         assert!(
             s.contains("First"),
-            "first-write title should survive rewrite"
+            "seeded title should survive skipped rewrite"
         );
         assert!(
-            s.contains("xmp:Rating"),
-            "second-write rating should be present"
+            !s.contains("xmp:Rating"),
+            "skipped HEIC metadata write must not add new embedded fields"
         );
         fs::remove_file(&path).ok();
     }
 
     #[test]
     fn apply_metadata_heic_preserves_fixture_with_seeded_xmp_item() {
-        let seed_xmp = build_xmp_packet(&MetadataWrite {
-            description: Some("Original iOS caption".into()),
-            people: vec!["Casey".into()],
-            media_subtype: Some("portrait".into()),
-            ..MetadataWrite::default()
-        })
-        .expect("seed XMP packet");
-        let source = heic_with_xmp_packet(&seed_xmp);
-
         let dir = test_tmp_dir("meta_heic_tests");
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("seeded_xmp.heic");
-        fs::write(&path, &source).unwrap();
-        apply_metadata_with_default_suffix(
+        let path = write_seeded_heic(
+            &dir,
+            "seeded_xmp.heic",
+            &MetadataWrite {
+                description: Some("Original iOS caption".into()),
+                people: vec!["Casey".into()],
+                media_subtype: Some("portrait".into()),
+                ..MetadataWrite::default()
+            },
+        );
+        let source = fs::read(&path).unwrap();
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 rating: Some(5),
@@ -1577,28 +1511,27 @@ mod tests {
                 keywords: vec!["Favorites".into()],
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC metadata rewrite should preserve seeded XMP");
+        );
 
         let rewritten = fs::read(&path).unwrap();
-        let xmp = extract_xmp_from_heic(&rewritten).expect("XMP missing after rewrite");
+        let xmp = extract_xmp_from_heic(&rewritten).expect("XMP missing after skip");
         let s = std::str::from_utf8(&xmp).unwrap();
         assert!(
             s.contains("Original iOS caption"),
-            "seeded description should survive rewrite"
+            "seeded description should survive skipped rewrite"
         );
         assert!(s.contains("Casey"), "seeded person should survive rewrite");
         assert!(
             s.contains("portrait"),
             "seeded kei media subtype should survive rewrite"
         );
-        assert!(s.contains("xmp:Rating"), "rewrite rating missing");
-        assert!(s.contains("Kei rewrite"), "rewrite title missing");
-        assert!(s.contains("Favorites"), "rewrite keyword missing");
+        assert!(!s.contains("xmp:Rating"), "skipped rewrite added rating");
+        assert!(!s.contains("Kei rewrite"), "skipped rewrite added title");
+        assert!(!s.contains("Favorites"), "skipped rewrite added keyword");
         assert_eq!(
             count_xmp_items_in_heic(&rewritten),
             1,
-            "rewrite must update the existing XMP item instead of appending duplicates"
+            "skipped rewrite must not append duplicate XMP items"
         );
         assert_eq!(
             find_mdat_bytes(&source),
@@ -1616,33 +1549,17 @@ mod tests {
         let original = heif_ftyp_without_meta();
         fs::write(&path, &original).unwrap();
 
-        let err = apply_metadata_with_default_suffix(
+        assert_heif_embed_skip_preserves(
             &path,
             &MetadataWrite {
                 rating: Some(3),
                 ..MetadataWrite::default()
             },
-        )
-        .expect_err("HEIC without a meta box should reject XMP rewrite");
-
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("Inserting XMP into HEIC"),
-            "error should name the failed HEIC rewrite step: {message}"
-        );
-        assert!(
-            message.contains("no `meta` box"),
-            "error should include the structural HEIC failure: {message}"
         );
         assert_eq!(
             fs::read(&path).unwrap(),
             original,
-            "failed HEIC rewrite must leave original media bytes untouched"
-        );
-        let tmp_path = temp_path_for(&path, ".meta-tmp");
-        assert!(
-            !tmp_path.exists(),
-            "failed HEIC rewrite must not leave a metadata temp file behind"
+            "skipped HEIC rewrite must leave original media bytes untouched"
         );
         fs::remove_file(&path).ok();
     }
@@ -1656,21 +1573,21 @@ mod tests {
             title: Some("Repeat".into()),
             ..MetadataWrite::default()
         };
+        let original = fs::read(&path).unwrap();
 
         apply_metadata_with_default_suffix(&path, &write).unwrap();
         let first = fs::read(&path).unwrap();
         apply_metadata_with_default_suffix(&path, &write).unwrap();
         let second = fs::read(&path).unwrap();
 
-        // Rewriting with the same data must not accumulate XMP items or
-        // otherwise grow the file on subsequent passes.
         assert_eq!(
-            first.len(),
-            second.len(),
-            "re-writing identical metadata must be idempotent"
+            first, original,
+            "first skipped HEIC metadata write must leave bytes unchanged"
         );
-        let xmp_count = count_xmp_items_in_heic(&second);
-        assert_eq!(xmp_count, 1, "expected exactly one XMP item after rewrite");
+        assert_eq!(
+            second, first,
+            "repeated skipped HEIC metadata writes must stay idempotent"
+        );
         fs::remove_file(&path).ok();
     }
 
@@ -1755,21 +1672,22 @@ mod tests {
     // even when the file already carried the same value. Content-sniff
     // dispatch + XMP packet parsing fixes the read path symmetric with #271.
     //
-    // These tests round-trip via `apply_metadata` rather than relying on
-    // the fixture having pre-existing EXIF, so they pin the read path
-    // independent of whatever XMP `tests/data/sample.heic` ships with.
+    // These tests seed XMP directly rather than relying on the fixture having
+    // pre-existing EXIF, so they pin the read path independent of whatever XMP
+    // `tests/data/sample.heic` ships with. Embedded HEIC writes are currently
+    // disabled, so `apply_metadata` is intentionally not part of this probe
+    // regression.
     #[test]
-    fn probe_exif_heic_reports_datetime_after_apply() {
+    fn probe_exif_heic_reports_seeded_datetime() {
         let dir = test_tmp_dir("probe_heic_tests");
-        let path = fresh_heic(&dir, "probe_dt.heic");
-        apply_metadata_with_default_suffix(
-            &path,
+        let path = write_seeded_heic(
+            &dir,
+            "probe_dt.heic",
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC datetime write");
+        );
         let probe = probe_exif(&path).expect("probe_exif must succeed on HEIC");
         assert!(
             probe.datetime_original.is_some(),
@@ -1784,11 +1702,11 @@ mod tests {
     }
 
     #[test]
-    fn probe_exif_heic_reports_gps_after_apply() {
+    fn probe_exif_heic_reports_seeded_gps() {
         let dir = test_tmp_dir("probe_heic_tests");
-        let path = fresh_heic(&dir, "probe_gps.heic");
-        apply_metadata_with_default_suffix(
-            &path,
+        let path = write_seeded_heic(
+            &dir,
+            "probe_gps.heic",
             &MetadataWrite {
                 gps: Some(GpsCoords {
                     latitude: 37.7749,
@@ -1797,8 +1715,7 @@ mod tests {
                 }),
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC GPS write");
+        );
         let probe = probe_exif(&path).expect("probe_exif must succeed on HEIC");
         assert!(
             probe.has_gps,
@@ -1837,11 +1754,9 @@ mod tests {
     #[test]
     fn probe_exif_dispatches_heif_on_extension_less_part_file() {
         let dir = test_tmp_dir("probe_heic_tests");
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC.kei-tmp");
-        fs::write(&path, SAMPLE_HEIC).unwrap();
-        apply_metadata_with_default_suffix(
-            &path,
+        let path = write_seeded_heic(
+            &dir,
+            "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC.kei-tmp",
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
                 gps: Some(GpsCoords {
@@ -1851,8 +1766,7 @@ mod tests {
                 }),
                 ..MetadataWrite::default()
             },
-        )
-        .expect("HEIC metadata write on .kei-tmp");
+        );
         let probe = probe_exif(&path).expect("probe_exif on .kei-tmp HEIC");
         assert!(
             probe.datetime_original.is_some(),
@@ -1887,26 +1801,22 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
-    // ── Regression: dispatch must work on part-file paths (issue #269) ──
+    // ── Regression: HEIC skips must work on part-file paths (issue #552) ──
     //
-    // The download pipeline writes metadata onto the `<base32>.kei-tmp`
-    // part file *before* the atomic rename to the final `.HEIC` name. A
-    // dispatch keyed off `path.extension()` saw `kei-tmp`, missed the
-    // HEIF branch, and routed HEIC bytes to XMP Toolkit, which has no
-    // HEIF handler — every first-pass HEIC metadata write logged "Failed
-    // to write metadata: Opening …kei-tmp.meta-tmp for XMP update" and
-    // set a retry marker, then the next sync's metadata-rewrite pass
-    // silently fixed it on the renamed file. Content sniffing eliminates
-    // the spurious failure on the first pass.
+    // The download pipeline writes embedded metadata onto the `<base32>.kei-tmp`
+    // part file before the atomic rename to the final `.HEIC` name. While the
+    // HEIC embedded writer is disabled, content sniffing must still route that
+    // extension-shadowed part file to the safe skip path, not XMP Toolkit.
 
     #[test]
-    fn apply_metadata_dispatches_heif_on_extension_less_part_file() {
+    fn apply_metadata_skips_heif_on_extension_less_part_file() {
         let dir = test_tmp_dir("meta_heic_tests");
         fs::create_dir_all(&dir).unwrap();
         // Mimic the download part-file: base32-ish stem with `.kei-tmp`
         // suffix shadowing the real `.heic` extension.
         let path = dir.join("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.kei-tmp");
         fs::write(&path, SAMPLE_HEIC).unwrap();
+        let original = fs::read(&path).unwrap();
         apply_metadata_with_default_suffix(
             &path,
             &MetadataWrite {
@@ -1915,12 +1825,16 @@ mod tests {
                 ..MetadataWrite::default()
             },
         )
-        .expect("HEIC metadata write must succeed on .kei-tmp part file");
-        let xmp = extract_xmp_from_heic(&fs::read(&path).unwrap())
-            .expect("XMP must be embedded via the HEIF writer, not XMP Toolkit");
-        let s = std::str::from_utf8(&xmp).unwrap();
-        assert!(s.contains("xmp:Rating"), "XMP missing rating");
-        assert!(s.contains("PartFile"), "XMP missing title");
+        .expect("HEIC metadata skip must succeed on .kei-tmp part file");
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            original,
+            "extension-shadowed HEIC part files must be skipped without modification"
+        );
+        assert!(
+            !temp_path_for(&path, ".meta-tmp").exists(),
+            "skipped extension-shadowed HEIC part files must not leave a temp file"
+        );
         fs::remove_file(&path).ok();
     }
 
@@ -1976,6 +1890,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("uri_infe.heic");
         fs::write(&path, &bytes).unwrap();
+        let original = fs::read(&path).unwrap();
 
         apply_metadata_with_default_suffix(
             &path,
@@ -1985,13 +1900,13 @@ mod tests {
                 ..MetadataWrite::default()
             },
         )
-        .expect("HEIC metadata write must succeed on a file with a `uri ` infe item");
+        .expect("disabled HEIC metadata write must skip a file with a `uri ` infe item");
 
-        let xmp = extract_xmp_from_heic(&fs::read(&path).unwrap())
-            .expect("XMP must be embedded after round-tripping a uri-bearing HEIC");
-        let s = std::str::from_utf8(&xmp).unwrap();
-        assert!(s.contains("xmp:Rating"), "XMP missing rating");
-        assert!(s.contains("UriItem"), "XMP missing title");
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            original,
+            "disabled HEIC metadata writes must not round-trip uri-bearing item graphs"
+        );
         fs::remove_file(&path).ok();
     }
 

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1018,14 +1018,14 @@ fn sync_xmp_sidecar_writes_sidecar_file() {
     });
 }
 
-/// [metadata].embed_xmp on a HEIC file: kei routes through the mp4-atom HEIC writer
-/// rather than xmp_toolkit. The resulting HEIC must carry an XMP packet
-/// as a MIME item inside the `meta` box; we detect it by looking for the
-/// `<x:xmpmeta` magic in the file bytes.
+/// [metadata].embed_xmp on a HEIC file: embedded HEIC writes are temporarily
+/// skipped because the previous mp4-atom writer could corrupt Apple HEIC item
+/// graphs. Sync should still succeed and leave the downloaded HEIC usable;
+/// sidecars remain the supported HEIC metadata export path.
 #[cfg(feature = "xmp")]
 #[test]
 #[ignore]
-fn sync_embed_xmp_on_heic_writes_mime_item() {
+fn sync_embed_xmp_on_heic_skips_embedded_write() {
     let (username, password, cookie_dir) = common::require_preauth();
 
     common::with_auth_retry(|| {
@@ -1066,16 +1066,9 @@ fn sync_embed_xmp_on_heic_writes_mime_item() {
             return;
         }
 
-        let bytes = std::fs::read(heics[0]).expect("read HEIC");
-        // <x:xmpmeta is the opening tag the xmp_toolkit serializer emits.
-        // mp4-atom embeds that packet unchanged inside the HEIC `mime` item.
-        let needle = b"<x:xmpmeta";
-        let found = bytes
-            .windows(needle.len())
-            .any(|w| w.eq_ignore_ascii_case(needle));
         assert!(
-            found,
-            "HEIC `{}` must carry an XMP packet after embed_xmp",
+            std::fs::metadata(heics[0]).expect("stat HEIC").len() > 0,
+            "HEIC `{}` should still be downloaded when embed_xmp is enabled",
             heics[0].display()
         );
     });


### PR DESCRIPTION
## Summary
- Disabled embedded HEIC/HEIF/AVIF metadata writes via XMP Toolkit and `mp4-atom` rewrite because the current rewrite path can corrupt Apple HEIC item graphs.
- Kept JPEG/TIFF embedded writes and XMP sidecars working, and kept HEIC metadata probing by adding direct seed/write fixtures for tests.
- Updated changelog, feature docs, and a sync integration test to describe/verify the temporary skip behavior.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test "apply_metadata_heic_" -- --nocapture`
- `cargo test "probe_exif_heic_" -- --nocapture`
- `just gate` (fails due sandbox environment blocking local TCP bind)
