### PR TITLE
Polish user-facing error messages

### DIFF
--- a/src/auth/endpoints.rs
+++ b/src/auth/endpoints.rs
@@ -45,7 +45,7 @@ impl Endpoints {
                 home: "https://www.icloud.com.cn",
                 setup: "https://setup.icloud.com.cn/setup/ws/1",
             }),
-            _ => anyhow::bail!("Domain '{domain}' is not supported yet"),
+            _ => anyhow::bail!("Unsupported iCloud domain `{domain}`. Use `com` or `cn`."),
         }
     }
 }

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -23,28 +23,28 @@ const INVALID_CREDENTIALS_RECOVERY: &str = "Update kei's stored password, then r
 /// Custom error types for iCloud authentication.
 #[derive(Debug, Error)]
 pub enum AuthError {
-    #[error("Failed login: {0}")]
+    #[error("Could not log in to iCloud: {0}")]
     FailedLogin(String),
 
-    #[error("Invalid authentication token: {0}")]
+    #[error("The saved iCloud login token is no longer valid: {0}")]
     InvalidToken(String),
 
-    #[error("API error (HTTP {code}): {message}")]
+    #[error("Apple authentication returned HTTP {code}: {message}")]
     ApiError { code: u16, message: String },
 
-    #[error("Two-factor authentication failed: {0}")]
+    #[error("Two-factor authentication did not complete: {0}")]
     TwoFactorFailed(String),
 
-    #[error("Apple service error ({code}): {message}")]
+    #[error("Apple authentication service returned {code}: {message}")]
     ServiceError { code: String, message: String },
 
     #[error(
-        "Terminal Apple authentication error ({code}): {message}. {}",
+        "Apple authentication needs your attention ({code}): {message}. {}",
         terminal_apple_auth_recovery(code)
     )]
     TerminalAppleAuth { code: String, message: String },
 
-    #[error("Two-factor authentication is required (no code provided)")]
+    #[error("Two-factor authentication is required. Run `kei login get-code`, then `kei login submit-code <CODE>`.")]
     TwoFactorRequired,
 
     /// The Apple ID has FIDO/WebAuthn hardware security keys registered.
@@ -54,14 +54,14 @@ pub enum AuthError {
     /// user hit that downstream failure and loop through re-auth.
     #[error(
         "This Apple ID has FIDO/WebAuthn hardware security keys registered{}. \
-         kei does not yet support this authentication method (see issue #221).\n\n\
+         kei cannot use Apple accounts that require security keys yet (see issue #221).\n\n\
          To use kei with this account, remove the security keys at:\n  \
          Settings > Apple ID & iCloud > Sign-In & Security > Security Keys",
         format_fido_keys(key_names)
     )]
     FidoNotSupported { key_names: Vec<String> },
 
-    #[error("Session lock held by another instance: {0}")]
+    #[error("Another kei process is using the iCloud session: {0}")]
     LockContention(String),
 
     #[error(transparent)]
@@ -252,20 +252,23 @@ mod tests {
         let err = AuthError::TwoFactorRequired;
         assert_eq!(
             err.to_string(),
-            "Two-factor authentication is required (no code provided)"
+            "Two-factor authentication is required. Run `kei login get-code`, then `kei login submit-code <CODE>`."
         );
     }
 
     #[test]
     fn failed_login_display() {
         let err = AuthError::FailedLogin("bad password".into());
-        assert_eq!(err.to_string(), "Failed login: bad password");
+        assert_eq!(err.to_string(), "Could not log in to iCloud: bad password");
     }
 
     #[test]
     fn invalid_token_display() {
         let err = AuthError::InvalidToken("expired".into());
-        assert_eq!(err.to_string(), "Invalid authentication token: expired");
+        assert_eq!(
+            err.to_string(),
+            "The saved iCloud login token is no longer valid: expired"
+        );
     }
 
     #[test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -192,8 +192,7 @@ async fn authenticate_inner(
                     .is_some_and(AuthError::is_transient_apple_failure)
                 {
                     return Err(e.context(
-                        "Apple's auth service is returning transient errors (HTTP 429/5xx). \
-                         Wait a few minutes and retry",
+                        "Apple's authentication service is temporarily failing (HTTP 429/5xx). Wait a few minutes and retry.",
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
@@ -273,7 +272,9 @@ async fn authenticate_inner(
         let password = crate::password::invoke_password_provider(password_provider)
             .await
             .ok_or_else(|| {
-                AuthError::FailedLogin("No password available (see error above for details)".into())
+                AuthError::FailedLogin(
+                    "No password was available. Check the password-source error above.".into(),
+                )
             })?;
 
         tracing::debug!(apple_id = %apple_id, "Authenticating");
@@ -312,7 +313,8 @@ async fn authenticate_inner(
         data = Some(account_data);
     }
 
-    let data = data.ok_or_else(|| anyhow::anyhow!("Authentication produced no account data"))?;
+    let data =
+        data.ok_or_else(|| anyhow::anyhow!("Apple authentication did not return account data."))?;
 
     let requires_2fa = check_requires_2fa(&data);
     if requires_2fa {
@@ -449,8 +451,7 @@ pub async fn send_2fa_push(
                     .is_some_and(AuthError::is_transient_apple_failure)
                 {
                     return Err(e.context(
-                        "Apple's auth service is returning transient errors (HTTP 429/5xx). \
-                         Wait a few minutes and retry",
+                        "Apple's authentication service is temporarily failing (HTTP 429/5xx). Wait a few minutes and retry.",
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
@@ -500,7 +501,9 @@ pub async fn send_2fa_push(
         let password = crate::password::invoke_password_provider(password_provider)
             .await
             .ok_or_else(|| {
-                AuthError::FailedLogin("No password available (see error above for details)".into())
+                AuthError::FailedLogin(
+                    "No password was available. Check the password-source error above.".into(),
+                )
             })?;
         srp::authenticate_srp(
             &mut session,
@@ -530,10 +533,11 @@ pub async fn send_2fa_push(
         data = Some(account_data);
     }
 
-    let data = data.ok_or_else(|| anyhow::anyhow!("Authentication produced no account data"))?;
+    let data =
+        data.ok_or_else(|| anyhow::anyhow!("Apple authentication did not return account data."))?;
 
     if !check_requires_2fa(&data) {
-        anyhow::bail!("Session is already authenticated, 2FA is not required");
+        anyhow::bail!("This iCloud session is already authenticated; no 2FA code is needed.");
     }
 
     twofa::trigger_push_notification(&mut session, &endpoints, &client_id, domain).await
@@ -747,7 +751,7 @@ mod tests {
         .expect_err("unsupported domain should fail before session auth");
 
         assert!(
-            err.to_string().contains("not supported"),
+            err.to_string().contains("Unsupported iCloud domain"),
             "unexpected error: {err:#}"
         );
         assert!(
@@ -771,7 +775,7 @@ mod tests {
             .expect_err("unsupported domain should fail before SRP");
 
         assert!(
-            err.to_string().contains("not supported"),
+            err.to_string().contains("Unsupported iCloud domain"),
             "unexpected error: {err:#}"
         );
         assert!(

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -154,13 +154,13 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
             .truncate(true)
             .open(&tmp)
             .await
-            .with_context(|| format!("Failed to open temp file {}", tmp.display()))?;
+            .with_context(|| format!("Could not open temporary file {}", tmp.display()))?;
         f.write_all(data)
             .await
-            .with_context(|| format!("Failed to write temp file {}", tmp.display()))?;
+            .with_context(|| format!("Could not write temporary file {}", tmp.display()))?;
         f.sync_all()
             .await
-            .with_context(|| format!("Failed to fsync temp file {}", tmp.display()))?;
+            .with_context(|| format!("Could not fsync temporary file {}", tmp.display()))?;
     }
     #[cfg(unix)]
     {
@@ -169,7 +169,7 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     }
     fs::rename(&tmp, path)
         .await
-        .with_context(|| format!("Failed to rename {} to {}", tmp.display(), path.display()))?;
+        .with_context(|| format!("Could not rename {} to {}", tmp.display(), path.display()))?;
     crate::fs_util::fsync_parent_dir_async_best_effort(path).await;
     Ok(())
 }
@@ -314,10 +314,7 @@ impl Session {
         let cookie_dir = cookie_dir.to_path_buf();
 
         fs::create_dir_all(&cookie_dir).await.with_context(|| {
-            format!(
-                "Failed to create cookie directory: {}",
-                cookie_dir.display()
-            )
+            format!("Could not create cookie directory {}", cookie_dir.display())
         })?;
 
         // Acquire an exclusive file lock to prevent concurrent instances for
@@ -327,16 +324,14 @@ impl Session {
             let lock_path = lock_path.clone();
             move || {
                 let file = std::fs::File::create(&lock_path).with_context(|| {
-                    format!("Failed to create lock file: {}", lock_path.display())
+                    format!("Could not create session lock file {}", lock_path.display())
                 })?;
                 let acquired = file
                     .try_lock_exclusive()
-                    .with_context(|| format!("Failed to acquire lock: {}", lock_path.display()))?;
+                    .with_context(|| format!("Could not acquire session lock {}", lock_path.display()))?;
                 if !acquired {
                     return Err(crate::auth::error::AuthError::LockContention(format!(
-                        "Another kei instance is running for this account (lock: {}). \
-                         If running in Docker, check for orphaned containers with \
-                         `docker ps` and stop them with `docker stop <name>`.",
+                        "Another kei instance is running for this account (lock: {}). If running in Docker, check for orphaned containers with `docker ps` and stop them with `docker stop <name>`.",
                         lock_path.display()
                     ))
                     .into());
@@ -543,7 +538,7 @@ impl Session {
     /// Release the exclusive file lock without dropping the Session.
     /// This allows a new Session to acquire the lock (e.g. during re-authentication).
     pub(crate) fn release_lock(&self) -> Result<()> {
-        FileExt::unlock(&self.lock_file).context("Failed to release session lock file")
+        FileExt::unlock(&self.lock_file).context("Could not release the session lock file")
     }
 
     /// Re-acquire the exclusive file lock after a prior `release_lock()`.
@@ -554,10 +549,10 @@ impl Session {
         let acquired = self
             .lock_file
             .try_lock_exclusive()
-            .context("Failed to re-acquire session lock")?;
+            .context("Could not reacquire the session lock")?;
         if !acquired {
             return Err(crate::auth::error::AuthError::LockContention(
-                "Another kei instance acquired the lock while it was released".into(),
+                "Another kei instance acquired the session lock while it was released.".into(),
             )
             .into());
         }
@@ -645,7 +640,7 @@ impl Session {
             atomic_write(&session_path, json.as_bytes())
                 .await
                 .with_context(|| {
-                    format!("Failed to write session data to {}", session_path.display())
+                    format!("Could not write session data to {}", session_path.display())
                 })?;
             tracing::debug!("Saved session data to file");
         }
@@ -733,7 +728,7 @@ impl Session {
             serde_json::to_string_pretty(&entries)?.as_bytes(),
         )
         .await
-        .with_context(|| format!("Failed to write cookies to {}", cookiejar_path.display()))?;
+        .with_context(|| format!("Could not write cookies to {}", cookiejar_path.display()))?;
 
         Ok(())
     }

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -355,7 +355,7 @@ pub async fn authenticate_srp(
     domain: &str,
 ) -> Result<()> {
     let n = BigUint::parse_bytes(N_HEX.as_bytes(), 16)
-        .ok_or_else(|| anyhow::anyhow!("Failed to parse SRP prime"))?;
+        .ok_or_else(|| anyhow::anyhow!("Could not initialize Apple SRP login parameters."))?;
     let g = BigUint::from(G_VAL);
 
     let mut a_bytes = vec![0u8; 32];
@@ -435,24 +435,25 @@ pub async fn authenticate_srp(
     let body: super::responses::SrpInitResponse = response.json().with_context(|| {
         let text = response.text();
         format!(
-            "SRP init: expected JSON but got (HTTP {}): {:?}",
+            "Apple login returned an unexpected response during SRP setup (HTTP {}): {:?}",
             response.status,
             crate::truncate_str(&text, 200)
         )
     })?;
 
-    let iterations = u32::try_from(body.iteration).context("SRP iteration count exceeds u32")?;
+    let iterations =
+        u32::try_from(body.iteration).context("Apple SRP iteration count is too large")?;
     anyhow::ensure!(
         iterations <= 1_000_000,
-        "SRP iteration count {iterations} exceeds safety limit"
+        "Apple SRP iteration count {iterations} exceeds kei's safety limit."
     );
 
     let salt = BASE64
         .decode(&body.salt)
-        .context("Failed to decode SRP salt")?;
+        .context("Could not decode Apple SRP salt")?;
     let b_pub_bytes = BASE64
         .decode(&body.b)
-        .context("Failed to decode SRP public key")?;
+        .context("Could not decode Apple SRP public key")?;
     let b_pub = BigUint::from_bytes_be(&b_pub_bytes);
 
     let password_key = derive_apple_password(password, &body.protocol, &salt, iterations);
@@ -467,10 +468,16 @@ pub async fn authenticate_srp(
     let u = compute_u(&a_pub, &b_pub, &n);
 
     if u == BigUint::ZERO {
-        return Err(AuthError::FailedLogin("SRP: u is zero, aborting".into()).into());
+        return Err(AuthError::FailedLogin(
+            "Apple SRP login returned an invalid challenge.".into(),
+        )
+        .into());
     }
     if &b_pub % &n == BigUint::ZERO {
-        return Err(AuthError::FailedLogin("SRP: B mod N is zero, aborting".into()).into());
+        return Err(AuthError::FailedLogin(
+            "Apple SRP login returned an invalid public key.".into(),
+        )
+        .into());
     }
 
     let v = g.modpow(&x, &n);
@@ -582,7 +589,7 @@ pub async fn authenticate_srp(
         if !repair_response.is_success() {
             return Err(AuthError::ApiError {
                 code: 412,
-                message: format!("Repair failed: {}", repair_response.text()),
+                message: format!("Apple account repair failed: {}", repair_response.text()),
             }
             .into());
         }
@@ -597,8 +604,7 @@ pub async fn authenticate_srp(
         return Err(AuthError::ApiError {
             code: status,
             message: format!(
-                "Apple returned HTTP {status}{detail} — this is usually a temporary \
-                 Apple server issue, try again in a few minutes"
+                "Apple returned HTTP {status}{detail}. This is usually a temporary Apple server issue; try again in a few minutes."
             ),
         }
         .into());
@@ -629,9 +635,10 @@ pub async fn authenticate_srp(
         } else {
             format!(": {body}")
         };
-        return Err(
-            AuthError::FailedLogin(format!("Invalid email/password combination{detail}")).into(),
-        );
+        return Err(AuthError::FailedLogin(format!(
+            "Apple rejected the iCloud username or password{detail}"
+        ))
+        .into());
     } else if response.status == 429 {
         return Err(AuthError::ApiError {
             code: 429,
@@ -736,7 +743,9 @@ where
     if let Some(resp) = last_transient {
         return Ok(resp);
     }
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("SRP {step}: retry loop exhausted")))
+    Err(last_err.unwrap_or_else(|| {
+        anyhow::anyhow!("Apple SRP login step `{step}` did not succeed after all retries.")
+    }))
 }
 
 #[cfg(test)]
@@ -1023,7 +1032,9 @@ mod tests {
         let err = run_srp(vec![response(200, b"not json".to_vec())])
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("SRP init: expected JSON"));
+        assert!(err
+            .to_string()
+            .contains("Apple login returned an unexpected response during SRP setup"));
     }
 
     #[tokio::test]
@@ -1031,7 +1042,7 @@ mod tests {
         let err = run_srp(vec![response(200, srp_init_body(&BASE64.encode([0u8])))])
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("B mod N is zero"));
+        assert!(err.to_string().contains("invalid public key"));
     }
 
     #[tokio::test]

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -200,7 +200,7 @@ async fn retry_auth_request(
         tokio::time::sleep(delay).await;
     }
     Err(anyhow::anyhow!(
-        "{log_label}: retry loop exhausted without a decisive response"
+        "{log_label}: Apple did not return a usable response after all retries."
     ))
 }
 
@@ -397,7 +397,7 @@ pub async fn trust_session(
     session
         .get(&url, Some(headers))
         .await
-        .context("Failed to trust session")?;
+        .context("Could not mark the iCloud session trusted")?;
     tracing::debug!("Session trusted successfully");
     Ok(true)
 }
@@ -440,7 +440,7 @@ pub async fn validate_token(
     let text = read_response_body(response, "validate_token body").await;
     let data: AccountLoginResponse = serde_json::from_str(&text).with_context(|| {
         format!(
-            "Validate: expected JSON but got: {:?}",
+            "Apple session validation returned an unexpected response: {:?}",
             crate::truncate_str(&text, 200)
         )
     })?;
@@ -486,7 +486,7 @@ pub async fn authenticate_with_token(
     let text = read_response_body(response, "accountLogin body").await;
     let body: AccountLoginResponse = serde_json::from_str(&text).with_context(|| {
         format!(
-            "Account login: expected JSON but got: {:?}",
+            "Apple account login returned an unexpected response: {:?}",
             crate::truncate_str(&text, 200)
         )
     })?;
@@ -498,7 +498,7 @@ pub async fn authenticate_with_token(
     // re-run with auth.domain = "cn" to use the correct regional endpoint.
     if let Some(domain_to_use) = &body.domain_to_use {
         return Err(anyhow::anyhow!(
-            "Apple insists on using {domain_to_use} for your request. Please set auth.domain in config"
+            "Apple requires iCloud domain `{domain_to_use}` for this account. Set [auth].domain in the config file."
         ));
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -2951,7 +2951,7 @@ mod wiremock_tests {
 
         let msg = format!("{err}");
         assert!(
-            msg.contains("import-existing interrupted by shutdown signal")
+            msg.contains("Import was interrupted while scanning library")
                 && msg.contains("test-all"),
             "error message must name the shutdown and library label, got: {msg}",
         );
@@ -2986,7 +2986,7 @@ mod wiremock_tests {
         .expect_err("must bail on fetcher panic");
         let msg = format!("{err}");
         assert!(
-            msg.contains("import scan aborted") && msg.contains("test-all"),
+            msg.contains("Import scan stopped") && msg.contains("test-all"),
             "error message must name the abort + label, got: {msg}"
         );
     }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -158,7 +158,7 @@ async fn verify_strict_prefix(
 
     let prefix_len_u64 = expected_size.min(STRICT_IMPORT_PREFIX_BYTES);
     let prefix_len = usize::try_from(prefix_len_u64)
-        .context("strict import prefix length does not fit in usize")?;
+        .context("Strict import prefix length is too large for this system")?;
     if prefix_len == 0 {
         return Ok(StrictImportDecision::Accepted);
     }
@@ -166,11 +166,13 @@ async fn verify_strict_prefix(
     let mut local_prefix = vec![0_u8; prefix_len];
     let mut local = tokio::fs::File::open(local_path)
         .await
-        .with_context(|| format!("opening {} for strict import", local_path.display()))?;
-    local
-        .read_exact(&mut local_prefix)
-        .await
-        .with_context(|| format!("reading strict prefix from {}", local_path.display()))?;
+        .with_context(|| format!("Could not open {} for strict import", local_path.display()))?;
+    local.read_exact(&mut local_prefix).await.with_context(|| {
+        format!(
+            "Could not read strict import prefix from {}",
+            local_path.display()
+        )
+    })?;
 
     let range_end = prefix_len_u64.saturating_sub(1);
     let response = client
@@ -178,10 +180,10 @@ async fn verify_strict_prefix(
         .header(reqwest::header::RANGE, format!("bytes=0-{range_end}"))
         .send()
         .await
-        .with_context(|| format!("fetching strict import prefix from {cloud_url}"))?;
+        .with_context(|| format!("Could not fetch strict import prefix from {cloud_url}"))?;
     let status = response.status();
     if !(status == reqwest::StatusCode::PARTIAL_CONTENT || status == reqwest::StatusCode::OK) {
-        anyhow::bail!("strict import prefix fetch returned HTTP {status}");
+        anyhow::bail!("Strict import prefix check returned HTTP {status}.");
     }
 
     let mut cloud_prefix = Vec::with_capacity(prefix_len);
@@ -190,17 +192,17 @@ async fn verify_strict_prefix(
         let Some(chunk) = stream.next().await else {
             break;
         };
-        let chunk = chunk.context("reading strict import prefix response")?;
+        let chunk = chunk.context("Could not read strict import prefix response")?;
         let remaining = prefix_len - cloud_prefix.len();
         let take = chunk.len().min(remaining);
         let Some(prefix) = chunk.get(..take) else {
-            anyhow::bail!("strict import prefix chunk shorter than expected");
+            anyhow::bail!("Strict import prefix response ended sooner than expected.");
         };
         cloud_prefix.extend_from_slice(prefix);
     }
     if cloud_prefix.len() < prefix_len {
         anyhow::bail!(
-            "strict import prefix fetch returned {} bytes, expected {prefix_len}",
+            "Strict import prefix check returned {} bytes, expected {prefix_len}.",
             cloud_prefix.len()
         );
     }
@@ -459,7 +461,7 @@ where
             tokio::select! {
                 () = shutdown_token.cancelled() => {
                     anyhow::bail!(
-                        "import-existing interrupted by shutdown signal for library '{library_label}'"
+                        "Import was interrupted while scanning library `{library_label}`."
                     );
                 }
                 result = stream.next() => result,
@@ -491,7 +493,7 @@ where
                 // report as clean, leaving unmatched files to re-download
                 // on the next sync.
                 anyhow::bail!(
-                    "import scan aborted for library '{library_label}': fetcher returned error: {e}"
+                    "Import scan stopped for library `{library_label}` because iCloud returned an error: {e}"
                 );
             }
         };
@@ -705,8 +707,7 @@ where
     // on panic; absence of a send is the clean-exit signal.
     if panic_rx.await.unwrap_or(false) {
         anyhow::bail!(
-            "import scan aborted for library '{library_label}': a fetcher task panicked; \
-             results are incomplete, see earlier error log"
+            "Import scan stopped for library `{library_label}` because a fetcher task crashed. Results are incomplete; see the earlier error log."
         );
     }
 
@@ -742,9 +743,7 @@ pub(crate) async fn run_import_existing(
         Some(crate::cli::RecentLimit::Count(n)) => Some(n),
         Some(crate::cli::RecentLimit::Days(n)) => {
             anyhow::bail!(
-                "`--recent {n}d` isn't supported for import-existing (which scans \
-                 existing files rather than filtering by iCloud date). Use a plain \
-                 count like `--recent 1000` instead."
+                "`--recent {n}d` is not supported for import-existing because it scans existing files instead of filtering by iCloud date. Use a count like `--recent 1000` instead."
             );
         }
     };
@@ -753,9 +752,9 @@ pub(crate) async fn run_import_existing(
     // swallows read errors and would otherwise report "0 files matched".
     match tokio::fs::metadata(&directory).await {
         Ok(m) if m.is_dir() => {}
-        Ok(_) => anyhow::bail!("Not a directory: {}", directory.display()),
+        Ok(_) => anyhow::bail!("Download path is not a directory: {}", directory.display()),
         Err(e) => anyhow::bail!(
-            "Cannot read download directory {}: {e}",
+            "Could not read download directory {}: {e}",
             directory.display()
         ),
     }
@@ -819,16 +818,15 @@ pub(crate) async fn run_import_existing(
     let prior_db_total = db.get_summary().await?.total_assets;
     if prior_db_total > 0 && !args.force_empty {
         use futures_util::{StreamExt, TryStreamExt};
-        let counts: Vec<u64> =
-            futures_util::stream::iter(libraries.iter())
-                .map(|library| async move {
-                    library.all().len().await.with_context(|| {
-                        format!("counting assets in library {}", library.zone_name())
-                    })
+        let counts: Vec<u64> = futures_util::stream::iter(libraries.iter())
+            .map(|library| async move {
+                library.all().len().await.with_context(|| {
+                    format!("Could not count assets in library {}", library.zone_name())
                 })
-                .buffered(libraries.len().max(1))
-                .try_collect()
-                .await?;
+            })
+            .buffered(libraries.len().max(1))
+            .try_collect()
+            .await?;
         let empty_zones: Vec<&str> = libraries
             .iter()
             .zip(&counts)
@@ -969,12 +967,7 @@ fn validate_non_empty_libraries(empty_zones: &[&str], prior_db_total: u64) -> an
         format!("libraries {}", empty_zones.join(", "))
     };
     anyhow::bail!(
-        "{zones} returned 0 assets but the state DB has {prior_db_total} prior asset \
-         rows -- aborting to avoid a misleading `matched: 0` report. Most often this \
-         is a transient iCloud permissions glitch or stale auth; re-run after \
-         confirming via `kei list libraries` or the iCloud web UI. Pass --force-empty \
-         (or set KEI_FORCE_EMPTY=true) if you genuinely emptied the library or are \
-         attaching a new sub-library to an account that already has data."
+        "{zones} returned 0 assets, but the state database already has {prior_db_total} asset rows. Stopping to avoid a misleading `matched: 0` import. This is usually a temporary iCloud permission or stale-login problem. Check with `kei list libraries` or the iCloud web UI, then retry. Use `--force-empty` (or KEI_FORCE_EMPTY=true) only if that library is intentionally empty."
     );
 }
 
@@ -1003,7 +996,7 @@ fn build_import_download_config(
         .unwrap_or_default();
     if directory_str.is_empty() {
         anyhow::bail!(crate::upgrade_hints::with_stale_env_hint(String::from(
-            "[download] directory is required for import-existing",
+            "Set [download].directory in the config file before running import-existing.",
         )));
     }
     let directory_path = config::expand_tilde(&directory_str);
@@ -3471,7 +3464,7 @@ mod build_config_tests {
         let err = build_import_download_config(None).expect_err("empty directory should bail");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("[download] directory is required for import-existing"),
+            msg.contains("Set [download].directory"),
             "error must name the missing TOML field, got: {msg}"
         );
     }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3066,11 +3066,11 @@ mod wiremock_tests {
         .expect_err("must bail on fetcher Err");
         let msg = format!("{err}");
         assert!(
-            msg.contains("import scan aborted") && msg.contains("test-all"),
+            msg.contains("Import scan stopped") && msg.contains("test-all"),
             "error message must name the abort + library label, got: {msg}",
         );
         assert!(
-            msg.contains("fetcher returned error"),
+            msg.contains("iCloud returned an error"),
             "error message must name the fetcher source, got: {msg}",
         );
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -22,7 +22,7 @@ pub(crate) async fn run_list(
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
+        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username before listing iCloud Photos.");
     }
 
     let password_provider =

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -19,7 +19,9 @@ pub(crate) async fn run_login(
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("username is required for login (set ICLOUD_USERNAME or [auth].username)");
+        anyhow::bail!(
+            "Set your iCloud username with ICLOUD_USERNAME or [auth].username before logging in."
+        );
     }
 
     let password_provider =

--- a/src/commands/password.rs
+++ b/src/commands/password.rs
@@ -18,7 +18,7 @@ pub(crate) fn run_password(
 
     if username.is_empty() {
         anyhow::bail!(
-            "username is required for password management (set ICLOUD_USERNAME or [auth].username)"
+            "Set your iCloud username with ICLOUD_USERNAME or [auth].username before managing a password."
         );
     }
 
@@ -27,8 +27,8 @@ pub(crate) fn run_password(
     match action {
         cli::PasswordAction::Set => {
             let input = rpassword::prompt_password("iCloud Password: ")
-                .map_err(|e| anyhow::anyhow!("Failed to read password: {e}"))?;
-            anyhow::ensure!(!input.is_empty(), "Password must not be empty");
+                .map_err(|e| anyhow::anyhow!("Could not read password: {e}"))?;
+            anyhow::ensure!(!input.is_empty(), "Password cannot be empty.");
             let backend = store.store(&input)?;
             println!("Password stored in {} backend.", backend.as_str());
         }

--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -226,7 +226,7 @@ pub(crate) async fn run_reconcile(
     }
 
     if mark_errors > 0 {
-        anyhow::bail!("reconcile partially failed: {mark_errors} state updates errored");
+        anyhow::bail!("Reconcile found {mark_errors} missing files that could not be marked failed in the state database.");
     }
 
     Ok(())

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -72,9 +72,7 @@ pub(crate) async fn run_reset_sync_token(
         use std::io::Write;
         if !std::io::stdin().is_terminal() {
             anyhow::bail!(
-                "reset sync-token needs `--yes` when stdin is not a terminal. \
-                 Next sync will re-enumerate every asset, which can take a long \
-                 time on a large library; pass `--yes` to confirm."
+                "`kei reset sync-token` needs `--yes` when stdin is not a terminal. The next sync will re-enumerate every asset, which can take a long time on a large library."
             );
         }
         println!("This will clear stored sync tokens at:");

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -45,7 +45,7 @@ pub(crate) async fn init_photos_service(
         .as_ref()
         .and_then(|ws| ws.ckdatabasews.as_ref())
         .map(|ep| ep.url.clone())
-        .ok_or_else(|| anyhow::anyhow!("No ckdatabasews URL"))?;
+        .ok_or_else(|| anyhow::anyhow!("Apple did not return the CloudKit Photos service URL."))?;
 
     // Persist the active ckdatabasews URL so validate_session can detect
     // partition changes during watch-mode revalidation.
@@ -424,16 +424,14 @@ pub(crate) async fn resolve_libraries(
             .map(icloud::photos::PhotoLibrary::zone_name)
             .collect();
         anyhow::bail!(
-            "--library '{missed}' not found. Available zones: {}. Run `kei list libraries` to see every zone with its truncated form.",
+            "`--library {missed}` did not match any iCloud Photos library. Available zones: {}. Run `kei list libraries` to see every zone with its truncated form.",
             known.join(", ")
         );
     }
 
     if chosen.is_empty() {
         anyhow::bail!(
-            "--library resolved to zero libraries against this account; \
-             pass at least one of primary / shared / a zone name without \
-             excluding everything"
+            "`--library` did not select any libraries for this account. Choose `primary`, `shared`, or a zone name, and do not exclude everything."
         );
     }
 
@@ -459,10 +457,7 @@ pub(crate) async fn resolve_libraries(
         let mut sorted = zones.clone();
         sorted.sort_unstable();
         anyhow::bail!(
-            "Multiple selected libraries collapse to the same `{{library}}` path \
-             segment `{truncated}`: [{full}]. The 8-char shared-library prefix \
-             collides; pin one of these zones via `--library <longer-prefix>` \
-             (use `kei list libraries` to see every zone with its truncated form).",
+            "Multiple selected libraries would use the same `{{library}}` folder name `{truncated}`: [{full}]. Select one explicitly with a longer `--library <prefix>` value. Run `kei list libraries` to see the full zone names.",
             full = sorted.join(", "),
         );
     }
@@ -494,7 +489,7 @@ where
 
     all_libraries
         .await
-        .context("failed to resolve cross-zone album hydration libraries")
+        .context("Could not resolve libraries needed for cross-library album matching")
 }
 
 /// Match a `--library` entry (full zone name or truncated 8-char form)
@@ -626,7 +621,7 @@ fn validate_collection_album_selector(
             for name in included {
                 if smart_names.contains(name.as_str()) {
                     anyhow::bail!(
-                        "'{name}' is a smart folder; pass `--smart-folder {name}` instead of `--album`"
+                        "`{name}` is a smart folder. Use `--smart-folder {name}` instead of `--album {name}`."
                     );
                 }
                 if excluded.contains(name) {
@@ -635,7 +630,7 @@ fn validate_collection_album_selector(
                 if !collection_album_names.contains(name) {
                     let available: Vec<&str> =
                         collection_album_names.iter().map(String::as_str).collect();
-                    anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+                    anyhow::bail!("Album `{name}` was not found. Available albums: {available:?}");
                 }
             }
             bail_unknown_excluded_collection_albums(excluded, collection_album_names)
@@ -650,7 +645,7 @@ fn bail_unknown_excluded_collection_albums(
     for name in excluded {
         if !collection_album_names.contains(name) {
             let available: Vec<&str> = collection_album_names.iter().map(String::as_str).collect();
-            anyhow::bail!("Excluded album '{name}' not found. Available albums: {available:?}");
+            anyhow::bail!("Excluded album `{name}` was not found. Available albums: {available:?}");
         }
     }
     Ok(())
@@ -688,7 +683,7 @@ fn pick_selected_smart_folder_names(
                     let mut available: Vec<&str> = smart_names.iter().copied().collect();
                     available.sort();
                     anyhow::bail!(
-                        "'{name}' is not an Apple smart folder. Available: {available:?}"
+                        "`{name}` is not an Apple smart folder. Available smart folders: {available:?}"
                     );
                 }
             }
@@ -779,7 +774,7 @@ async fn collect_album_asset_ids(
     let count = album
         .len()
         .await
-        .with_context(|| format!("failed to get asset count for album '{}'", album.name))?;
+        .with_context(|| format!("Could not count assets in album `{}`", album.name))?;
     let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
     tokio::pin!(stream);
     while let Some(result) = stream.next().await {
@@ -1017,7 +1012,7 @@ fn pick_album_names(
             for name in included {
                 if smart_names.contains(name.as_str()) {
                     anyhow::bail!(
-                        "'{name}' is a smart folder; pass `--smart-folder {name}` instead of `--album`"
+                        "`{name}` is a smart folder. Use `--smart-folder {name}` instead of `--album {name}`."
                     );
                 }
                 if excluded.contains(name) {
@@ -1031,7 +1026,7 @@ fn pick_album_names(
                         .filter(|k| !smart_names.contains(k.as_str()))
                         .collect();
                     available.sort();
-                    anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+                    anyhow::bail!("Album `{name}` was not found. Available albums: {available:?}");
                 }
             }
             bail_unknown_excluded_albums(excluded, album_map, smart_names)?;
@@ -1055,7 +1050,7 @@ fn bail_unknown_excluded_albums(
                 .filter(|k| !smart_names.contains(k.as_str()))
                 .collect();
             available.sort();
-            anyhow::bail!("Excluded album '{name}' not found. Available albums: {available:?}");
+            anyhow::bail!("Excluded album `{name}` was not found. Available albums: {available:?}");
         }
     }
     Ok(())
@@ -1068,7 +1063,9 @@ fn bail_excluded_not_a_smart_folder(
     if !smart_names.contains(name) {
         let mut available: Vec<&str> = smart_names.iter().copied().collect();
         available.sort();
-        anyhow::bail!("Excluded '{name}' is not an Apple smart folder. Available: {available:?}");
+        anyhow::bail!(
+            "Excluded smart folder `{name}` was not found. Available smart folders: {available:?}"
+        );
     }
     Ok(())
 }
@@ -1833,7 +1830,7 @@ mod tests {
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("failed to resolve cross-zone album hydration libraries"),
+            msg.contains("Could not resolve libraries needed for cross-library album matching"),
             "missing context: {msg}"
         );
         assert!(
@@ -2406,7 +2403,7 @@ libraries = ["shared"]
         let sel = selector_from(&["primary", "!primary"]);
         let err = resolve_libraries(&sel, &mut ps).await.unwrap_err();
         assert!(
-            err.to_string().contains("zero libraries"),
+            err.to_string().contains("did not select any libraries"),
             "unexpected error: {err}"
         );
     }

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -122,7 +122,9 @@ pub(crate) async fn run_verify(
     }
 
     if missing > 0 || corrupted > 0 {
-        anyhow::bail!("verify failed: {missing} missing, {corrupted} corrupted");
+        anyhow::bail!(
+            "Verification found {missing} missing files and {corrupted} corrupted files."
+        );
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -423,7 +423,7 @@ pub(crate) fn load_toml_config(path: &Path, required: bool) -> anyhow::Result<Op
             Ok(Some(config))
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound && !required => Ok(None),
-        Err(e) => Err(e).context(format!("Failed to read config file {}", path.display()))?,
+        Err(e) => Err(e).context(format!("Could not read config file {}", path.display()))?,
     }
 }
 
@@ -452,7 +452,7 @@ pub(crate) fn resolve_media_selection(
     skip_photos_override: Option<bool>,
 ) -> anyhow::Result<MediaSelection> {
     let mut selection = if let Some(kinds) = toml_filters.and_then(|f| f.media.as_ref()) {
-        anyhow::ensure!(!kinds.is_empty(), "[filters] media must not be empty");
+        anyhow::ensure!(!kinds.is_empty(), "[filters].media cannot be empty.");
         let mut seen = BTreeSet::new();
         let mut selection = MediaSelection {
             photos: false,
@@ -462,7 +462,7 @@ pub(crate) fn resolve_media_selection(
         for kind in kinds {
             anyhow::ensure!(
                 seen.insert(*kind),
-                "[filters] media contains duplicate `{}`",
+                "[filters].media contains duplicate `{}`.",
                 media_kind_name(*kind)
             );
             match kind {
@@ -485,7 +485,7 @@ pub(crate) fn resolve_media_selection(
 
     anyhow::ensure!(
         selection.photos || selection.videos || selection.live_photos,
-        "[filters] media must select at least one media category"
+        "[filters].media must select at least one media category."
     );
 
     Ok(selection)
@@ -575,7 +575,7 @@ fn validate_template_tokens(folder_structure: &str, kind: TemplateKind) -> anyho
         }
         if stripped.contains(token) {
             anyhow::bail!(
-                "'{token}' is not valid in {flag}; move it to {owner} (template was \"{folder_structure}\")"
+                "`{token}` cannot be used in {flag}. Move it to {owner}. Template: \"{folder_structure}\""
             );
         }
     }
@@ -587,7 +587,7 @@ fn validate_template_tokens(folder_structure: &str, kind: TemplateKind) -> anyho
         let count = stripped.matches(token).count();
         if count > 1 {
             anyhow::bail!(
-                "'{token}' may only appear once in {flag}; got {count} occurrences in \"{folder_structure}\""
+                "`{token}` can appear only once in {flag}. Found {count} in \"{folder_structure}\"."
             );
         }
     }
@@ -597,7 +597,7 @@ fn validate_template_tokens(folder_structure: &str, kind: TemplateKind) -> anyho
 
     if has_library && segments.first() != Some(&TOKEN_LIBRARY) {
         anyhow::bail!(
-            "'{TOKEN_LIBRARY}' must be the first path segment of {flag}; got \"{folder_structure}\""
+            "`{TOKEN_LIBRARY}` must be the first path segment in {flag}. Template: \"{folder_structure}\""
         );
     }
     if let Some(cat) = category.filter(|c| stripped.contains(*c)) {
@@ -608,7 +608,7 @@ fn validate_template_tokens(folder_structure: &str, kind: TemplateKind) -> anyho
             } else {
                 "must be the first path segment"
             };
-            anyhow::bail!("'{cat}' {position} of {flag}; got \"{folder_structure}\"");
+            anyhow::bail!("`{cat}` {position} in {flag}. Template: \"{folder_structure}\"");
         }
     }
 
@@ -712,7 +712,7 @@ pub(crate) fn validate_download_dir(path: &Path) -> anyhow::Result<()> {
     // trimmed.is_empty() catches "/" (trimmed to "")
     if trimmed.is_empty() || DENIED.contains(&trimmed) {
         anyhow::bail!(
-            "Refusing to use system directory '{}' as download directory",
+            "Refusing to use system directory '{}' as the download directory.",
             path.display()
         );
     }
@@ -859,7 +859,7 @@ pub(crate) fn resolve_path_derivation_fields(
     let alternative = resolve_flag(cli.alternative, toml_photos.and_then(|p| p.alternative));
     anyhow::ensure!(
         resolution != PhotoResolution::None || edited || alternative,
-        "photos.resolution = \"none\" requires photos.edited = true or photos.alternative = true"
+        "[photos].resolution = \"none\" requires [photos].edited = true or [photos].alternative = true."
     );
     let raw_policy = resolve(
         cli.raw_policy,
@@ -1105,7 +1105,7 @@ impl Config {
         // (`kei password set`), password files, and shell-command sources.
         if toml_auth.and_then(|a| a.password.as_ref()).is_some() {
             anyhow::bail!(
-                "config file sets `[auth] password`, which is not accepted. \
+                "The config file sets `[auth].password`, which kei no longer accepts. \
                  Plaintext passwords in config files are a security risk. \
                  Use one of: `kei password set` (OS keyring or encrypted file), \
                  `[auth] password_file`, or `[auth] password_command` instead."
@@ -1124,8 +1124,7 @@ impl Config {
         #[cfg(windows)]
         if password_command.is_some() {
             anyhow::bail!(
-                "`--password-command` / `[auth] password_command` is not supported on Windows: \
-                 kei runs commands via `sh -c`, which isn't on the stock Windows PATH. \
+                "`--password-command` and `[auth].password_command` are not supported on Windows because kei runs commands through `sh -c`, which is not on the default Windows PATH. \
                  Use `--password-file` / `[auth] password_file`, or run kei under WSL."
             );
         }
@@ -1137,10 +1136,10 @@ impl Config {
                 .and_then(|t| t.auth.as_ref()?.username.as_ref())
                 .is_some()
         {
-            anyhow::ensure!(!username.is_empty(), "username must not be empty");
+            anyhow::ensure!(!username.is_empty(), "The iCloud username cannot be empty.");
         }
         if let Some(pw_str) = &password_str {
-            anyhow::ensure!(!pw_str.is_empty(), "password must not be empty");
+            anyhow::ensure!(!pw_str.is_empty(), "The iCloud password cannot be empty.");
         }
 
         // Reject both `password_file` and `password_command` in the same TOML
@@ -1148,8 +1147,7 @@ impl Config {
         if let Some(toml_a) = toml_auth {
             anyhow::ensure!(
                 !(toml_a.password_file.is_some() && toml_a.password_command.is_some()),
-                "config file sets both `[auth] password_file` and \
-                 `[auth] password_command` — pick one"
+                "The config file sets both `[auth].password_file` and `[auth].password_command`. Pick one password source."
             );
         }
 
@@ -1162,13 +1160,13 @@ impl Config {
         if let Some(existing) = cookie_directory.ancestors().find(|a| a.exists()) {
             anyhow::ensure!(
                 existing.is_dir(),
-                "cookie directory path contains a non-directory component: {}",
+                "The cookie directory path contains a file where a directory is needed: {}",
                 existing.display()
             );
         }
         std::fs::create_dir_all(&cookie_directory).map_err(|e| {
             anyhow::anyhow!(
-                "cannot create cookie directory {}: {e}",
+                "Could not create cookie directory {}: {e}",
                 cookie_directory.display()
             )
         })?;
@@ -1197,7 +1195,7 @@ impl Config {
             Some(n)
         } else if let Some(s) = toml_dl.and_then(|d| d.bandwidth_limit.as_ref()) {
             Some(crate::cli::parse_bandwidth_limit(s).map_err(|e| {
-                anyhow::anyhow!("invalid [download].bandwidth_limit in config: {e}")
+                anyhow::anyhow!("Invalid [download].bandwidth_limit in config: {e}")
             })?)
         } else {
             None
@@ -1221,7 +1219,7 @@ impl Config {
             .unwrap_or(threads_default);
         anyhow::ensure!(
             (1..=64).contains(&threads_num),
-            "threads must be in 1..=64, got {threads_num}"
+            "[download].threads must be between 1 and 64, got {threads_num}."
         );
         let temp_suffix = resolve(
             overrides.temp_suffix,
@@ -1277,7 +1275,7 @@ impl Config {
         );
         anyhow::ensure!(
             max_retries <= 100,
-            "retry per_transfer must be <= 100, got {max_retries}"
+            "[download.retry].per_transfer must be 100 or less, got {max_retries}."
         );
         // Lifetime cap on download attempts per asset (0 disables). CLI >
         // TOML > 10, matching every other resolved value. The runtime
@@ -1331,7 +1329,7 @@ impl Config {
             .iter()
             .map(|p| {
                 glob::Pattern::new(p)
-                    .map_err(|e| anyhow::anyhow!("invalid --filename-exclude pattern '{p}': {e}"))
+                    .map_err(|e| anyhow::anyhow!("Invalid --filename-exclude pattern '{p}': {e}"))
             })
             .collect::<anyhow::Result<_>>()?;
         let persistent_recent = toml_filters.and_then(|f| f.recent);
@@ -1360,18 +1358,18 @@ impl Config {
             Some(crate::cli::RecentLimit::Days(n)) => {
                 anyhow::ensure!(
                     explicit_skip_created_before_str.is_none(),
-                    "`--recent {n}d` and `--skip-created-before` are equivalent controls - pick one"
+                    "`--recent {n}d` and `--skip-created-before` do the same thing. Pick one."
                 );
                 (None, Some(n))
             }
         };
         anyhow::ensure!(
             recent_raw.is_some() || !recent_scope_was_set,
-            "`recent_scope` only applies when `recent` is set"
+            "`recent_scope` only applies when `recent` is set."
         );
         anyhow::ensure!(
             !matches!(recent_raw, Some(crate::cli::RecentLimit::Days(_))) || !recent_scope_was_set,
-            "`recent_scope` only applies to count-form `recent` values, not `Nd` days windows"
+            "`recent_scope` only applies to count-form `recent` values, not `Nd` day windows."
         );
         let skip_created_before_str = if let Some(n) = recent_days {
             Some(format!("{n}d"))
@@ -1462,7 +1460,7 @@ impl Config {
             Some(addr) => addr,
             None => match toml_server.and_then(|s| s.bind.as_deref()) {
                 Some(raw) => raw.parse::<std::net::IpAddr>().map_err(|e| {
-                    anyhow::anyhow!("[server] bind is not a valid IP address ({raw:?}): {e}")
+                    anyhow::anyhow!("[server].bind must be an IP address, but got {raw:?}: {e}")
                 })?,
                 None => DEFAULT_HTTP_BIND,
             },
@@ -1474,8 +1472,7 @@ impl Config {
             && live_photo_mode == LivePhotoMode::Skip
         {
             anyhow::bail!(
-                "[filters] media selects only live-photos, but [photos] live_photo_mode = \"skip\" \
-                 would download nothing. Enable photos or videos, or change live_photo_mode."
+                "[filters].media selects only live photos, but [photos].live_photo_mode = \"skip\" would download nothing. Enable photos or videos, or change live_photo_mode."
             );
         }
 
@@ -1953,18 +1950,23 @@ pub(crate) fn persist_first_run_config(
     }
 
     let content = toml::to_string_pretty(&minimal)
-        .map_err(|e| anyhow::anyhow!("failed to serialize config: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Could not serialize config: {e}"))?;
 
     let output = format!("# Generated by kei on first run. Edit freely.\n\n{content}");
     std::fs::write(config_path, &output)
-        .with_context(|| format!("writing config to {}", config_path.display()))?;
+        .with_context(|| format!("Could not write config to {}", config_path.display()))?;
 
     // Restrict permissions on Unix
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(config_path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("chmod 0o600 on {}", config_path.display()))?;
+            .with_context(|| {
+                format!(
+                    "Could not set secure permissions on {}",
+                    config_path.display()
+                )
+            })?;
     }
 
     tracing::info!(path = %config_path.display(), "Saved configuration for future runs");
@@ -1980,8 +1982,8 @@ pub(crate) fn persist_first_run_config(
 pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>> {
     if let Some(days_str) = s.strip_suffix('d') {
         if let Ok(days) = days_str.parse::<u64>() {
-            let days =
-                i64::try_from(days).map_err(|_e| anyhow::anyhow!("interval '{s}' is too large"))?;
+            let days = i64::try_from(days)
+                .map_err(|_e| anyhow::anyhow!("Date interval '{s}' is too large"))?;
             return Ok(Local::now() - chrono::Duration::days(days));
         }
     }
@@ -1998,8 +2000,7 @@ pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>>
         }
     }
     anyhow::bail!(
-        "Cannot parse '{s}' as a date. Expected ISO date (2025-01-02), \
-         datetime (2025-01-02T14:30:00), or interval (20d)"
+        "Could not parse '{s}' as a date. Use a date like 2025-01-02, a datetime like 2025-01-02T14:30:00, or an interval like 20d."
     )
 }
 
@@ -2064,13 +2065,13 @@ mod tests {
         let err = validate_template_tokens("%Y/{library}/%m", TemplateKind::Unfiled).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'{library}' must be the first path segment"),
+                .contains("`{library}` must be the first path segment"),
             "{err}"
         );
         let err =
             validate_template_tokens("{album}/{library}/%Y", TemplateKind::Albums).unwrap_err();
         assert!(
-            err.to_string().contains("'{library}' must be the first"),
+            err.to_string().contains("`{library}` must be the first"),
             "{err}"
         );
     }
@@ -2108,10 +2109,10 @@ mod tests {
     fn validate_template_tokens_rejects_duplicate_tokens() {
         let err = validate_template_tokens("{library}/{library}/{album}", TemplateKind::Albums)
             .unwrap_err();
-        assert!(err.to_string().contains("only appear once"), "{err}");
+        assert!(err.to_string().contains("can appear only once"), "{err}");
 
         let err = validate_template_tokens("{album}/{album}", TemplateKind::Albums).unwrap_err();
-        assert!(err.to_string().contains("only appear once"), "{err}");
+        assert!(err.to_string().contains("can appear only once"), "{err}");
     }
 
     #[test]
@@ -2360,7 +2361,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("Failed to read config file"),
+            err.contains("Could not read config file"),
             "Error should mention config file: {err}"
         );
     }
@@ -2893,7 +2894,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None)
             .expect_err("`{library}` not as first segment must bail");
         assert!(
-            err.to_string().contains("'{library}' must be the first"),
+            err.to_string().contains("`{library}` must be the first"),
             "{err}"
         );
     }
@@ -3229,7 +3230,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("`[auth] password`"),
+            err.contains("`[auth].password`"),
             "Error should name the rejected field; got: {err}"
         );
         assert!(
@@ -3256,7 +3257,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("`[auth] password`"),
+                .contains("`[auth].password`"),
             "Error should name the rejected field even for empty values"
         );
     }
@@ -4544,7 +4545,7 @@ mod tests {
         let err = resolve_path_derivation_fields(PathDerivationCliArgs::default(), Some(&toml))
             .expect_err("resolution none needs an extra");
         assert!(
-            err.to_string().contains("requires photos.edited"),
+            err.to_string().contains("requires [photos].edited"),
             "unexpected error: {err}"
         );
     }
@@ -5226,7 +5227,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("'--album all' cannot be combined with literal album names"),
+            msg.contains("`--album all` cannot be combined with album names"),
             "unexpected error: {msg}"
         );
     }
@@ -5322,7 +5323,7 @@ mod tests {
         sync.config_overrides.albums = vec!["Vacation".to_string(), "!Vacation".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
-            err.to_string().contains("cannot both include and exclude"),
+            err.to_string().contains("includes and excludes"),
             "unexpected error: {err}"
         );
     }
@@ -5334,7 +5335,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'--album none' cannot be combined"),
+                .contains("`--album none` cannot be combined"),
             "unexpected error: {err}"
         );
     }
@@ -5346,7 +5347,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'{album}' is not valid in --folder-structure"),
+                .contains("`{album}` cannot be used in --folder-structure"),
             "unexpected error: {err}"
         );
     }
@@ -5358,7 +5359,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'{album}' is not valid in --folder-structure"),
+                .contains("`{album}` cannot be used in --folder-structure"),
             "unexpected error: {err}"
         );
     }
@@ -5370,7 +5371,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'{album}' is not valid in --folder-structure"),
+                .contains("`{album}` cannot be used in --folder-structure"),
             "unexpected error: {err}"
         );
     }
@@ -5382,7 +5383,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(
             err.to_string()
-                .contains("'{album}' is not valid in --folder-structure"),
+                .contains("`{album}` cannot be used in --folder-structure"),
             "unexpected error: {err}"
         );
     }
@@ -6121,7 +6122,7 @@ mod tests {
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
         assert!(err
             .to_string()
-            .contains("invalid --filename-exclude pattern"));
+            .contains("Invalid --filename-exclude pattern"));
     }
 
     #[test]
@@ -6252,7 +6253,7 @@ mod tests {
         sync.config_overrides.smart_folders =
             vec!["all".to_string(), "all-with-sensitive".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
-        assert!(err.to_string().contains("mutually exclusive"));
+        assert!(err.to_string().contains("cannot be used together"));
     }
 
     fn build_with_unfiled(cli: Option<bool>, toml_str: Option<&str>) -> Config {
@@ -6778,7 +6779,7 @@ mod tests {
             .to_string();
         assert!(err.contains("--recent 30d"), "{err}");
         assert!(err.contains("--skip-created-before"), "{err}");
-        assert!(err.contains("pick one"), "{err}");
+        assert!(err.contains("Pick one"), "{err}");
     }
 
     #[test]
@@ -6928,7 +6929,7 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("media must not be empty"), "{err}");
+        assert!(err.contains("[filters].media cannot be empty"), "{err}");
     }
 
     #[test]

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -141,14 +141,14 @@ impl CredentialStore {
 
     fn keyring_entry(&self) -> Result<keyring::Entry> {
         keyring::Entry::new(KEYRING_SERVICE, &self.username)
-            .context("Failed to create keyring entry")
+            .context("Could not open the OS keyring entry")
     }
 
     fn keyring_store(&self, password: &str) -> Result<()> {
         let entry = self.keyring_entry()?;
         entry
             .set_password(password)
-            .context("Failed to store password in keyring")
+            .context("Could not store password in the OS keyring")
     }
 
     fn keyring_retrieve(&self) -> Result<Option<SecretString>> {
@@ -156,7 +156,9 @@ impl CredentialStore {
         match entry.get_password() {
             Ok(pw) => Ok(Some(SecretString::from(pw))),
             Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(anyhow::anyhow!(e).context("Failed to retrieve from keyring")),
+            Err(e) => {
+                Err(anyhow::anyhow!(e).context("Could not read password from the OS keyring"))
+            }
         }
     }
 
@@ -194,11 +196,12 @@ impl CredentialStore {
     fn load_or_create_key(&self) -> Result<[u8; 32]> {
         let key_path = self.key_file_path();
         if key_path.exists() {
-            let data = std::fs::read(&key_path)
-                .with_context(|| format!("Failed to read key file: {}", key_path.display()))?;
+            let data = std::fs::read(&key_path).with_context(|| {
+                format!("Could not read credential key file {}", key_path.display())
+            })?;
             anyhow::ensure!(
                 data.len() == 32,
-                "Credential key file is corrupt (expected 32 bytes, got {})",
+                "Credential key file is corrupt: expected 32 bytes, got {}.",
                 data.len()
             );
             let mut key = [0u8; 32];
@@ -214,18 +217,18 @@ impl CredentialStore {
     fn file_store(&self, password: &str) -> Result<()> {
         std::fs::create_dir_all(&self.config_dir).with_context(|| {
             format!(
-                "Failed to create config directory: {}",
+                "Could not create config directory {}",
                 self.config_dir.display()
             )
         })?;
 
         let key_bytes = self.load_or_create_key()?;
-        let cipher =
-            Aes256Gcm::new_from_slice(&key_bytes).context("Failed to create AES cipher")?;
+        let cipher = Aes256Gcm::new_from_slice(&key_bytes)
+            .context("Could not initialize credential encryption")?;
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
         let ciphertext = cipher
             .encrypt(&nonce, password.as_bytes())
-            .map_err(|e| anyhow::anyhow!("Encryption failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("Could not encrypt credential: {e}"))?;
 
         // File format: 12-byte nonce ‖ ciphertext
         let mut data = Vec::with_capacity(12 + ciphertext.len());
@@ -250,24 +253,24 @@ impl CredentialStore {
 
         let key_bytes = self.load_or_create_key()?;
         let data = std::fs::read(&cred_path)
-            .with_context(|| format!("Failed to read credential file: {}", cred_path.display()))?;
+            .with_context(|| format!("Could not read credential file {}", cred_path.display()))?;
 
         anyhow::ensure!(
             data.len() > 12,
-            "Credential file is corrupt (too short): {}",
+            "Credential file is corrupt or incomplete: {}",
             cred_path.display()
         );
 
         let (nonce_bytes, ciphertext) = data.split_at(12);
         let nonce = aes_gcm::Nonce::from_slice(nonce_bytes);
-        let cipher =
-            Aes256Gcm::new_from_slice(&key_bytes).context("Failed to create AES cipher")?;
+        let cipher = Aes256Gcm::new_from_slice(&key_bytes)
+            .context("Could not initialize credential decryption")?;
         let plaintext = cipher.decrypt(nonce, ciphertext).map_err(|_e| {
-            anyhow::anyhow!("Failed to decrypt credential (wrong key or corrupt file)")
+            anyhow::anyhow!("Could not decrypt stored credential. The key may be wrong or the credential file may be corrupt.")
         })?;
 
         let password =
-            String::from_utf8(plaintext).context("Decrypted credential is not valid UTF-8")?;
+            String::from_utf8(plaintext).context("Stored credential is not valid UTF-8")?;
         Ok(Some(SecretString::from(password)))
     }
 
@@ -277,7 +280,7 @@ impl CredentialStore {
             DeleteOutcome::Deleted => Ok(()),
             DeleteOutcome::NotFound => {
                 anyhow::bail!(
-                    "No credential file found: {}",
+                    "No credential file found at {}",
                     self.credential_file_path().display()
                 )
             }
@@ -294,7 +297,7 @@ impl CredentialStore {
             Ok(()) => DeleteOutcome::Deleted,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => DeleteOutcome::NotFound,
             Err(e) => DeleteOutcome::Failed(anyhow::anyhow!(e).context(format!(
-                "Failed to delete credential file: {}",
+                "Could not delete credential file {}",
                 cred_path.display()
             ))),
         }
@@ -311,9 +314,9 @@ fn keyring_delete_error_outcome(error: keyring::Error) -> DeleteOutcome {
             );
             DeleteOutcome::NotFound
         }
-        e => {
-            DeleteOutcome::Failed(anyhow::anyhow!(e).context("Failed to delete keyring credential"))
-        }
+        e => DeleteOutcome::Failed(
+            anyhow::anyhow!(e).context("Could not delete the OS keyring credential"),
+        ),
     }
 }
 
@@ -347,7 +350,7 @@ fn finish_delete(
 
     if failed.is_empty() {
         if deleted.is_empty() {
-            anyhow::bail!("No stored credential found for {username}");
+            anyhow::bail!("No stored credential was found for {username}.");
         }
         return Ok(());
     }
@@ -363,10 +366,10 @@ fn finish_delete(
         .collect::<Vec<_>>()
         .join("; ");
     if deleted.is_empty() {
-        anyhow::bail!("Failed to delete credential backend(s) {failed_names}: {details}");
+        anyhow::bail!("Could not delete credential from {failed_names}: {details}");
     }
     anyhow::bail!(
-        "Credential deletion partially failed; deleted from {}, but failed backend(s) {failed_names}: {details}",
+        "Credential was deleted from {}, but kei could not delete it from {failed_names}: {details}",
         deleted.join(", ")
     );
 }
@@ -487,7 +490,7 @@ mod tests {
         .to_string();
         assert!(
             partial.contains("deleted from encrypted-file")
-                && partial.contains("failed backend(s) keyring"),
+                && partial.contains("could not delete it from keyring"),
             "partial delete must preserve which backend succeeded and which failed: {partial}"
         );
 
@@ -499,7 +502,7 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(
-            missing.contains("No stored credential found"),
+            missing.contains("No stored credential was found"),
             "two missing backends must not be treated as file-only success: {missing}"
         );
     }
@@ -513,7 +516,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("No stored credential found"),
+            err.to_string().contains("No stored credential was found"),
             "expected no-credential error, got: {err}"
         );
     }
@@ -528,7 +531,7 @@ mod tests {
         .unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("partially failed") && msg.contains("encrypted-file"),
+            msg.contains("could not delete it from encrypted-file"),
             "partial failure must name the failed backend: {msg}"
         );
     }

--- a/src/download/error.rs
+++ b/src/download/error.rs
@@ -7,20 +7,20 @@ use thiserror::Error;
 /// permanent ones (auth errors, disk failures) so the retry loop can abort early.
 #[derive(Debug, Error)]
 pub(crate) enum DownloadError {
-    #[error("HTTP error {status} downloading {path}")]
+    #[error("Apple returned HTTP {status} while downloading {path}")]
     HttpStatus { status: u16, path: Box<str> },
 
-    #[error("Content-length mismatch for {path}: expected {expected} bytes, received {received}")]
+    #[error("Download size changed for {path}: expected {expected} bytes, received {received}")]
     ContentLengthMismatch {
         path: Box<str>,
         expected: u64,
         received: u64,
     },
 
-    #[error("Disk error: {0}")]
+    #[error("Could not write to disk: {0}")]
     Disk(Box<std::io::Error>),
 
-    #[error("HTTP error downloading {path} (status={status}, content_length={content_length:?}, bytes_so_far={bytes_written}): {source}")]
+    #[error("Download failed for {path} after {bytes_written} bytes (HTTP {status}, content length {content_length:?}): {source}")]
     Http {
         source: Box<dyn std::error::Error + Send + Sync>,
         path: Box<str>,
@@ -29,10 +29,10 @@ pub(crate) enum DownloadError {
         bytes_written: u64,
     },
 
-    #[error("Invalid content for {path}: {reason}")]
+    #[error("Downloaded content for {path} did not pass validation: {reason}")]
     InvalidContent { path: Box<str>, reason: Box<str> },
 
-    #[error("Download interrupted for {path} after {bytes_written} bytes")]
+    #[error("Download was interrupted for {path} after {bytes_written} bytes")]
     Interrupted { path: Box<str>, bytes_written: u64 },
 
     #[error(transparent)]

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -85,9 +85,9 @@ pub(super) fn temp_download_path(
 ) -> anyhow::Result<PathBuf> {
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(checksum)
-        .context("Failed to decode base64 checksum")?;
+        .context("Could not decode the base64 checksum from Apple")?;
     if decoded.is_empty() {
-        anyhow::bail!("Decoded checksum is empty");
+        anyhow::bail!("Apple returned an empty checksum.");
     }
     let encoded = data_encoding::BASE32_NOPAD.encode(&decoded);
     let download_dir = download_path.parent().unwrap_or_else(|| Path::new("."));
@@ -377,13 +377,11 @@ async fn attempt_download<C: DownloadClient>(
             .await
             .map_err(|e| match e.kind() {
                 std::io::ErrorKind::AlreadyExists => DownloadError::Other(anyhow::anyhow!(
-                    "Concurrent writer detected on {}: another kei instance appears to be \
-                     downloading the same file. Only one kei instance may target a given \
-                     directory at a time",
+                    "Another kei process is already writing {}. Only one kei instance may use the same download directory at a time.",
                     part_path.display()
                 )),
                 _ => {
-                    DownloadError::Other(anyhow::anyhow!("Failed to open temp download file: {e}"))
+                    DownloadError::Other(anyhow::anyhow!("Could not open temporary download file: {e}"))
                 }
             })?
     } else {
@@ -393,7 +391,9 @@ async fn attempt_download<C: DownloadClient>(
             .open(&part_path)
             .await
             .map_err(|e| {
-                DownloadError::Other(anyhow::anyhow!("Failed to open temp download file: {e}"))
+                DownloadError::Other(anyhow::anyhow!(
+                    "Could not open temporary download file: {e}"
+                ))
             })?
     };
 
@@ -546,7 +546,7 @@ pub(super) async fn rename_part_to_final(
         }
         Err(e) => Err(e).with_context(|| {
             format!(
-                "failed to rename {} to {}",
+                "Could not move completed download from {} to {}",
                 part_path.display(),
                 final_path.display()
             )
@@ -725,7 +725,7 @@ pub(crate) async fn compute_sha256(path: &Path) -> anyhow::Result<String> {
     let path = path.to_path_buf();
     tokio::task::spawn_blocking(move || {
         let mut file = std::fs::File::open(&path)
-            .with_context(|| format!("opening {} for SHA-256", path.display()))?;
+            .with_context(|| format!("Could not open {} for SHA-256", path.display()))?;
         let mut sha256 = Sha256::new();
         // 64 KiB reduces read() syscalls ~8x vs 8 KiB on multi-GB videos
         // without meaningful RSS impact on the blocking pool.
@@ -734,7 +734,7 @@ pub(crate) async fn compute_sha256(path: &Path) -> anyhow::Result<String> {
             use std::io::Read;
             let n = file
                 .read(&mut buf)
-                .with_context(|| format!("reading {} for SHA-256", path.display()))?;
+                .with_context(|| format!("Could not read {} for SHA-256", path.display()))?;
             if n == 0 {
                 break;
             }
@@ -765,14 +765,14 @@ struct DecodedChecksum {
 fn decode_api_checksum(base64_checksum: &str) -> anyhow::Result<DecodedChecksum> {
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(base64_checksum)
-        .context("Failed to decode API checksum from base64")?;
+        .context("Could not decode API checksum from base64")?;
     let (hash_bytes, is_sha1) = match bytes.len() {
         20 => (&bytes[..], true),
         21 => (&bytes[1..], true),
         32 => (&bytes[..], false),
         33 => (&bytes[1..], false),
         other => anyhow::bail!(
-            "Unexpected API checksum length: {other} bytes (expected 20, 21, 32, or 33)"
+            "Apple returned an unsupported checksum length: {other} bytes (expected 20, 21, 32, or 33)."
         ),
     };
     let mut hex = String::with_capacity(hash_bytes.len() * 2);

--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -293,9 +293,7 @@ pub(super) fn state_write_circuit_breaker_tripped(flush: &StateWriteFlush) -> bo
 
 pub(super) fn state_db_unwritable_error(pending_total: usize) -> anyhow::Error {
     anyhow::anyhow!(
-        "State DB appears unwritable: all {pending_total} deferred state writes failed after \
-         {STATE_WRITE_MAX_RETRIES} retries each. Check disk space and permissions on the state \
-         DB file; halting sync to avoid re-downloading into an untracked tree."
+        "The state database appears unwritable: all {pending_total} deferred state writes failed after {STATE_WRITE_MAX_RETRIES} retries each. Check disk space and permissions on the state database file. Stopping sync to avoid downloading files that kei cannot track."
     )
 }
 

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -27,7 +27,7 @@ use mp4_atom::{Atom, Buf, DecodeMaybe, FourCC, Header, Iinf, Iloc};
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum HeifError {
     #[cfg(test)]
-    #[error("ISO-BMFF decode failed at byte offset {offset}/{total}: {source}")]
+    #[error("Could not read HEIC metadata at byte {offset} of {total}: {source}")]
     Decode {
         offset: u64,
         total: u64,
@@ -36,10 +36,12 @@ pub(crate) enum HeifError {
     },
 
     #[cfg(test)]
-    #[error("Unparsable trailing bytes at offset {offset}/{total} (file likely truncated)")]
+    #[error(
+        "Could not read trailing HEIC bytes at byte {offset} of {total}; the file may be truncated"
+    )]
     UnparsableTail { offset: u64, total: u64 },
 
-    #[error("`{kind}` sub-box of `meta` failed to decode: {source}")]
+    #[error("Could not read HEIC metadata box `{kind}`: {source}")]
     MetaSubBoxDecode {
         kind: FourCC,
         #[source]
@@ -47,11 +49,11 @@ pub(crate) enum HeifError {
     },
 
     #[cfg(test)]
-    #[error("HEIC has no `meta` box at the top level ({input_len} bytes scanned)")]
+    #[error("Could not find a top-level HEIC `meta` box after scanning {input_len} bytes")]
     MissingMeta { input_len: usize },
 
     #[cfg(test)]
-    #[error("Failed to re-encode `{kind}` atom: {source}")]
+    #[error("Could not rewrite HEIC atom `{kind}`: {source}")]
     Encode {
         kind: FourCC,
         #[source]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -97,7 +97,7 @@ fn probe_exif_xmp(path: &Path) -> Result<ExifProbe> {
 
 #[cfg(feature = "xmp")]
 fn probe_exif_xmp_toolkit(path: &Path) -> Result<ExifProbe> {
-    let mut file = XmpFile::new().context("creating XmpFile handle")?;
+    let mut file = XmpFile::new().context("Could not create XMP handle")?;
     if file
         .open_file(path, OpenFileOptions::default().for_read().only_xmp())
         .is_err()
@@ -358,7 +358,10 @@ pub(crate) fn write_sidecar(
     ensure_initialized();
 
     let Some(name) = media_path.file_name() else {
-        anyhow::bail!("sidecar target has no filename: {}", media_path.display());
+        anyhow::bail!(
+            "Cannot write an XMP sidecar because the media path has no filename: {}",
+            media_path.display()
+        );
     };
     let mut sidecar_name = name.to_os_string();
     sidecar_name.push(".xmp");
@@ -385,18 +388,26 @@ pub(crate) fn write_sidecar(
             XmpMeta::new().context("creating XmpMeta")?
         }
         Err(e) => {
-            return Err(e)
-                .with_context(|| format!("Reading existing sidecar {}", sidecar_path.display()));
+            return Err(e).with_context(|| {
+                format!(
+                    "Could not read existing XMP sidecar {}",
+                    sidecar_path.display()
+                )
+            });
         }
     };
     apply_to_xmp(&mut meta, write)?;
     let bytes = meta.to_string().into_bytes();
 
-    std::fs::write(&tmp_path, &bytes)
-        .with_context(|| format!("Writing XMP sidecar {}", tmp_path.display()))?;
+    std::fs::write(&tmp_path, &bytes).with_context(|| {
+        format!(
+            "Could not write temporary XMP sidecar {}",
+            tmp_path.display()
+        )
+    })?;
     atomic_install(&tmp_path, &sidecar_path).with_context(|| {
         format!(
-            "Installing XMP sidecar {} -> {}",
+            "Could not install XMP sidecar {} -> {}",
             tmp_path.display(),
             sidecar_path.display()
         )
@@ -446,18 +457,23 @@ fn apply_metadata_xmp_toolkit_with_installer(
     ensure_initialized();
 
     let tmp_path = temp_path_for(path, temp_suffix);
-    std::fs::copy(path, &tmp_path)
-        .with_context(|| format!("Copying {} -> {}", path.display(), tmp_path.display()))?;
+    std::fs::copy(path, &tmp_path).with_context(|| {
+        format!(
+            "Could not copy {} to {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
 
     let guard = TmpGuard::new(&tmp_path);
 
     let result: Result<()> = (|| {
-        let mut file = XmpFile::new().context("creating XmpFile handle")?;
+        let mut file = XmpFile::new().context("Could not create XMP handle")?;
         file.open_file(
             &tmp_path,
             OpenFileOptions::default().for_update().use_smart_handler(),
         )
-        .with_context(|| format!("Opening {} for XMP update", tmp_path.display()))?;
+        .with_context(|| format!("Could not open {} for XMP update", tmp_path.display()))?;
 
         let mut meta = file
             .xmp()
@@ -466,21 +482,21 @@ fn apply_metadata_xmp_toolkit_with_installer(
 
         if !file.can_put_xmp(&meta) {
             anyhow::bail!(
-                "format handler for {} does not support writing XMP",
+                "The XMP format handler cannot write metadata to {}",
                 tmp_path.display()
             );
         }
         file.put_xmp(&meta)
-            .with_context(|| format!("Writing XMP into {}", tmp_path.display()))?;
+            .with_context(|| format!("Could not write XMP metadata into {}", tmp_path.display()))?;
         file.try_close()
-            .with_context(|| format!("Closing {} after XMP update", tmp_path.display()))?;
+            .with_context(|| format!("Could not close {} after XMP update", tmp_path.display()))?;
         Ok(())
     })();
 
     result?;
     install(&tmp_path, path).with_context(|| {
         format!(
-            "Installing metadata {} -> {}",
+            "Could not install metadata update {} -> {}",
             tmp_path.display(),
             path.display()
         )
@@ -493,7 +509,7 @@ fn apply_metadata_xmp_toolkit_with_installer(
 #[cfg(not(feature = "xmp"))]
 fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) -> Result<()> {
     let input = std::fs::read(path)
-        .with_context(|| format!("Reading {} for native EXIF update", path.display()))?;
+        .with_context(|| format!("Could not read {} for native EXIF update", path.display()))?;
     let Some(file_type) = native_file_type(&input, path) else {
         tracing::debug!(
             path = %path.display(),
@@ -505,7 +521,9 @@ fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) 
     let mut metadata = match Metadata::new_from_vec(&input, file_type) {
         Ok(metadata) => metadata,
         Err(e) if e.to_string().contains("No EXIF data found") => Metadata::new(),
-        Err(e) => return Err(e).with_context(|| format!("Reading EXIF from {}", path.display())),
+        Err(e) => {
+            return Err(e).with_context(|| format!("Could not read EXIF from {}", path.display()))
+        }
     };
     if let Some(dt) = &write.datetime {
         metadata.set_tag(ExifTag::DateTimeOriginal(dt.clone()));
@@ -550,13 +568,21 @@ fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) 
     let mut output = input;
     metadata
         .write_to_vec(&mut output, file_type)
-        .with_context(|| format!("Writing native EXIF into {}", path.display()))?;
+        .with_context(|| format!("Could not write native EXIF into {}", path.display()))?;
     let tmp_path = temp_path_for(path, temp_suffix);
-    std::fs::write(&tmp_path, &output)
-        .with_context(|| format!("Writing native EXIF temp {}", tmp_path.display()))?;
+    std::fs::write(&tmp_path, &output).with_context(|| {
+        format!(
+            "Could not write native EXIF temp file {}",
+            tmp_path.display()
+        )
+    })?;
     let guard = TmpGuard::new(&tmp_path);
-    atomic_install(&tmp_path, path)
-        .with_context(|| format!("Installing native EXIF {}", path.display()))?;
+    atomic_install(&tmp_path, path).with_context(|| {
+        format!(
+            "Could not install native EXIF update for {}",
+            path.display()
+        )
+    })?;
     guard.disarm();
     tracing::debug!(path = %path.display(), "Applied native EXIF metadata");
     Ok(())
@@ -717,16 +743,18 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
 #[cfg(test)]
 fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Result<()> {
     use std::io::{Read, Seek, SeekFrom};
-    file.seek(SeekFrom::Start(0))
-        .with_context(|| format!("Rewinding {} for magic-byte probe", tmp_path.display()))?;
+    file.seek(SeekFrom::Start(0)).with_context(|| {
+        format!(
+            "Could not rewind {} for media validation",
+            tmp_path.display()
+        )
+    })?;
     let mut head = [0u8; 12];
     file.read_exact(&mut head)
-        .with_context(|| format!("Reading magic bytes of {}", tmp_path.display()))?;
+        .with_context(|| format!("Could not read magic bytes of {}", tmp_path.display()))?;
     if !heif::is_heif_content(&head) {
         anyhow::bail!(
-            "Post-rewrite HEIC at {} lacks an ISO-BMFF ftyp/HEIF brand in the \
-             first 12 bytes (got {:02x?}); refusing to atomic-rename a \
-             corrupt file over the user's data",
+            "HEIC metadata rewrite produced invalid media at {}: the first 12 bytes did not include an ISO-BMFF ftyp/HEIF brand (got {:02x?}). Refusing to replace the user's file.",
             tmp_path.display(),
             head
         );
@@ -740,7 +768,7 @@ fn validate_heif_post_rewrite(file: &mut std::fs::File, tmp_path: &Path) -> Resu
 #[cfg(all(test, feature = "xmp"))]
 fn build_xmp_packet(write: &MetadataWrite) -> Result<Vec<u8>> {
     ensure_initialized();
-    let mut meta = XmpMeta::new().context("creating XmpMeta")?;
+    let mut meta = XmpMeta::new().context("Could not create XMP metadata")?;
     apply_to_xmp(&mut meta, write)?;
     Ok(meta.to_string().into_bytes())
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1823,7 +1823,7 @@ async fn route_incremental_asset_to_passes(
     let db = config
         .state_db
         .as_ref()
-        .context("album-aware incremental routing requires a state DB")?;
+        .context("Album-aware incremental routing requires a state database")?;
     let memberships = db
         .get_live_selected_album_memberships_for_asset(
             &config.library,
@@ -1833,7 +1833,7 @@ async fn route_incremental_asset_to_passes(
         .await
         .with_context(|| {
             format!(
-                "failed to look up album memberships for asset {}",
+                "Could not look up album memberships for asset {}",
                 asset.asset_record_name()
             )
         })?;
@@ -1892,10 +1892,11 @@ fn merge_download_outcomes(left: &DownloadOutcome, right: &DownloadOutcome) -> D
 }
 
 async fn collect_pass_asset_ids(pass: &crate::commands::AlbumPass) -> Result<FxHashSet<String>> {
-    let count =
-        pass.album.len().await.with_context(|| {
-            format!("failed to get asset count for album '{}'", pass.album.name)
-        })?;
+    let count = pass
+        .album
+        .len()
+        .await
+        .with_context(|| format!("Could not count assets in album `{}`", pass.album.name))?;
     let (stream, _token_rx) = pass.album.photo_stream_with_token(None, Some(count), 1);
     tokio::pin!(stream);
     let mut ids = FxHashSet::default();

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1413,9 +1413,7 @@ where
     if let Some(free) = initial_free_at_start {
         if free < MIN_FREE_BYTES_HARD {
             return Err(anyhow::anyhow!(
-                "Insufficient free disk space: only {} bytes available on {}, \
-                 need at least {MIN_FREE_BYTES_HARD} bytes. Free up space or choose a \
-                 different [download] directory.",
+                "Not enough free disk space: only {} bytes are available on {}, but kei needs at least {MIN_FREE_BYTES_HARD} bytes. Free up space or choose a different [download].directory.",
                 free,
                 config.directory.display(),
             ));
@@ -2216,7 +2214,7 @@ where
 
     if producer_panicked {
         return Err(anyhow::anyhow!(
-            "Asset producer panicked — sync may be incomplete ({} pending state writes flushed)",
+            "The asset producer task crashed, so sync may be incomplete ({} pending state writes were flushed).",
             state_write_failures,
         ));
     }
@@ -2984,7 +2982,7 @@ async fn download_single_task(
     if let Some(parent) = task.download_path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+            .with_context(|| format!("Could not create directory {}", parent.display()))?;
     }
 
     tracing::debug!(
@@ -3029,7 +3027,7 @@ async fn download_single_task(
                 &task.checksum,
                 context.temp_suffix,
             )
-            .context("failed to compute part path")?,
+            .context("Could not compute temporary download path")?,
         )
     } else {
         None
@@ -5229,7 +5227,7 @@ mod tests {
         .await
         .expect_err("should propagate producer panic");
         assert!(
-            err.to_string().contains("producer panicked"),
+            err.to_string().contains("producer task crashed"),
             "Expected producer panic error, got: {err}"
         );
     }

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -2,17 +2,17 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ICloudError {
-    #[error("Connection error: {0}")]
+    #[error("Could not connect to iCloud: {0}")]
     Connection(String),
     #[error(
-        "iCloud service not activated ({code}): {reason}\n\n\
+        "iCloud Photos is not available through Apple's web API ({code}): {reason}\n\n\
          This usually means one of:\n  \
          1. Advanced Data Protection (ADP) is enabled, which blocks third-party iCloud access.\n     \
             To fix, change both settings on your iPhone/iPad:\n     \
             - Disable ADP: Settings > Apple ID > iCloud > Advanced Data Protection\n     \
             - Enable web access: Settings > Apple ID > iCloud > Access iCloud Data on the Web\n  \
          2. iCloud setup is incomplete.\n     \
-            → Log into https://icloud.com/ and finish setting up your iCloud service."
+            Log in to https://icloud.com/ and finish setting up iCloud Photos."
     )]
     ServiceNotActivated { code: String, reason: String },
     /// CloudKit rejected the request with an auth-class HTTP status. Typically
@@ -20,12 +20,12 @@ pub enum ICloudError {
     /// not caught earlier), or - rarely - another 4xx that maps to the same
     /// recovery path. The caller should invalidate any cached session data
     /// and re-authenticate with SRP before retrying.
-    #[error("Session expired (HTTP {status} from CloudKit)")]
+    #[error("Your iCloud session expired (CloudKit HTTP {status})")]
     SessionExpired { status: u16 },
     /// CloudKit returned HTTP 421 Misdirected Request. The HTTP/2 connection
     /// was routed to the wrong CloudKit partition; the caller should reset
     /// the connection pool and retry on a fresh connection.
-    #[error("Misdirected Request (HTTP 421 from CloudKit)")]
+    #[error("Apple routed the iCloud request to the wrong CloudKit partition (HTTP 421)")]
     MisdirectedRequest,
     #[error(transparent)]
     Http(Box<reqwest::Error>),

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -441,9 +441,10 @@ impl PhotoAlbum {
         )
         .await?;
 
-        let batch: super::cloudkit::BatchQueryResponse =
-            serde_json::from_value(response).context("failed to parse album count response")?;
-        Self::count_from_query(batch.batch.first()).context("failed to read album count response")
+        let batch: super::cloudkit::BatchQueryResponse = serde_json::from_value(response)
+            .context("Could not read Apple's album count response")?;
+        Self::count_from_query(batch.batch.first())
+            .context("Could not find the album count in Apple's response")
     }
 
     /// Return item counts for a same-library pass set with one
@@ -514,10 +515,10 @@ impl PhotoAlbum {
         (0..albums.len())
             .map(|index| {
                 let query = batch.batch.get(index).ok_or_else(|| {
-                    anyhow::anyhow!("missing batched count result for pass {index}")
+                    anyhow::anyhow!("Apple did not return an album count for pass {index}.")
                 })?;
                 Self::count_from_query(Some(query)).with_context(|| {
-                    format!("failed to read batched album count result for pass {index}")
+                    format!("Could not read Apple's album count result for pass {index}")
                 })
             })
             .collect()
@@ -543,20 +544,20 @@ impl PhotoAlbum {
     }
 
     fn count_from_query(query: Option<&super::cloudkit::QueryResponse>) -> anyhow::Result<u64> {
-        let query = query.context("missing album count query result")?;
+        let query = query.context("Apple did not return an album count query result")?;
         let record = query
             .records
             .first()
-            .context("album count query returned no records")?;
+            .context("Apple's album count query returned no records")?;
         let item_count = record
             .fields
             .get("itemCount")
-            .context("album count record missing itemCount")?;
+            .context("Apple's album count record did not include itemCount")?;
         let value = item_count
             .get("value")
-            .context("album count itemCount missing value")?;
+            .context("Apple's album count itemCount did not include a value")?;
         value.as_u64().with_context(|| {
-            format!("album count itemCount value was not an unsigned integer: {value}")
+            format!("Apple's album count itemCount was not a non-negative integer: {value}")
         })
     }
 
@@ -575,8 +576,7 @@ impl PhotoAlbum {
         let items = stream.collect::<Result<Vec<_>, _>>().await?;
         if panic_rx.await.unwrap_or(false) {
             anyhow::bail!(
-                "photo enumeration aborted: a fetcher task panicked; \
-                 results are incomplete, see earlier error log"
+                "Photo enumeration stopped because a fetcher task crashed. Results are incomplete; see the earlier error log."
             );
         }
         Ok(items)
@@ -1035,7 +1035,7 @@ impl PhotoAlbum {
 
             let changes_resp: ChangesZoneResponse = serde_json::from_value(response)?;
             let Some(zone_result) = changes_resp.zones.into_iter().next() else {
-                anyhow::bail!("changes/zone returned empty zones array");
+                anyhow::bail!("Apple changes/zone returned no zones.");
             };
             let zone_name = zone_result.zone_id.zone_name.clone();
             check_changes_zone_error(
@@ -1115,7 +1115,7 @@ impl PhotoAlbum {
                 };
 
                 let Some(zone_result) = changes_resp.zones.into_iter().next() else {
-                    break Some(anyhow::anyhow!("changes/zone returned empty zones array"));
+                    break Some(anyhow::anyhow!("Apple changes/zone returned no zones."));
                 };
 
                 // Check for zone-level errors BEFORE advancing current_token.
@@ -1391,8 +1391,7 @@ impl PhotoAlbum {
                             enumeration_incomplete = true;
                             let _ = tx
                                 .send(Err(anyhow::anyhow!(
-                                    "photo enumeration incomplete: records/query returned {} \
-                                     consecutive empty pages without a server completion proof",
+                                    "Photo enumeration is incomplete: Apple returned {} consecutive empty pages without confirming the end of the stream.",
                                     MAX_EMPTY_PAGE_PROBES
                                 )))
                                 .await;
@@ -1527,8 +1526,7 @@ impl PhotoAlbum {
                     enumeration_incomplete = true;
                     let _ = tx
                         .send(Err(anyhow::anyhow!(
-                            "photo enumeration incomplete: {} unpaired CPLMaster/CPLAsset \
-                             records exceeded the pending-pair buffer",
+                            "Photo enumeration is incomplete: {} unpaired CPLMaster/CPLAsset records exceeded the pending-pair buffer.",
                             pending_record_count
                         )))
                         .await;
@@ -1557,8 +1555,7 @@ impl PhotoAlbum {
                 }
                 let _ = tx
                     .send(Err(anyhow::anyhow!(
-                        "photo enumeration incomplete: {} unpaired CPLMaster records and {} \
-                         unpaired CPLAsset records remained at end of stream",
+                        "Photo enumeration is incomplete: {} unpaired CPLMaster records and {} unpaired CPLAsset records remained at the end of the stream.",
                         pending_masters.len(),
                         pending_assets.len()
                     )))
@@ -1849,7 +1846,7 @@ mod tests {
         let err = PhotoAlbum::count_from_query(Some(&query)).expect_err("missing count fails");
 
         assert!(
-            err.to_string().contains("missing itemCount"),
+            err.to_string().contains("did not include itemCount"),
             "unexpected error: {err:#}"
         );
     }
@@ -1861,7 +1858,7 @@ mod tests {
         let err = PhotoAlbum::count_from_query(Some(&query)).expect_err("malformed count fails");
 
         assert!(
-            err.to_string().contains("was not an unsigned integer"),
+            err.to_string().contains("was not a non-negative integer"),
             "unexpected error: {err:#}"
         );
     }
@@ -2391,7 +2388,7 @@ mod tests {
         assert_eq!(ids, vec!["master-before-empty-tail"]);
         assert_eq!(errors.len(), 1);
         assert!(
-            errors[0].contains("consecutive empty pages without a server completion proof"),
+            errors[0].contains("without confirming the end of the stream"),
             "unexpected error: {}",
             errors[0]
         );
@@ -3569,7 +3566,7 @@ mod tests {
         assert!(err.is_err());
         let err_msg = format!("{}", err.unwrap_err());
         assert!(
-            err_msg.contains("Invalid sync token"),
+            err_msg.contains("sync token is no longer valid"),
             "error should mention invalid sync token, got: {err_msg}"
         );
 

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -160,12 +160,12 @@ impl PhotoLibrary {
         });
         let Some(indexing_state) = indexing_state else {
             return Err(ICloudError::Connection(
-                "Photo library indexing state is missing; results may be incomplete".into(),
+                "Apple did not report whether the photo library is fully indexed; results may be incomplete".into(),
             ));
         };
         if indexing_state != "FINISHED" {
             return Err(ICloudError::Connection(format!(
-                "Photo library indexing state is {indexing_state}; expected FINISHED"
+                "Apple says the photo library is still indexing ({indexing_state}); wait until indexing is finished, then retry."
             )));
         }
 
@@ -336,7 +336,7 @@ impl PhotoLibrary {
             .await?;
 
             let query: super::cloudkit::QueryResponse = serde_json::from_value(response)
-                .context("failed to parse library query response")?;
+                .context("Could not read Apple's library query response")?;
 
             let page_size = query.records.len();
             all_records.extend(query.records);
@@ -515,7 +515,7 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            err.to_string().contains("RUNNING") && err.to_string().contains("FINISHED"),
+            err.to_string().contains("RUNNING") && err.to_string().contains("indexing is finished"),
             "error should name observed and expected indexing states: {err}"
         );
     }
@@ -527,7 +527,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            err.to_string().contains("indexing state is missing"),
+            err.to_string()
+                .contains("did not report whether the photo library is fully indexed"),
             "missing indexing state must fail closed: {err}"
         );
     }

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -119,7 +119,7 @@ impl PhotosService {
             return Ok(lib);
         }
         anyhow::bail!(
-            "Unknown library: '{name}'. Run `kei list libraries` to see available libraries."
+            "iCloud Photos library `{name}` was not found. Run `kei list libraries` to see available libraries."
         )
     }
 
@@ -152,7 +152,7 @@ impl PhotosService {
         }
         self.private_libraries
             .as_ref()
-            .context("internal error: private libraries were not cached")
+            .context("Internal error: private iCloud Photos libraries were not cached")
     }
 
     /// Fetch shared libraries (lazily, first call triggers the HTTP request).
@@ -165,7 +165,7 @@ impl PhotosService {
         }
         self.shared_libraries
             .as_ref()
-            .context("internal error: shared libraries were not cached")
+            .context("Internal error: shared iCloud Photos libraries were not cached")
     }
 
     async fn fetch_libraries(
@@ -226,7 +226,7 @@ impl PhotosService {
                 }
                 Err(e) => {
                     tracing::error!(zone = %zone_name, error = %e, "Failed to load library zone");
-                    anyhow::bail!("Failed to load library zone {zone_name}: {e}");
+                    anyhow::bail!("Could not load iCloud Photos library zone {zone_name}: {e}");
                 }
             }
         }
@@ -260,7 +260,7 @@ impl PhotosService {
         )
         .await?;
         let parsed: ChangesDatabaseResponse = serde_json::from_value(response)
-            .context("failed to parse changes database response")?;
+            .context("Could not read Apple's changes/database response")?;
         Ok(parsed)
     }
 }
@@ -740,7 +740,7 @@ mod tests {
         let err = svc.get_library("DoesNotExist").await.unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("Unknown library") && msg.contains("DoesNotExist"),
+            msg.contains("iCloud Photos library") && msg.contains("DoesNotExist"),
             "error should name the unknown library: {msg}"
         );
     }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -123,7 +123,7 @@ impl PhotosSession for crate::auth::SharedSession {
 /// the payload without re-requesting. Truncated to keep memory bounded
 /// when CloudKit occasionally returns large HTML error pages.
 #[derive(Debug, thiserror::Error)]
-#[error("HTTP {status} for {url}")]
+#[error("Apple returned HTTP {status} for {url}")]
 pub(crate) struct HttpStatusError {
     pub status: u16,
     pub url: String,
@@ -200,7 +200,7 @@ const SERVICE_NOT_ACTIVATED_ERRORS: &[&str] = &["ZONE_NOT_FOUND", "AUTHENTICATIO
 /// Error type for `CloudKit` server errors embedded in the JSON response body.
 /// These are distinct from HTTP-level errors and represent API-level failures.
 #[derive(Debug, thiserror::Error)]
-#[error("CloudKit server error: {code} — {reason}")]
+#[error("Apple CloudKit reported {code}: {reason}")]
 pub struct CloudKitServerError {
     pub(crate) code: Box<str>,
     pub(crate) reason: Box<str>,
@@ -383,14 +383,14 @@ pub async fn retry_post(
 #[derive(Debug, thiserror::Error)]
 pub enum SyncTokenError {
     /// Token is invalid/corrupted — fall back to full enumeration
-    #[error("Invalid sync token: {reason}")]
+    #[error("The saved iCloud sync token is no longer valid: {reason}")]
     InvalidToken { reason: Box<str> },
     /// Zone no longer exists — stop syncing this zone
-    #[error("Zone not found: {zone_name}")]
+    #[error("Apple no longer reports iCloud Photos zone {zone_name}")]
     ZoneNotFound { zone_name: Box<str> },
     /// Unexpected zone-level error (e.g. `RETRY_LATER`, THROTTLED) —
     /// treat as transient; do NOT advance the sync token.
-    #[error("Unexpected zone error in {zone_name}: {error_code}")]
+    #[error("Apple returned an unexpected iCloud Photos zone error for {zone_name}: {error_code}")]
     UnexpectedZoneError {
         zone_name: Box<str>,
         error_code: Box<str>,
@@ -761,7 +761,10 @@ mod tests {
         let err = SyncTokenError::InvalidToken {
             reason: "bad token".into(),
         };
-        assert_eq!(err.to_string(), "Invalid sync token: bad token");
+        assert_eq!(
+            err.to_string(),
+            "The saved iCloud sync token is no longer valid: bad token"
+        );
     }
 
     #[test]
@@ -769,7 +772,10 @@ mod tests {
         let err = SyncTokenError::ZoneNotFound {
             zone_name: "SharedSync-ABC".into(),
         };
-        assert_eq!(err.to_string(), "Zone not found: SharedSync-ABC");
+        assert_eq!(
+            err.to_string(),
+            "Apple no longer reports iCloud Photos zone SharedSync-ABC"
+        );
     }
 
     #[test]
@@ -782,14 +788,17 @@ mod tests {
         assert!(downcasted.is_some());
         assert_eq!(
             downcasted.unwrap().to_string(),
-            "Invalid sync token: expired"
+            "The saved iCloud sync token is no longer valid: expired"
         );
     }
 
     #[test]
     fn test_sync_token_error_display_empty_reason() {
         let err = SyncTokenError::InvalidToken { reason: "".into() };
-        assert_eq!(err.to_string(), "Invalid sync token: ");
+        assert_eq!(
+            err.to_string(),
+            "The saved iCloud sync token is no longer valid: "
+        );
     }
 
     /// T-2: Mock session returns HTTP 503 on first call, 200 on second.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ pub(crate) fn check_min_disk_space(available_bytes: u64, directory: &Path) -> an
     if available_bytes < MIN_FREE_BYTES {
         let avail_mb = available_bytes / (1024 * 1024);
         anyhow::bail!(
-            "Insufficient disk space: only {avail_mb} MiB available in {} (minimum 1 GiB)",
+            "Not enough disk space: only {avail_mb} MiB is available in {}. kei needs at least 1 GiB.",
             directory.display()
         );
     }
@@ -487,7 +487,7 @@ fn get_db_path(globals: &config::GlobalArgs, toml: Option<&TomlConfig>) -> anyho
     let (username, _, _, cookie_dir) =
         config::resolve_auth(globals, &cli::PasswordArgs::default(), toml);
     if username.is_empty() {
-        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
+        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username.");
     }
     Ok(cookie_dir.join(format!(
         "{}.db",
@@ -1422,11 +1422,11 @@ mod tests {
             );
             let msg = format!("{:#}", r.expect_err("expected Err"));
             assert!(
-                msg.contains("Insufficient disk space"),
+                msg.contains("Not enough disk space"),
                 "error message must call out the disk-space reason; got: {msg}"
             );
             assert!(
-                msg.contains("minimum 1 GiB"),
+                msg.contains("at least 1 GiB"),
                 "error message must state the minimum so operators know what to free; got: {msg}"
             );
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -570,7 +570,7 @@ pub(crate) fn spawn_server(
 
     let addr = SocketAddr::new(bind, port);
     let std_listener = std::net::TcpListener::bind(addr)
-        .map_err(|e| anyhow::anyhow!("Failed to bind HTTP server on {bind}:{port}: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Could not start the HTTP server on {bind}:{port}: {e}"))?;
     let local_addr = std_listener.local_addr()?;
     std_listener.set_nonblocking(true)?;
     let listener = tokio::net::TcpListener::from_std(std_listener)?;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -67,10 +67,10 @@ fn migrate_file(src: &Path, dst: &Path) -> anyhow::Result<bool> {
     }
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating parent directory {}", parent.display()))?;
+            .with_context(|| format!("Could not create parent directory {}", parent.display()))?;
     }
     std::fs::copy(src, dst)
-        .with_context(|| format!("copying {} to {}", src.display(), dst.display()))?;
+        .with_context(|| format!("Could not copy {} to {}", src.display(), dst.display()))?;
     Ok(true)
 }
 
@@ -79,12 +79,16 @@ fn migrate_file(src: &Path, dst: &Path) -> anyhow::Result<bool> {
 /// Returns the number of files successfully copied.
 fn migrate_directory_contents(src_dir: &Path, dst_dir: &Path) -> anyhow::Result<usize> {
     use anyhow::Context;
-    std::fs::create_dir_all(dst_dir)
-        .with_context(|| format!("creating destination directory {}", dst_dir.display()))?;
+    std::fs::create_dir_all(dst_dir).with_context(|| {
+        format!(
+            "Could not create destination directory {}",
+            dst_dir.display()
+        )
+    })?;
 
     let mut count = 0;
-    for entry in
-        std::fs::read_dir(src_dir).with_context(|| format!("reading {}", src_dir.display()))?
+    for entry in std::fs::read_dir(src_dir)
+        .with_context(|| format!("Could not read {}", src_dir.display()))?
     {
         let entry = entry?;
         let file_type = entry.file_type()?;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -298,7 +298,7 @@ async fn run_script(
         tracing::warn!("Notification script timed out, killing");
         let _ = child.kill().await;
         anyhow::bail!(
-            "notification script timed out after {}s",
+            "Notification script timed out after {} seconds.",
             SCRIPT_TIMEOUT.as_secs()
         )
     }

--- a/src/password.rs
+++ b/src/password.rs
@@ -149,7 +149,7 @@ impl PasswordSource {
             Self::Interactive => {
                 if !std::io::stdin().is_terminal() {
                     anyhow::bail!(
-                        "No password configured and stdin is not a terminal. \
+                        "No iCloud password is configured, and kei cannot prompt because stdin is not a terminal. \
                          Set a password with one of:\n  \
                          - ICLOUD_PASSWORD environment variable\n  \
                          - kei password set (OS keyring or encrypted file)\n  \
@@ -200,7 +200,7 @@ pub fn build_password_source(
 pub(crate) fn read_password_file(path: &Path) -> anyhow::Result<SecretString> {
     warn_if_permissive_mode(path);
     let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read password file: {}", path.display()))?;
+        .with_context(|| format!("Could not read password file {}", path.display()))?;
     let trimmed = strip_trailing_newline(&contents);
     anyhow::ensure!(
         !trimmed.is_empty(),
@@ -299,7 +299,7 @@ fn run_password_command_with_timeout(
         let _ = (cmd, timeout);
         anyhow::bail!(
             "`--password-command` / `[auth] password_command` is not supported on Windows: \
-             kei runs commands via `sh -c`, which isn't on the stock Windows PATH. \
+             kei runs commands through `sh -c`, which is not on the default Windows PATH. \
              Use `--password-file` / `[auth] password_file`, or run kei under WSL."
         );
     }
@@ -314,7 +314,7 @@ fn run_password_command_with_timeout(
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit())
             .spawn()
-            .with_context(|| format!("Failed to execute password command: {cmd}"))?;
+            .with_context(|| format!("Could not run password command: {cmd}"))?;
 
         // Poll with 5ms → 50ms backoff; clamp each sleep to the remaining
         // deadline so we never overshoot the timeout budget.
@@ -330,7 +330,7 @@ fn run_password_command_with_timeout(
                         let _ = child.kill();
                         let _ = child.wait();
                         anyhow::bail!(
-                            "password command timed out after {}s: {cmd}",
+                            "Password command timed out after {} seconds: {cmd}",
                             timeout.as_secs()
                         );
                     }
@@ -353,14 +353,14 @@ fn run_password_command_with_timeout(
         if let Some(mut stdout) = child.stdout.take() {
             stdout
                 .read_to_end(&mut buf)
-                .with_context(|| format!("reading password command stdout: {cmd}"))?;
+                .with_context(|| format!("Could not read password command output: {cmd}"))?;
         }
         let stdout =
             String::from_utf8(buf).context("Password command output is not valid UTF-8")?;
         let trimmed = strip_trailing_newline(&stdout);
         anyhow::ensure!(
             !trimmed.is_empty(),
-            "Password command produced empty output: {cmd}"
+            "Password command did not print a password: {cmd}"
         );
         Ok(SecretString::from(trimmed.to_string()))
     }
@@ -469,7 +469,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent.txt");
         let err = read_password_file(&path).unwrap_err();
-        assert!(err.to_string().contains("Failed to read"), "{err}");
+        assert!(err.to_string().contains("Could not read"), "{err}");
     }
 
     // ── run_password_command ────────────────────────────────────────
@@ -499,7 +499,10 @@ mod tests {
     #[test]
     fn run_password_command_empty() {
         let err = run_password_command("printf ''").unwrap_err();
-        assert!(err.to_string().contains("empty"), "{err}");
+        assert!(
+            err.to_string().contains("did not print a password"),
+            "{err}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/report.rs
+++ b/src/report.rs
@@ -195,9 +195,9 @@ pub(crate) async fn write_report(path: &Path, report: &SyncReport) -> anyhow::Re
         let temp_path = parent.join(format!(".kei-report-{}.tmp", std::process::id()));
 
         std::fs::write(&temp_path, json.as_bytes())
-            .with_context(|| format!("writing report to {}", temp_path.display()))?;
+            .with_context(|| format!("Could not write report to {}", temp_path.display()))?;
         atomic_install(&temp_path, &path)
-            .with_context(|| format!("installing report at {}", path.display()))?;
+            .with_context(|| format!("Could not install report at {}", path.display()))?;
 
         tracing::debug!(path = %path.display(), "Wrote JSON report");
         Ok(())

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -150,7 +150,7 @@ fn selector_token<'a>(raw: &'a str, flag: &str) -> anyhow::Result<SelectorToken<
     if let Some(literal) = raw.strip_prefix('=') {
         anyhow::ensure!(
             !literal.is_empty(),
-            "--{flag} literal value must not be empty"
+            "`--{flag}` literal value cannot be empty."
         );
         return Ok(SelectorToken {
             name: literal,
@@ -160,10 +160,10 @@ fn selector_token<'a>(raw: &'a str, flag: &str) -> anyhow::Result<SelectorToken<
     }
 
     let (name, exclude) = raw.strip_prefix('!').map_or((raw, false), |r| (r, true));
-    anyhow::ensure!(!name.is_empty(), "--{flag} value must not be empty");
+    anyhow::ensure!(!name.is_empty(), "`--{flag}` needs a value.");
     anyhow::ensure!(
         !name.starts_with('='),
-        "`!=value` is not supported for --{flag}; use `=value` for a literal value or `!value` for an exclusion"
+        "`!=value` is not valid for `--{flag}`. Use `=value` for a literal value or `!value` for an exclusion."
     );
     Ok(SelectorToken {
         name,
@@ -195,7 +195,7 @@ fn insert_unique(
     display_name: impl FnOnce() -> String,
 ) -> anyhow::Result<()> {
     if !set.insert(value) {
-        anyhow::bail!("--{flag} '{}' specified more than once", display_name());
+        anyhow::bail!("`--{flag} {}` was provided more than once.", display_name());
     }
     Ok(())
 }
@@ -222,19 +222,19 @@ pub(crate) fn parse_album_selector(
 
     for entry in raw {
         let trimmed = entry.trim();
-        anyhow::ensure!(!trimmed.is_empty(), "--album value must not be empty");
+        anyhow::ensure!(!trimmed.is_empty(), "`--album` needs a value.");
         let token = selector_token(trimmed, "album")?;
         let name = token.name;
         if name.eq_ignore_ascii_case("all") && !token.escaped {
             anyhow::ensure!(
                 !token.exclude,
-                "'!all' is not a valid --album value; pass --album none instead"
+                "`--album !all` is not valid. Use `--album none` instead."
             );
             has_all = true;
         } else if name.eq_ignore_ascii_case("none") && !token.escaped {
             anyhow::ensure!(
                 !token.exclude,
-                "'!none' is not a valid --album value; just omit it"
+                "`--album !none` is not valid. Omit that value instead."
             );
             has_none = true;
         } else if token.exclude {
@@ -253,14 +253,14 @@ pub(crate) fn parse_album_selector(
     if has_none {
         anyhow::ensure!(
             !has_all && included.is_empty() && excluded.is_empty(),
-            "'--album none' cannot be combined with other --album values"
+            "`--album none` cannot be combined with other `--album` values."
         );
         return Ok(AlbumSelector::None);
     }
     if has_all {
         anyhow::ensure!(
             included.is_empty(),
-            "'--album all' cannot be combined with literal album names; use '!name' to exclude one"
+            "`--album all` cannot be combined with album names. Use `--album !name` to exclude one."
         );
         return Ok(AlbumSelector::All { excluded });
     }
@@ -286,26 +286,20 @@ pub(crate) fn parse_smart_folder_selector(raw: &[String]) -> anyhow::Result<Smar
 
     for entry in raw {
         let trimmed = entry.trim();
-        anyhow::ensure!(
-            !trimmed.is_empty(),
-            "--smart-folder value must not be empty"
-        );
+        anyhow::ensure!(!trimmed.is_empty(), "`--smart-folder` needs a value.");
         let token = selector_token(trimmed, "smart-folder")?;
         let name = token.name;
         if name.eq_ignore_ascii_case("all") && !token.escaped {
-            anyhow::ensure!(!token.exclude, "'!all' is not a valid --smart-folder value");
+            anyhow::ensure!(!token.exclude, "`--smart-folder !all` is not valid.");
             has_all = true;
         } else if name.eq_ignore_ascii_case("all-with-sensitive") && !token.escaped {
             anyhow::ensure!(
                 !token.exclude,
-                "'!all-with-sensitive' is not a valid --smart-folder value"
+                "`--smart-folder !all-with-sensitive` is not valid."
             );
             has_all_sensitive = true;
         } else if name.eq_ignore_ascii_case("none") && !token.escaped {
-            anyhow::ensure!(
-                !token.exclude,
-                "'!none' is not a valid --smart-folder value"
-            );
+            anyhow::ensure!(!token.exclude, "`--smart-folder !none` is not valid.");
             has_none = true;
         } else if token.exclude {
             insert_unique(&mut excluded, name.to_string(), "smart-folder", || {
@@ -323,18 +317,18 @@ pub(crate) fn parse_smart_folder_selector(raw: &[String]) -> anyhow::Result<Smar
     if has_none {
         anyhow::ensure!(
             !has_all && !has_all_sensitive && included.is_empty() && excluded.is_empty(),
-            "'--smart-folder none' cannot be combined with other --smart-folder values"
+            "`--smart-folder none` cannot be combined with other `--smart-folder` values."
         );
         return Ok(SmartFolderSelector::None);
     }
     if has_all || has_all_sensitive {
         anyhow::ensure!(
             !(has_all && has_all_sensitive),
-            "'--smart-folder all' and '--smart-folder all-with-sensitive' are mutually exclusive"
+            "`--smart-folder all` and `--smart-folder all-with-sensitive` cannot be used together."
         );
         anyhow::ensure!(
             included.is_empty(),
-            "'--smart-folder all' cannot be combined with literal names; use '!name' to exclude one"
+            "`--smart-folder all` cannot be combined with smart folder names. Use `--smart-folder !name` to exclude one."
         );
         return Ok(SmartFolderSelector::All {
             include_sensitive: has_all_sensitive,
@@ -375,7 +369,7 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
 
     for entry in raw {
         let trimmed = entry.trim();
-        anyhow::ensure!(!trimmed.is_empty(), "--library value must not be empty");
+        anyhow::ensure!(!trimmed.is_empty(), "`--library` needs a value.");
         let token = selector_token(trimmed, "library")?;
         let name = token.name;
         // CloudKit zone names use `-`, never `:`. The `:` forms are an old
@@ -384,15 +378,15 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
         // users don't get a "not found" surprise after a network round-trip.
         if name.contains(':') {
             anyhow::bail!(
-                "--library values are bare names (`primary`, `shared`, `all`) or zone names (`PrimarySync`, `SharedSync-XYZ`); \
-                 friendly forms like '{name}' are not supported. Run `kei list libraries` to see every zone."
+                "`--library` accepts `primary`, `shared`, `all`, or zone names like `PrimarySync` and `SharedSync-XYZ`. \
+                 `{name}` is not supported. Run `kei list libraries` to see the available zone names."
             );
         }
         if name.eq_ignore_ascii_case("all") && !token.escaped {
-            anyhow::ensure!(!token.exclude, "'!all' is not a valid --library value");
+            anyhow::ensure!(!token.exclude, "`--library !all` is not valid.");
             has_all = true;
         } else if name.eq_ignore_ascii_case("none") && !token.escaped {
-            anyhow::ensure!(!token.exclude, "'!none' is not a valid --library value");
+            anyhow::ensure!(!token.exclude, "`--library !none` is not valid.");
             has_none = true;
         } else if name.eq_ignore_ascii_case("primary") && !token.escaped {
             if token.exclude {
@@ -423,7 +417,7 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
 
     if has_none {
         anyhow::bail!(
-            "'--library none' is not allowed: kei needs at least one source library to sync"
+            "`--library none` is not allowed because kei needs at least one iCloud library to sync."
         );
     }
     if has_all {
@@ -442,7 +436,7 @@ pub(crate) fn parse_library_selector(raw: &[String]) -> anyhow::Result<LibrarySe
 
     if sel.is_empty() {
         anyhow::bail!(
-            "--library resolved to no libraries; pass at least one of primary / shared / a zone name"
+            "`--library` did not select any libraries. Choose `primary`, `shared`, or a zone name."
         );
     }
     Ok(sel)
@@ -457,7 +451,7 @@ fn contradiction_check(
     excluded: &BTreeSet<String>,
 ) -> anyhow::Result<()> {
     if let Some(name) = included.intersection(excluded).next() {
-        anyhow::bail!("cannot both include and exclude '{name}' in --{category}; pick one");
+        anyhow::bail!("`--{category}` includes and excludes `{name}`. Pick one.");
     }
     Ok(())
 }
@@ -677,13 +671,13 @@ mod tests {
     #[test]
     fn album_all_plus_named_bails() {
         let err = parse_album_selector(&s(&["all", "Vacation"]), false).unwrap_err();
-        assert!(err.to_string().contains("'--album all'"));
+        assert!(err.to_string().contains("`--album all`"));
     }
 
     #[test]
     fn album_none_plus_other_bails() {
         let err = parse_album_selector(&s(&["none", "Vacation"]), false).unwrap_err();
-        assert!(err.to_string().contains("'--album none'"));
+        assert!(err.to_string().contains("`--album none`"));
     }
 
     #[test]
@@ -695,13 +689,13 @@ mod tests {
     #[test]
     fn album_empty_string_bails() {
         let err = parse_album_selector(&s(&[""]), false).unwrap_err();
-        assert!(err.to_string().contains("must not be empty"));
+        assert!(err.to_string().contains("needs a value"));
     }
 
     #[test]
     fn album_bang_sentinel_bails() {
         let err = parse_album_selector(&s(&["!all"]), false).unwrap_err();
-        assert!(err.to_string().contains("'!all'"));
+        assert!(err.to_string().contains("`--album !all`"));
     }
 
     #[test]
@@ -816,7 +810,7 @@ mod tests {
     #[test]
     fn smart_folder_all_and_all_with_sensitive_mutually_exclusive() {
         let err = parse_smart_folder_selector(&s(&["all", "all-with-sensitive"])).unwrap_err();
-        assert!(err.to_string().contains("mutually exclusive"));
+        assert!(err.to_string().contains("cannot be used together"));
     }
 
     #[test]
@@ -846,7 +840,7 @@ mod tests {
     #[test]
     fn smart_folder_none_plus_other_bails() {
         let err = parse_smart_folder_selector(&s(&["none", "Favorites"])).unwrap_err();
-        assert!(err.to_string().contains("'--smart-folder none'"));
+        assert!(err.to_string().contains("`--smart-folder none`"));
     }
 
     #[test]
@@ -942,7 +936,7 @@ mod tests {
     #[test]
     fn bang_equals_escape_form_is_rejected() {
         let err = parse_library_selector(&s(&["!=primary"])).unwrap_err();
-        assert!(err.to_string().contains("not supported"));
+        assert!(err.to_string().contains("not valid"));
     }
 
     #[test]
@@ -966,7 +960,7 @@ mod tests {
     #[test]
     fn library_none_bails() {
         let err = parse_library_selector(&s(&["none"])).unwrap_err();
-        assert!(err.to_string().contains("'--library none'"));
+        assert!(err.to_string().contains("`--library none`"));
     }
 
     #[test]
@@ -1271,7 +1265,7 @@ mod tests {
         );
         let msg = r.unwrap_err().to_string();
         assert!(
-            msg.contains("must not be empty") || msg.contains("empty"),
+            msg.contains("needs a value"),
             "error must name the empty-input cause; got: {msg}"
         );
     }

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -155,7 +155,7 @@ pub(crate) fn purge_kei_state(kei_dir: &Path, extra_dirs: &[PathBuf]) -> Result<
             Ok(())
         }
         Err(e) => Err(e)
-            .with_context(|| format!("failed to remove state directory {}", kei_dir.display())),
+            .with_context(|| format!("Could not remove state directory {}", kei_dir.display())),
     }
 }
 
@@ -177,9 +177,9 @@ pub(crate) fn kei_state_dir_dotted() -> Option<PathBuf> {
 /// `canonicalize` resolves those so the registry entry points at the
 /// real binary.
 pub(crate) fn current_executable() -> Result<PathBuf> {
-    let raw = std::env::current_exe().context("failed to resolve current executable path")?;
+    let raw = std::env::current_exe().context("Could not find the current executable path")?;
     raw.canonicalize()
-        .with_context(|| format!("failed to canonicalize executable path {}", raw.display()))
+        .with_context(|| format!("Could not resolve executable path {}", raw.display()))
 }
 
 #[cfg(test)]

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -71,6 +71,6 @@ async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
         "preparing to install kei service",
     );
     Err(anyhow::anyhow!(
-        "`kei install` is not implemented on this platform"
+        "`kei install` is not available on this platform."
     ))
 }

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -159,7 +159,7 @@ pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Resul
     let previous_linger = current_linger_state().await;
     let contents = render_user_unit_with_linger(&exe, config_path, previous_linger);
     let unit_path =
-        user_unit_path().ok_or_else(|| anyhow!("could not resolve XDG_CONFIG_HOME or $HOME"))?;
+        user_unit_path().ok_or_else(|| anyhow!("Could not find XDG_CONFIG_HOME or $HOME."))?;
     write_unit(&unit_path, &contents)?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,
@@ -247,8 +247,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
     if let Some(path) = system_path.as_ref() {
         if !is_root() {
             bail!(
-                "system-wide kei.service is registered at {}; \
-                 rerun `kei uninstall` as root to remove it",
+                "system-wide kei.service is registered at {}. Run `kei uninstall` as root to remove it.",
                 path.display()
             );
         }
@@ -260,7 +259,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
 
     if args.purge {
         let Some(config_dir) = dirs::config_dir() else {
-            bail!("--purge requested but no XDG config dir resolves; cannot locate kei state");
+            bail!("`--purge` needs XDG_CONFIG_HOME or a home directory so kei can find its state.");
         };
         purge_kei_state(&config_dir.join("kei"), &[])?;
     }
@@ -418,18 +417,24 @@ fn parse_systemd_timestamp(raw: &str) -> Option<DateTime<Utc>> {
 
 fn write_unit(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create unit directory {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Could not create systemd unit directory {}",
+                parent.display()
+            )
+        })?;
     }
     std::fs::write(path, contents)
-        .with_context(|| format!("failed to write unit file {}", path.display()))
+        .with_context(|| format!("Could not write systemd unit file {}", path.display()))
 }
 
 fn remove_unit_file(path: &Path) -> Result<()> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e).with_context(|| format!("failed to remove unit file {}", path.display())),
+        Err(e) => {
+            Err(e).with_context(|| format!("Could not remove systemd unit file {}", path.display()))
+        }
     }
 }
 
@@ -660,7 +665,7 @@ where
         .args(&args)
         .output()
         .await
-        .context("failed to invoke `systemctl` (is systemd installed and on PATH?)")?;
+        .context("Could not run `systemctl`. Is systemd installed and on PATH?")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let argv = args
@@ -689,7 +694,7 @@ async fn show_unit(scope: &[&str]) -> Result<ProbeOutcome> {
         .args(&argv)
         .output()
         .await
-        .context("failed to invoke `systemctl show`")?;
+        .context("Could not run `systemctl show`")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if is_session_bus_unavailable(&stderr) {

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -138,7 +138,7 @@ fn kei_state_dir() -> Option<PathBuf> {
 pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
     let home = dirs::home_dir().ok_or_else(|| {
-        anyhow!("could not resolve $HOME; required for plist + LaunchAgents path")
+        anyhow!("Could not find $HOME, which is needed for the LaunchAgents plist path.")
     })?;
     let plist_path = home.join(LAUNCH_AGENTS_SUBDIR).join(PLIST_FILE_NAME);
     let log_dir = home.join(LOG_SUBDIR);
@@ -157,7 +157,7 @@ pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Resul
     }
 
     std::fs::create_dir_all(&log_dir)
-        .with_context(|| format!("failed to create log directory {}", log_dir.display()))?;
+        .with_context(|| format!("Could not create log directory {}", log_dir.display()))?;
 
     write_plist(&plist_path, &xml)?;
     tracing::info!(
@@ -206,7 +206,7 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
 
     if args.purge {
         let Some(kei_dir) = kei_state_dir() else {
-            bail!("--purge requested but $HOME does not resolve; cannot locate kei state");
+            bail!("`--purge` needs $HOME so kei can find its state.");
         };
         let extras: Vec<PathBuf> = user_log_dir().into_iter().collect();
         purge_kei_state(&kei_dir, &extras)?;
@@ -301,27 +301,29 @@ fn write_plist(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).with_context(|| {
             format!(
-                "failed to create LaunchAgents directory {}",
+                "Could not create LaunchAgents directory {}",
                 parent.display()
             )
         })?;
     }
     std::fs::write(path, contents)
-        .with_context(|| format!("failed to write plist {}", path.display()))
+        .with_context(|| format!("Could not write launchd plist {}", path.display()))
 }
 
 fn remove_plist_file(path: &Path) -> Result<()> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e).with_context(|| format!("failed to remove plist {}", path.display())),
+        Err(e) => {
+            Err(e).with_context(|| format!("Could not remove launchd plist {}", path.display()))
+        }
     }
 }
 
 fn serialize_plist(dict: &Dictionary) -> Result<String> {
     let mut buf = Vec::new();
-    plist::to_writer_xml(&mut buf, dict).context("failed to serialize launchd plist to XML")?;
-    String::from_utf8(buf).context("plist serializer emitted non-UTF-8 bytes")
+    plist::to_writer_xml(&mut buf, dict).context("Could not build launchd plist XML")?;
+    String::from_utf8(buf).context("launchd plist XML was not valid UTF-8")
 }
 
 /// Tries `launchctl bootstrap gui/<uid>` first; falls back to the legacy
@@ -402,7 +404,7 @@ async fn run_launchctl(args: &[&str]) -> Result<()> {
         .args(args)
         .output()
         .await
-        .context("failed to invoke `launchctl` (is this macOS?)")?;
+        .context("Could not run `launchctl`. Is this macOS?")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -422,7 +424,7 @@ async fn launchctl_print() -> Result<StatusInputs> {
         .args(["print", &target])
         .output()
         .await
-        .context("failed to invoke `launchctl print`")?;
+        .context("Could not run `launchctl print`")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if is_domain_unavailable(&stderr) || is_not_loaded(&stderr) {

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -71,17 +71,12 @@ impl InstallPlan {
     reason = "platform backend modules are compiled cross-platform; Windows builds do not call the macOS rejection helper"
 )]
 pub(crate) fn reject_macos_system_install() -> Result<()> {
-    bail!(
-        "macOS only ships a per-user LaunchAgent; \
-         rerun without --system (or with --user) to install."
-    )
+    bail!("macOS service install is per-user only. Run `kei install --user` or omit `--system`.")
 }
 
 pub(crate) fn reject_windows_system_install() -> Result<()> {
     bail!(
-        "`kei install --system` is not supported on Windows; \
-         use `kei install` (per-user) so the service shares your Credential Manager vault \
-         and `~/.config/kei` state directory"
+        "`kei install --system` is not supported on Windows. Use `kei install` for a per-user service that can access your Credential Manager vault and `~/.config/kei` state directory."
     )
 }
 
@@ -107,9 +102,7 @@ fn ensure_linux_system_apply_is_root(config_path: &Path) -> Result<()> {
         return Ok(());
     }
     bail!(
-        "`kei install --system` must be run as root (EUID=0); \
-         rerun:  sudo kei install --system --config {}  \
-         Or use `kei install --user` for a per-user install.",
+        "`kei install --system` must be run as root (EUID=0). Run `sudo kei install --system --config {}` or use `kei install --user` for a per-user install.",
         config_path.display()
     )
 }
@@ -120,8 +113,7 @@ fn linux_sudo_user() -> Result<String> {
         return Ok(user);
     }
     bail!(
-        "$SUDO_USER not set; rerun via `sudo kei install --system` so the service \
-         can be configured to run as your account rather than root"
+        "$SUDO_USER is not set. Re-run with `sudo kei install --system` so kei can configure the service to run as your account instead of root."
     )
 }
 
@@ -133,8 +125,7 @@ fn linux_system_preview_user() -> Result<String> {
 
     if effective_uid() == 0 {
         bail!(
-            "$SUDO_USER not set; rerun via `sudo kei install --system --dry-run` so the service \
-             can be previewed for your account rather than root"
+            "$SUDO_USER is not set. Re-run with `sudo kei install --system --dry-run` so kei can preview the service for your account instead of root."
         );
     }
 
@@ -144,8 +135,7 @@ fn linux_system_preview_user() -> Result<String> {
         }
     }
     bail!(
-        "could not determine which user the system unit would run as; \
-         set SUDO_USER or USER before running `kei install --system --dry-run`"
+        "Could not determine which user the system service would run as. Set SUDO_USER or USER before running `kei install --system --dry-run`."
     )
 }
 
@@ -202,7 +192,7 @@ mod tests {
         assert!(reject_macos_system_install()
             .expect_err("macOS system install must fail")
             .to_string()
-            .contains("per-user LaunchAgent"));
+            .contains("per-user only"));
         assert!(reject_windows_system_install()
             .expect_err("Windows system install must fail")
             .to_string()

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -38,7 +38,7 @@ async fn dispatch() -> Result<()> {
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 async fn dispatch() -> Result<()> {
     Err(anyhow::anyhow!(
-        "`kei service status` is not implemented on this platform"
+        "`kei service status` is not available on this platform."
     ))
 }
 

--- a/src/service/uninstall.rs
+++ b/src/service/uninstall.rs
@@ -46,6 +46,6 @@ async fn dispatch(args: UninstallArgs) -> Result<()> {
         "preparing to uninstall kei service",
     );
     Err(anyhow::anyhow!(
-        "`kei uninstall` is not implemented on this platform"
+        "`kei uninstall` is not available on this platform."
     ))
 }

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -57,8 +57,9 @@ const FAILURE_RESET_PERIOD: Duration = Duration::from_secs(86_400);
 /// `--user` and the default both produce the same per-user SCM entry).
 pub(crate) async fn install_user(plan: InstallPlan, config_path: &Path) -> Result<()> {
     let exe = current_executable()?;
-    let user = current_user_name()
-        .context("could not resolve current Windows user (USERNAME / USERPROFILE unset?)")?;
+    let user = current_user_name().context(
+        "Could not determine the current Windows user. USERNAME or USERPROFILE is not set.",
+    )?;
 
     let inputs = ServiceInfoInputs {
         exec: &exe,
@@ -115,9 +116,8 @@ pub(crate) async fn uninstall(args: &UninstallArgs) -> Result<()> {
     }
 
     if args.purge {
-        let kei_dir = kei_state_dir().ok_or_else(|| {
-            anyhow!("--purge requested but USERPROFILE is not set; cannot locate kei state")
-        })?;
+        let kei_dir = kei_state_dir()
+            .ok_or_else(|| anyhow!("`--purge` needs USERPROFILE so kei can find its state."))?;
         purge_kei_state(&kei_dir, &[])?;
     }
 
@@ -309,7 +309,7 @@ fn prompt_windows_password(user: &str) -> Result<String> {
         "Windows password for {user} (used by SCM to launch kei under your account; \
          stored as an LSA secret, not in kei): "
     );
-    rpassword::prompt_password(prompt).context("failed to read Windows password from stdin")
+    rpassword::prompt_password(prompt).context("Could not read Windows password from stdin")
 }
 
 // ── SCM glue ───────────────────────────────────────────────────────────
@@ -428,10 +428,10 @@ mod scm_impl {
                 &info,
                 ServiceAccess::CHANGE_CONFIG | ServiceAccess::START | ServiceAccess::QUERY_STATUS,
             )
-            .context("CreateServiceW failed (run from an elevated PowerShell?)")?;
+            .context("Could not create the Windows service. Run from an elevated PowerShell.")?;
         service
             .set_description(SERVICE_DESCRIPTION)
-            .context("ChangeServiceConfig2W (description) failed")?;
+            .context("Could not set the Windows service description")?;
         service
             .update_failure_actions(ServiceFailureActions {
                 reset_period: ServiceFailureResetPeriod::After(FAILURE_RESET_PERIOD),
@@ -445,9 +445,11 @@ mod scm_impl {
                     RESTART_COUNT
                 ]),
             })
-            .context("ChangeServiceConfig2W (failure actions) failed")?;
+            .context("Could not set Windows service failure actions")?;
         let no_args: &[&str] = &[];
-        service.start(no_args).context("StartServiceW failed")?;
+        service
+            .start(no_args)
+            .context("Could not start the Windows service")?;
         Ok(())
     }
 
@@ -465,7 +467,7 @@ mod scm_impl {
             Err(ref e) if raw_os_error(e) == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {
                 return Ok(false);
             }
-            Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
+            Err(e) => return Err(anyhow!("Could not open the Windows service: {e}")),
         };
 
         if let Ok(status) = service.query_status() {
@@ -474,7 +476,9 @@ mod scm_impl {
                 wait_for_stop(&service, Duration::from_secs(30));
             }
         }
-        service.delete().context("DeleteService failed")?;
+        service
+            .delete()
+            .context("Could not delete the Windows service")?;
         Ok(true)
     }
 
@@ -505,11 +509,11 @@ mod scm_impl {
             Err(ref e) if raw_os_error(e) == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {
                 return Ok(StatusInputs::NotInstalled);
             }
-            Err(e) => return Err(anyhow!("OpenServiceW failed: {e}")),
+            Err(e) => return Err(anyhow!("Could not open the Windows service: {e}")),
         };
         let status = service
             .query_status()
-            .context("QueryServiceStatusEx failed")?;
+            .context("Could not query the Windows service status")?;
         Ok(StatusInputs::Probed {
             state: service_state_view(status.current_state),
             pid: status.process_id,
@@ -518,8 +522,7 @@ mod scm_impl {
 
     fn open_manager(access: ServiceManagerAccess) -> Result<ServiceManager> {
         ServiceManager::local_computer(None::<&str>, access).context(
-            "OpenSCManagerW failed -- `kei install` and `kei uninstall` on Windows require an \
-             elevated PowerShell or Command Prompt",
+            "Could not open the Windows Service Control Manager. `kei install` and `kei uninstall` on Windows require an elevated PowerShell or Command Prompt.",
         )
     }
 
@@ -551,7 +554,7 @@ mod scm_impl {
             service_dispatcher::start(SERVICE_NAME, ffi_service_main)
         })
         .await
-        .context("SCM dispatcher task panicked")?;
+        .context("Windows service dispatcher task crashed")?;
 
         match dispatcher_result {
             Ok(()) => {
@@ -568,7 +571,9 @@ mod scm_impl {
                     .ok_or_else(|| anyhow!("internal: SCM payload missing on foreground path"))?;
                 crate::sync_loop::run_sync(&payload.globals, payload.sync).await
             }
-            Err(e) => Err(anyhow!("StartServiceCtrlDispatcher failed: {e}")),
+            Err(e) => Err(anyhow!(
+                "Could not start the Windows service dispatcher: {e}"
+            )),
         }
     }
 
@@ -604,11 +609,11 @@ mod scm_impl {
         };
 
         let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)
-            .context("RegisterServiceCtrlHandlerExW failed")?;
+            .context("Could not register the Windows service control handler")?;
 
         status_handle
             .set_service_status(service_status(ServiceState::Running, 0))
-            .context("set_service_status(running) failed")?;
+            .context("Could not report the Windows service as running")?;
 
         let outcome = run_payload_under_scm(shutdown_rx);
 
@@ -626,9 +631,9 @@ mod scm_impl {
     }
 
     fn run_payload_under_scm(mut shutdown_rx: tokio::sync::oneshot::Receiver<()>) -> Result<()> {
-        let payload = lock_scm_payload()?
-            .take()
-            .ok_or_else(|| anyhow!("kei service main started without a stashed payload"))?;
+        let payload = lock_scm_payload()?.take().ok_or_else(|| {
+            anyhow!("Internal error: kei service main started without service state.")
+        })?;
 
         // Dedicated single-thread runtime for the sync loop. Lives on
         // the OS thread SCM spawned for service main; the foreground
@@ -636,7 +641,7 @@ mod scm_impl {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .context("failed to build SCM-mode tokio runtime")?;
+            .context("Could not start the Windows service runtime")?;
 
         runtime.block_on(async move {
             tokio::select! {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -234,7 +234,7 @@ fn print_toml_preview(toml_content: &str) {
 
 pub(crate) fn run_setup(config_path: &Path) -> anyhow::Result<SetupResult> {
     if !std::io::stdin().is_terminal() {
-        bail!("The setup wizard requires an interactive terminal.");
+        bail!("The setup wizard needs an interactive terminal.");
     }
 
     println!();
@@ -462,7 +462,7 @@ fn write_setup_files_with_store(
 ) -> anyhow::Result<SetupWriteResult> {
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+            .with_context(|| format!("Could not create directory {}", parent.display()))?;
     }
 
     let (credential_backend, write_env) = match &answers.secret_source {
@@ -493,7 +493,7 @@ fn write_setup_files_with_store(
 
 fn write_config_file(config_path: &Path, toml_content: &str) -> anyhow::Result<()> {
     std::fs::write(config_path, toml_content)
-        .with_context(|| format!("Failed to write {}", config_path.display()))?;
+        .with_context(|| format!("Could not write {}", config_path.display()))?;
     #[cfg(unix)]
     set_restricted_permissions(config_path)?;
     Ok(())
@@ -516,7 +516,7 @@ fn write_env_file(config_path: &Path, answers: &SetupAnswers) -> anyhow::Result<
     let env_content =
         format!("ICLOUD_USERNAME='{escaped_user}'\nICLOUD_PASSWORD='{escaped_pass}'\n",);
     std::fs::write(&env_path, &env_content)
-        .with_context(|| format!("Failed to write {}", env_path.display()))?;
+        .with_context(|| format!("Could not write {}", env_path.display()))?;
     #[cfg(unix)]
     set_restricted_permissions(&env_path)?;
     Ok(env_path)
@@ -531,7 +531,7 @@ fn set_restricted_permissions(path: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("Failed to set permissions on {}", path.display()))
+        .with_context(|| format!("Could not set secure permissions on {}", path.display()))
 }
 
 fn print_secret_summary(answers: &SetupAnswers, write_result: &SetupWriteResult) {
@@ -731,7 +731,7 @@ fn ask_secret_source(answers: &mut SetupAnswers) -> anyhow::Result<()> {
                 .with_prompt("Password file path")
                 .validate_with(|input: &String| {
                     if input.trim().is_empty() {
-                        Err("password file path cannot be empty")
+                        Err("Password file path cannot be empty.")
                     } else {
                         Ok(())
                     }
@@ -744,7 +744,7 @@ fn ask_secret_source(answers: &mut SetupAnswers) -> anyhow::Result<()> {
                 .with_prompt("Password command")
                 .validate_with(|input: &String| {
                     if input.trim().is_empty() {
-                        Err("password command cannot be empty")
+                        Err("Password command cannot be empty.")
                     } else {
                         Ok(())
                     }
@@ -1018,12 +1018,12 @@ fn parse_positive_or_blank<T: std::str::FromStr>(s: &str) -> Result<Option<T>, S
         return Ok(None);
     }
     if trimmed == "0" {
-        return Err("must be greater than zero (or leave blank to disable)".to_string());
+        return Err("Enter a number greater than zero, or leave blank to disable.".to_string());
     }
     trimmed
         .parse::<T>()
         .map(Some)
-        .map_err(|_e| "must be a positive integer or blank".to_string())
+        .map_err(|_e| "Enter a positive integer, or leave blank.".to_string())
 }
 
 // ── Step 7: Running mode ───────────────────────────────────────────
@@ -1049,7 +1049,7 @@ fn ask_running_mode(answers: &mut SetupAnswers) -> anyhow::Result<()> {
                 if (60..=86400).contains(n) {
                     Ok(())
                 } else {
-                    Err("must be between 60 and 86400 seconds".to_string())
+                    Err("Enter a value between 60 and 86400 seconds.".to_string())
                 }
             })
             .interact_text()?;
@@ -1177,7 +1177,7 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
             if (1..=64).contains(n) {
                 Ok(())
             } else {
-                Err("must be between 1 and 64".to_string())
+                Err("Enter a value between 1 and 64.".to_string())
             }
         })
         .interact_text()?;
@@ -1192,7 +1192,7 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
             if (0..=100).contains(n) {
                 Ok(())
             } else {
-                Err("must be between 0 and 100".to_string())
+                Err("Enter a value between 0 and 100.".to_string())
             }
         })
         .interact_text()?;

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -14,25 +14,25 @@ pub enum StateError {
     /// file" on a fresh install (issue #264). This variant surfaces the
     /// underlying mkdir failure (e.g. permission denied) distinctly from
     /// a SQLite-level open error.
-    #[error("Failed to create parent directory {path}: {source}")]
+    #[error("Could not create the state database directory {path}: {source}")]
     ParentDir {
         path: PathBuf,
         source: std::io::Error,
     },
 
     /// Failed to open or create the database file.
-    #[error("Failed to open database at {path}: {source}")]
+    #[error("Could not open the state database at {path}: {source}")]
     Open {
         path: PathBuf,
         source: rusqlite::Error,
     },
 
     /// Failed to run a database migration.
-    #[error("Database migration failed: {0}")]
+    #[error("Could not update the state database schema: {0}")]
     Migration(#[from] rusqlite::Error),
 
     /// A query failed.
-    #[error("Database query failed ({operation}): {source}")]
+    #[error("State database operation failed while {operation}: {source}")]
     Query {
         operation: &'static str,
         #[source]
@@ -40,22 +40,22 @@ pub enum StateError {
     },
 
     /// Failed to acquire the database lock (mutex poisoned).
-    #[error("Database lock acquisition failed ({0})")]
+    #[error("Could not lock the state database ({0})")]
     LockPoisoned(String),
 
     /// Failed to spawn a blocking task.
-    #[error("Failed to spawn blocking task: {0}")]
+    #[error("Could not start a background database task: {0}")]
     Spawn(#[from] tokio::task::JoinError),
 
     /// The database schema version is newer than supported.
-    #[error("Database schema version {found} is newer than supported version {expected}")]
+    #[error("This state database is from a newer kei version (schema {found}); this kei supports schema {expected}")]
     UnsupportedSchemaVersion { found: i32, expected: i32 },
 
     /// A producer-dispatch invariant was violated — typically a write
     /// path was reached without the corresponding `upsert_seen` having
     /// run first. The asset row didn't exist, so the operation became a
     /// no-op. Surface it loudly rather than silently swallow.
-    #[error("State invariant violated ({operation}): {detail}")]
+    #[error("State database consistency check failed while {operation}: {detail}")]
     Invariant {
         operation: &'static str,
         detail: String,
@@ -64,7 +64,7 @@ pub enum StateError {
     /// `mark_downloaded` matched zero rows. The asset row should have
     /// been upserted before this call; its absence indicates a missed
     /// upsert step or out-of-band row deletion.
-    #[error("mark_downloaded: no row for asset {asset_id} version_size {version_size}")]
+    #[error("Could not mark asset {asset_id} ({version_size}) downloaded because it was not in the state database")]
     AssetRowMissing {
         asset_id: String,
         version_size: String,
@@ -96,7 +96,7 @@ mod tests {
         };
         let display = err.to_string();
         assert!(
-            display.starts_with("Database query failed (test_op): "),
+            display.starts_with("State database operation failed while test_op: "),
             "unexpected display: {display}"
         );
     }
@@ -121,7 +121,7 @@ mod tests {
         let err = StateError::LockPoisoned("get_metadata: poisoned".to_string());
         assert_eq!(
             err.to_string(),
-            "Database lock acquisition failed (get_metadata: poisoned)"
+            "Could not lock the state database (get_metadata: poisoned)"
         );
     }
 
@@ -138,7 +138,7 @@ mod tests {
         );
         assert_eq!(
             display,
-            "Database schema version 5 is newer than supported version 3"
+            "This state database is from a newer kei version (schema 5); this kei supports schema 3"
         );
     }
 
@@ -170,7 +170,7 @@ mod tests {
             "expected path in display, got: {display}"
         );
         assert!(
-            display.starts_with("Failed to open database at"),
+            display.starts_with("Could not open the state database at"),
             "unexpected prefix: {display}"
         );
     }
@@ -187,7 +187,7 @@ mod tests {
             "expected path in display, got: {display}"
         );
         assert!(
-            display.starts_with("Failed to create parent directory"),
+            display.starts_with("Could not create the state database directory"),
             "unexpected prefix: {display}"
         );
         assert!(

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -400,14 +400,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     tracing::info!(concurrency = config.download.threads_num, "Starting kei");
 
     if config.auth.username.is_empty() {
-        anyhow::bail!("username is required (set ICLOUD_USERNAME or [auth].username)");
+        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username.");
     }
 
     // retry-failed + dry-run is unsupported: dry-run skips the state DB,
     // but retry-failed needs it to know which assets failed.
     if is_retry_failed && config.runtime.dry_run {
         anyhow::bail!(
-            "--dry-run cannot be used with retry-failed (retry needs the state database)"
+            "`--dry-run` cannot be used with `--retry-failed` because retrying failed downloads needs to update the state database."
         );
     }
 
@@ -415,8 +415,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // when the user simply forgot the destination.
     if config.download.directory.as_os_str().is_empty() {
         let message = crate::upgrade_hints::with_stale_env_hint(String::from(
-            "[download] directory is required for downloading \
-             (set it in the config file)",
+            "Set [download].directory in the config file before syncing.",
         ));
         anyhow::bail!(message);
     }
@@ -426,14 +425,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .await
         .with_context(|| {
             format!(
-                "Failed to create download directory {}",
+                "Could not create download directory {}",
                 config.download.directory.display()
             )
         })?;
     let probe = config.download.directory.join(".kei_probe");
     tokio::fs::write(&probe, b"").await.with_context(|| {
         format!(
-            "Download directory {} is not writable",
+            "Cannot write to download directory {}",
             config.download.directory.display()
         )
     })?;
@@ -677,7 +676,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 Some(db as Arc<dyn state::StateDb>)
             }
             Err(e) => {
-                anyhow::bail!("Failed to open state database {}: {e}", db_path.display());
+                anyhow::bail!("Could not open state database {}: {e}", db_path.display());
             }
         }
     };
@@ -1025,7 +1024,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 reauth_attempts += 1;
                 if reauth_attempts >= MAX_REAUTH_ATTEMPTS {
                     anyhow::bail!(
-                        "Session expired, giving up after {MAX_REAUTH_ATTEMPTS} re-auth attempts"
+                        "Your iCloud session expired and kei could not refresh it after {MAX_REAUTH_ATTEMPTS} attempts. Run `kei login` and try again."
                     );
                 }
                 tracing::warn!(
@@ -1766,8 +1765,7 @@ async fn reacquire_session_lock_after_idle(
         );
     }
     Err(e.context(
-        "failed to reacquire the iCloud session lock after watch sleep; \
-         refusing to resume sync without exclusive session ownership",
+        "Could not regain the iCloud session lock after watch mode slept. Stopping so another kei process cannot use the same session at the same time.",
     ))
 }
 
@@ -1876,7 +1874,7 @@ mod tests {
             "expected LockContention, got: {err:#}"
         );
         assert!(
-            format!("{err:#}").contains("refusing to resume sync"),
+            format!("{err:#}").contains("Stopping so another kei process"),
             "error should explain why watch mode stopped: {err:#}"
         );
     }
@@ -5336,8 +5334,8 @@ mod tests {
         assert_eq!(failed.len(), 1, "failed asset should be persisted");
         let last_error = failed[0].last_error.as_deref().expect("failed asset error");
         assert!(
-            last_error.contains("Failed to open temp download file")
-                || last_error.contains("failed to create directory"),
+            last_error.contains("Could not open temporary download file")
+                || last_error.contains("Could not create directory"),
             "failed asset error should name the failing filesystem operation, got: {last_error}"
         );
         let root = download_root.display().to_string();

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -1973,7 +1973,7 @@ fn password_command_failure() {
         .assert()
         .code(3)
         .stderr(
-            predicate::str::contains("No password available")
+            predicate::str::contains("No password was available")
                 .or(predicate::str::contains("exited with status")),
         );
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -635,7 +635,7 @@ fn login_requires_username() {
         .args(["login"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 #[test]
 fn list_albums_requires_username() {
@@ -644,7 +644,7 @@ fn list_albums_requires_username() {
         .args(["list", "albums"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 #[test]
 fn password_set_requires_username() {
@@ -653,7 +653,7 @@ fn password_set_requires_username() {
         .args(["password", "set"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 #[test]
 fn password_clear_requires_username() {
@@ -662,7 +662,7 @@ fn password_clear_requires_username() {
         .args(["password", "clear"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 #[test]
 fn password_backend_requires_username() {
@@ -671,7 +671,7 @@ fn password_backend_requires_username() {
         .args(["password", "backend"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 /// `password backend` against a fresh cookie dir prints the credential
@@ -721,7 +721,7 @@ fn sync_requires_username() {
         .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 #[test]
@@ -744,7 +744,7 @@ fn service_run_uses_sync_worker_path_and_requires_username() {
         .stderr(predicate::str::contains(
             "service mode: applied default watch interval",
         ))
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 #[test]
@@ -756,7 +756,7 @@ fn sync_requires_directory() {
         .args(["sync"])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("[download] directory is required"));
+        .stderr(predicate::str::contains("Set [download].directory"));
 }
 #[test]
 fn import_existing_requires_directory() {
@@ -767,9 +767,7 @@ fn import_existing_requires_directory() {
         .args(["import-existing"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "[download] directory is required for import-existing",
-        ));
+        .stderr(predicate::str::contains("Set [download].directory"));
 }
 #[test]
 fn import_existing_rejects_nonexistent_directory() {
@@ -787,7 +785,7 @@ fn import_existing_rejects_nonexistent_directory() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Cannot read download directory /does/not/exist/anywhere",
+            "Could not read download directory /does/not/exist/anywhere",
         ));
 }
 
@@ -1017,7 +1015,7 @@ fn config_empty_username_in_toml() {
         .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("must not be empty"));
+        .stderr(predicate::str::contains("cannot be empty"));
 }
 #[test]
 fn config_toml_password_field_rejected() {
@@ -1034,7 +1032,7 @@ fn config_toml_password_field_rejected() {
         .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("`[auth] password`"))
+        .stderr(predicate::str::contains("`[auth].password`"))
         .stderr(predicate::str::contains("kei password set"));
 }
 
@@ -1058,7 +1056,7 @@ fn config_multiple_password_sources_in_toml() {
         .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("pick one"));
+        .stderr(predicate::str::contains("Pick one"));
 }
 #[test]
 fn config_strftime_folder_structure_accepted() {
@@ -2000,7 +1998,7 @@ fn exit_1_for_missing_directory_on_sync() {
         .args(["sync"])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("[download] directory is required"));
+        .stderr(predicate::str::contains("Set [download].directory"));
 }
 
 #[cfg(unix)]
@@ -2038,7 +2036,9 @@ fn sync_unwritable_download_directory_errors_before_auth() {
         ])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("is not writable"));
+        .stderr(predicate::str::contains(
+            "Cannot write to download directory",
+        ));
 
     std::fs::set_permissions(&download_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
     assert!(
@@ -2057,7 +2057,7 @@ fn exit_1_for_missing_username_on_sync() {
         .args(["sync", "--config", config_path.to_str().unwrap()])
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -2181,7 +2181,7 @@ fn config_setup_requires_interactive_terminal() {
         .assert()
         .code(1)
         .stderr(predicate::str::contains(
-            "The setup wizard requires an interactive terminal",
+            "The setup wizard needs an interactive terminal",
         ));
 }
 
@@ -3274,7 +3274,7 @@ fn removed_legacy_album_in_cli_errors() {
 fn removed_legacy_album_in_toml_errors() {
     let stderr = run_config_show_error("folder_structure = \"{album}/%B\"\n");
     assert!(
-        stderr.contains("'{album}' is not valid in --folder-structure")
+        stderr.contains("`{album}` cannot be used in --folder-structure")
             && stderr.contains("--folder-structure-albums"),
         "stderr: {stderr}"
     );
@@ -3286,7 +3286,7 @@ fn removed_legacy_album_env_is_ignored() {
         .arg("--only-print-filenames")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("'{album}' is not valid in --folder-structure").not());
+        .stderr(predicate::str::contains("`{album}` cannot be used in --folder-structure").not());
 }
 #[test]
 fn removed_legacy_album_errors_even_with_user_set_albums_template() {
@@ -3294,7 +3294,7 @@ fn removed_legacy_album_errors_even_with_user_set_albums_template() {
         "folder_structure = \"{album}/%Y\"\nfolder_structure_albums = \"{album}/custom\"\n",
     );
     assert!(
-        stderr.contains("'{album}' is not valid in --folder-structure")
+        stderr.contains("`{album}` cannot be used in --folder-structure")
             && stderr.contains("--folder-structure-albums"),
         "stderr: {stderr}"
     );
@@ -3411,7 +3411,7 @@ fn sync_bails_on_within_album_contradiction() {
     sync_cmd_for_config_body("\n[filters]\nalbums = [\"Family\", \"!Family\"]\n")
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("include and exclude"))
+        .stderr(predicate::str::contains("includes and excludes"))
         .stderr(predicate::str::contains("Family"));
 }
 #[test]
@@ -3584,7 +3584,7 @@ fn removed_sync_env_vars_do_not_supply_sync_config() {
         .clone();
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("[download] directory is required"),
+        stderr.contains("Set [download].directory"),
         "stale sync env vars must not provide durable config; stderr: {stderr}"
     );
     assert_removed_env_config_hint(&stderr);
@@ -3613,7 +3613,7 @@ fn removed_sync_env_vars_do_not_supply_import_config() {
         .clone();
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("[download] directory is required for import-existing"),
+        stderr.contains("Set [download].directory"),
         "stale sync env vars must not provide import config; stderr: {stderr}"
     );
     assert_removed_env_config_hint(&stderr);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -460,9 +460,7 @@ fn import_existing_requires_directory() {
         .args(["import-existing"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "[download] directory is required for import-existing",
-        ));
+        .stderr(predicate::str::contains("Set [download].directory"));
 }
 
 // ── Removed durable boolean flags fail ─────────────────────────────────
@@ -932,7 +930,7 @@ fn exit_code_1_on_missing_username() {
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("username is required"));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 /// Exit code 3 (auth failure) when password file is empty.
@@ -966,7 +964,7 @@ fn exit_code_3_on_empty_password_file() {
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .code(3)
-        .stderr(predicate::str::contains("No password available"));
+        .stderr(predicate::str::contains("No password was available"));
 }
 
 /// Exit code 3 (auth failure) when password file contains only a newline.
@@ -997,7 +995,7 @@ fn exit_code_3_on_newline_only_password_file() {
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .code(3)
-        .stderr(predicate::str::contains("No password available"));
+        .stderr(predicate::str::contains("No password was available"));
 }
 
 /// Exit code 2 (clap validation error) for invalid argument values.
@@ -1310,7 +1308,7 @@ fn submit_code_fails_without_username() {
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error").or(predicate::str::contains("required")));
+        .stderr(predicate::str::contains("Set your iCloud username"));
 }
 
 // ── --report-json removed from public sync CLI ───────────────────────

--- a/tests/service_linux.rs
+++ b/tests/service_linux.rs
@@ -176,7 +176,7 @@ fn dry_run_install_system_rejects_root_preview_user() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "could not determine which user the system unit would run as",
+            "Could not determine which user the system service would run as",
         ));
 }
 
@@ -193,7 +193,7 @@ fn dry_run_install_system_rejects_control_character_preview_user() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "could not determine which user the system unit would run as",
+            "Could not determine which user the system service would run as",
         ));
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(

--- a/tests/service_macos.rs
+++ b/tests/service_macos.rs
@@ -150,7 +150,7 @@ fn install_system_is_rejected_with_clear_message() {
         .args(["install", "--system", "--dry-run"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("per-user LaunchAgent"));
+        .stderr(predicate::str::contains("per-user only"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Rewrote kei error messages across auth, config, selection, download, iCloud, service, state, setup, and sync paths so they read in plainer, more actionable language.
- Updated string-only unit and integration test expectations for the new wording.
- Left CLI flags, config keys, schema, and runtime behavior unchanged.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test behavioral`
- `cargo test --test cli`
- `cargo test --test service_linux`
- `just gate`
