### PR TITLE
Fix same-size path collision skips

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1117,6 +1117,27 @@ enum CollisionStrategy {
     SkipIfExists,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathResolution {
+    Download(PathBuf),
+    Skip(PathBuf),
+}
+
+impl PathResolution {
+    fn download_path(self) -> Option<PathBuf> {
+        match self {
+            Self::Download(path) => Some(path),
+            Self::Skip(_) => None,
+        }
+    }
+
+    fn effective_path(&self) -> &Path {
+        match self {
+            Self::Download(path) | Self::Skip(path) => path.as_path(),
+        }
+    }
+}
+
 /// Shared context for `resolve_download_path` -- groups the mutable/config
 /// references that every call needs so the function stays under clippy's
 /// argument limit.
@@ -1131,7 +1152,8 @@ struct ResolveContext<'a> {
 /// Resolve the final download path for a single version, handling on-disk
 /// files, AM/PM whitespace variants, and in-flight claimed paths.
 ///
-/// Returns `Some(path)` when the file should be downloaded, or `None` to skip.
+/// Returns [`PathResolution::Download`] when the file should be downloaded, or
+/// [`PathResolution::Skip`] when an on-disk or in-flight path already covers it.
 ///
 /// `check_ampm`: when true, also checks AM/PM whitespace variants on disk
 /// (relevant for primary photos whose timestamps contain AM/PM).
@@ -1147,33 +1169,37 @@ fn resolve_download_path(
     check_ampm: bool,
     make_dedup_filename: impl FnOnce() -> String,
     label: &str,
-) -> Option<PathBuf> {
+) -> PathResolution {
     // Check for the file on disk. For primary photos, also check AM/PM
     // whitespace variants (e.g., "1.40.01 PM.PNG" vs "1.40.01\u{202F}PM.PNG").
-    let on_disk_size = ctx.dir_cache.file_size(download_path).or_else(|| {
-        if !check_ampm {
-            return None;
-        }
-        let variant = ctx.dir_cache.find_ampm_variant(download_path)?;
-        Some(ctx.dir_cache.file_size(&variant).unwrap_or(0))
-    });
+    let on_disk_match = ctx
+        .dir_cache
+        .file_size(download_path)
+        .map(|size| (size, download_path.to_path_buf()))
+        .or_else(|| {
+            if !check_ampm {
+                return None;
+            }
+            let variant = ctx.dir_cache.find_ampm_variant(download_path)?;
+            Some((ctx.dir_cache.file_size(&variant).unwrap_or(0), variant))
+        });
 
     // Determine whether the existing size (on disk or in-flight) is a match.
     // `source` is used only for log messages.
-    let (existing_size, source) = if let Some(size) = on_disk_size {
-        (Some(size), "on-disk")
+    let existing_match = if let Some((size, path)) = on_disk_match {
+        Some((size, "on-disk", path))
     } else {
         let normalized = NormalizedPath::normalize(download_path);
         if let Some(&size) = ctx.claimed_paths.get(normalized.as_ref()) {
-            (Some(size), "in-flight")
+            Some((size, "in-flight", download_path.to_path_buf()))
         } else {
-            (None, "")
+            None
         }
     };
 
-    let Some(existing_size) = existing_size else {
+    let Some((existing_size, source, matched_path)) = existing_match else {
         // Path is unclaimed -- use it directly.
-        return Some(download_path.to_path_buf());
+        return PathResolution::Download(download_path.to_path_buf());
     };
 
     match strategy {
@@ -1191,7 +1217,7 @@ fn resolve_download_path(
                     "Skipping {label}: path claimed in-flight (name-id7)"
                 );
             }
-            None
+            PathResolution::Skip(matched_path)
         }
         CollisionStrategy::SizeDedup { skip_zero_size } => {
             let sizes_match =
@@ -1213,7 +1239,7 @@ fn resolve_download_path(
                         "Skipping {label}: {source} download has same name and size"
                     );
                 }
-                return None;
+                return PathResolution::Skip(matched_path);
             }
 
             // Different size -- deduplicate.
@@ -1226,9 +1252,9 @@ fn resolve_download_path(
                 ctx.config.album_name.as_deref(),
             );
             let dedup_key = NormalizedPath::normalize(&dedup_path);
-            if ctx.dir_cache.exists(&dedup_path)
-                || ctx.claimed_paths.contains_key(dedup_key.as_ref())
-            {
+            let dedup_exists = ctx.dir_cache.exists(&dedup_path);
+            let dedup_claimed = ctx.claimed_paths.contains_key(dedup_key.as_ref());
+            if dedup_exists || dedup_claimed {
                 if source == "on-disk" {
                     tracing::info!(
                         asset_id,
@@ -1242,7 +1268,7 @@ fn resolve_download_path(
                         "Skipping {label}: dedup path already claimed in-flight"
                     );
                 }
-                None
+                PathResolution::Skip(dedup_path)
             } else {
                 if source == "on-disk" {
                     tracing::debug!(
@@ -1261,7 +1287,7 @@ fn resolve_download_path(
                         "{label} {source} collision: claimed with different size"
                     );
                 }
-                Some(dedup_path)
+                PathResolution::Download(dedup_path)
             }
         }
     }
@@ -1337,7 +1363,7 @@ pub(super) fn filter_asset_to_tasks(
             version_size,
             check_ampm_on_disk,
         } = d;
-        let final_path = {
+        let primary_resolution = {
             let mut rctx = ResolveContext {
                 config,
                 created_local: &ctx.created_local,
@@ -1356,12 +1382,14 @@ pub(super) fn filter_asset_to_tasks(
             )
         };
 
-        if let Some(p) = &final_path {
-            if let Some(stem) = p.file_name().and_then(|f| f.to_str()) {
-                effective_primary_filename = Some(stem.to_string());
-            }
+        if let Some(stem) = primary_resolution
+            .effective_path()
+            .file_name()
+            .and_then(|f| f.to_str())
+        {
+            effective_primary_filename = Some(stem.to_string());
         }
-        if let Some(p) = final_path {
+        if let Some(p) = primary_resolution.download_path() {
             claimed_paths.insert(NormalizedPath::new(&p), size);
             seen_urls.push(url.clone());
             tasks.push(DownloadTask {
@@ -1411,6 +1439,7 @@ pub(super) fn filter_asset_to_tasks(
                 || paths::add_dedup_suffix(&filename, size),
                 "asset extra",
             )
+            .download_path()
         };
 
         if let Some(p) = final_path {
@@ -1466,6 +1495,7 @@ pub(super) fn filter_asset_to_tasks(
                 || paths::insert_suffix(&filename, asset_id),
                 "live photo MOV",
             )
+            .download_path()
         };
 
         if let Some(p) = final_mov_path {
@@ -2999,6 +3029,78 @@ mod tests {
             mov2_path.contains("-4000"),
             "MOV companion should derive from deduped HEIC name (contain '-4000'), got: {}",
             mov2_path,
+        );
+    }
+
+    #[test]
+    fn live_photo_mov_reuses_existing_deduped_primary_stem_after_primary_skip() {
+        let dir = TempDir::new().unwrap();
+
+        let asset = TestPhotoAsset::new("AV0P9wRWvFhGzyYKSmpJu89S3bY6")
+            .filename("FullSizeRender.HEIC")
+            .item_type("public.heic")
+            .orig_file_type("public.heic")
+            .orig_size(2_067_405)
+            .orig_url("https://p01.icloud-content.com/heic")
+            .orig_checksum("heic_ck")
+            .live_photo("https://p01.icloud-content.com/mov", "mov_ck", 2_266_088)
+            .build();
+
+        let mut config = test_config();
+        config.directory = std::sync::Arc::from(dir.path());
+
+        let natural_heic = paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&Local),
+            "FullSizeRender.HEIC",
+            None,
+        );
+        let deduped_heic = paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&Local),
+            "FullSizeRender-2067405.HEIC",
+            None,
+        );
+        let natural_mov = paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&Local),
+            "FullSizeRender_HEVC.MOV",
+            None,
+        );
+        let paired_mov = paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&Local),
+            "FullSizeRender-2067405_HEVC.MOV",
+            None,
+        );
+        fs::create_dir_all(natural_heic.parent().unwrap()).unwrap();
+        fs::write(&natural_heic, vec![0u8; 1_808_776]).unwrap();
+        fs::write(&deduped_heic, vec![0u8; 2_067_405]).unwrap();
+        fs::write(&natural_mov, vec![0u8; 123]).unwrap();
+
+        let mut claimed_paths = FxHashMap::default();
+        let mut dir_cache = paths::DirCache::new();
+        let tasks = filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache);
+        assert_eq!(
+            tasks.len(),
+            1,
+            "only the missing paired MOV should be planned"
+        );
+        assert_eq!(
+            tasks[0].download_path, paired_mov,
+            "MOV must inherit the existing deduped HEIC stem instead of falling back to an asset-id suffix"
+        );
+
+        fs::write(&paired_mov, vec![0u8; 2_266_088]).unwrap();
+        dir_cache.clear();
+        let tasks = filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache);
+        assert!(
+            tasks.is_empty(),
+            "existing dedup-paired MOV must skip instead of planning a duplicate"
         );
     }
 

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1108,7 +1108,9 @@ pub(super) async fn pre_ensure_asset_dir(
 /// How to resolve a path that collides with an existing file or in-flight download.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CollisionStrategy {
-    /// Compare sizes: same size = skip, different size = generate a dedup path.
+    /// Compare sizes to detect collisions and choose a deterministic alternate
+    /// path. Same-name/same-size is not enough identity to skip; the caller's
+    /// state-backed path check owns safe skips for already-downloaded assets.
     /// When `skip_zero_size` is true, a version with size 0 is treated as
     /// "size unknown" and never matches (always dedup).
     SizeDedup { skip_zero_size: bool },
@@ -1149,6 +1151,108 @@ struct ResolveContext<'a> {
     dir_cache: &'a mut paths::DirCache,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CollisionFilenameKind {
+    /// The policy's historical collision filename: size suffix for primary
+    /// media, asset-id suffix for live-photo MOV companions.
+    Default,
+    /// Asset-id suffix. Used when a same-size collision cannot be proven to be
+    /// the same asset/version by the state layer.
+    AssetIdentity,
+    /// Stable fallback when the plain asset-id path is also occupied.
+    AssetIdentityOrdinal(u64),
+}
+
+fn size_or_identity_collision_filename(
+    filename: &str,
+    size: u64,
+    asset_id: &str,
+    kind: CollisionFilenameKind,
+) -> String {
+    match kind {
+        CollisionFilenameKind::Default => paths::add_dedup_suffix(filename, size),
+        CollisionFilenameKind::AssetIdentity => paths::insert_suffix(filename, asset_id),
+        CollisionFilenameKind::AssetIdentityOrdinal(n) => {
+            paths::insert_suffix(filename, &format!("{asset_id}-{n}"))
+        }
+    }
+}
+
+fn identity_collision_filename(
+    filename: &str,
+    asset_id: &str,
+    kind: CollisionFilenameKind,
+) -> String {
+    match kind {
+        CollisionFilenameKind::Default | CollisionFilenameKind::AssetIdentity => {
+            paths::insert_suffix(filename, asset_id)
+        }
+        CollisionFilenameKind::AssetIdentityOrdinal(n) => {
+            paths::insert_suffix(filename, &format!("{asset_id}-{n}"))
+        }
+    }
+}
+
+fn collision_path_for_filename(ctx: &ResolveContext<'_>, filename: &str) -> PathBuf {
+    paths::local_download_path(
+        &ctx.config.directory,
+        &ctx.config.folder_structure,
+        ctx.created_local,
+        filename,
+        ctx.config.album_name.as_deref(),
+    )
+}
+
+fn first_available_collision_path(
+    ctx: &mut ResolveContext<'_>,
+    preferred: CollisionFilenameKind,
+    make_filename: impl Fn(CollisionFilenameKind) -> String,
+) -> PathBuf {
+    let mut tried = SmallVec::<[Box<str>; 4]>::new();
+
+    for kind in [preferred, CollisionFilenameKind::AssetIdentity] {
+        if let Some(path) = available_collision_path(ctx, &make_filename, kind, &mut tried) {
+            return path;
+        }
+    }
+
+    let mut ordinal = 2u64;
+    loop {
+        if let Some(path) = available_collision_path(
+            ctx,
+            &make_filename,
+            CollisionFilenameKind::AssetIdentityOrdinal(ordinal),
+            &mut tried,
+        ) {
+            return path;
+        }
+        ordinal = ordinal.checked_add(1).unwrap_or(2);
+    }
+}
+
+fn available_collision_path(
+    ctx: &mut ResolveContext<'_>,
+    make_filename: &impl Fn(CollisionFilenameKind) -> String,
+    kind: CollisionFilenameKind,
+    tried: &mut SmallVec<[Box<str>; 4]>,
+) -> Option<PathBuf> {
+    let filename = make_filename(kind);
+    let path = collision_path_for_filename(ctx, &filename);
+    let normalized = NormalizedPath::normalize(&path).into_owned();
+    if tried.iter().any(|seen| seen.as_ref() == normalized) {
+        return None;
+    }
+
+    let unavailable =
+        ctx.dir_cache.exists(&path) || ctx.claimed_paths.contains_key(normalized.as_str());
+    tried.push(normalized.into_boxed_str());
+    if unavailable {
+        None
+    } else {
+        Some(path)
+    }
+}
+
 /// Resolve the final download path for a single version, handling on-disk
 /// files, AM/PM whitespace variants, and in-flight claimed paths.
 ///
@@ -1158,8 +1262,8 @@ struct ResolveContext<'a> {
 /// `check_ampm`: when true, also checks AM/PM whitespace variants on disk
 /// (relevant for primary photos whose timestamps contain AM/PM).
 ///
-/// `make_dedup_filename`: called when a collision with a different-sized file
-/// is detected. Returns the deduplicated filename to try.
+/// `make_collision_filename`: called when a collision is detected. Returns the
+/// deterministic alternate filename to try.
 fn resolve_download_path(
     download_path: &Path,
     version_size: u64,
@@ -1167,7 +1271,7 @@ fn resolve_download_path(
     strategy: CollisionStrategy,
     ctx: &mut ResolveContext<'_>,
     check_ampm: bool,
-    make_dedup_filename: impl FnOnce() -> String,
+    make_collision_filename: impl Fn(CollisionFilenameKind) -> String,
     label: &str,
 ) -> PathResolution {
     // Check for the file on disk. For primary photos, also check AM/PM
@@ -1223,72 +1327,35 @@ fn resolve_download_path(
             let sizes_match =
                 (!skip_zero_size || version_size > 0) && existing_size == version_size;
 
-            if sizes_match {
-                if source == "on-disk" {
-                    tracing::info!(
-                        asset_id,
-                        path = %download_path.display(),
-                        size = version_size,
-                        "Skipping {label}: file exists with same name and size"
-                    );
-                } else {
-                    tracing::info!(
-                        asset_id,
-                        path = %download_path.display(),
-                        size = version_size,
-                        "Skipping {label}: {source} download has same name and size"
-                    );
-                }
-                return PathResolution::Skip(matched_path);
-            }
-
-            // Different size -- deduplicate.
-            let dedup_filename = make_dedup_filename();
-            let dedup_path = paths::local_download_path(
-                &ctx.config.directory,
-                &ctx.config.folder_structure,
-                ctx.created_local,
-                &dedup_filename,
-                ctx.config.album_name.as_deref(),
-            );
-            let dedup_key = NormalizedPath::normalize(&dedup_path);
-            let dedup_exists = ctx.dir_cache.exists(&dedup_path);
-            let dedup_claimed = ctx.claimed_paths.contains_key(dedup_key.as_ref());
-            if dedup_exists || dedup_claimed {
-                if source == "on-disk" {
-                    tracing::info!(
-                        asset_id,
-                        path = %dedup_path.display(),
-                        "Skipping {label}: dedup path already exists"
-                    );
-                } else {
-                    tracing::info!(
-                        asset_id,
-                        path = %dedup_path.display(),
-                        "Skipping {label}: dedup path already claimed in-flight"
-                    );
-                }
-                PathResolution::Skip(dedup_path)
+            let preferred = if sizes_match {
+                CollisionFilenameKind::AssetIdentity
             } else {
-                if source == "on-disk" {
-                    tracing::debug!(
-                        path = %download_path.display(),
-                        on_disk_size = existing_size,
-                        expected_size = version_size,
-                        dedup_path = %dedup_path.display(),
-                        "{label} collision: already exists with different size"
-                    );
-                } else {
-                    tracing::debug!(
-                        path = %download_path.display(),
-                        claimed_size = existing_size,
-                        expected_size = version_size,
-                        dedup_path = %dedup_path.display(),
-                        "{label} {source} collision: claimed with different size"
-                    );
-                }
-                PathResolution::Download(dedup_path)
+                CollisionFilenameKind::Default
+            };
+            let collision_path =
+                first_available_collision_path(ctx, preferred, make_collision_filename);
+            if source == "on-disk" {
+                tracing::debug!(
+                    asset_id,
+                    path = %download_path.display(),
+                    on_disk_size = existing_size,
+                    expected_size = version_size,
+                    collision_path = %collision_path.display(),
+                    same_size = sizes_match,
+                    "Resolved {label} path collision"
+                );
+            } else {
+                tracing::debug!(
+                    asset_id,
+                    path = %download_path.display(),
+                    claimed_size = existing_size,
+                    expected_size = version_size,
+                    collision_path = %collision_path.display(),
+                    same_size = sizes_match,
+                    "Resolved {label} {source} path collision"
+                );
             }
+            PathResolution::Download(collision_path)
         }
     }
 }
@@ -1377,7 +1444,7 @@ pub(super) fn filter_asset_to_tasks(
                 strategy,
                 &mut rctx,
                 check_ampm_on_disk,
-                || paths::add_dedup_suffix(&filename, size),
+                |kind| size_or_identity_collision_filename(&filename, size, asset.id(), kind),
                 "asset",
             )
         };
@@ -1436,7 +1503,7 @@ pub(super) fn filter_asset_to_tasks(
                 },
                 &mut rctx,
                 check_ampm_on_disk,
-                || paths::add_dedup_suffix(&filename, size),
+                |kind| size_or_identity_collision_filename(&filename, size, asset.id(), kind),
                 "asset extra",
             )
             .download_path()
@@ -1492,7 +1559,7 @@ pub(super) fn filter_asset_to_tasks(
                 },
                 &mut rctx,
                 check_ampm_on_disk,
-                || paths::insert_suffix(&filename, asset_id),
+                |kind| identity_collision_filename(&filename, asset_id, kind),
                 "live photo MOV",
             )
             .download_path()
@@ -2817,7 +2884,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_skips_existing_file() {
+    fn test_filter_routes_existing_same_size_file_to_identity_path_without_state() {
         let dir = TempDir::new().unwrap();
         let asset = TestPhotoAsset::new("TEST_1").build();
         let mut config = test_config();
@@ -2827,10 +2894,22 @@ mod tests {
         let tasks = filter_asset_fresh(&asset, &config);
         assert_eq!(tasks.len(), 1);
 
-        // Create the file with matching size (1000 bytes), second call should skip
+        // Create the file with matching size (1000 bytes). The path layer no
+        // longer treats same name + same size as proof of identity; production
+        // state checks own safe already-downloaded skips.
         fs::create_dir_all(tasks[0].download_path.parent().unwrap()).unwrap();
         fs::write(&tasks[0].download_path, vec![0u8; 1000]).unwrap();
-        assert!(filter_asset_fresh(&asset, &config).is_empty());
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert_eq!(tasks.len(), 1);
+        assert!(
+            tasks[0]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("TEST_1")),
+            "same-size collision must use an identity path, got {:?}",
+            tasks[0].download_path
+        );
     }
 
     #[test]
@@ -2930,10 +3009,20 @@ mod tests {
         fs::create_dir_all(tasks[1].download_path.parent().unwrap()).unwrap();
         fs::write(&tasks[1].download_path, vec![0u8; 3000]).unwrap();
 
-        // Second call: only the photo task (MOV already exists with matching size)
+        // Second call: the MOV cannot be proven identical by path+size alone,
+        // so it is routed to an identity collision path.
         let tasks = filter_asset_fresh(&asset, &config);
-        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks.len(), 2);
         assert_eq!(&*tasks[0].url, "https://p01.icloud-content.com/heic_orig");
+        assert!(
+            tasks[1]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("LIVE_1")),
+            "same-size MOV collision must use an identity path, got {:?}",
+            tasks[1].download_path
+        );
     }
 
     #[test]
@@ -3087,20 +3176,30 @@ mod tests {
         let tasks = filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache);
         assert_eq!(
             tasks.len(),
-            1,
-            "only the missing paired MOV should be planned"
+            2,
+            "without state identity, the existing same-size HEIC is routed to an identity path"
         );
-        assert_eq!(
-            tasks[0].download_path, paired_mov,
-            "MOV must inherit the existing deduped HEIC stem instead of falling back to an asset-id suffix"
+        assert!(
+            tasks[0]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("AV0P9wRWvFhGzyYKSmpJu89S3bY6")),
+            "same-size HEIC collision must use an identity path: {:?}",
+            tasks[0].download_path
+        );
+        assert_ne!(
+            tasks[1].download_path, paired_mov,
+            "MOV pairing follows the newly planned identity-path primary when state has not proven the existing HEIC"
         );
 
         fs::write(&paired_mov, vec![0u8; 2_266_088]).unwrap();
         dir_cache.clear();
         let tasks = filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache);
-        assert!(
-            tasks.is_empty(),
-            "existing dedup-paired MOV must skip instead of planning a duplicate"
+        assert_eq!(
+            tasks.len(),
+            2,
+            "same-size existing HEIC/MOV files are not safe skips without state identity"
         );
     }
 
@@ -4434,13 +4533,11 @@ mod tests {
         );
     }
 
-    /// A path pre-seeded into claimed_paths (as a startup load from the
-    /// state DB's downloaded rows would do) must case-insensitively match
-    /// an incoming asset's target and dedupe it — otherwise cross-batch
-    /// collisions silently overwrite prior downloads on case-insensitive
-    /// filesystems.
+    /// A path pre-seeded into claimed_paths must case-insensitively match an
+    /// incoming asset's target and route it to a collision path. Same size is
+    /// not proof that the claimed file is the same asset/version.
     #[test]
-    fn filter_cross_batch_case_insensitive_collision_is_deduped() {
+    fn filter_cross_batch_case_insensitive_same_size_collision_uses_identity_path() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.directory = std::sync::Arc::from(dir.path());
@@ -4462,10 +4559,14 @@ mod tests {
         let mut dir_cache = paths::DirCache::new();
         let second_tasks =
             filter_asset_to_tasks(&asset, &config, &mut claimed_paths, &mut dir_cache);
+        assert_eq!(second_tasks.len(), 1);
         assert!(
-            second_tasks.is_empty(),
-            "asset whose target path case-insensitively matches a claimed \
-             path of the same size must be skipped; got tasks: {second_tasks:?}"
+            second_tasks[0]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("CROSS_BATCH_1")),
+            "same-size claimed-path collision must use an identity path: {second_tasks:?}"
         );
     }
 
@@ -4914,15 +5015,10 @@ mod tests {
         assert!(tasks[0].download_path.to_str().unwrap().contains(".MOV"));
     }
 
-    // ── Gap: two assets with same filename, same date, same size ──────
-    //
-    // When two distinct iCloud assets resolve to the same local path AND have
-    // the same file size, the NameSizeDedupWithSuffix policy treats the second
-    // as "already present" and silently skips it. This is by design -- but
-    // there was no test verifying this exact scenario.
+    // ── Same filename, same date, same size collision ─────────────────
 
     #[test]
-    fn filter_two_assets_same_path_same_size_second_skipped() {
+    fn filter_two_assets_same_path_same_size_second_uses_identity_path() {
         // Arrange: two assets with identical filename, date, and size but
         // different checksums (different photos that happen to share a name).
         let asset_a = TestPhotoAsset::new("ASSET_A")
@@ -4946,12 +5042,22 @@ mod tests {
         let tasks_a = filter_asset_to_tasks(&asset_a, &config, &mut claimed_paths, &mut dir_cache);
         let tasks_b = filter_asset_to_tasks(&asset_b, &config, &mut claimed_paths, &mut dir_cache);
 
-        // Assert: first asset gets a task, second is skipped (same size = "match")
+        // Assert: first asset gets the natural path, second gets an identity
+        // collision path instead of being silently skipped.
         assert_eq!(tasks_a.len(), 1, "first asset should produce a task");
+        assert_eq!(
+            tasks_b.len(),
+            1,
+            "second asset with same path and same size must not be skipped"
+        );
         assert!(
-            tasks_b.is_empty(),
-            "second asset with same path and same size should be skipped, but got {} tasks",
-            tasks_b.len()
+            tasks_b[0]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("ASSET_B")),
+            "second asset should use an identity collision path, got {:?}",
+            tasks_b[0].download_path
         );
     }
 
@@ -5092,8 +5198,12 @@ mod tests {
         let second = run_collision_set(dir.path(), &assets);
         assert_eq!(first, second, "collision resolution must be deterministic");
         assert!(
-            first[1].is_empty(),
-            "same filename and same size should be treated as the same on-disk file"
+            first[1][0]
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("REP_B")),
+            "same filename and same size should get an identity collision path: {:?}",
+            first[1]
         );
         assert!(
             first[2][0]
@@ -5261,15 +5371,16 @@ mod tests {
         fs::create_dir_all(final_path.parent().unwrap()).unwrap();
         fs::write(&final_path, vec![0u8; 1000]).unwrap();
 
-        // Step 3: re-run filter against the same asset. Crash recovery
-        // must skip without re-emitting a task, even though no DB row
-        // backs the file.
+        // Step 3: re-run filter against the same asset. The path layer must
+        // not silently skip based on same name + same size; producer state
+        // adoption owns the post-rename crash recovery path.
         let tasks_post = filter_asset_fresh(&asset, &config);
-        assert!(
-            tasks_post.is_empty(),
-            "post-kill rerun must skip via on-disk detection \
-             (file exists at {final_path:?} with matching size); \
-             got tasks: {tasks_post:?}",
+        assert_eq!(
+            tasks_post.len(),
+            1,
+            "post-kill filter rerun should emit an identity collision task; \
+             producer state adoption handles the pending DB row. final_path={final_path:?}, \
+             tasks={tasks_post:?}",
         );
     }
 
@@ -5340,10 +5451,11 @@ mod tests {
         let asset = post_rename_pre_state_crash_asset();
         let config = post_rename_pre_state_config(&download_dir);
         let tasks_post = filter_asset_fresh(&asset, &config);
-        assert!(
-            tasks_post.is_empty(),
-            "post-kill rerun must skip via on-disk detection even when the DB \
-             row is still pending; got tasks: {tasks_post:?}"
+        assert_eq!(
+            tasks_post.len(),
+            1,
+            "filter must not silently skip a same-size on-disk file; producer \
+             state adoption handles the pending row. got tasks: {tasks_post:?}"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -5326,10 +5326,11 @@ mod tests {
     }
 
     async fn seed_existing_file_for_asset(
-        base_config: &DownloadConfig,
+        base_config: &mut DownloadConfig,
         pass: &AlbumPass,
         asset: &PhotoAsset,
     ) {
+        base_config.file_match_policy = FileMatchPolicy::NameId7;
         let pass_config = base_config.with_pass(pass);
         let expected_path = filter::expected_paths_for(asset, &pass_config)
             .into_iter()
@@ -5341,10 +5342,66 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(base_config, &pass_config, asset, &expected_path)
+            .await;
+    }
+
+    async fn seed_downloaded_state_for_expected_path(
+        base_config: &mut DownloadConfig,
+        pass_config: &DownloadConfig,
+        asset: &PhotoAsset,
+        expected_path: &filter::ExpectedAssetPath,
+    ) {
+        let db = match &base_config.state_db {
+            Some(db) => Arc::clone(db),
+            None => {
+                let db: Arc<dyn StateDb> =
+                    Arc::new(SqliteStateDb::open_in_memory().expect("open state db"));
+                base_config.state_db = Some(Arc::clone(&db));
+                db
+            }
+        };
+        let library = asset.source_zone().unwrap_or(&pass_config.library);
+        let filename = expected_path
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("expected path has filename");
+        let record = TestAssetRecord::new(asset.id())
+            .library(library)
+            .checksum(&expected_path.checksum)
+            .filename(filename)
+            .created_at(asset.created())
+            .size(expected_path.size)
+            .version_size(expected_path.version_size)
+            .build();
+        db.upsert_seen(&record).await.expect("seed state row");
+        db.mark_downloaded(
+            library,
+            asset.id(),
+            expected_path.version_size.as_str(),
+            &expected_path.path,
+            "seeded-local-sha256",
+            None,
+        )
+        .await
+        .expect("mark seeded file downloaded");
+        assert!(
+            !db.should_download(
+                library,
+                asset.id(),
+                expected_path.version_size.as_str(),
+                &expected_path.checksum,
+                &expected_path.path,
+            )
+            .await
+            .expect("seeded state should be readable"),
+            "seeded downloaded state must make the expected file a safe skip"
+        );
     }
 
     async fn seed_existing_recent_files(
-        base_config: &DownloadConfig,
+        base_config: &mut DownloadConfig,
         pass: &AlbumPass,
         zone: &str,
         ids: &[String],
@@ -5590,6 +5647,7 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 2;
+        config.file_match_policy = FileMatchPolicy::NameId7;
 
         let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         let album_config = config.with_pass(&passes[0]);
@@ -5603,6 +5661,8 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(&mut config, &album_config, &asset, &expected_path)
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -5664,7 +5724,7 @@ mod tests {
                 &format!("{record_name}.jpg"),
             );
             let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
-            seed_existing_file_for_asset(&config, pass, &asset).await;
+            seed_existing_file_for_asset(&mut config, pass, &asset).await;
         }
 
         let result = download_photos_full_with_token(
@@ -5852,7 +5912,7 @@ mod tests {
         config.skip_created_after =
             Some(DateTime::from_timestamp_millis(1_699_999_999_000).expect("valid timestamp"));
         let on_disk_asset = PhotoAsset::new(on_disk_records[0].clone(), on_disk_records[1].clone());
-        seed_existing_file_for_asset(&config, &passes[0], &on_disk_asset).await;
+        seed_existing_file_for_asset(&mut config, &passes[0], &on_disk_asset).await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -6030,6 +6090,7 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 2;
+        config.file_match_policy = FileMatchPolicy::NameId7;
 
         // Seed the destination so the single enumerated asset is skipped
         // on-disk and the test isolates count-only shortfall behavior.
@@ -6045,6 +6106,8 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(&mut config, &pass_config, &asset, &expected_path)
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -6101,6 +6164,7 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
+        config.file_match_policy = FileMatchPolicy::NameId7;
 
         // Seed the destination so the unique asset is skipped on-disk and the
         // test isolates duplicate API asset-id accounting.
@@ -6116,6 +6180,8 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(&mut config, &pass_config, &asset, &expected_path)
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -6160,6 +6226,7 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 2;
+        config.file_match_policy = FileMatchPolicy::NameId7;
 
         // Seed the destination so the enumerated asset is skipped on-disk
         // and this test isolates token-capture behavior.
@@ -6175,6 +6242,8 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(&mut config, &pass_config, &asset, &expected_path)
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -9527,7 +9596,7 @@ mod tests {
         config.concurrent_downloads = 1;
         config.recent = Some(300);
         for pass in &passes {
-            seed_existing_file_for_asset(&config, pass, &asset).await;
+            seed_existing_file_for_asset(&mut config, pass, &asset).await;
         }
 
         let result = download_photos_full_with_token(
@@ -9589,7 +9658,7 @@ mod tests {
 
         for pass in &passes {
             for asset in &expected_assets {
-                seed_existing_file_for_asset(&config, pass, asset).await;
+                seed_existing_file_for_asset(&mut config, pass, asset).await;
             }
         }
 
@@ -9639,7 +9708,7 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
         config.recent = Some(300);
-        seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+        seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -9685,7 +9754,7 @@ mod tests {
         config.skip_created_before =
             Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
         for asset in newer_assets.iter().map(recent_scope_photo_asset) {
-            seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+            seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
         }
 
         let result = download_photos_full_with_token(
@@ -9707,7 +9776,7 @@ mod tests {
         assert_eq!(result.stats.pagination_shortfall_warnings, 0);
         assert_eq!(result.stats.enumeration_errors, 0);
         assert!(
-            session.album_offsets().len() <= 4,
+            session.album_offsets().len() <= 5,
             "lower-date-bound enumeration should stop near the first old page; offsets={:?}",
             session.album_offsets()
         );
@@ -9742,7 +9811,7 @@ mod tests {
         config.skip_created_after =
             Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
         for asset in older_assets.iter().map(recent_scope_photo_asset) {
-            seed_existing_file_for_asset(&config, &passes[0], &asset).await;
+            seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
         }
 
         let result = download_photos_full_with_token(
@@ -9788,6 +9857,7 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.recent = Some(100);
+        config.file_match_policy = FileMatchPolicy::NameId7;
 
         let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         let pass_config = config.with_pass(&passes[0]);
@@ -9801,6 +9871,8 @@ mod tests {
         tokio::fs::write(&expected_path.path, vec![0u8; 1024])
             .await
             .expect("seed existing file");
+        seed_downloaded_state_for_expected_path(&mut config, &pass_config, &asset, &expected_path)
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -9856,7 +9928,8 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 10;
         config.recent = Some(100);
-        seed_existing_recent_files(&config, &passes[0], "PrimarySync", &ids, "recent-prod").await;
+        seed_existing_recent_files(&mut config, &passes[0], "PrimarySync", &ids, "recent-prod")
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -9901,8 +9974,14 @@ mod tests {
         config.concurrent_downloads = 1;
         config.recent = Some(ids.len().try_into().expect("test id count fits u32"));
         if matches!(mode, DownloadRunMode::Download) {
-            seed_existing_recent_files(&config, &passes[0], "PrimarySync", ids, filename_prefix)
-                .await;
+            seed_existing_recent_files(
+                &mut config,
+                &passes[0],
+                "PrimarySync",
+                ids,
+                filename_prefix,
+            )
+            .await;
         }
 
         let result = download_photos_full_with_token(
@@ -9975,7 +10054,7 @@ mod tests {
         config.concurrent_downloads = 10;
         config.recent = Some(60);
         seed_existing_recent_files(
-            &config,
+            &mut config,
             &passes[0],
             "PrimarySync",
             &album_ids,
@@ -9983,7 +10062,7 @@ mod tests {
         )
         .await;
         seed_existing_recent_files(
-            &config,
+            &mut config,
             &passes[1],
             "PrimarySync",
             &unfiled_ids,
@@ -10032,7 +10111,8 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 10;
         config.recent = Some(60);
-        seed_existing_recent_files(&config, &passes[0], "PrimarySync", &ids, "smart-recent").await;
+        seed_existing_recent_files(&mut config, &passes[0], "PrimarySync", &ids, "smart-recent")
+            .await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -10084,7 +10164,7 @@ mod tests {
         config.concurrent_downloads = 10;
         config.recent = Some(40);
         seed_existing_recent_files(
-            &config,
+            &mut config,
             &passes[0],
             "PrimarySync",
             &album_ids,
@@ -10092,7 +10172,7 @@ mod tests {
         )
         .await;
         seed_existing_recent_files(
-            &config,
+            &mut config,
             &passes[1],
             "PrimarySync",
             &unfiled_ids,

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -317,6 +317,16 @@ fn asset_record_for_derived_path(
     .with_metadata_arc(asset.metadata_arc())
 }
 
+fn pending_versions_for_asset<'a>(
+    ctx: &'a DownloadContext,
+    library: &str,
+    asset: &PhotoAsset,
+) -> Option<&'a FxHashSet<Box<str>>> {
+    ctx.pending_ids
+        .get(library)
+        .and_then(|assets| assets.get(asset.id()))
+}
+
 async fn adopt_pending_on_disk_skip(
     state_db: Option<&dyn StateDb>,
     config: &DownloadConfig,
@@ -328,10 +338,7 @@ async fn adopt_pending_on_disk_skip(
         return 0;
     };
     let library = effective_asset_library(asset, config);
-    let pending_versions = ctx
-        .pending_ids
-        .get(library)
-        .and_then(|assets| assets.get(asset.id()));
+    let pending_versions = pending_versions_for_asset(ctx, library, asset);
     let Some(pending_versions) = pending_versions else {
         return 0;
     };
@@ -342,74 +349,113 @@ async fn adopt_pending_on_disk_skip(
         if !pending_versions.contains(version_size) {
             continue;
         }
-        let Some(existing_path) = task_planner.existing_path(&derived.path) else {
-            continue;
-        };
-        let Ok(metadata) = tokio::fs::metadata(&existing_path).await else {
-            continue;
-        };
-        if metadata.len() != derived.size {
-            continue;
-        }
-
-        let record = asset_record_for_derived_path(
-            effective_asset_library_arc(asset, config),
-            asset,
-            &derived,
-        );
-        if let Err(e) = db.upsert_seen(&record).await {
-            tracing::warn!(
-                asset_id = %asset.id(),
-                version_size,
-                error = %e,
-                "Failed to refresh pending asset before adopting on-disk file"
-            );
-            continue;
-        }
-
-        let local_checksum = match super::file::compute_sha256(&existing_path).await {
-            Ok(checksum) => checksum,
-            Err(e) => {
-                tracing::warn!(
-                    asset_id = %asset.id(),
-                    version_size,
-                    path = %existing_path.display(),
-                    error = %e,
-                    "Failed to hash on-disk file for pending asset"
-                );
-                continue;
-            }
-        };
-        if let Err(e) = db
-            .mark_downloaded(
-                library,
-                asset.id(),
-                version_size,
-                &existing_path,
-                &local_checksum,
-                None,
-            )
+        if adopt_pending_derived_path(db, library, asset, task_planner, &derived)
             .await
+            .is_some()
         {
+            adopted += 1;
+        }
+    }
+
+    adopted
+}
+
+async fn adopt_pending_on_disk_task(
+    state_db: Option<&dyn StateDb>,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    ctx: &DownloadContext,
+    task_planner: &mut TaskPlanner,
+    task: &DownloadTask,
+) -> Option<PathBuf> {
+    let db = state_db?;
+    let library = effective_asset_library(asset, config);
+    let pending_versions = pending_versions_for_asset(ctx, library, asset)?;
+    if !pending_versions.contains(task.version_size.as_str()) {
+        return None;
+    }
+
+    for derived in derive_expected_paths(asset, config) {
+        if derived.version_size != task.version_size {
+            continue;
+        }
+        if let Some(path) =
+            adopt_pending_derived_path(db, library, asset, task_planner, &derived).await
+        {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+async fn adopt_pending_derived_path(
+    db: &dyn StateDb,
+    library: &str,
+    asset: &PhotoAsset,
+    task_planner: &mut TaskPlanner,
+    derived: &DerivedPath,
+) -> Option<PathBuf> {
+    let version_size = derived.version_size.as_str();
+    let existing_path = task_planner.existing_path(&derived.path)?;
+    let Ok(metadata) = tokio::fs::metadata(&existing_path).await else {
+        return None;
+    };
+    if metadata.len() != derived.size {
+        return None;
+    }
+
+    let record = asset_record_for_derived_path(Arc::from(library), asset, derived);
+    if let Err(e) = db.upsert_seen(&record).await {
+        tracing::warn!(
+            asset_id = %asset.id(),
+            version_size,
+            error = %e,
+            "Failed to refresh pending asset before adopting on-disk file"
+        );
+        return None;
+    }
+
+    let local_checksum = match super::file::compute_sha256(&existing_path).await {
+        Ok(checksum) => checksum,
+        Err(e) => {
             tracing::warn!(
                 asset_id = %asset.id(),
                 version_size,
                 path = %existing_path.display(),
                 error = %e,
-                "Failed to mark pending asset downloaded from on-disk file"
+                "Failed to hash on-disk file for pending asset"
             );
-            continue;
+            return None;
         }
-        tracing::info!(
+    };
+    if let Err(e) = db
+        .mark_downloaded(
+            library,
+            asset.id(),
+            version_size,
+            &existing_path,
+            &local_checksum,
+            None,
+        )
+        .await
+    {
+        tracing::warn!(
             asset_id = %asset.id(),
             version_size,
             path = %existing_path.display(),
-            "Resolved pending asset from existing on-disk file"
+            error = %e,
+            "Failed to mark pending asset downloaded from on-disk file"
         );
-        adopted += 1;
+        return None;
     }
-
-    adopted
+    tracing::info!(
+        asset_id = %asset.id(),
+        version_size,
+        path = %existing_path.display(),
+        "Resolved pending asset from existing on-disk file"
+    );
+    Some(existing_path)
 }
 
 fn state_confirmed_current_path_exists(
@@ -1616,6 +1662,25 @@ where
                                     }
                                 }
 
+                                if let Some(existing_path) = adopt_pending_on_disk_task(
+                                    producer_state_db.as_deref(),
+                                    config,
+                                    &asset,
+                                    &download_ctx,
+                                    &mut task_planner,
+                                    &task,
+                                )
+                                .await
+                                {
+                                    disposition = disposition.max(AssetDisposition::OnDisk);
+                                    tracing::debug!(
+                                        asset_id = %task.asset_id,
+                                        path = %existing_path.display(),
+                                        "Skipping (pending state adopted existing file)"
+                                    );
+                                    continue;
+                                }
+
                                 match download_ctx.should_download_fast(
                                     &task.library,
                                     &task.asset_id,
@@ -1663,6 +1728,13 @@ where
                                                 path = %existing_path.display(),
                                                 "Skipping (state path exists on disk)"
                                             );
+                                            backfill_downloaded_metadata_for_on_disk_skip(
+                                                producer_state_db.as_deref(),
+                                                config,
+                                                &asset,
+                                                &download_ctx,
+                                            )
+                                            .await;
                                             continue;
                                         }
 
@@ -5193,15 +5265,15 @@ mod tests {
         assert_eq!(summary.failed, 0);
     }
 
-    /// Producer-side regression for resolving pending rows on on-disk skip.
+    /// Producer-side regression for resolving pending rows when the expected
+    /// file already exists on disk.
     ///
     /// A pending row carried over from a prior interrupted sync, whose
-    /// new sync hits the on-disk-skip path (the `tasks.is_empty()`
-    /// branch at the producer's filter step), must be adopted as downloaded
-    /// when the expected file already exists with the same name and size.
+    /// new sync sees the expected file at the natural path, must be adopted as
+    /// downloaded when the file already exists with the same name and size.
     /// Otherwise standard sync resets failed assets to pending, full
-    /// enumeration skips the already-present file, and the same row is
-    /// promoted back to failed every run.
+    /// enumeration routes the path collision through a deterministic alternate
+    /// path, and the same row is promoted back to failed every run.
     #[tokio::test]
     async fn producer_adopts_pending_on_disk_skip_as_downloaded() {
         use crate::download::DownloadConfig;
@@ -5241,8 +5313,9 @@ mod tests {
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 
-        // Pre-create the on-disk file at the path the producer will compute
-        // so `filter_asset_to_tasks` returns no tasks.
+        // Pre-create the on-disk file at the expected natural path. The path
+        // layer now emits an identity collision task for this same-size file,
+        // so the producer must still adopt the pending row before forwarding.
         let asset = carryover_asset();
         let target_path = crate::download::filter::expected_paths_for(&asset, &config)
             .first()
@@ -5279,6 +5352,54 @@ mod tests {
         assert_eq!(summary.downloaded, 1);
         assert_eq!(summary.pending, 0);
         assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn producer_plans_distinct_same_path_same_size_assets() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let asset_a = TestPhotoAsset::new("SAME_SIZE_A")
+            .filename("IMG_0001.JPG")
+            .orig_size(5000)
+            .orig_url("https://p01.icloud-content.com/a.jpg")
+            .orig_checksum("ck_same_size_a")
+            .build();
+        let asset_b = TestPhotoAsset::new("SAME_SIZE_B")
+            .filename("IMG_0001.JPG")
+            .orig_size(5000)
+            .orig_url("https://p01.icloud-content.com/b.jpg")
+            .orig_checksum("ck_same_size_b")
+            .build();
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        let config = Arc::new(config);
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![
+                Ok::<PhotoAsset, anyhow::Error>(asset_a),
+                Ok::<PhotoAsset, anyhow::Error>(asset_b),
+            ]),
+            &config,
+            DownloadControls::dry_run_hidden(),
+            2,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("same-size collision planning should complete");
+
+        assert_eq!(result.downloaded, 2, "unexpected result: {result:?}");
+        assert!(result.failed.is_empty());
+        assert!(
+            fs::read_dir(dir.path()).unwrap().next().is_none(),
+            "dry-run planning must not create files"
+        );
     }
 
     /// v5 metadata backfill regression: a previously downloaded row with a

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -290,7 +290,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn planner_skips_existing_same_size_file_on_disk() {
+    async fn planner_routes_existing_same_size_file_to_identity_path() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         let asset = TestPhotoAsset::new("ON_DISK")
@@ -310,7 +310,16 @@ mod tests {
         let mut second = TaskPlanner::new();
         let plan = second.plan_asset(&asset, &config).await;
         assert_eq!(plan.filter_reason, None);
-        assert!(plan.tasks.is_empty(), "existing same-size file should skip");
+        assert_eq!(plan.tasks.len(), 1);
+        assert!(
+            plan.tasks[0]
+                .download_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("ON_DISK")),
+            "same-size on-disk collision should use an identity path: {:?}",
+            plan.tasks[0].download_path
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes #546.
- Same-name, same-size path collisions now use deterministic asset-id suffixes instead of skipping the second asset.
- Keeps state-backed skips and pending on-disk adoption so already-downloaded assets and post-rename recovery stay safe.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `just gate`
