### PR TITLE
Fix systemd watchdog heartbeat

### DIFF
--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -877,6 +877,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         &config.download.folder_structure_smart_folders,
     );
     sd_notifier.notify_ready();
+    let _systemd_watchdog_task = sd_notifier.start_watchdog_heartbeat(shutdown_token.clone());
     // Friendly-mode greeting. Lands above any future bar via
     // active_bar::with_suspended; no-op in off mode. Once per process.
     crate::personality::narration::greet_to_stderr(config.ui.personality_mode, is_watch_mode);

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -3,10 +3,27 @@
 //! All functions are no-ops when `enabled` is false or on non-Linux platforms.
 //! This keeps the rest of the codebase free from `#[cfg]` conditionals.
 
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
 /// Holds the runtime flag controlling whether sd-notify messages are sent.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SystemdNotifier {
     enabled: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct SystemdWatchdogTask {
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for SystemdWatchdogTask {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
 }
 
 impl SystemdNotifier {
@@ -45,6 +62,37 @@ impl SystemdNotifier {
             return;
         }
         self.send_impl_watchdog();
+    }
+
+    /// Start a background watchdog heartbeat when systemd requested one.
+    ///
+    /// systemd passes `WATCHDOG_USEC` to notify services when `WatchdogSec=`
+    /// is active. A long watch-mode sleep can be much larger than that
+    /// timeout, so a cycle-bound ping is not enough; keep pinging until the
+    /// sync run exits or shutdown starts.
+    pub(crate) fn start_watchdog_heartbeat(
+        self,
+        shutdown_token: CancellationToken,
+    ) -> SystemdWatchdogTask {
+        let Some(timeout) = self.watchdog_timeout() else {
+            return SystemdWatchdogTask { handle: None };
+        };
+        let interval = watchdog_heartbeat_interval(timeout);
+        let handle = tokio::spawn(watchdog_heartbeat_loop(
+            interval,
+            shutdown_token,
+            move || self.notify_watchdog(),
+        ));
+        SystemdWatchdogTask {
+            handle: Some(handle),
+        }
+    }
+
+    fn watchdog_timeout(self) -> Option<Duration> {
+        if !self.enabled {
+            return None;
+        }
+        self.watchdog_timeout_impl()
     }
 
     #[cfg(target_os = "linux")]
@@ -94,11 +142,50 @@ impl SystemdNotifier {
     fn send_impl_watchdog(self) {
         let _ = self;
     }
+
+    #[cfg(target_os = "linux")]
+    fn watchdog_timeout_impl(self) -> Option<Duration> {
+        sd_notify::watchdog_enabled()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn watchdog_timeout_impl(self) -> Option<Duration> {
+        let _ = self;
+        None
+    }
+}
+
+fn watchdog_heartbeat_interval(timeout: Duration) -> Duration {
+    if timeout.is_zero() {
+        return Duration::from_secs(1);
+    }
+    timeout
+        .checked_div(2)
+        .filter(|d| !d.is_zero())
+        .unwrap_or(timeout)
+}
+
+async fn watchdog_heartbeat_loop<F>(
+    interval: Duration,
+    shutdown_token: CancellationToken,
+    mut notify_watchdog: F,
+) where
+    F: FnMut(),
+{
+    notify_watchdog();
+    loop {
+        tokio::select! {
+            () = tokio::time::sleep(interval) => notify_watchdog(),
+            () = shutdown_token.cancelled() => break,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     #[test]
     fn disabled_notifier_is_noop() {
@@ -117,5 +204,48 @@ mod tests {
         n.notify_stopping();
         n.notify_status("test");
         n.notify_watchdog();
+    }
+
+    #[test]
+    fn watchdog_heartbeat_interval_is_half_timeout() {
+        assert_eq!(
+            watchdog_heartbeat_interval(Duration::from_secs(120)),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            watchdog_heartbeat_interval(Duration::from_micros(1)),
+            Duration::from_nanos(500)
+        );
+        assert_eq!(
+            watchdog_heartbeat_interval(Duration::ZERO),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watchdog_heartbeat_loop_pings_until_shutdown() {
+        let shutdown_token = CancellationToken::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let notify_calls = Arc::clone(&calls);
+        let task = tokio::spawn(watchdog_heartbeat_loop(
+            Duration::from_secs(60),
+            shutdown_token.clone(),
+            move || {
+                notify_calls.fetch_add(1, Ordering::SeqCst);
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        shutdown_token.cancel();
+        task.await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Keep sending systemd watchdog heartbeats for the lifetime of `kei service run` when `WatchdogSec=` is active.
- Start the heartbeat after `READY=1`, so long sync cycles and long watch-mode sleeps don't trip systemd's watchdog.
- Add focused coverage for the heartbeat interval and shutdown behavior.

Fixes #574.

## Tests
- `cargo check`
- `cargo test systemd::tests --lib`
- `cargo test --test service_linux`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Live #574 repro: v0.21.4 emitted one `WATCHDOG=1` and then none during `Waiting 60 seconds...`
- Live #574 fix proof: this branch emitted 15 `WATCHDOG=1` messages over 16s, including while waiting for the next cycle
- Bounded live sanity: `target/debug/kei sync --only-print-filenames --recent 1 --no-progress-bar --log-level info`
- `just gate`
- `just service-smoke`
