### PR TITLE
Use url serializer for photo query params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "url",
- "urlencoding",
  "uuid",
  "windows-service",
  "windows-sys 0.52.0",
@@ -3196,12 +3195,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,6 @@ bitflags = "2"
 url = "2"
 dirs = "6"
 async-trait = "0.1"
-urlencoding = "2"
 memchr = "2"
 
 # SQLite state tracking

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -218,20 +218,24 @@ pub(crate) const VIDEO_VERSION_LOOKUP: &[(AssetVersionSize, &str, &str)] = &[
 
 pub(crate) fn encode_params(params: &HashMap<String, Value>) -> String {
     use std::borrow::Cow;
-    let mut pairs: Vec<String> = params
+
+    let mut pairs: Vec<(&str, Cow<'_, str>)> = params
         .iter()
         .map(|(k, v)| {
-            let val: Cow<'_, str> = match v {
+            let val = match v {
                 Value::String(s) => Cow::Borrowed(s.as_str()),
                 Value::Bool(b) => Cow::Owned(b.to_string()),
                 Value::Number(n) => Cow::Owned(n.to_string()),
                 other => Cow::Owned(other.to_string()),
             };
-            format!("{}={}", urlencoding::encode(k), urlencoding::encode(&val))
+            (k.as_str(), val)
         })
         .collect();
-    pairs.sort();
-    pairs.join("&")
+    pairs.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+
+    url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(pairs)
+        .finish()
 }
 
 /// Build the request body for `/changes/database`.
@@ -323,7 +327,7 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("q".to_string(), Value::String("hello world".to_string()));
         let encoded = encode_params(&params);
-        assert_eq!(encoded, "q=hello%20world");
+        assert_eq!(encoded, "q=hello+world");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use `url::form_urlencoded::Serializer` for iCloud Photos query parameter encoding instead of the separate `urlencoding` crate.
- Keep query parameter output sorted for deterministic request URLs and tests.
- Remove `urlencoding` from Cargo dependencies and the lockfile.

## Context
Closes #612.

## Tests
- `cargo check`
- `cargo test test_encode_params -- --test-threads=1`
- `cargo test --lib icloud::photos -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate` - passed outside the sandbox after the sandboxed run hit a Wiremock localhost bind denial
