### PR TITLE
Harden unknown media download validation

### DIFF
--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -895,7 +895,7 @@ fn detect_error_sentinel(header: &[u8]) -> Option<&'static str> {
 /// Returns:
 /// - `Some(true)` — header matches a known-valid signature
 /// - `Some(false)` — extension is recognized but header does not match
-///   (caller logs a warning; the file is still saved)
+///   (caller decides whether another known media signature can safely pass)
 /// - `None` — extension is not in the signature table; skip the check
 ///
 /// MOV handling intentionally differs from the other ISO-BMFF extensions.
@@ -962,17 +962,19 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
     )
 }
 
-/// Validate downloaded content using kei's permissive valid-media policy.
+/// Validate downloaded content using kei's media-body policy.
 ///
-/// Hard-fail only when kei has positive evidence the file is unsafe or
-/// incomplete: zero bytes, known HTML/JSON error bodies, known error-document
-/// content types checked before writing, or byte-count mismatches checked by
-/// the caller.
-/// Extension-specific magic mismatches are warnings, not hard failures: iCloud
-/// sometimes assigns `.PNG` names to JPEG bytes, and kei's signature table is
-/// intentionally not treated as a complete media catalog. Unknown-but-not-known
-/// bad headers are saved when size checks have passed. Filenames stay exactly as
-/// planned; validation never rewrites extensions.
+/// Hard-fail when kei has positive evidence the file is unsafe or incomplete:
+/// zero bytes, known HTML/JSON error bodies, known error-document content types
+/// checked before writing, byte-count mismatches checked by the caller, or a
+/// known media extension whose bytes are neither the expected media type nor
+/// any other media type kei recognizes.
+///
+/// Extension-specific media mismatches are warnings, not hard failures: iCloud
+/// sometimes assigns `.PNG` names to JPEG bytes. Filenames stay exactly as
+/// planned; validation never rewrites extensions. Unknown extensions remain
+/// permissive so provider-side sidecars or new formats are not silently blocked
+/// before kei has a type-specific policy for them.
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,
@@ -1030,12 +1032,13 @@ fn validate_downloaded_content(
             );
             return Ok(());
         }
-        tracing::warn!(
-            path = %download_path.display(),
-            expected_extension = %ext,
-            header = %format_args!("{preview:02x?}"),
-            "File header does not match expected extension and is not recognized by kei; saving anyway",
-        );
+        return Err(DownloadError::InvalidContent {
+            path: download_path.display().to_string().into(),
+            reason: format!(
+                "file header does not match expected .{ext} media and is not recognized as another supported media type (first bytes: {preview:02x?})"
+            )
+            .into(),
+        });
     }
 
     Ok(())
@@ -1656,9 +1659,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_unrecognized_header_for_known_extension() {
+    fn validate_rejects_unrecognized_header_for_known_extension() {
         let (part, dest, _dir) = write_temp_file("photo.jpg", b"not media bytes");
-        assert!(validate_downloaded_content(&part, &dest).is_ok());
+        let err = validate_downloaded_content(&part, &dest).unwrap_err();
+        assert!(matches!(err, DownloadError::InvalidContent { .. }));
+        assert!(
+            err.to_string()
+                .contains("not recognized as another supported media type"),
+            "error should explain why unknown media bytes failed: {err}"
+        );
     }
 
     #[test]
@@ -2022,12 +2031,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attempt_download_promotes_unrecognized_header_under_known_extension() {
+    async fn attempt_download_rejects_same_size_unknown_media_body_under_known_extension() {
         let body = b"not media bytes";
         let client = StubDownloadClient::ok(body);
         let (download_path, part_path, _dir) = setup_download_dir("unknown_header", "jpg");
 
-        attempt_download(
+        let err = attempt_download(
             &client,
             "http://stub",
             &download_path,
@@ -2038,10 +2047,14 @@ mod tests {
             None,
         )
         .await
-        .unwrap();
+        .unwrap_err();
 
-        assert!(!part_path.exists(), ".part should be promoted");
-        assert_eq!(std::fs::read(&download_path).unwrap(), body);
+        assert!(
+            matches!(err, DownloadError::InvalidContent { .. }),
+            "expected InvalidContent, got: {err}"
+        );
+        assert!(!part_path.exists(), ".part should be removed");
+        assert!(!download_path.exists(), "final path must not exist");
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4203,7 +4203,9 @@ mod tests {
         remaining_failures: AtomicUsize,
         calls: AtomicUsize,
         successes: AtomicUsize,
+        failed_calls: AtomicUsize,
         downloaded_id_loads: AtomicUsize,
+        track_failed_calls: bool,
         fail_metadata_clear: bool,
         fail_complete_sync_run: bool,
     }
@@ -4214,10 +4216,18 @@ mod tests {
                 remaining_failures: AtomicUsize::new(fail_count),
                 calls: AtomicUsize::new(0),
                 successes: AtomicUsize::new(0),
+                failed_calls: AtomicUsize::new(0),
                 downloaded_id_loads: AtomicUsize::new(0),
+                track_failed_calls: false,
                 fail_metadata_clear: false,
                 fail_complete_sync_run: false,
             }
+        }
+
+        fn with_mark_failed_tracking() -> Self {
+            let mut s = Self::new(0);
+            s.track_failed_calls = true;
+            s
         }
 
         fn with_failing_metadata_clear() -> Self {
@@ -4242,6 +4252,10 @@ mod tests {
 
         fn downloaded_id_load_count(&self) -> usize {
             self.downloaded_id_loads.load(Ordering::Relaxed)
+        }
+
+        fn failed_call_count(&self) -> usize {
+            self.failed_calls.load(Ordering::Relaxed)
         }
     }
 
@@ -4284,7 +4298,12 @@ mod tests {
         }
 
         async fn mark_failed(&self, _: &str, _: &str, _: &str, _: &str) -> Result<(), StateError> {
-            unimplemented!()
+            if self.track_failed_calls {
+                self.failed_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            } else {
+                unimplemented!()
+            }
         }
 
         #[cfg(test)]
@@ -4830,6 +4849,85 @@ mod tests {
             attempted: STATE_DB_UNWRITABLE_THRESHOLD,
             failures: STATE_DB_UNWRITABLE_THRESHOLD,
         }));
+    }
+
+    #[tokio::test]
+    async fn download_pass_invalid_unknown_media_marks_failed_not_downloaded() {
+        use base64::Engine as _;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let body = b"not media bytes";
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let db = Arc::new(FailingStateDb::with_mark_failed_tracking());
+        let state_db: Arc<dyn StateDb> = db.clone();
+        let client = Client::new();
+        let retry = RetryConfig {
+            max_retries: 0,
+            base_delay_secs: 0,
+            max_delay_secs: 0,
+        };
+        let checksum = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+        let download_path = dir.path().join("unknown_header.jpg");
+        let part_path =
+            super::super::file::temp_download_path(&download_path, &checksum, ".kei-tmp")
+                .expect("valid temp path");
+        let task = DownloadTask {
+            url: format!("{}/photo.jpg", server.uri()).into(),
+            download_path: download_path.clone(),
+            checksum: checksum.into(),
+            asset_id: "UNKNOWN_MEDIA".into(),
+            library: "PrimarySync".into(),
+            metadata: Arc::new(MetadataPayload::default()),
+            size: body.len() as u64,
+            created_local: chrono::Local::now(),
+            version_size: VersionSizeKey::Original,
+            media_type: crate::state::MediaType::Photo,
+        };
+
+        let result = run_download_pass(
+            PassConfig {
+                client: &client,
+                retry_config: &retry,
+                metadata: MetadataFlags::default(),
+                concurrency: 1,
+                reporting: DownloadReporting::hidden(),
+                temp_suffix: std::sync::Arc::from(".kei-tmp"),
+                shutdown_token: CancellationToken::new(),
+                state_db: Some(state_db),
+                rate_limit_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                bandwidth_limiter: None,
+                library: std::sync::Arc::from("PrimarySync"),
+            },
+            vec![task],
+        )
+        .await;
+
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(db.call_count(), 0, "invalid media must not mark_downloaded");
+        assert_eq!(
+            db.failed_call_count(),
+            1,
+            "invalid media should be recorded failed"
+        );
+        assert!(
+            !download_path.exists(),
+            "invalid media must not publish final path"
+        );
+        assert!(!part_path.exists(), "invalid media .part should be removed");
+        let outcome = crate::download::DownloadOutcome::PartialFailure {
+            failed_count: result.failed.len(),
+        };
+        assert!(
+            !crate::sync_cycle::should_store_sync_token(&outcome, false),
+            "partial media-download failures must block sync-token advancement"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary
- Reject downloaded bodies for known media extensions when the header is neither the expected media type nor another supported media type.
- Keep valid media with mismatched extensions working, including iCloud PNG names served as JPEG bytes.
- Add coverage that invalid media stays in failure state, removes the `.part`, skips `mark_downloaded`, and blocks sync-token advancement.

Fixes #551.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test unknown --lib`
- `just gate` (outside sandbox so mock servers can bind localhost ports)
