### PR TITLE
Fix truncated state-backed sync skips

### DIFF
--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -397,11 +397,8 @@ async fn adopt_pending_derived_path(
     derived: &DerivedPath,
 ) -> Option<PathBuf> {
     let version_size = derived.version_size.as_str();
-    let existing_path = task_planner.existing_path(&derived.path)?;
-    let Ok(metadata) = tokio::fs::metadata(&existing_path).await else {
-        return None;
-    };
-    if metadata.len() != derived.size {
+    let (existing_path, existing_size) = task_planner.existing_path_with_size(&derived.path)?;
+    if existing_size != derived.size {
         return None;
     }
 
@@ -472,10 +469,23 @@ fn state_confirmed_current_path_exists(
         if derived.version_size != task.version_size {
             continue;
         }
-        let Some(existing_path) = task_planner.existing_path(&derived.path) else {
+        let Some((existing_path, existing_size)) =
+            task_planner.existing_path_with_size(&derived.path)
+        else {
             continue;
         };
         if existing_path == stored_path {
+            if derived.size > 0 && existing_size < derived.size {
+                tracing::warn!(
+                    asset_id = %asset.id(),
+                    version_size = %derived.version_size.as_str(),
+                    path = %existing_path.display(),
+                    on_disk_size = existing_size,
+                    expected_size = derived.size,
+                    "State path is smaller than expected; re-downloading instead of skipping"
+                );
+                return None;
+            }
             return Some(existing_path);
         }
     }
@@ -5829,6 +5839,100 @@ mod tests {
             failed.is_empty(),
             "metadata-mutated downloaded file should remain downloaded, not failed"
         );
+    }
+
+    /// Data-sacred regression for state-backed on-disk skips.
+    ///
+    /// A downloaded DB row with a matching remote checksum is not enough to
+    /// trust a too-small local file. If the stored current path exists but is
+    /// shorter than the API-reported size, the producer must route the asset
+    /// back through the download phase instead of letting the truncated file
+    /// mask the real media.
+    #[tokio::test]
+    async fn truncated_downloaded_file_is_forwarded_not_on_disk_skipped() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn asset() -> PhotoAsset {
+            TestPhotoAsset::new("TRUNCATED_DOWNLOADED")
+                .filename("IMG_TRUNCATED.JPG")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(1234)
+                // Allowlisted CDN host so the asset reaches the download
+                // phase; the non-base64 checksum fails locally without
+                // doing network I/O.
+                .orig_url("https://p01.icloud-content.com/IMG_TRUNCATED.JPG")
+                .orig_checksum("ck_truncated_downloaded")
+                .build()
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let existing_asset = asset();
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let target_path = crate::download::filter::expected_paths_for(&existing_asset, &config)
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
+        fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+        fs::write(&target_path, []).unwrap();
+
+        let record = crate::test_helpers::TestAssetRecord::new("TRUNCATED_DOWNLOADED")
+            .checksum("ck_truncated_downloaded")
+            .filename("IMG_TRUNCATED.JPG")
+            .size(1234)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "TRUNCATED_DOWNLOADED",
+            "original",
+            &target_path,
+            "local_checksum_for_truncated_file",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let stream1 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset())]);
+        let result = stream_and_download_from_stream(
+            &client,
+            stream1,
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.downloaded, 0,
+            "dead test URL should not produce a successful download"
+        );
+        assert_eq!(
+            result.skip_summary.on_disk, 0,
+            "truncated downloaded file must not be counted as an on-disk skip"
+        );
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(
+            failed.len(),
+            1,
+            "truncated file must be forwarded for re-download (which fails against the dead URL)"
+        );
+        assert_eq!(&*failed[0].id, "TRUNCATED_DOWNLOADED");
     }
 
     // ── run_metadata_rewrites end-to-end ───────────────────────────────────

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -73,10 +73,19 @@ impl TaskPlanner {
     }
 
     pub(super) fn existing_path(&mut self, path: &Path) -> Option<std::path::PathBuf> {
-        if self.dir_cache.exists(path) {
-            Some(path.to_path_buf())
+        self.existing_path_with_size(path).map(|(path, _)| path)
+    }
+
+    pub(super) fn existing_path_with_size(
+        &mut self,
+        path: &Path,
+    ) -> Option<(std::path::PathBuf, u64)> {
+        if let Some(size) = self.dir_cache.file_size(path) {
+            Some((path.to_path_buf(), size))
         } else {
-            self.dir_cache.find_ampm_variant(path)
+            let variant = self.dir_cache.find_ampm_variant(path)?;
+            let size = self.dir_cache.file_size(&variant)?;
+            Some((variant, size))
         }
     }
 }

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -996,10 +996,8 @@ fn roundtrip_name_id7_sync_skips_after_import() {
     });
 }
 
-/// Import with videos disabled, sync without that filter. Sync still must NOT
-/// re-download the photos imported. Videos (which import skipped) should
-/// also be skipped by sync because the state DB has nothing on them and
-/// the on-disk files match.
+/// Import and sync with videos disabled. Sync still must NOT re-download the
+/// photos imported under the media-filtered state DB.
 #[test]
 #[ignore]
 fn roundtrip_skip_videos_sync_skips_imported_photos() {
@@ -1010,11 +1008,8 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
         // import-existing doesn't expose media selection as a flag. Use TOML
         // to force it.
         let test_data = tempdir().unwrap();
-        let toml_path = write_kei_toml(
-            test_data.path(),
-            download_dir,
-            "[filters]\nmedia = [\"photos\", \"live-photos\"]\n",
-        );
+        let media_filter_toml = "[filters]\nmedia = [\"photos\", \"live-photos\"]\n";
+        let toml_path = write_kei_toml(test_data.path(), download_dir, media_filter_toml);
 
         let recent = ROUNDTRIP_RECENT.to_string();
         let import_out = import_cmd(
@@ -1036,8 +1031,13 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
             return;
         }
 
-        let (downloaded, _skipped) =
-            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), "");
+        let (downloaded, _skipped) = run_sync_against_fixture(
+            &username,
+            &password,
+            download_dir,
+            test_data.path(),
+            media_filter_toml,
+        );
         assert_eq!(
             downloaded, 0,
             "sync re-downloaded {downloaded} after media-filtered import; matched={}",

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -387,25 +387,7 @@ fn verify_checksums_detects_corruption() {
             .timeout(std::time::Duration::from_secs(TIMEOUT_CMD))
             .assert();
 
-        let config_path = sync_config(
-            &cookie_dir,
-            download_dir.path(),
-            "",
-            "media = [\"photos\", \"live-photos\"]\n",
-        );
-        common::cmd()
-            .env("ICLOUD_USERNAME", &username)
-            .env("KEI_DATA_DIR", &cookie_dir)
-            .args([
-                "sync",
-                "--recent",
-                "1",
-                "--password",
-                &password,
-                "--config",
-                config_path.to_str().unwrap(),
-                "--no-progress-bar",
-            ])
+        sync_cmd(&username, &password, &cookie_dir, download_dir.path(), 1)
             .timeout(std::time::Duration::from_secs(TIMEOUT_SYNC))
             .assert()
             .success();


### PR DESCRIPTION
## Summary
- Re-download state-backed files when the stored path exists but is smaller than the API-reported asset size.
- Reuse the cached path-size lookup for pending on-disk adoption.
- Harden live test coverage for truncated files and media-filtered import roundtrips.

## Tests
- `cargo test truncated_downloaded_file_is_forwarded_not_on_disk_skipped --lib`
- `cargo test producer_adopts_pending_on_disk_skip_as_downloaded --lib`
- `cargo test metadata_mutated_downloaded_file_is_not_size_dedup_redownloaded --lib`
- `cargo test --test sync sync_truncated_file_does_not_cause_data_loss -- --ignored --test-threads=1`
- `cargo test --test state_auth verify_checksums_detects_corruption -- --ignored --test-threads=1`
- `cargo test --test import_existing_live roundtrip_default_layout_sync_skips_after_import -- --ignored --test-threads=1`
- `cargo test --test import_existing_live roundtrip_skip_videos_sync_skips_imported_photos -- --ignored --test-threads=1`
- `just gate`
