### PR TITLE
Demote bounded sync-token notices

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -417,6 +417,20 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
     }
 }
 
+pub(crate) fn sync_token_blocked_bounded_log_message(reason: &str) -> Option<&'static str> {
+    match reason {
+        RECENT_LIMITED_FULL_ENUMERATION_REASON => Some(
+            "--recent mode is bounded and does not persist a full enumeration sync token. Run \
+             without --recent for checkpointed incremental token flow.",
+        ),
+        DATE_BOUNDED_FULL_ENUMERATION_REASON => Some(
+            "Date-bounded mode is bounded and does not persist a full enumeration sync token. \
+             Run without the lower date bound for checkpointed incremental token flow.",
+        ),
+        _ => None,
+    }
+}
+
 pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
     match reason {
         "pagination_shortfall" => {
@@ -439,10 +453,10 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
             "kei stopped before iCloud enumeration reached the natural end of the stream"
         }
         RECENT_LIMITED_FULL_ENUMERATION_REASON => {
-            "a count-limited recent sync is a partial enumeration, so kei blocked token advancement"
+            "a count-limited recent sync is a bounded enumeration, so kei intentionally did not persist a full-enumeration sync token"
         }
         DATE_BOUNDED_FULL_ENUMERATION_REASON => {
-            "a lower-date-bounded sync is a partial enumeration, so kei blocked token advancement"
+            "a lower-date-bounded sync is a bounded enumeration, so kei intentionally did not persist a full-enumeration sync token"
         }
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON => {
             "album membership state is not complete enough for incremental routing yet"

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -546,16 +546,28 @@ pub(crate) async fn run_cycle(
                         _ => "No per-pass sync token observation details were collected for this reason"
                             .to_string(),
                     };
-                    tracing::warn!(
-                        zone = %lib_state.zone_name,
-                        reason,
-                        source,
-                        explanation,
-                        observation,
-                        "Sync token did not advance after this successful sync. Here's why: {}. {}. Next cycle will run full enumeration",
-                        explanation,
-                        observation
-                    );
+                    if let Some(message) = download::sync_token_blocked_bounded_log_message(reason)
+                    {
+                        tracing::info!(
+                            zone = %lib_state.zone_name,
+                            reason,
+                            source,
+                            explanation,
+                            observation,
+                            "{message}"
+                        );
+                    } else {
+                        tracing::warn!(
+                            zone = %lib_state.zone_name,
+                            reason,
+                            source,
+                            explanation,
+                            observation,
+                            "Sync token did not advance after this successful sync. Here's why: {}. {}. Next cycle will run full enumeration",
+                            explanation,
+                            observation
+                        );
+                    }
                 }
             }
         } else if sync_result.sync_token.is_some() {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -3151,6 +3151,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_cycle_recent_full_download_does_not_store_zone_token() {
+        let (capture, _guard) = crate::test_helpers::TracingCapture::install();
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(40);
         let db = make_state_db();
@@ -3194,6 +3195,55 @@ mod tests {
                 .expect("read zone token"),
             None,
             "recent-limited full cycle must not persist a zone token"
+        );
+        let events = capture.events();
+        assert!(
+            events.iter().any(|event| {
+                event.level == tracing::Level::INFO
+                    && event.field("reason") == Some("recent_limited_full_enumeration")
+                    && event.message().is_some_and(|message| {
+                        message.contains("--recent mode is bounded")
+                            && message.contains("does not persist a full enumeration sync token")
+                    })
+            }),
+            "recent-limited token suppression should log at info: {events:?}"
+        );
+        assert!(
+            !events.iter().any(|event| {
+                event.level == tracing::Level::WARN
+                    && event.field("reason") == Some("recent_limited_full_enumeration")
+            }),
+            "recent-limited token suppression must not warn: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_true_token_unsafe_condition_still_warns() {
+        let (capture, _guard) = crate::test_helpers::TracingCapture::install();
+
+        let result = run_full_cycle_with_album(
+            make_empty_full_album(""),
+            false,
+            download::DownloadControls::download_hidden(),
+        )
+        .await;
+
+        assert_eq!(result.failed_count, 0);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some("icloud_blank_sync_token")
+        );
+        let events = capture.events();
+        assert!(
+            events.iter().any(|event| {
+                event.level == tracing::Level::WARN
+                    && event.field("reason") == Some("icloud_blank_sync_token")
+                    && event
+                        .message()
+                        .is_some_and(|message| message.contains("Sync token did not advance"))
+            }),
+            "true token-unsafe sync-token suppression should still warn: {events:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Demote expected bounded sync-token notices for `--recent` and lower-date-bounded runs to `INFO`.
- Keep true token-unsafe conditions, like blank iCloud sync tokens, at `WARN`.
- Update regression coverage for both paths.

Fixes #556.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo test run_cycle_recent_full_download_does_not_store_zone_token --lib`
- `cargo test run_cycle_true_token_unsafe_condition_still_warns --lib`
- `cargo test full_sync_recent_download_suppresses_token_without_shortfall --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate` (passed unrestricted after sandbox loopback bind failures)
