### PR TITLE
Remove legacy credential key migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `just full-test` now fails up front with a clear GNU/Linux userland message when required GNU `find`/`stat` behavior, `flock`, or `timeout` is unavailable. (fixes [#583])
 - The round-trip serializer gate now documents its heuristic limits and requires a reviewer rationale for no-inverse exceptions or emergency bypasses. (fixes [#583])
 - `just full-test` now quotes the configured Docker image consistently in Docker smoke commands, including the default-command smoke that runs through `bash -c`. (fixes [#583])
+- Encrypted-file credentials now use `.kei-state` directly. The old `.credential-key` auto-rename path was removed; users who still have that pre-0.6.2 key file must rename it to `.kei-state` manually before using the encrypted-file backend. (fixes [#613])
 
 [#479]: https://github.com/rhoopr/kei/issues/479
 [#506]: https://github.com/rhoopr/kei/issues/506
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#587]: https://github.com/rhoopr/kei/issues/587
 [#588]: https://github.com/rhoopr/kei/issues/588
 [#590]: https://github.com/rhoopr/kei/issues/590
+[#613]: https://github.com/rhoopr/kei/issues/613
 
 ## [0.21.8] - 2026-06-10
 
@@ -1139,7 +1141,7 @@ All deprecated syntax continues to work and prints a one-line warning to stderr.
 
 ### Changed
 
-- **Credential key file renamed** - The encrypted credential key file is renamed from `.credential-key` to `.session-state`. Existing files are migrated silently.
+- **Credential key file renamed** - The encrypted credential key file was renamed from `.credential-key` to `.session-state`. Current releases use `.kei-state` and no longer auto-migrate `.credential-key`; rename it to `.kei-state` manually if you're upgrading from that old file name.
 
 [#166]: https://github.com/rhoopr/kei/issues/166
 

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -176,15 +176,7 @@ impl CredentialStore {
     // ── Encrypted file backend ─────────────────────────────────────
 
     fn key_file_path(&self) -> PathBuf {
-        let new_path = self.config_dir.join(".kei-state");
-        // Migrate legacy name silently.
-        if !new_path.exists() {
-            let legacy = self.config_dir.join(".credential-key");
-            if legacy.exists() {
-                let _ = std::fs::rename(&legacy, &new_path);
-            }
-        }
-        new_path
+        self.config_dir.join(".kei-state")
     }
 
     fn credential_file_path(&self) -> PathBuf {
@@ -637,6 +629,37 @@ mod tests {
 
         let key = std::fs::read(store.key_file_path()).unwrap();
         assert_eq!(key.len(), 32);
+    }
+
+    #[test]
+    fn legacy_credential_key_is_not_auto_renamed() {
+        let (_td, dir) = test_dir("legacy_key");
+        let legacy_path = dir.join(".credential-key");
+        std::fs::write(&legacy_path, [7u8; 32]).unwrap();
+
+        let store = CredentialStore::new("user@example.com", &dir);
+        let key_path = store.key_file_path();
+        assert_eq!(key_path, dir.join(".kei-state"));
+        assert!(
+            legacy_path.exists(),
+            "legacy .credential-key must be left for manual user migration"
+        );
+        assert!(
+            !key_path.exists(),
+            ".kei-state must not be created or renamed by path lookup"
+        );
+
+        store.load_or_create_key().unwrap();
+        assert!(
+            legacy_path.exists(),
+            "creating .kei-state must not consume legacy .credential-key"
+        );
+        assert!(key_path.exists());
+        assert_ne!(
+            std::fs::read(key_path).unwrap(),
+            vec![7u8; 32],
+            ".kei-state must not reuse the legacy key bytes automatically"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Removed the encrypted-file credential key auto-rename from `.credential-key` to `.kei-state`.
- Added a regression test that leaves `.credential-key` untouched and creates `.kei-state` directly.
- Updated the changelog so old automatic migration guidance now tells users to rename the key manually.

## Tests
- `cargo check`
- `cargo test credential::tests::legacy_credential_key_is_not_auto_renamed`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `just gate`

## Context
Fixes #613.
