### PR TITLE
Relax strict iCloud token gates

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3650,7 +3650,7 @@ async fn download_photos_full_with_token(
                     config.concurrent_downloads,
                     pass_config.concurrent_downloads,
                     controls,
-                    strict_empty_tail_errors && total_count.is_some(),
+                    strict_empty_tail_errors,
                 );
                 let stream = filter_stream_to_enumeration_bounds(stream, config, recent_frontier);
 
@@ -3747,7 +3747,7 @@ async fn download_photos_full_with_token(
                         config.concurrent_downloads,
                         pass_config.concurrent_downloads,
                         controls,
-                        strict_empty_tail_errors && stream_total_count.is_some(),
+                        strict_empty_tail_errors,
                     );
                     let library = Arc::<str>::from(pass.album.zone_name());
                     let stream = filter_stream_to_enumeration_bounds(
@@ -3822,7 +3822,7 @@ async fn download_photos_full_with_token(
                     config.concurrent_downloads,
                     config.concurrent_downloads,
                     controls,
-                    strict_empty_tail_errors && total_count.is_some(),
+                    strict_empty_tail_errors,
                 );
                 token_receivers.push(token_rx);
                 filter_stream_to_enumeration_bounds(stream, config, recent_frontier.as_ref())
@@ -6217,19 +6217,7 @@ mod tests {
         // Seed the destination so the single enumerated asset is skipped
         // on-disk and the test isolates count-only shortfall behavior.
         let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
-        let pass_config = config.with_pass(&passes[0]);
-        let expected_path = filter::expected_paths_for(&asset, &pass_config)
-            .into_iter()
-            .next()
-            .expect("mock asset should have an expected path");
-        tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
-            .await
-            .expect("create parent dir");
-        tokio::fs::write(&expected_path.path, vec![0u8; 1024])
-            .await
-            .expect("seed existing file");
-        seed_downloaded_state_for_expected_path(&mut config, &pass_config, &asset, &expected_path)
-            .await;
+        seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -6269,12 +6257,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_album_count_is_diagnostic_when_stream_completes() {
+    async fn malformed_album_count_blocks_token_on_ambiguous_empty_tail() {
+        let records = mock_photo_records_with_filename("MASTER_BEFORE_GAP", "before-gap.jpg");
+        let later_records = mock_photo_records_with_filename("MASTER_AFTER_GAP", "after-gap.jpg");
         let session = MockPhotosFlow::new()
             .album_count_response(json!({
                 "batch": [{"records": [{"fields": {"itemCount": {"value": "not-a-count"}}}]}]
             }))
+            .query_page(records.clone(), Some("zone-token"))
             .empty_query_page(Some("zone-token"))
+            .empty_query_page(Some("zone-token"))
+            .empty_query_page(Some("zone-token"))
+            .empty_query_page(Some("zone-token"))
+            .empty_query_page(Some("zone-token"))
+            .query_page(later_records, Some("zone-token"))
             .build();
         let passes = vec![AlbumPass {
             kind: PassKind::Album,
@@ -6286,6 +6282,10 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
+        config.file_match_policy = FileMatchPolicy::NameId7;
+
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
 
         let result = download_photos_full_with_token(
             &Client::new(),
@@ -6297,21 +6297,28 @@ mod tests {
         .await
         .expect("malformed album count should produce a sync result");
 
-        assert!(
-            matches!(result.outcome, DownloadOutcome::Success),
-            "unexpected result: {result:?}"
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(
+            result.stats.assets_seen, 1,
+            "enumeration must not walk past the ambiguous empty-tail terminator"
         );
-        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.stats.enumeration_errors, 1);
         assert_eq!(result.stats.count_probe_failures, 1);
         assert_eq!(result.stats.pagination_shortfall_warnings, 0);
         assert_eq!(result.stats.pagination_shortfall_assets, 0);
-        assert!(!result.stats.sync_token_blocked);
-        assert_eq!(result.stats.sync_token_blocked_reason, None);
-        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
+        );
+        assert_eq!(result.sync_token, None);
     }
 
     #[tokio::test]
-    async fn missing_album_count_item_count_is_diagnostic_not_zero() {
+    async fn missing_album_count_item_count_blocks_ambiguous_empty_tail() {
         let session = MockPhotosFlow::new()
             .album_count_response(json!({
                 "batch": [{"records": [{"fields": {}}]}]
@@ -6339,12 +6346,19 @@ mod tests {
         .await
         .expect("missing album count should produce a sync result");
 
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
         assert_eq!(result.stats.assets_seen, 0);
-        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.stats.enumeration_errors, 1);
         assert_eq!(result.stats.count_probe_failures, 1);
-        assert_eq!(result.stats.sync_token_blocked_reason, None);
-        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
+        );
+        assert_eq!(result.sync_token, None);
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -223,6 +223,14 @@ pub struct SyncStats {
     pub exif_failures: usize,
     pub state_write_failures: usize,
     pub enumeration_errors: usize,
+    /// Best-effort count-probe failures observed before full enumeration.
+    /// These are reported separately from producer enumeration errors because
+    /// a naturally drained CloudKit stream with usable sync tokens can still
+    /// be complete even when the count side-channel was flaky.
+    pub count_probe_failures: usize,
+    /// Pending DB rows pruned after a clean full enumeration proved they were
+    /// not re-seen. State-only cleanup; media files are never deleted.
+    pub stale_pending_pruned: u64,
     /// Number of count-only CloudKit pagination shortfall warnings observed.
     /// These are not hard enumeration failures and do not imply download
     /// failures.
@@ -329,6 +337,8 @@ impl SyncStats {
         self.exif_failures += other.exif_failures;
         self.state_write_failures += other.state_write_failures;
         self.enumeration_errors += other.enumeration_errors;
+        self.count_probe_failures += other.count_probe_failures;
+        self.stale_pending_pruned += other.stale_pending_pruned;
         self.pagination_shortfall_warnings += other.pagination_shortfall_warnings;
         self.pagination_shortfall_assets += other.pagination_shortfall_assets;
         self.enumeration_incomplete = self.enumeration_incomplete || other.enumeration_incomplete;
@@ -2735,6 +2745,24 @@ async fn has_metadata_backfill_work(config: &DownloadConfig) -> bool {
     }
 }
 
+fn should_prune_stale_pending_after_full_enumeration(
+    sync_result: &SyncResult,
+    config: &DownloadConfig,
+    controls: DownloadControls,
+    shutdown_token: &CancellationToken,
+) -> bool {
+    sync_result.full_enumeration_ran
+        && matches!(sync_result.outcome, DownloadOutcome::Success)
+        && sync_result.stats.enumeration_errors == 0
+        && !sync_result.stats.enumeration_incomplete
+        && !sync_result.stats.interrupted
+        && config.recent.is_none()
+        && config.skip_created_before.is_none()
+        && !controls.run_mode.is_dry_run()
+        && !controls.run_mode.only_print_filenames()
+        && !shutdown_token.is_cancelled()
+}
+
 fn set_full_enumeration_reason(result: &mut SyncResult, reason: FullEnumerationReason) {
     if result.full_enumeration_ran && result.stats.full_enumeration_reason.is_none() {
         result.stats.full_enumeration_reason = Some(reason);
@@ -3267,6 +3295,39 @@ pub async fn download_photos_with_sync(
         }
     };
 
+    let mut result = result;
+    if let (Ok(sync_result), Some(db)) = (&mut result, config.state_db.as_ref()) {
+        if should_prune_stale_pending_after_full_enumeration(
+            sync_result,
+            config.as_ref(),
+            controls,
+            &shutdown_token,
+        ) {
+            match db
+                .prune_stale_pending_not_seen_since(&config.library, sync_started_at)
+                .await
+            {
+                Ok(pruned) if pruned > 0 => {
+                    sync_result.stats.stale_pending_pruned = pruned;
+                    tracing::warn!(
+                        count = pruned,
+                        library = %config.library,
+                        diagnostic = "stale_pending_pruned",
+                        "Pruned stale pending state rows after clean full enumeration"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        library = %config.library,
+                        "Failed to prune stale pending rows"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
     // Pending is transient — anything still pending after a complete sync either
     // wasn't enumerated or failed silently. Skip on interrupt where pending is expected.
     if let Some(db) = &config.state_db {
@@ -3291,11 +3352,9 @@ pub async fn download_photos_with_sync(
 
 /// Fold per-pass `album.len()` results into a `(counts, error_count)` tuple,
 /// logging a `warn!` for each failure. Errors are mapped to a count of 0 so
-/// downstream concurrency math still has a value, but the returned error
-/// count is the load-bearing signal: callers must treat it as an enumeration
-/// failure that suppresses sync token advancement (a swallowed `len()` error
-/// previously caused `total = 0`, which silently bypassed the pagination
-/// undercount check and advanced the token past un-enumerated change events).
+/// downstream progress and concurrency math still has a value. The returned
+/// error count is diagnostic only: callers must not turn a failed count
+/// side-channel into a semantic completeness bound.
 fn fold_pass_count_results(
     results: Vec<anyhow::Result<u64>>,
     passes: &[crate::commands::AlbumPass],
@@ -3311,9 +3370,8 @@ fn fold_pass_count_results(
                 tracing::warn!(
                     album = %pass.album,
                     error = %e,
-                    "Failed to query album length; treating count as 0 and \
-                     blocking sync token advancement to force full \
-                     re-enumeration on next run"
+                    "Failed to query album length; treating count as a display-only \
+                     zero and relying on the record stream for completeness"
                 );
                 0
             }
@@ -3372,23 +3430,25 @@ async fn build_pass_count_plan(
     // HTTP call. This matters for default multi-pass syncs and especially
     // `-a all`, where the old per-pass count probe scaled linearly before
     // the first byte of the first download.
-    // Capture per-pass `len()` errors instead of swallowing them as zero.
-    // A swallowed `len()` failure converted `total` to 0, which short-circuited
-    // the pagination-undercount check at line ~1450 (it only fires when
-    // `total > 0`); the cycle then returned `Success` with zero assets and the
-    // sync token advanced past un-enumerated change events. Treat any failure
-    // as a per-album enumeration error so token advancement is suppressed.
+    // Capture per-pass `len()` errors separately from stream errors. A failed
+    // count endpoint is not itself proof that records/query was incomplete,
+    // so token safety below is decided by natural stream completion and
+    // sync-token usability instead of a fabricated count bound.
     let pass_albums: Vec<&crate::icloud::photos::PhotoAlbum> =
         passes.iter().map(|pass| &pass.album).collect();
     let pass_count_results = crate::icloud::photos::PhotoAlbum::len_many(&pass_albums).await;
     let (display_counts, len_errors) = fold_pass_count_results(pass_count_results, passes);
-    let stream_total_counts = display_counts.iter().copied().map(Some).collect();
-    let exact_total = capped_exact_total(&display_counts, config.recent);
+    let stream_total_counts = if len_errors > 0 {
+        vec![None; passes.len()]
+    } else {
+        display_counts.iter().copied().map(Some).collect()
+    };
+    let exact_total = (len_errors == 0).then(|| capped_exact_total(&display_counts, config.recent));
 
     PassCountPlan {
         display_counts,
         stream_total_counts,
-        exact_total: Some(exact_total),
+        exact_total,
         len_errors,
     }
 }
@@ -3509,7 +3569,7 @@ async fn download_photos_full_with_token(
     // instead of serializing round trips across albums. Download workers are
     // divided across active pass pipelines so real downloads do not multiply
     // the user-selected `[download].threads` by the number of albums.
-    let (mut streaming_result, token_receivers) = if needs_per_pass {
+    let (streaming_result, token_receivers) = if needs_per_pass {
         let mut combined_result = StreamingResult {
             // Enumeration is "complete" only when every pass finished
             // its stream cleanly. Start optimistic; flip to false on the
@@ -3590,7 +3650,7 @@ async fn download_photos_full_with_token(
                     config.concurrent_downloads,
                     pass_config.concurrent_downloads,
                     controls,
-                    strict_empty_tail_errors,
+                    strict_empty_tail_errors && total_count.is_some(),
                 );
                 let stream = filter_stream_to_enumeration_bounds(stream, config, recent_frontier);
 
@@ -3687,7 +3747,7 @@ async fn download_photos_full_with_token(
                         config.concurrent_downloads,
                         pass_config.concurrent_downloads,
                         controls,
-                        strict_empty_tail_errors,
+                        strict_empty_tail_errors && stream_total_count.is_some(),
                     );
                     let library = Arc::<str>::from(pass.album.zone_name());
                     let stream = filter_stream_to_enumeration_bounds(
@@ -3762,7 +3822,7 @@ async fn download_photos_full_with_token(
                     config.concurrent_downloads,
                     config.concurrent_downloads,
                     controls,
-                    strict_empty_tail_errors,
+                    strict_empty_tail_errors && total_count.is_some(),
                 );
                 token_receivers.push(token_rx);
                 filter_stream_to_enumeration_bounds(stream, config, recent_frontier.as_ref())
@@ -3786,16 +3846,11 @@ async fn download_photos_full_with_token(
         (result, token_receivers)
     };
 
-    // Fold `len()` failures into the streaming result's enumeration error
-    // tally so `build_download_outcome` returns `PartialFailure`. This is the
-    // signal `should_store_sync_token` reads to suppress token advancement.
-    streaming_result.enumeration_errors += len_errors;
-    // A `len()` failure on any pass means we never had a reliable
-    // total to enumerate against, so the per-zone enumeration marker must
-    // stay set even if the producer drained its (possibly truncated) stream.
-    if len_errors > 0 {
-        streaming_result.enumeration_complete = false;
-    }
+    // Count-probe failures stay diagnostic unless the primary records/query
+    // stream also proves unsafe. Do not fold them into `enumeration_errors`
+    // or force `enumeration_complete = false`; otherwise a flaky count
+    // endpoint can trap users in repeated full enumeration after CloudKit
+    // delivered a naturally drained stream and a usable token.
     if exact_total.is_some() {
         exact_total = Some(capped_exact_total(&pagination_counts, config.recent));
     }
@@ -3867,8 +3922,8 @@ async fn download_photos_full_with_token(
     let token_eligible = config.recent.is_none()
         && config.skip_created_before.is_none()
         && !controls.run_mode.only_print_filenames()
-        && !count_lookup_failed
         && !pagination_undercount
+        && streaming_result.enumeration_complete
         && streaming_result.enumeration_errors == 0;
     let mut token_block_reason: Option<&'static str> = None;
     let mut token_expected_receivers: Option<usize> = None;
@@ -3965,6 +4020,7 @@ async fn download_photos_full_with_token(
     .await?;
     stats.pagination_shortfall_warnings = pagination_shortfall_warnings;
     stats.pagination_shortfall_assets = pagination_shortfall_assets;
+    stats.count_probe_failures = len_errors;
     if token_eligible {
         stats.sync_token_expected_receivers = token_expected_receivers;
         stats.sync_token_receivers_with_token = token_receivers_with_token;
@@ -3973,14 +4029,14 @@ async fn download_photos_full_with_token(
         stats.sync_token_receivers_dropped = token_receivers_dropped;
         stats.sync_token_unique_values = token_unique_values;
     }
-    if count_lookup_failed {
-        stats.sync_token_blocked = true;
-        stats.sync_token_blocked_reason = Some(ICLOUD_ALBUM_COUNT_ERROR_REASON);
-        stats.sync_token_blocked_source =
-            Some(sync_token_blocked_source(ICLOUD_ALBUM_COUNT_ERROR_REASON));
-        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(
-            ICLOUD_ALBUM_COUNT_ERROR_REASON,
-        ));
+    if count_lookup_failed && token_eligible && sync_token.is_some() {
+        if !stats.sync_token_blocked {
+            tracing::warn!(
+                count_probe_failures = len_errors,
+                "Count probes failed, but records/query completed naturally with a usable \
+                 sync token; recording diagnostic and allowing token advancement"
+            );
+        }
     } else if pagination_undercount {
         stats.sync_token_blocked = true;
         stats.sync_token_blocked_reason = Some("pagination_shortfall");
@@ -4006,6 +4062,14 @@ async fn download_photos_full_with_token(
         stats.sync_token_blocked_reason = Some(reason);
         stats.sync_token_blocked_source = Some(sync_token_blocked_source(reason));
         stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(reason));
+    } else if count_lookup_failed && !stats.sync_token_blocked {
+        stats.sync_token_blocked = true;
+        stats.sync_token_blocked_reason = Some(ICLOUD_ALBUM_COUNT_ERROR_REASON);
+        stats.sync_token_blocked_source =
+            Some(sync_token_blocked_source(ICLOUD_ALBUM_COUNT_ERROR_REASON));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(
+            ICLOUD_ALBUM_COUNT_ERROR_REASON,
+        ));
     }
 
     // Clear enumeration-in-progress markers when the producer reached the
@@ -6205,7 +6269,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_album_count_is_enumeration_error_and_blocks_sync_token() {
+    async fn malformed_album_count_is_diagnostic_when_stream_completes() {
         let session = MockPhotosFlow::new()
             .album_count_response(json!({
                 "batch": [{"records": [{"fields": {"itemCount": {"value": "not-a-count"}}}]}]
@@ -6233,30 +6297,21 @@ mod tests {
         .await
         .expect("malformed album count should produce a sync result");
 
-        assert!(matches!(
-            result.outcome,
-            DownloadOutcome::PartialFailure { failed_count: 1 }
-        ));
-        assert_eq!(result.stats.enumeration_errors, 1);
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "unexpected result: {result:?}"
+        );
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.stats.count_probe_failures, 1);
         assert_eq!(result.stats.pagination_shortfall_warnings, 0);
         assert_eq!(result.stats.pagination_shortfall_assets, 0);
-        assert!(result.stats.sync_token_blocked);
-        assert_eq!(
-            result.stats.sync_token_blocked_reason,
-            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
-        );
-        assert_eq!(result.stats.sync_token_blocked_source, Some("icloud"));
-        assert_eq!(
-            result.stats.sync_token_blocked_explanation,
-            Some(sync_token_blocked_explanation(
-                ICLOUD_ALBUM_COUNT_ERROR_REASON
-            ))
-        );
-        assert_eq!(result.sync_token, None);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
     }
 
     #[tokio::test]
-    async fn missing_album_count_item_count_is_enumeration_error_not_zero() {
+    async fn missing_album_count_item_count_is_diagnostic_not_zero() {
         let session = MockPhotosFlow::new()
             .album_count_response(json!({
                 "batch": [{"records": [{"fields": {}}]}]
@@ -6284,12 +6339,50 @@ mod tests {
         .await
         .expect("missing album count should produce a sync result");
 
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.stats.count_probe_failures, 1);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
+    }
+
+    #[tokio::test]
+    async fn malformed_album_count_still_blocks_when_stream_errors() {
+        let session = MockPhotosFlow::new()
+            .album_count_response(json!({
+                "batch": [{"records": [{"fields": {"itemCount": {"value": "not-a-count"}}}]}]
+            }))
+            .error("stream failed")
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("stream error should produce a sync result");
+
         assert!(matches!(
             result.outcome,
             DownloadOutcome::PartialFailure { failed_count: 1 }
         ));
-        assert_eq!(result.stats.assets_seen, 0);
         assert_eq!(result.stats.enumeration_errors, 1);
+        assert_eq!(result.stats.count_probe_failures, 1);
+        assert!(result.stats.sync_token_blocked);
         assert_eq!(
             result.stats.sync_token_blocked_reason,
             Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
@@ -9470,6 +9563,8 @@ mod tests {
             exif_failures: 1,
             state_write_failures: 2,
             enumeration_errors: 3,
+            count_probe_failures: 4,
+            stale_pending_pruned: 5,
             pagination_shortfall_warnings: 1,
             pagination_shortfall_assets: 9,
             enumeration_incomplete: false,
@@ -9517,6 +9612,8 @@ mod tests {
             exif_failures: 4,
             state_write_failures: 5,
             enumeration_errors: 6,
+            count_probe_failures: 7,
+            stale_pending_pruned: 8,
             pagination_shortfall_warnings: 2,
             pagination_shortfall_assets: 11,
             enumeration_incomplete: true,
@@ -9552,6 +9649,14 @@ mod tests {
         assert_eq!(acc.exif_failures, 5, "exif_failures must sum");
         assert_eq!(acc.state_write_failures, 7, "state_write_failures must sum");
         assert_eq!(acc.enumeration_errors, 9, "enumeration_errors must sum");
+        assert_eq!(
+            acc.count_probe_failures, 11,
+            "count_probe_failures must sum"
+        );
+        assert_eq!(
+            acc.stale_pending_pruned, 13,
+            "stale_pending_pruned must sum"
+        );
         assert_eq!(
             acc.pagination_shortfall_warnings, 3,
             "pagination shortfall warnings must sum"

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -119,6 +119,13 @@ pub trait DownloadStateStore: Send + Sync {
     async fn prepare_for_retry(&self, library: Option<&str>)
         -> Result<(u64, u64, u64), StateError>;
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError>;
+    async fn prune_stale_pending_not_seen_since(
+        &self,
+        _library: &str,
+        _seen_since: i64,
+    ) -> Result<u64, StateError> {
+        Ok(0)
+    }
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError>;
     async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError>;
     async fn get_downloaded_checksums(
@@ -620,6 +627,13 @@ pub trait StateDb: Send + Sync {
     ///
     /// Returns the number of assets promoted.
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError>;
+    async fn prune_stale_pending_not_seen_since(
+        &self,
+        _library: &str,
+        _seen_since: i64,
+    ) -> Result<u64, StateError> {
+        Ok(0)
+    }
 
     // ── Bulk read operations ──
 
@@ -1124,6 +1138,14 @@ where
         DownloadStateStore::promote_pending_to_failed(self, seen_since).await
     }
 
+    async fn prune_stale_pending_not_seen_since(
+        &self,
+        library: &str,
+        seen_since: i64,
+    ) -> Result<u64, StateError> {
+        DownloadStateStore::prune_stale_pending_not_seen_since(self, library, seen_since).await
+    }
+
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
         DownloadStateStore::get_downloaded_ids(self).await
     }
@@ -1509,6 +1531,14 @@ impl DownloadStateStore for dyn StateDb + '_ {
 
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
         StateDb::promote_pending_to_failed(self, seen_since).await
+    }
+
+    async fn prune_stale_pending_not_seen_since(
+        &self,
+        library: &str,
+        seen_since: i64,
+    ) -> Result<u64, StateError> {
+        StateDb::prune_stale_pending_not_seen_since(self, library, seen_since).await
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
@@ -2973,6 +3003,27 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn prune_stale_pending_not_seen_since(
+        &self,
+        library: &str,
+        seen_since: i64,
+    ) -> Result<u64, StateError> {
+        let library = library.to_string();
+        self.with_conn("prune_stale_pending_not_seen_since", move |conn| {
+            let pruned = conn
+                .execute(
+                    "DELETE FROM assets \
+                     WHERE library = ?1 AND status = 'pending' AND last_seen_at < ?2",
+                    rusqlite::params![library, seen_since],
+                )
+                .map_err(|e| StateError::query("prune_stale_pending_not_seen_since", e))?
+                as u64;
+
+            Ok(pruned)
+        })
+        .await
+    }
+
     pub(crate) async fn get_downloaded_ids(
         &self,
     ) -> Result<HashSet<(String, String, String)>, StateError> {
@@ -3998,6 +4049,14 @@ impl DownloadStateStore for SqliteStateDb {
 
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
         SqliteStateDb::promote_pending_to_failed(self, seen_since).await
+    }
+
+    async fn prune_stale_pending_not_seen_since(
+        &self,
+        library: &str,
+        seen_since: i64,
+    ) -> Result<u64, StateError> {
+        SqliteStateDb::prune_stale_pending_not_seen_since(self, library, seen_since).await
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
@@ -7199,6 +7258,65 @@ mod tests {
         let failed = db.get_failed().await.unwrap();
         assert_eq!(failed.len(), 1);
         assert_eq!(&*failed[0].id, "NEW_ASSET");
+    }
+
+    #[tokio::test]
+    async fn prune_stale_pending_not_seen_since_deletes_only_old_pending_for_library() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let old_primary = TestAssetRecord::new("OLD_PRIMARY")
+            .checksum("ck_old_primary")
+            .filename("old-primary.jpg")
+            .size(1000)
+            .build();
+        let fresh_primary = TestAssetRecord::new("FRESH_PRIMARY")
+            .checksum("ck_fresh_primary")
+            .filename("fresh-primary.jpg")
+            .size(1000)
+            .build();
+        let old_shared = TestAssetRecord::new("OLD_SHARED")
+            .library("SharedSync")
+            .checksum("ck_old_shared")
+            .filename("old-shared.jpg")
+            .size(1000)
+            .build();
+        let downloaded = TestAssetRecord::new("DOWNLOADED_PRIMARY")
+            .checksum("ck_downloaded_primary")
+            .filename("downloaded-primary.jpg")
+            .size(1000)
+            .build();
+
+        db.upsert_seen(&old_primary).await.unwrap();
+        db.upsert_seen(&fresh_primary).await.unwrap();
+        db.upsert_seen(&old_shared).await.unwrap();
+        db.upsert_seen(&downloaded).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "DOWNLOADED_PRIMARY",
+            "original",
+            Path::new("/tmp/downloaded-primary.jpg"),
+            "local",
+            Some("download"),
+        )
+        .await
+        .unwrap();
+
+        let sync_started_at = chrono::Utc::now().timestamp() - 1800;
+        db.backdate_last_seen("OLD_PRIMARY", sync_started_at - 10);
+        db.backdate_last_seen("OLD_SHARED", sync_started_at - 10);
+
+        let pruned = db
+            .prune_stale_pending_not_seen_since("PrimarySync", sync_started_at)
+            .await
+            .unwrap();
+
+        assert_eq!(pruned, 1);
+        let pending = db.get_pending().await.unwrap();
+        let ids: HashSet<&str> = pending.iter().map(|row| row.id.as_ref()).collect();
+        assert!(!ids.contains("OLD_PRIMARY"));
+        assert!(ids.contains("FRESH_PRIMARY"));
+        assert!(ids.contains("OLD_SHARED"));
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.downloaded, 1, "downloaded rows must not change");
     }
 
     // Regression test for #211: a pending asset the producer didn't enumerate

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -84,21 +84,19 @@ pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_r
     matches!(outcome, download::DownloadOutcome::Success) && !dry_run
 }
 
-/// Cycle-level gate that combines the per-library outcome check with the
-/// cross-library "any plan is stale" override.
+/// Library-level gate that combines the per-library outcome check with the
+/// stale-plan flag for the same zone.
 ///
-/// If any library entered the cycle with a reused plan (the prior
-/// album refresh failed), suppress sync-token advancement for every library
-/// in the cycle. A stale plan can route assets created or moved between
-/// cycles to the wrong pass; advancing the token would skip the change
-/// events that would surface those assets correctly on the next refresh,
-/// leaving `asset_albums` permanently incomplete.
+/// A reused album plan can route assets created or moved between cycles to
+/// the wrong pass, so the affected zone must not advance. Unaffected zones
+/// can still store their own zone tokens; the broader database pre-check
+/// token remains conservative until every selected zone is clean.
 pub(crate) fn should_store_sync_token_for_cycle(
     outcome: &download::DownloadOutcome,
     dry_run: bool,
-    cycle_has_stale_plan: bool,
+    library_plan_is_stale: bool,
 ) -> bool {
-    should_store_sync_token(outcome, dry_run) && !cycle_has_stale_plan
+    should_store_sync_token(outcome, dry_run) && !library_plan_is_stale
 }
 
 fn has_active_passes(lib_state: &LibraryState) -> bool {
@@ -308,18 +306,11 @@ pub(crate) async fn run_cycle(
     let mut cycle_session_expired = false;
     let mut cycle_stats = download::SyncStats::default();
 
-    // If ANY library entered the cycle with a stale plan (the prior
-    // album refresh failed and the previous plan is being reused), suppress
-    // sync-token advancement for every library in this cycle. A reused plan
-    // can route assets created or moved between cycles to the wrong pass and
-    // produce silently incomplete `asset_albums` data; without this gate the
-    // change events for those assets sit behind the advanced token and
-    // never replay.
     let cycle_has_stale_plan = library_states.iter().any(|s| s.plan_is_stale);
     if cycle_has_stale_plan {
         tracing::warn!(
             "One or more libraries are running on a stale album plan; sync \
-             token will not advance this cycle"
+             database pre-check token will not advance this cycle"
         );
     }
     let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
@@ -494,7 +485,7 @@ pub(crate) async fn run_cycle(
         let should_store_token = should_store_sync_token_for_cycle(
             &sync_result.outcome,
             config.runtime.dry_run,
-            cycle_has_stale_plan,
+            lib_state.plan_is_stale,
         ) && !sync_result.stats.interrupted
             && !shutdown_token.is_cancelled();
         if should_store_token {
@@ -504,6 +495,13 @@ pub(crate) async fn run_cycle(
                         db_sync_token_advance_safe = false;
                         tracing::warn!(error = %e, "Failed to store sync token");
                     } else {
+                        if cycle_has_stale_plan && !lib_state.plan_is_stale {
+                            tracing::warn!(
+                                zone = %lib_state.zone_name,
+                                diagnostic = "stale_plan_unaffected_zone",
+                                "Stored clean zone sync token despite another selected zone's stale plan"
+                            );
+                        }
                         tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
                     }
                 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4673,10 +4673,10 @@ mod tests {
         );
     }
 
-    /// A cycle that consumed a stale plan from a prior
-    /// failed `resolve_passes` MUST NOT advance the sync token even when the
-    /// per-library outcome is `Success`. A reused plan can route assets to
-    /// the wrong pass; advancing the token would skip the change events
+    /// A library that consumed a stale plan from a prior failed
+    /// `resolve_passes` MUST NOT advance its sync token even when its
+    /// outcome is `Success`. A reused plan can route assets to the wrong
+    /// pass; advancing the affected zone token would skip the change events
     /// that would surface the corrected membership on the next cycle.
     #[test]
     fn sync_loop_stale_plan_blocks_sync_token_advance_even_on_success() {
@@ -4686,7 +4686,7 @@ mod tests {
         // With a stale plan: even Success must NOT advance the token.
         assert!(
             !should_store_sync_token_for_cycle(&outcome, false, true),
-            "stale-plan flag must veto token advancement on Success"
+            "same-library stale-plan flag must veto token advancement on Success"
         );
     }
 
@@ -4706,9 +4706,70 @@ mod tests {
         assert!(!should_store_sync_token_for_cycle(&success, true, false));
         assert!(!should_store_sync_token_for_cycle(&success, true, true));
 
-        // Only (Success, dry_run=false, stale=false) advances.
+        // Only (Success, dry_run=false, library_stale=false) advances.
         assert!(should_store_sync_token_for_cycle(&success, false, false));
         assert!(!should_store_sync_token_for_cycle(&success, false, true));
+    }
+
+    #[tokio::test]
+    async fn run_cycle_clean_zone_advances_despite_other_stale_plan() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "primary-prev")
+            .await
+            .expect("seed primary token");
+        db.set_metadata("sync_token:SharedSync-TEST", "shared-prev")
+            .await
+            .expect("seed shared token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let clean_state =
+            make_run_cycle_library_state("PrimarySync", "sync_token:PrimarySync", "primary-new");
+        let mut stale_state = make_run_cycle_library_state(
+            "SharedSync-TEST",
+            "sync_token:SharedSync-TEST",
+            "shared-new",
+        );
+        stale_state.plan_is_stale = true;
+        let states = vec![&clean_state, &stale_state];
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert!(
+            !result.db_sync_token_advance_safe,
+            "database precheck token must wait for every selected zone to be clean"
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read primary token")
+                .as_deref(),
+            Some("primary-new"),
+            "unaffected clean zone should advance its own token"
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:SharedSync-TEST")
+                .await
+                .expect("read shared token")
+                .as_deref(),
+            Some("shared-prev"),
+            "stale zone must keep its old token"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Let clean full enumerations advance zone tokens when only the iCloud count side-channel failed, while reporting `count_probe_failures`.
- Prune stale pending DB rows after clean library-scoped full enumerations and report `stale_pending_pruned`.
- Scope stale-plan zone-token blocking to the affected library while keeping the database pre-check token conservative.

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test malformed_album_count --lib`
- `cargo test prune_stale_pending_not_seen_since --lib`
- `cargo test stale_plan --lib`
- `cargo test sync_loop_run_cycle_aggregates_stats_across_libraries --lib`
- `just gate`
