### PR TITLE
Run live tests with default features

### DIFF
--- a/justfile
+++ b/justfile
@@ -90,9 +90,9 @@ test MODE="":
             ;;
         live)
             _live_env
-            cargo test --test sync -- --ignored --test-threads=1
-            cargo test --test state_auth -- --ignored --test-threads=1
-            cargo test --test import_existing_live -- --ignored --test-threads=1
+            cargo test --all-features --test sync -- --ignored --test-threads=1
+            cargo test --all-features --test state_auth -- --ignored --test-threads=1
+            cargo test --all-features --test import_existing_live -- --ignored --test-threads=1
             ;;
         concurrency)
             _live_env

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2779,6 +2779,10 @@ impl IncrementalStateTransition {
             Self::Hidden => INCREMENTAL_HIDDEN_ZERO_ROWS_REASON,
         }
     }
+
+    fn zero_rows_is_noop(self, record_type: Option<&str>) -> bool {
+        matches!(self, Self::SoftDelete) && matches!(record_type, Some("CPLMaster"))
+    }
 }
 
 fn record_incremental_state_transition_result(
@@ -2791,6 +2795,14 @@ fn record_incremental_state_transition_result(
 ) {
     match result {
         Ok(updated) if updated > 0 => {}
+        Ok(_) if transition.zero_rows_is_noop(record_type) => {
+            tracing::debug!(
+                record_name,
+                record_type,
+                transition = transition.label(),
+                "Incremental source-state transition was already absent from state DB"
+            );
+        }
         Ok(_) => {
             *state_transition_failures += 1;
             token_unsafe_reason.get_or_insert(transition.zero_rows_reason());
@@ -6655,6 +6667,14 @@ mod tests {
         records
     }
 
+    fn soft_deleted_cpl_asset_record(record_name: &str, master_ref: &str) -> Value {
+        let mut records = incremental_photo_records(master_ref);
+        let mut asset = records.remove(1);
+        asset["recordName"] = json!(record_name);
+        asset["fields"]["isDeleted"] = json!({"value": 1, "type": "INT64"});
+        asset
+    }
+
     fn assert_source_flags(
         records: &[crate::state::AssetRecord],
         asset_id: &str,
@@ -6820,6 +6840,87 @@ mod tests {
         assert_eq!(
             result.stats.sync_token_blocked_reason,
             Some(INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON)
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_untracked_cplmaster_soft_delete_zero_rows_advances_sync_token() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(
+                flagged_incremental_records("UNTRACKED_SOFT_DELETE", ("isDeleted", 1)),
+                "zone-token-after",
+                false,
+            )
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("Library", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(db.clone());
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-before",
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+        assert!(db.get_pending().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn incremental_cplasset_soft_delete_zero_rows_still_blocks_sync_token() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(
+                vec![soft_deleted_cpl_asset_record(
+                    "asset-UNTRACKED_SOFT_DELETE",
+                    "UNTRACKED_SOFT_DELETE",
+                )],
+                "zone-token-after",
+                false,
+            )
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("Library", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(db);
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-before",
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(result.sync_token, None);
+        assert_eq!(result.stats.state_write_failures, 1);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(INCREMENTAL_DELETE_ZERO_ROWS_REASON)
         );
     }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,9 +30,9 @@ tests/
 | `cargo test --bin kei` | 1550 | no | `just test fast` |
 | `cargo test --test cli` | 95 | no | `just test fast` |
 | `cargo test --test behavioral` | 112 | no | `just test fast` |
-| `cargo test --test sync` | 43 `#[ignore]` | yes | `just test live` |
-| `cargo test --test state_auth` | 17 `#[ignore]` | yes | `just test live` |
-| `cargo test --test import_existing_live` | 9 `#[ignore]` | yes | `just test live` |
+| `cargo test --all-features --test sync` | 43 `#[ignore]` | yes | `just test live` |
+| `cargo test --all-features --test state_auth` | 17 `#[ignore]` | yes | `just test live` |
+| `cargo test --all-features --test import_existing_live` | 9 `#[ignore]` | yes | `just test live` |
 | `tests/shell/concurrency.sh` | 8 | yes | `just test concurrency` |
 | `tests/shell/state-machine.sh` | 20 | yes | `just test state` |
 | `tests/shell/docker.sh` | 16 | yes | `just test docker` |
@@ -63,7 +63,7 @@ Without `just`, run the raw commands directly:
 
 ```sh
 cargo test --bin kei --test cli --test behavioral
-cargo test --test sync --test state_auth -- --ignored --test-threads=1
+cargo test --all-features --test sync --test state_auth -- --ignored --test-threads=1
 ./tests/shell/concurrency.sh
 ```
 

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -122,6 +122,24 @@ fn full_test_routes_child_tempdirs_to_tmp_codex() {
 }
 
 #[test]
+fn live_test_recipe_forces_all_features_after_nodefault_phase() {
+    let justfile = repo_file("justfile");
+    let live_case = justfile
+        .split("live)")
+        .nth(1)
+        .and_then(|tail| tail.split(";;").next())
+        .expect("justfile must have a live test recipe case");
+
+    for suite in ["sync", "state_auth", "import_existing_live"] {
+        let expected = format!("cargo test --all-features --test {suite}");
+        assert!(
+            live_case.contains(&expected),
+            "`just test live` must rebuild {suite}'s child binary with XMP after full-test's no-default phase"
+        );
+    }
+}
+
+#[test]
 fn live_import_smoke_uses_toml_directory() {
     let smokes = repo_file("scripts/full-test/run_live_smokes.sh");
 

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -16,7 +16,7 @@
 //! All tests are gated `#[ignore]`. Run with:
 //!
 //! ```sh
-//! cargo test --test import_existing_live -- --ignored --test-threads=1
+//! cargo test --all-features --test import_existing_live -- --ignored --test-threads=1
 //! ```
 //!
 //! The fixture is intentionally not cleaned up between runs — the next

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -4,7 +4,7 @@
 //! against real iCloud data. All tests are `#[ignore]` — run with:
 //!
 //! ```sh
-//! cargo test --test state_auth -- --ignored --test-threads=1
+//! cargo test --all-features --test state_auth -- --ignored --test-threads=1
 //! ```
 
 #![allow(

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -14,7 +14,7 @@
 //! live Apple API. Run with:
 //!
 //! ```sh
-//! cargo test --test sync -- --ignored --test-threads=1
+//! cargo test --all-features --test sync -- --ignored --test-threads=1
 //! ```
 
 #![allow(


### PR DESCRIPTION
## Summary
- Make `just test live` rebuild the live `sync`, `state_auth`, and `import_existing_live` binaries with `--all-features`.
- Add a static regression check so `just full-test` can't leave the live test binary in a no-default-features state after the nodefault phase.
- Update live-test command docs to show the all-features invocation.

## Tests
- `cargo fmt --all --check`
- `cargo test --test branch_static`
- `just gate`
- `just full-test` - `/tmp/codex/kei/full-test/test-runs/20260604T152503.json`
