### PR TITLE
Fix stale live test expectations

### DIFF
--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -552,7 +552,7 @@ fn import_recent_days_form_is_rejected() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "isn't supported for import-existing",
+            "--recent 30d` is not supported for import-existing",
         ));
     });
 }
@@ -703,7 +703,9 @@ fn import_bails_on_missing_download_dir() {
         .timeout(Duration::from_secs(IMPORT_TIMEOUT_SECS))
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Cannot read download directory"));
+        .stderr(predicate::str::contains(
+            "Could not read download directory",
+        ));
     });
 }
 

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -435,7 +435,9 @@ fn import_existing_with_nonexistent_directory_fails() {
             .timeout(std::time::Duration::from_secs(60))
             .assert()
             .failure()
-            .stderr(predicate::str::contains("Cannot read download directory"));
+            .stderr(predicate::str::contains(
+                "Could not read download directory",
+            ));
     });
 }
 


### PR DESCRIPTION
## Summary
- Updated live test expectations for current `import-existing` error text.
- Covers the missing download directory case and the `--recent 30d` rejection message.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --test state_auth import_existing_with_nonexistent_directory_fails -- --ignored --test-threads=1`
- `cargo test --all-features --test import_existing_live import_bails_on_missing_download_dir -- --ignored --test-threads=1`
- `cargo test --all-features --test import_existing_live -- --ignored --test-threads=1`
- `just test live` reached passing `sync` and `state_auth`; it exposed the stale `import_existing_live` assertion fixed here, then the full `import_existing_live` suite passed separately.
- `scripts/full-test/run_shell_suites.sh`
- `scripts/full-test/run_live_smokes.sh`
- `scripts/full-test/run_live_import_rehearsal.sh`
- `just service-smoke`
- `KEI_FULL_TEST_REAL_SERVICE=1 scripts/full-test/run_real_service_lifecycle.sh`
- `just gate`
