### PR TITLE
Add product charter and roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Today kei syncs iCloud Photos. Immich, Google Takeout, Nextcloud, and Ente suppo
 > [!IMPORTANT]
 > kei needs iCloud Photos web access. If `Advanced Data Protection` is on, turn it off and enable "Access iCloud Data on the Web" in your Apple ID settings. See [Authentication](https://github.com/rhoopr/kei/wiki/Authentication#advanced-data-protection-adp).
 
+## Product direction
+
+kei is built around reliable local backup: safe file writes, explainable state,
+service-friendly operation, and no destructive behavior unless you explicitly
+ask for it.
+
+Read the [product charter](docs/product-charter.md) and
+[roadmap](docs/roadmap.md) for current priorities.
 
 ## Common setups
 
@@ -144,6 +152,8 @@ Coming from `icloudpd`? Read [Migrating from icloudpd](docs/migration-from-iclou
 - [Commands](https://github.com/rhoopr/kei/wiki/Home#commands)
 - [Credentials](https://github.com/rhoopr/kei/wiki/Credentials)
 - [Troubleshooting](https://github.com/rhoopr/kei/wiki/Troubleshooting)
+- [Product charter](docs/product-charter.md)
+- [Roadmap](docs/roadmap.md)
 
 Open an issue for bugs or sharp edges: [Issues](https://github.com/rhoopr/kei/issues)
 

--- a/docs/product-charter.md
+++ b/docs/product-charter.md
@@ -1,0 +1,79 @@
+# kei product charter
+
+kei is a reliability-first local backup engine for cloud-hosted photos and
+videos.
+
+Today kei backs up iCloud Photos. The product direction is broader: source
+media from cloud services, keep a useful local catalog, and write files or
+exports that users can trust.
+
+## Product promise
+
+kei copies photo and video libraries into storage the user controls, with safe
+file writes, resumable sync, and enough state to explain what happened.
+
+The default product promise is local backup, not photo management. kei should
+make a local archive safer and easier to operate before it grows into
+destructive cleanup, provider-to-provider sync, or downstream upload workflows.
+
+## Who kei is for
+
+- People backing up iCloud Photos to a local disk, NAS, server, or external
+  drive.
+- Docker, systemd, launchd, Windows service, and other headless users.
+- Large-library users who need retryable sync, progress, reports, and clear
+  failure states.
+- People migrating from `icloudpd` or adopting an existing local archive.
+- Self-hosted photo users who need a dependable local source for tools such as
+  Immich.
+
+## Product principles
+
+- User data is sacred. kei must not lose, corrupt, truncate, overwrite, or
+  silently discard media or metadata.
+- Local file changes are opt-in. Capturing metadata in the state database is
+  safe by default. Rewriting, deleting, or pruning local files needs an explicit
+  user action.
+- Sync should be explainable. A user should be able to tell what kei scanned,
+  what it downloaded, what failed, and whether the next run can continue safely.
+- Headless operation is first-class. Watch mode, Docker, service managers,
+  health files, notifications, and reports are product surfaces, not afterthoughts.
+- Provider quirks stay at provider boundaries. iCloud-specific behavior should
+  not leak into the core model unless the risk is named and contained.
+- The local state database should become a supported catalog. It already tracks
+  useful truth about assets, files, checksums, albums, libraries, and sync
+  history. Future commands should expose that truth directly.
+
+## Current focus
+
+The next product focus is backup confidence.
+
+Users should be able to answer practical questions without reading logs:
+
+- Is kei running?
+- What is it working on?
+- What is already backed up?
+- What failed?
+- Are any local files missing or damaged?
+- What should I send when I need help?
+
+This points to status improvements, manifest export, local drift detection,
+support diagnostics, and better retry workflows before larger destination or
+deletion features.
+
+## Non-goals
+
+- A full photo manager UI.
+- Silent destructive sync.
+- iCloud-side deletion bundled into normal backup.
+- Chasing every inherited `icloudpd` flag when a clearer kei-native workflow is
+  better.
+- Treating private provider APIs as safe. If kei has to depend on them, the risk
+  should be documented and guarded with tests.
+
+## Roadmap source of truth
+
+The public roadmap lives in [docs/roadmap.md](roadmap.md). GitHub milestones and
+issues track committed release work. GitHub Discussions are for discovery, RFCs,
+and user feedback. `.scratch/` files are retained research and planning notes,
+not public product truth.

--- a/docs/product-charter.md
+++ b/docs/product-charter.md
@@ -46,7 +46,11 @@ destructive cleanup, provider-to-provider sync, or downstream upload workflows.
 
 ## Current focus
 
-The next product focus is backup confidence.
+The near-term requirement is stability and reliability. No new product surface
+should be prioritized until normal sync, interrupted-run recovery, reporting,
+retry behavior, token safety, and support paths feel rock solid.
+
+Backup confidence is the user-visible proof of that reliability.
 
 Users should be able to answer practical questions without reading logs:
 
@@ -54,12 +58,15 @@ Users should be able to answer practical questions without reading logs:
 - What is it working on?
 - What is already backed up?
 - What failed?
+- Can the next run recover safely?
+- Did sync tokens advance only when it was safe?
 - Are any local files missing or damaged?
 - What should I send when I need help?
 
-This points to status improvements, manifest export, local drift detection,
-support diagnostics, and better retry workflows before larger destination or
-deletion features.
+This points first to hardening existing sync, recovery, status, reports, and
+retry behavior. Support tools such as manifest export or a redacted diagnostic
+bundle should come only when they help prove or debug reliability. Catalog query,
+provider expansion, destination work, UI, and deletion workflows are later.
 
 ## Non-goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,245 @@
+# kei roadmap
+
+This roadmap is directional. GitHub milestones and issues track committed
+release work.
+
+## Current focus
+
+Backup confidence.
+
+kei already does the hard parts of local iCloud Photos backup: resumable
+downloads, safe file landing, checksum checks, stateful retries, service mode,
+reports, and selected-library sync. The next product step is to make that safety
+visible to users.
+
+## Roadmap themes
+
+### Backup confidence
+
+Help users prove their archive is healthy.
+
+Candidate work:
+
+- Show active sync work in `kei status`.
+- Detect missing or damaged local files during incremental sync.
+- Retry failed downloads without scanning the whole library.
+- Export a local manifest in JSON and CSV.
+- Add `kei doctor` with a redacted support bundle.
+- Add a first read-only local catalog query command.
+
+Success criteria:
+
+- Users can see what kei is doing during a long unattended run.
+- Users can export what kei believes is backed up.
+- Users can diagnose common setup and state problems without sharing secrets.
+- A damaged or missing local file can be found and repaired without guesswork.
+
+### Headless operations
+
+Make unattended operation easier to run and support.
+
+Candidate work:
+
+- Add a notification test command.
+- Improve webhook and desktop notification flows.
+- Make browser-based watch-mode 2FA easier.
+- Document Grafana or Prometheus examples.
+- Keep service output machine-readable and predictable.
+
+Success criteria:
+
+- Service users can tell whether kei is healthy without opening an interactive
+  shell.
+- Notification and metrics setup can be tested before waiting for a real sync
+  event.
+- Support reports explain the local installation without exposing credentials.
+
+### Scale and sync efficiency
+
+Reduce wasted work on large libraries.
+
+Candidate work:
+
+- Stream large incremental syncs.
+- Plan full-library syncs before downloads where that avoids duplicate or stale
+  work.
+- Continue improving filtered sync follow-ups.
+- Keep sync-token advancement tied to complete and safe enumeration.
+
+Success criteria:
+
+- Large libraries start producing useful work quickly.
+- Selected albums, smart folders, and libraries avoid unnecessary whole-library
+  scans where the provider model allows it.
+- Incomplete enumeration does not advance tokens.
+
+### Media fidelity
+
+Preserve the media users expect.
+
+Candidate work:
+
+- Handle edited-photo naming better.
+- Add safe HEIC, HEIF, and AVIF embedded metadata writes when the write path is
+  proven safe.
+- Improve cross-library deduplication.
+- Research shared albums separately from shared libraries.
+
+Success criteria:
+
+- Originals, edits, Live Photos, RAW siblings, and metadata stay traceable.
+- File rewrites remain opt-in and safe.
+- Provider-specific media quirks stay documented.
+
+### Destinations and providers
+
+Grow beyond local iCloud-to-folder backup once the local catalog is strong.
+
+Candidate work:
+
+- Immich integration.
+- Google Takeout import.
+- Nextcloud or WebDAV.
+- S3 or object storage.
+- More packaging where it has clear user demand.
+
+Success criteria:
+
+- New sources or destinations reuse the local catalog instead of bypassing it.
+- Destructive or upload workflows have explicit dry-run and safety gates.
+- The file-backed backup remains useful even when a downstream destination fails.
+
+### Destructive lifecycle workflows
+
+Add cleanup only after backup confidence surfaces exist.
+
+Candidate work:
+
+- `kei prune --dry-run` for local deletion planning.
+- A later explicit delete mode, if dry-run proves the model.
+- iCloud-side deletion only as a separate later workflow.
+
+Success criteria:
+
+- The first cleanup slice is read-only.
+- Users can see why each file is a candidate.
+- No destructive behavior is bundled into normal sync.
+
+## Near-term milestones
+
+### v0.22 - Backup confidence
+
+Goal: make kei's local backup state visible and auditable.
+
+User outcome: a user can tell what is backed up, what is damaged or missing, and
+what information to send when they need help.
+
+Candidate work:
+
+- Active sync work in `kei status`.
+- Manifest export.
+- Local drift detection for incremental sync.
+- State-write failure token-blocking regression coverage.
+- Targeted failed-download retry, if it fits the release.
+- First `kei doctor` slice, if manifest and status primitives are ready.
+
+Out of scope:
+
+- Local file deletion.
+- iCloud-side deletion.
+- Immich upload.
+
+Success criteria:
+
+- Backup status is understandable without reading debug logs.
+- Manifest output is read-only and state-backed.
+- Missing or damaged local files are visible during routine maintenance.
+
+### v0.23 - Headless operations
+
+Goal: make service and Docker operation easier to observe.
+
+User outcome: a headless user can test notifications, inspect health, and gather
+support data without restarting into an interactive workflow.
+
+Candidate work:
+
+- Notification test command.
+- Better webhook and desktop notification setup.
+- Watch-mode 2FA browser page.
+- Grafana or Prometheus example docs.
+
+Out of scope:
+
+- Provider expansion.
+- Destructive cleanup.
+
+Success criteria:
+
+- Headless setups expose clear health and diagnostic signals.
+- Notification setup can be tested on demand.
+
+### v0.24 - Scale and sync efficiency
+
+Goal: reduce unnecessary work on large or filtered libraries.
+
+User outcome: large-library and filtered-sync users spend less time rescanning
+media that cannot affect the next run.
+
+Candidate work:
+
+- Large incremental sync streaming.
+- Full-library planning before download where it reduces waste.
+- Filtered sync follow-ups.
+- Targeted retry work if it did not fit v0.22.
+
+Out of scope:
+
+- Unsafe token advancement.
+- Optimizations that hide enumeration errors.
+
+Success criteria:
+
+- Large syncs do useful work earlier.
+- Token rules stay conservative when enumeration is incomplete.
+
+### v0.25 - Media fidelity
+
+Goal: improve how kei preserves media variants and metadata.
+
+User outcome: edited media, metadata, duplicates, and shared media are easier to
+understand and preserve.
+
+Candidate work:
+
+- Edited-photo filename improvements.
+- Safe HEIC, HEIF, and AVIF metadata writes.
+- Cross-library deduplication.
+- Shared albums research.
+
+Out of scope:
+
+- Broad provider expansion.
+- Default file rewrites.
+
+Success criteria:
+
+- Media variants stay traceable.
+- Metadata write behavior remains explicit and safe.
+
+### Later - Destinations and providers
+
+Goal: use kei's local catalog as the base for new sources and destinations.
+
+Candidate work:
+
+- Immich.
+- Google Takeout.
+- Nextcloud or WebDAV.
+- S3 or object storage.
+- Destructive lifecycle workflows after read-only planning exists.
+
+Success criteria:
+
+- New workflows build on the backup and catalog model.
+- Users can test and inspect changes before any destructive action.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,33 +5,42 @@ release work.
 
 ## Current focus
 
-Backup confidence.
+Stability and reliability, with backup confidence as the user-visible proof.
 
 kei already does the hard parts of local iCloud Photos backup: resumable
 downloads, safe file landing, checksum checks, stateful retries, service mode,
-reports, and selected-library sync. The next product step is to make that safety
-visible to users.
+reports, and selected-library sync. The near-term job is to make normal sync,
+interrupted-run recovery, reports, retry behavior, token safety, and support
+paths feel rock solid.
+
+New product surface should wait unless it directly proves or debugs reliability.
 
 ## Roadmap themes
 
 ### Backup confidence
 
-Help users prove their archive is healthy.
+Help users prove kei is syncing safely and recovering correctly.
 
 Candidate work:
 
+- Harden normal sync stability.
+- Harden interrupted sync recovery.
+- Improve failed-download visibility and retry behavior.
+- Guard against unsafe sync-token advancement.
 - Show active sync work in `kei status`.
 - Detect missing or damaged local files during incremental sync.
-- Retry failed downloads without scanning the whole library.
-- Export a local manifest in JSON and CSV.
-- Add `kei doctor` with a redacted support bundle.
-- Add a first read-only local catalog query command.
+- Add manifest export as reliability/support tooling once core sync and
+  reporting feel solid.
+- Add `kei doctor` or a redacted support bundle once core sync and reporting
+  feel solid.
 
 Success criteria:
 
+- Normal sync is dependable.
+- Interrupted sync resumes correctly.
+- Failed downloads are visible and recoverable.
+- Sync tokens advance only after safe, complete work.
 - Users can see what kei is doing during a long unattended run.
-- Users can export what kei believes is backed up.
-- Users can diagnose common setup and state problems without sharing secrets.
 - A damaged or missing local file can be found and repaired without guesswork.
 
 ### Headless operations
@@ -127,32 +136,42 @@ Success criteria:
 
 ## Near-term milestones
 
-### v0.22 - Backup confidence
+### v0.22 - Stability and reliability
 
-Goal: make kei's local backup state visible and auditable.
+Goal: make normal sync, recovery, reporting, and token safety feel rock solid.
 
-User outcome: a user can tell what is backed up, what is damaged or missing, and
-what information to send when they need help.
+User outcome: a user can trust routine sync, recover from interruption or
+failure, and tell whether their local backup is safe.
 
 Candidate work:
 
-- Active sync work in `kei status`.
-- Manifest export.
-- Local drift detection for incremental sync.
+- Normal sync stability.
+- Interrupted sync recovery.
+- Failed-download visibility and retry behavior.
 - State-write failure token-blocking regression coverage.
-- Targeted failed-download retry, if it fits the release.
-- First `kei doctor` slice, if manifest and status primitives are ready.
+- Active sync work in `kei status`.
+- Local missing or damaged file detection.
+- Manifest export as reliability/support tooling, only after core sync,
+  recovery, and reporting feel solid.
+- First `kei doctor` slice only if it directly helps prove or debug
+  reliability.
 
 Out of scope:
 
+- General catalog query.
 - Local file deletion.
 - iCloud-side deletion.
 - Immich upload.
+- Provider expansion.
+- UI work.
 
 Success criteria:
 
-- Backup status is understandable without reading debug logs.
-- Manifest output is read-only and state-backed.
+- Normal sync is stable enough to trust as the default path.
+- Interrupted sync resumes correctly.
+- Failed downloads are visible and recoverable.
+- Sync tokens do not advance after unsafe or incomplete work.
+- Status and reports explain whether the user is safe without debug logs.
 - Missing or damaged local files are visible during routine maintenance.
 
 ### v0.23 - Headless operations


### PR DESCRIPTION
## Summary
- Added `docs/product-charter.md` to define kei's product promise, target users, principles, non-goals, and roadmap source-of-truth rules.
- Added `docs/roadmap.md` as the public roadmap, with v0.22 framed around stability and reliability and backup confidence as the user-visible proof.
- Linked the charter and roadmap from the README without turning the README into a strategy memo.

## Tests
- `just gate` - passed outside the sandbox. The sandboxed run failed because localhost mock-server tests could not bind ports.

## Notes
- `.scratch/roadmap.md` has the historical note locally, but `.scratch/` is gitignored and repo rules ban `git add -f`, so that local retained-plan update is not part of this PR.
