### PR TITLE
Treat malformed album counts as enumeration errors

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -388,6 +388,7 @@ const INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON: &str = "incremental_hidden_s
 const INCREMENTAL_HIDDEN_ZERO_ROWS_REASON: &str = "incremental_hidden_no_matching_state";
 const SMART_FOLDER_REFRESH_FAILED_REASON: &str = "smart_folder_refresh_failed";
 const TARGETED_ALBUM_BACKFILL_FAILED_REASON: &str = "targeted_album_backfill_failed";
+const ICLOUD_ALBUM_COUNT_ERROR_REASON: &str = "icloud_album_count_error";
 pub(super) const PRODUCER_ENUMERATION_INCOMPLETE_REASON: &str = "producer_enumeration_incomplete";
 
 pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
@@ -404,6 +405,7 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
         | TARGETED_ALBUM_BACKFILL_FAILED_REASON => "kei",
         INCREMENTAL_DELETE_ZERO_ROWS_REASON
         | INCREMENTAL_HIDDEN_ZERO_ROWS_REASON
+        | ICLOUD_ALBUM_COUNT_ERROR_REASON
         | "pagination_shortfall"
         | "icloud_blank_sync_token"
         | "icloud_sync_token_mismatch"
@@ -419,6 +421,9 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
     match reason {
         "pagination_shortfall" => {
             "enumeration counts did not line up safely, so kei blocked token advancement"
+        }
+        ICLOUD_ALBUM_COUNT_ERROR_REASON => {
+            "iCloud returned a missing or malformed album count response"
         }
         "icloud_sync_token_missing" => {
             "iCloud did not return a sync token for this full enumeration"
@@ -3771,13 +3776,16 @@ async fn download_photos_full_with_token(
 
     // Check if enumeration saw significantly fewer assets than the API reported.
     // This catches silent pagination truncation, dropped pages, or API hiccups
-    // that would otherwise go unnoticed. Any `len()` failure also forces
-    // suppression because the recorded `total` is missing those passes.
+    // that would otherwise go unnoticed. Count lookup failures are tracked
+    // separately below so reports can distinguish malformed provider count
+    // responses from producer shortfalls.
     let mut pagination_shortfall_assets = 0u64;
     let mut pagination_shortfall_warnings = 0usize;
-    let pagination_undercount = if len_errors > 0 {
-        true
-    } else if !controls.run_mode.only_print_filenames() && !controls.run_mode.is_dry_run() {
+    let count_lookup_failed = len_errors > 0;
+    let pagination_undercount = if !count_lookup_failed
+        && !controls.run_mode.only_print_filenames()
+        && !controls.run_mode.is_dry_run()
+    {
         if let Some(total) = exact_total.filter(|total| *total > 0) {
             let duplicate_asset_ids =
                 u64::try_from(streaming_result.skip_summary.duplicates).unwrap_or(u64::MAX);
@@ -3833,6 +3841,7 @@ async fn download_photos_full_with_token(
     let token_eligible = config.recent.is_none()
         && config.skip_created_before.is_none()
         && !controls.run_mode.only_print_filenames()
+        && !count_lookup_failed
         && !pagination_undercount
         && streaming_result.enumeration_errors == 0;
     let mut token_block_reason: Option<&'static str> = None;
@@ -3938,7 +3947,15 @@ async fn download_photos_full_with_token(
         stats.sync_token_receivers_dropped = token_receivers_dropped;
         stats.sync_token_unique_values = token_unique_values;
     }
-    if pagination_undercount {
+    if count_lookup_failed {
+        stats.sync_token_blocked = true;
+        stats.sync_token_blocked_reason = Some(ICLOUD_ALBUM_COUNT_ERROR_REASON);
+        stats.sync_token_blocked_source =
+            Some(sync_token_blocked_source(ICLOUD_ALBUM_COUNT_ERROR_REASON));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(
+            ICLOUD_ALBUM_COUNT_ERROR_REASON,
+        ));
+    } else if pagination_undercount {
         stats.sync_token_blocked = true;
         stats.sync_token_blocked_reason = Some("pagination_shortfall");
         stats.sync_token_blocked_source = Some(sync_token_blocked_source("pagination_shortfall"));
@@ -4732,6 +4749,12 @@ mod tests {
                         "moreComing": false,
                         "records": self.records.clone(),
                     }]
+                }));
+            }
+
+            if url.contains("/internal/records/query/batch") {
+                return Ok(json!({
+                    "batch": [{"records": [{"fields": {"itemCount": {"value": 0}}}]}]
                 }));
             }
 
@@ -6153,6 +6176,133 @@ mod tests {
         assert_eq!(result.stats.sync_token_receivers_dropped, None);
         assert_eq!(result.stats.sync_token_unique_values, None);
         assert_eq!(result.sync_token, None, "token should stay blocked");
+    }
+
+    #[tokio::test]
+    async fn malformed_album_count_is_enumeration_error_and_blocks_sync_token() {
+        let session = MockPhotosFlow::new()
+            .album_count_response(json!({
+                "batch": [{"records": [{"fields": {"itemCount": {"value": "not-a-count"}}}]}]
+            }))
+            .empty_query_page(Some("zone-token"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("malformed album count should produce a sync result");
+
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(result.stats.enumeration_errors, 1);
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.pagination_shortfall_assets, 0);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
+        );
+        assert_eq!(result.stats.sync_token_blocked_source, Some("icloud"));
+        assert_eq!(
+            result.stats.sync_token_blocked_explanation,
+            Some(sync_token_blocked_explanation(
+                ICLOUD_ALBUM_COUNT_ERROR_REASON
+            ))
+        );
+        assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
+    async fn missing_album_count_item_count_is_enumeration_error_not_zero() {
+        let session = MockPhotosFlow::new()
+            .album_count_response(json!({
+                "batch": [{"records": [{"fields": {}}]}]
+            }))
+            .empty_query_page(Some("zone-token"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("missing album count should produce a sync result");
+
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(result.stats.enumeration_errors, 1);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
+        );
+        assert_eq!(result.sync_token, None);
+    }
+
+    #[tokio::test]
+    async fn well_formed_zero_album_count_allows_empty_token_capture() {
+        let session = MockPhotosFlow::new()
+            .album_count(0)
+            .empty_query_page(Some("zone-token"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("well-formed zero count should complete cleanly");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
     }
 
     #[tokio::test]

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -443,7 +443,7 @@ impl PhotoAlbum {
 
         let batch: super::cloudkit::BatchQueryResponse =
             serde_json::from_value(response).context("failed to parse album count response")?;
-        Ok(Self::count_from_query(batch.batch.first()))
+        Self::count_from_query(batch.batch.first()).context("failed to read album count response")
     }
 
     /// Return item counts for a same-library pass set with one
@@ -513,11 +513,12 @@ impl PhotoAlbum {
 
         (0..albums.len())
             .map(|index| {
-                batch
-                    .batch
-                    .get(index)
-                    .map(|query| Self::count_from_query(Some(query)))
-                    .ok_or_else(|| anyhow::anyhow!("missing batched count result for pass {index}"))
+                let query = batch.batch.get(index).ok_or_else(|| {
+                    anyhow::anyhow!("missing batched count result for pass {index}")
+                })?;
+                Self::count_from_query(Some(query)).with_context(|| {
+                    format!("failed to read batched album count result for pass {index}")
+                })
             })
             .collect()
     }
@@ -541,16 +542,22 @@ impl PhotoAlbum {
         })
     }
 
-    fn count_from_query(query: Option<&super::cloudkit::QueryResponse>) -> u64 {
-        query
-            .and_then(|q| q.records.first())
-            .and_then(|r| {
-                r.fields
-                    .get("itemCount")
-                    .and_then(|f| f.get("value"))
-                    .and_then(Value::as_u64)
-            })
-            .unwrap_or(0)
+    fn count_from_query(query: Option<&super::cloudkit::QueryResponse>) -> anyhow::Result<u64> {
+        let query = query.context("missing album count query result")?;
+        let record = query
+            .records
+            .first()
+            .context("album count query returned no records")?;
+        let item_count = record
+            .fields
+            .get("itemCount")
+            .context("album count record missing itemCount")?;
+        let value = item_count
+            .get("value")
+            .context("album count itemCount missing value")?;
+        value.as_u64().with_context(|| {
+            format!("album count itemCount value was not an unsigned integer: {value}")
+        })
     }
 
     /// Convenience wrapper over `photo_stream()` that collects all assets
@@ -1815,6 +1822,48 @@ mod tests {
         assert_eq!(counts, vec![10, 20, 30]);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(*batch_sizes.lock().unwrap(), vec![3]);
+    }
+
+    fn count_query_from_fields(fields: Value) -> crate::icloud::photos::cloudkit::QueryResponse {
+        let batch: crate::icloud::photos::cloudkit::BatchQueryResponse =
+            serde_json::from_value(json!({
+                "batch": [{"records": [{"fields": fields}]}]
+            }))
+            .expect("test count batch parses");
+        batch.batch.into_iter().next().expect("count query exists")
+    }
+
+    #[test]
+    fn count_from_query_accepts_well_formed_zero() {
+        let query = count_query_from_fields(json!({"itemCount": {"value": 0}}));
+
+        let count = PhotoAlbum::count_from_query(Some(&query)).expect("zero is a valid count");
+
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn count_from_query_rejects_missing_item_count() {
+        let query = count_query_from_fields(json!({}));
+
+        let err = PhotoAlbum::count_from_query(Some(&query)).expect_err("missing count fails");
+
+        assert!(
+            err.to_string().contains("missing itemCount"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn count_from_query_rejects_malformed_item_count() {
+        let query = count_query_from_fields(json!({"itemCount": {"value": "0"}}));
+
+        let err = PhotoAlbum::count_from_query(Some(&query)).expect_err("malformed count fails");
+
+        assert!(
+            err.to_string().contains("was not an unsigned integer"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -457,6 +457,11 @@ impl MockPhotosFlow {
         self
     }
 
+    pub fn album_count_response(mut self, response: Value) -> Self {
+        self.session = self.session.ok(response);
+        self
+    }
+
     pub fn query_page(mut self, records: Vec<Value>, sync_token: Option<&str>) -> Self {
         let mut page = json!({ "records": records });
         if let Some(token) = sync_token {
@@ -857,11 +862,27 @@ impl PhotosSession for MockPhotosSession {
             _body: body,
         });
 
-        let response = self.responses.lock().expect("poisoned").pop_front();
+        let response = {
+            let mut responses = self.responses.lock().expect("poisoned");
+            if url.contains("/internal/records/query/batch") {
+                match responses.front() {
+                    Some(MockResponse::Ok(value)) if value.get("batch").is_some() => {
+                        responses.pop_front()
+                    }
+                    Some(MockResponse::Err(_)) => responses.pop_front(),
+                    _ => None,
+                }
+            } else {
+                responses.pop_front()
+            }
+        };
 
         match response {
             Some(MockResponse::Ok(v)) => Ok(v),
             Some(MockResponse::Err(msg)) => Err(anyhow::anyhow!("{msg}")),
+            None if url.contains("/internal/records/query/batch") => Ok(json!({
+                "batch": [{"records": [{"fields": {"itemCount": {"value": 0}}}]}]
+            })),
             None => Ok(json!({"records": []})),
         }
     }


### PR DESCRIPTION
## Summary
- Treat missing or malformed iCloud album count responses as enumeration errors instead of zero counts.
- Block full-enumeration sync token capture when the count probe fails, with `icloud_album_count_error` diagnostics.
- Keep well-formed zero-count responses valid and covered by tests.

Fixes #548.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test --lib album_count`
- `just gate`
