### PR TITLE
Track asset-master mappings for hard deletes

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use filter::determine_media_type;
 pub(crate) use filter::AssetGroupings;
 use filter::DownloadTask;
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -505,6 +506,8 @@ const UNPARSABLE_RELATION_DELTA_REASON: &str = "unparsable_relation_delta";
 const UNKNOWN_ALBUM_RELATION_CONTAINER_REASON: &str = "unknown_album_relation_container";
 const UNKNOWN_ALBUM_RELATION_ASSET_REASON: &str = "unknown_album_relation_asset";
 const ALBUM_DELTA_STATE_WRITE_FAILED_REASON: &str = "album_delta_state_write_failed";
+const ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON: &str =
+    "asset_master_mapping_state_write_failed";
 const INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON: &str = "incremental_delete_state_write_failed";
 const INCREMENTAL_DELETE_ZERO_ROWS_REASON: &str = "incremental_delete_no_matching_state";
 const INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON: &str = "incremental_hidden_state_write_failed";
@@ -520,6 +523,7 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
     match reason {
         ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON
         | ALBUM_DELTA_STATE_WRITE_FAILED_REASON
+        | ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON
         | DATE_BOUNDED_FULL_ENUMERATION_REASON
         | INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON
         | INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON
@@ -597,6 +601,9 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
             "an album relation referenced an asset kei cannot hydrate for album routing yet"
         }
         ALBUM_DELTA_STATE_WRITE_FAILED_REASON => "kei could not persist album delta state safely",
+        ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON => {
+            "kei could not persist asset-to-master mapping state safely"
+        }
         INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON => {
             "kei could not persist an incremental source-delete safely"
         }
@@ -3050,11 +3057,17 @@ impl IncrementalStateTransition {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct SourceStateTransitionKey<'a> {
-    record_name: &'a str,
+    record_name: Cow<'a, str>,
     record_type: Option<&'a str>,
     unresolved_identity: bool,
+}
+
+impl SourceStateTransitionKey<'_> {
+    fn record_name(&self) -> &str {
+        self.record_name.as_ref()
+    }
 }
 
 fn record_incremental_state_transition_result(
@@ -3073,7 +3086,7 @@ fn record_incremental_state_transition_result(
             *state_transition_failures += 1;
             token_unsafe_reason.get_or_insert(INCREMENTAL_DELETE_ZERO_ROWS_REASON);
             tracing::warn!(
-                record_name = state_key.record_name,
+                record_name = state_key.record_name(),
                 record_type = state_key.record_type,
                 transition = transition.label(),
                 "Unresolved hard-delete event did not match local state; blocking sync token advancement"
@@ -3081,7 +3094,7 @@ fn record_incremental_state_transition_result(
         }
         Ok(_) => {
             tracing::debug!(
-                record_name = state_key.record_name,
+                record_name = state_key.record_name(),
                 record_type = state_key.record_type,
                 transition = transition.label(),
                 "Incremental source-state transition was already absent from state DB"
@@ -3091,7 +3104,7 @@ fn record_incremental_state_transition_result(
             *state_transition_failures += 1;
             token_unsafe_reason.get_or_insert(transition.write_failed_reason());
             tracing::warn!(
-                record_name = state_key.record_name,
+                record_name = state_key.record_name(),
                 error = %e,
                 transition = transition.label(),
                 "Failed to record incremental source-state transition in state DB"
@@ -3104,23 +3117,53 @@ fn source_state_transition_key(event: &ChangeEvent) -> SourceStateTransitionKey<
     if matches!(event.record_type.as_deref(), Some("CPLAsset")) {
         if let Some(master_record_name) = event.master_record_name.as_deref() {
             return SourceStateTransitionKey {
-                record_name: master_record_name,
+                record_name: Cow::Borrowed(master_record_name),
                 record_type: Some("CPLMaster"),
                 unresolved_identity: false,
             };
         }
         return SourceStateTransitionKey {
-            record_name: &event.record_name,
+            record_name: Cow::Borrowed(&event.record_name),
             record_type: event.record_type.as_deref(),
             unresolved_identity: true,
         };
     }
 
     SourceStateTransitionKey {
-        record_name: &event.record_name,
+        record_name: Cow::Borrowed(&event.record_name),
         record_type: event.record_type.as_deref(),
         unresolved_identity: event.record_type.is_none(),
     }
+}
+
+async fn hard_delete_state_transition_key<'a>(
+    event: &'a ChangeEvent,
+    config: &DownloadConfig,
+    db: &dyn DownloadStore,
+) -> std::result::Result<SourceStateTransitionKey<'a>, crate::state::error::StateError> {
+    let fallback = source_state_transition_key(event);
+    if !fallback.unresolved_identity {
+        return Ok(fallback);
+    }
+
+    let Some(master_record_name) = db
+        .get_master_record_name_for_asset(&config.library, &event.record_name)
+        .await?
+    else {
+        return Ok(fallback);
+    };
+
+    tracing::debug!(
+        asset_record_name = %event.record_name,
+        master_record_name = %master_record_name,
+        library = %config.library,
+        "Resolved hard-delete asset tombstone through asset/master mapping"
+    );
+    Ok(SourceStateTransitionKey {
+        record_name: Cow::Owned(master_record_name),
+        record_type: Some("CPLMaster"),
+        unresolved_identity: false,
+    })
 }
 
 fn clear_zone_token_block_from_targeted_backfill_stats(stats: &mut SyncStats) {
@@ -4632,6 +4675,28 @@ impl IncrementalDeltaSummary {
         }
     }
 
+    async fn persist_asset_mapping(&mut self, event: &ChangeEvent, config: &DownloadConfig) {
+        let Some(asset) = &event.asset else {
+            return;
+        };
+        let Some(db) = &config.state_db else {
+            return;
+        };
+        let library = asset.source_zone().unwrap_or(&config.library);
+        if let Err(e) = planner::upsert_asset_master_mapping(db.as_ref(), library, asset).await {
+            self.state_transition_failures += 1;
+            self.token_unsafe_reason
+                .get_or_insert(ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON);
+            tracing::warn!(
+                asset_id = %asset.id(),
+                asset_record_name = %asset.asset_record_name(),
+                library,
+                error = %e,
+                "Failed to record asset/master mapping from incremental delta"
+            );
+        }
+    }
+
     fn record_created(&mut self) {
         self.created_count += 1;
     }
@@ -4648,7 +4713,7 @@ impl IncrementalDeltaSummary {
                     let result = db
                         .mark_soft_deleted_affected(
                             &config.library,
-                            state_key.record_name,
+                            state_key.record_name(),
                             deleted_at,
                         )
                         .await;
@@ -4665,9 +4730,23 @@ impl IncrementalDeltaSummary {
                 self.hard_deleted_count += 1;
                 tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hard-deleted record");
                 if let Some(db) = &config.state_db {
-                    let state_key = source_state_transition_key(event);
+                    let state_key =
+                        match hard_delete_state_transition_key(event, config, db.as_ref()).await {
+                            Ok(state_key) => state_key,
+                            Err(e) => {
+                                self.state_transition_failures += 1;
+                                self.token_unsafe_reason
+                                    .get_or_insert(INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON);
+                                tracing::warn!(
+                                    record_name = %event.record_name,
+                                    error = %e,
+                                    "Failed to resolve hard-delete asset/master mapping"
+                                );
+                                return;
+                            }
+                        };
                     let result = db
-                        .mark_soft_deleted_affected(&config.library, state_key.record_name, None)
+                        .mark_soft_deleted_affected(&config.library, state_key.record_name(), None)
                         .await;
                     record_incremental_state_transition_result(
                         result,
@@ -4684,7 +4763,7 @@ impl IncrementalDeltaSummary {
                 if let Some(db) = &config.state_db {
                     let state_key = source_state_transition_key(event);
                     let result = db
-                        .mark_hidden_at_source_affected(&config.library, state_key.record_name)
+                        .mark_hidden_at_source_affected(&config.library, state_key.record_name())
                         .await;
                     record_incremental_state_transition_result(
                         result,
@@ -4901,6 +4980,7 @@ fn stream_incremental_assets_for_single_unfiled_pass(
             let event = result?;
             summary.observe_event(&event);
             IncrementalDeltaSummary::remember_asset_mapping(&event, &mut asset_to_master);
+            summary.persist_asset_mapping(&event, &config).await;
 
             if event.album.is_some() {
                 album_events.push(event);
@@ -5116,6 +5196,7 @@ async fn download_photos_incremental_collecting(
     let mut asset_to_master: FxHashMap<String, String> = FxHashMap::default();
     for event in &change_events {
         IncrementalDeltaSummary::remember_asset_mapping(event, &mut asset_to_master);
+        delta_summary.persist_asset_mapping(event, config).await;
     }
     let planned_album_containers: FxHashMap<&str, &str> = passes
         .iter()
@@ -8116,6 +8197,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incremental_change_persists_asset_master_mapping() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        let result = run_incremental_change_records(
+            db.clone(),
+            flagged_incremental_records("MAPPED_MASTER", ("isDeleted", 1)),
+        )
+        .await;
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-MAPPED_MASTER")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("MAPPED_MASTER")
+        );
+    }
+
+    #[tokio::test]
     async fn incremental_untracked_hidden_zero_rows_advances_sync_token() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
         let result = run_incremental_change_records(
@@ -8155,6 +8255,62 @@ mod tests {
         );
         let pending = db.get_pending().await.unwrap();
         assert_source_flags(&pending, "TRACKED_MASTER", false, false);
+    }
+
+    #[tokio::test]
+    async fn incremental_hard_delete_uses_library_scoped_asset_master_mapping() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        db.upsert_seen(
+            &TestAssetRecord::new("PRIMARY_MASTER")
+                .library("PrimarySync")
+                .build(),
+        )
+        .await
+        .unwrap();
+        db.upsert_seen(
+            &TestAssetRecord::new("SHARED_MASTER")
+                .library("SharedSync-AAAA")
+                .build(),
+        )
+        .await
+        .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-SAME", "PRIMARY_MASTER")
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("SharedSync-AAAA", "asset-SAME", "SHARED_MASTER")
+            .await
+            .unwrap();
+
+        let result = run_incremental_change_records(
+            db.clone(),
+            vec![hard_deleted_change_record("asset-SAME")],
+        )
+        .await;
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+
+        let pending = db.get_pending().await.unwrap();
+        let primary = pending
+            .iter()
+            .find(|record| record.library.as_ref() == "PrimarySync")
+            .expect("primary row");
+        let shared = pending
+            .iter()
+            .find(|record| record.library.as_ref() == "SharedSync-AAAA")
+            .expect("shared row");
+        assert_eq!(primary.id.as_ref(), "PRIMARY_MASTER");
+        assert!(
+            primary.metadata.is_deleted,
+            "PrimarySync mapping should resolve and mark the master row deleted"
+        );
+        assert_eq!(shared.id.as_ref(), "SHARED_MASTER");
+        assert!(
+            !shared.metadata.is_deleted,
+            "same CPLAsset record name in another library must stay isolated"
+        );
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3166,6 +3166,27 @@ async fn hard_delete_state_transition_key<'a>(
     })
 }
 
+async fn backfill_asset_master_mappings_from_album_history(db: &dyn DownloadStore) {
+    match db
+        .backfill_asset_master_mappings_from_album_memberships()
+        .await
+    {
+        Ok(0) => {}
+        Ok(inserted) => {
+            tracing::info!(
+                inserted,
+                "Backfilled asset/master mappings from album membership history"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to backfill asset/master mappings from album membership history"
+            );
+        }
+    }
+}
+
 fn clear_zone_token_block_from_targeted_backfill_stats(stats: &mut SyncStats) {
     stats.sync_token_blocked = false;
     stats.sync_token_blocked_reason = None;
@@ -3653,6 +3674,11 @@ pub async fn download_photos_with_sync(
 ) -> Result<SyncResult> {
     let sync_started_at = chrono::Utc::now().timestamp();
     cleanup_orphan_part_files(&config).await;
+    if matches!(config.sync_mode, SyncMode::Incremental { .. }) {
+        if let Some(db) = &config.state_db {
+            backfill_asset_master_mappings_from_album_history(db.as_ref()).await;
+        }
+    }
 
     // Give every non-downloaded asset a fresh start this sync:
     // failed -> pending (with attempts reset), and stale attempt counts on
@@ -8311,6 +8337,97 @@ mod tests {
             !shared.metadata.is_deleted,
             "same CPLAsset record name in another library must stay isolated"
         );
+    }
+
+    #[tokio::test]
+    async fn incremental_hard_delete_recovers_mapping_from_album_history() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        db.upsert_seen(
+            &TestAssetRecord::new("TRACKED_MASTER")
+                .library("PrimarySync")
+                .build(),
+        )
+        .await
+        .unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "TRACKED_MASTER",
+            VersionSizeKey::Original.as_str(),
+            std::path::Path::new("/tmp/codex/kei/tests/tracked-master.jpg"),
+            "seeded-local-sha256",
+            None,
+        )
+        .await
+        .unwrap();
+        db.upsert_album_container("PrimarySync", "container-a", "Vacation", "album")
+            .await
+            .unwrap();
+        db.upsert_album_membership_delta(
+            "PrimarySync",
+            "container-a",
+            "asset-TRACKED_MASTER",
+            Some("TRACKED_MASTER"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-TRACKED_MASTER")
+                .await
+                .unwrap(),
+            None
+        );
+
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(
+                vec![hard_deleted_change_record("asset-TRACKED_MASTER")],
+                "zone-token-after",
+                false,
+            )
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("Library", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-before".to_string(),
+        };
+        config.state_db = Some(db.clone());
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-TRACKED_MASTER")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("TRACKED_MASTER")
+        );
+        let is_deleted: i64 = db
+            .acquire_lock("test")
+            .unwrap()
+            .query_row(
+                "SELECT is_deleted FROM assets \
+                 WHERE library = 'PrimarySync' AND id = 'TRACKED_MASTER'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(is_deleted, 1);
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1205,6 +1205,22 @@ where
                     }
 
                     assets_seen_producer.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if let Some(db) = &producer_state_db {
+                        let library = effective_asset_library(&asset, config);
+                        if let Err(e) =
+                            planner::upsert_asset_master_mapping(db.as_ref(), library, &asset).await
+                        {
+                            state_write_failures_producer
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!(
+                                asset_id = %asset.id(),
+                                asset_record_name = %asset.asset_record_name(),
+                                library,
+                                error = %e,
+                                "Failed to record asset/master mapping"
+                            );
+                        }
+                    }
 
                     let plan = task_planner.plan_asset(&asset, config).await;
                     if let Some(reason) = plan.filter_reason {

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -116,6 +116,8 @@ pub(super) async fn upsert_seen_for_task<D>(
 where
     D: DownloadStateStore + ?Sized,
 {
+    upsert_asset_master_mapping(db, &task.library, asset).await?;
+
     let media_type = determine_media_type(task.version_size, asset);
     let record = AssetRecord::new_pending(
         Arc::clone(&task.library),
@@ -134,6 +136,20 @@ where
     )
     .with_metadata_arc(asset.metadata_arc());
     db.upsert_seen(&record).await
+}
+
+/// Persist the durable CloudKit identifier bridge used to resolve future
+/// `CPLAsset` hard-delete tombstones back to the `CPLMaster` keyed state row.
+pub(super) async fn upsert_asset_master_mapping<D>(
+    db: &D,
+    library: &str,
+    asset: &PhotoAsset,
+) -> Result<(), crate::state::error::StateError>
+where
+    D: DownloadStateStore + ?Sized,
+{
+    db.upsert_asset_master_mapping(library, asset.asset_record_name(), asset.id())
+        .await
 }
 
 /// Record an asset's membership in the current concrete album/smart-folder
@@ -411,6 +427,13 @@ mod tests {
         let pending = db.get_pending().await.unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id.as_ref(), "STATEFUL");
+        assert_eq!(
+            db.get_master_record_name_for_asset(&pass_config.library, asset.asset_record_name())
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("STATEFUL")
+        );
         let albums = db.get_all_asset_albums(&pass_config.library).await.unwrap();
         assert_eq!(albums, vec![("STATEFUL".to_string(), "Family".to_string())]);
     }
@@ -441,6 +464,13 @@ mod tests {
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].library.as_ref(), "SharedSync-abc");
         assert_eq!(pending[0].id.as_ref(), "CROSS_ZONE");
+        assert_eq!(
+            db.get_master_record_name_for_asset("SharedSync-abc", asset.asset_record_name())
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("CROSS_ZONE")
+        );
         assert!(
             db.get_all_asset_albums(&pass_config.library)
                 .await

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -179,6 +179,11 @@ pub trait DownloadStateStore: Send + Sync {
     ) -> Result<Option<String>, StateError> {
         Ok(None)
     }
+    async fn backfill_asset_master_mappings_from_album_memberships(
+        &self,
+    ) -> Result<u64, StateError> {
+        Ok(0)
+    }
     /// Persist a provider tombstone without changing local download state.
     ///
     /// A row can legitimately be both `status = 'downloaded'` and
@@ -2715,6 +2720,38 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn backfill_asset_master_mappings_from_album_memberships(
+        &self,
+    ) -> Result<u64, StateError> {
+        self.with_conn(
+            "backfill_asset_master_mappings_from_album_memberships",
+            move |conn| {
+                let now = Utc::now().timestamp();
+                let inserted = conn
+                    .execute(
+                        "INSERT OR IGNORE INTO asset_master_mappings \
+                        (library, asset_record_name, master_record_name, updated_at) \
+                     SELECT library, asset_record_name, MIN(master_record_name), ?1 \
+                     FROM asset_album_memberships \
+                     WHERE asset_record_name <> '' \
+                       AND master_record_name IS NOT NULL \
+                       AND master_record_name <> '' \
+                     GROUP BY library, asset_record_name \
+                     HAVING COUNT(DISTINCT master_record_name) = 1",
+                        rusqlite::params![now],
+                    )
+                    .map_err(|e| {
+                        StateError::query(
+                            "backfill_asset_master_mappings_from_album_memberships",
+                            e,
+                        )
+                    })?;
+                Ok(inserted as u64)
+            },
+        )
+        .await
+    }
+
     pub(crate) async fn mark_soft_deleted(
         &self,
         library: &str,
@@ -3056,6 +3093,12 @@ impl DownloadStateStore for SqliteStateDb {
         asset_record_name: &str,
     ) -> Result<Option<String>, StateError> {
         SqliteStateDb::get_master_record_name_for_asset(self, library, asset_record_name).await
+    }
+
+    async fn backfill_asset_master_mappings_from_album_memberships(
+        &self,
+    ) -> Result<u64, StateError> {
+        SqliteStateDb::backfill_asset_master_mappings_from_album_memberships(self).await
     }
 
     async fn mark_soft_deleted(
@@ -3689,6 +3732,90 @@ mod tests {
                 .await
                 .unwrap(),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn asset_master_mapping_backfill_uses_unambiguous_album_history() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for (library, container) in [
+            ("PrimarySync", "album-a"),
+            ("PrimarySync", "album-b"),
+            ("SharedSync-AAAA", "album-a"),
+        ] {
+            db.upsert_album_container(library, container, "Album", "album")
+                .await
+                .unwrap();
+        }
+
+        for (library, container, asset, master) in [
+            ("PrimarySync", "album-a", "asset-a", Some("master-a")),
+            ("PrimarySync", "album-b", "asset-a", Some("master-a")),
+            (
+                "SharedSync-AAAA",
+                "album-a",
+                "asset-a",
+                Some("master-shared"),
+            ),
+            (
+                "PrimarySync",
+                "album-a",
+                "asset-ambiguous",
+                Some("master-one"),
+            ),
+            (
+                "PrimarySync",
+                "album-b",
+                "asset-ambiguous",
+                Some("master-two"),
+            ),
+            ("PrimarySync", "album-a", "asset-missing", None),
+        ] {
+            db.upsert_album_membership_delta(library, container, asset, master, "icloud")
+                .await
+                .unwrap();
+        }
+        db.mark_album_membership_deleted("PrimarySync", "album-b", "asset-a")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.backfill_asset_master_mappings_from_album_memberships()
+                .await
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-a")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("master-a")
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("SharedSync-AAAA", "asset-a")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("master-shared")
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-ambiguous")
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-missing")
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            db.backfill_asset_master_mappings_from_album_memberships()
+                .await
+                .unwrap(),
+            0
         );
     }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -164,6 +164,21 @@ pub trait DownloadStateStore: Send + Sync {
         library: &str,
         asset_ids: &[&str],
     ) -> Result<(), StateError>;
+    async fn upsert_asset_master_mapping(
+        &self,
+        _library: &str,
+        _asset_record_name: &str,
+        _master_record_name: &str,
+    ) -> Result<(), StateError> {
+        Ok(())
+    }
+    async fn get_master_record_name_for_asset(
+        &self,
+        _library: &str,
+        _asset_record_name: &str,
+    ) -> Result<Option<String>, StateError> {
+        Ok(None)
+    }
     /// Persist a provider tombstone without changing local download state.
     ///
     /// A row can legitimately be both `status = 'downloaded'` and
@@ -2654,6 +2669,52 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn upsert_asset_master_mapping(
+        &self,
+        library: &str,
+        asset_record_name: &str,
+        master_record_name: &str,
+    ) -> Result<(), StateError> {
+        let library = library.to_owned();
+        let asset_record_name = asset_record_name.to_owned();
+        let master_record_name = master_record_name.to_owned();
+        self.with_conn("upsert_asset_master_mapping", move |conn| {
+            let now = Utc::now().timestamp();
+            conn.execute(
+                "INSERT INTO asset_master_mappings \
+                    (library, asset_record_name, master_record_name, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(library, asset_record_name) DO UPDATE SET \
+                    master_record_name = excluded.master_record_name, \
+                    updated_at = excluded.updated_at",
+                rusqlite::params![library, asset_record_name, master_record_name, now],
+            )
+            .map_err(|e| StateError::query("upsert_asset_master_mapping", e))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn get_master_record_name_for_asset(
+        &self,
+        library: &str,
+        asset_record_name: &str,
+    ) -> Result<Option<String>, StateError> {
+        let library = library.to_owned();
+        let asset_record_name = asset_record_name.to_owned();
+        self.with_conn("get_master_record_name_for_asset", move |conn| {
+            conn.query_row(
+                "SELECT master_record_name FROM asset_master_mappings \
+                 WHERE library = ?1 AND asset_record_name = ?2",
+                rusqlite::params![library, asset_record_name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| StateError::query("get_master_record_name_for_asset", e))
+        })
+        .await
+    }
+
     pub(crate) async fn mark_soft_deleted(
         &self,
         library: &str,
@@ -2972,6 +3033,29 @@ impl DownloadStateStore for SqliteStateDb {
         asset_ids: &[&str],
     ) -> Result<(), StateError> {
         SqliteStateDb::touch_last_seen_many(self, library, asset_ids).await
+    }
+
+    async fn upsert_asset_master_mapping(
+        &self,
+        library: &str,
+        asset_record_name: &str,
+        master_record_name: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::upsert_asset_master_mapping(
+            self,
+            library,
+            asset_record_name,
+            master_record_name,
+        )
+        .await
+    }
+
+    async fn get_master_record_name_for_asset(
+        &self,
+        library: &str,
+        asset_record_name: &str,
+    ) -> Result<Option<String>, StateError> {
+        SqliteStateDb::get_master_record_name_for_asset(self, library, asset_record_name).await
     }
 
     async fn mark_soft_deleted(
@@ -3573,6 +3657,39 @@ mod tests {
 
     fn test_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    #[tokio::test]
+    async fn asset_master_mapping_is_library_scoped() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        db.upsert_asset_master_mapping("PrimarySync", "asset-a", "master-primary")
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("SharedSync-AAAA", "asset-a", "master-shared")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-a")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("master-primary")
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("SharedSync-AAAA", "asset-a")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("master-shared")
+        );
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "missing")
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[derive(Debug)]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -2731,13 +2731,23 @@ impl SqliteStateDb {
                     .execute(
                         "INSERT OR IGNORE INTO asset_master_mappings \
                         (library, asset_record_name, master_record_name, updated_at) \
-                     SELECT library, asset_record_name, MIN(master_record_name), ?1 \
-                     FROM asset_album_memberships \
-                     WHERE asset_record_name <> '' \
-                       AND master_record_name IS NOT NULL \
-                       AND master_record_name <> '' \
-                     GROUP BY library, asset_record_name \
-                     HAVING COUNT(DISTINCT master_record_name) = 1",
+                     SELECT \
+                        membership.library, \
+                        membership.asset_record_name, \
+                        MIN(membership.master_record_name), \
+                        ?1 \
+                     FROM asset_album_memberships AS membership \
+                     WHERE membership.asset_record_name <> '' \
+                       AND membership.master_record_name IS NOT NULL \
+                       AND membership.master_record_name <> '' \
+                       AND NOT EXISTS ( \
+                           SELECT 1 \
+                           FROM asset_master_mappings AS mapping \
+                           WHERE mapping.library = membership.library \
+                             AND mapping.asset_record_name = membership.asset_record_name \
+                       ) \
+                     GROUP BY membership.library, membership.asset_record_name \
+                     HAVING COUNT(DISTINCT membership.master_record_name) = 1",
                         rusqlite::params![now],
                     )
                     .map_err(|e| {

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -428,16 +428,22 @@ INSERT OR IGNORE INTO asset_master_mappings (
     updated_at
 )
 SELECT
-    library,
-    asset_record_name,
-    MIN(master_record_name),
+    membership.library,
+    membership.asset_record_name,
+    MIN(membership.master_record_name),
     CAST(strftime('%s', 'now') AS INTEGER)
-FROM asset_album_memberships
-WHERE asset_record_name <> ''
-  AND master_record_name IS NOT NULL
-  AND master_record_name <> ''
-GROUP BY library, asset_record_name
-HAVING COUNT(DISTINCT master_record_name) = 1;
+FROM asset_album_memberships AS membership
+WHERE membership.asset_record_name <> ''
+  AND membership.master_record_name IS NOT NULL
+  AND membership.master_record_name <> ''
+  AND NOT EXISTS (
+      SELECT 1
+      FROM asset_master_mappings AS mapping
+      WHERE mapping.library = membership.library
+        AND mapping.asset_record_name = membership.asset_record_name
+  )
+GROUP BY membership.library, membership.asset_record_name
+HAVING COUNT(DISTINCT membership.master_record_name) = 1;
 ";
 
 /// Apply migration for a specific version.

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 14;
+pub(crate) const SCHEMA_VERSION: i32 = 15;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -404,6 +404,24 @@ CREATE TABLE IF NOT EXISTS scoped_db_sync_tokens (
 );
 ";
 
+/// V15 durable CPLAsset -> CPLMaster mapping.
+///
+/// CloudKit hard-delete tombstones can arrive with only a `recordName` and no
+/// `recordType` or fields. The download state is keyed by `CPLMaster`, so keep
+/// the last observed `CPLAsset.recordName` bridge per library.
+const SCHEMA_V15: &str = r"
+CREATE TABLE IF NOT EXISTS asset_master_mappings (
+    library TEXT NOT NULL,
+    asset_record_name TEXT NOT NULL,
+    master_record_name TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (library, asset_record_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_master_mappings_master
+    ON asset_master_mappings (library, master_record_name);
+";
+
 /// Apply migration for a specific version.
 ///
 /// `start_version` is the schema version the DB carried when `migrate()`
@@ -555,6 +573,7 @@ fn migrate_to_version(
             }
         }
         14 => conn.execute_batch(SCHEMA_V14)?,
+        15 => conn.execute_batch(SCHEMA_V15)?,
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -1719,5 +1738,48 @@ mod tests {
                 "v14 must create scoped_db_sync_tokens.{column}",
             );
         }
+    }
+
+    #[test]
+    fn test_v15_creates_asset_master_mappings_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        set_schema_version(&conn, 1).unwrap();
+        migrate(&conn).unwrap();
+
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name = 'asset_master_mappings'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "v15 must create asset_master_mappings");
+
+        for column in [
+            "library",
+            "asset_record_name",
+            "master_record_name",
+            "updated_at",
+        ] {
+            assert!(
+                column_exists(&conn, "asset_master_mappings", column).unwrap(),
+                "v15 must create asset_master_mappings.{column}",
+            );
+        }
+
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='index' AND name = 'idx_asset_master_mappings_master'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            exists, 1,
+            "v15 must create idx_asset_master_mappings_master"
+        );
     }
 }

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -420,6 +420,24 @@ CREATE TABLE IF NOT EXISTS asset_master_mappings (
 
 CREATE INDEX IF NOT EXISTS idx_asset_master_mappings_master
     ON asset_master_mappings (library, master_record_name);
+
+INSERT OR IGNORE INTO asset_master_mappings (
+    library,
+    asset_record_name,
+    master_record_name,
+    updated_at
+)
+SELECT
+    library,
+    asset_record_name,
+    MIN(master_record_name),
+    CAST(strftime('%s', 'now') AS INTEGER)
+FROM asset_album_memberships
+WHERE asset_record_name <> ''
+  AND master_record_name IS NOT NULL
+  AND master_record_name <> ''
+GROUP BY library, asset_record_name
+HAVING COUNT(DISTINCT master_record_name) = 1;
 ";
 
 /// Apply migration for a specific version.
@@ -1780,6 +1798,66 @@ mod tests {
         assert_eq!(
             exists, 1,
             "v15 must create idx_asset_master_mappings_master"
+        );
+    }
+
+    #[test]
+    fn test_v15_backfills_unambiguous_album_membership_mappings() {
+        let conn = Connection::open_in_memory().unwrap();
+        for version in 1..=14 {
+            migrate_to_version(&conn, 0, version).unwrap();
+        }
+
+        conn.execute_batch(
+            "
+            INSERT INTO asset_album_memberships (
+                library,
+                asset_record_name,
+                master_record_name,
+                container_id,
+                generation,
+                is_deleted,
+                source,
+                updated_at
+            ) VALUES
+                ('PrimarySync', 'asset-a', 'master-a', 'album-1', 1, 0, 'icloud', 1),
+                ('PrimarySync', 'asset-a', 'master-a', 'album-2', 1, 1, 'icloud', 1),
+                ('SharedSync-AAAA', 'asset-a', 'master-shared', 'album-1', 1, 0, 'icloud', 1),
+                ('PrimarySync', 'asset-ambiguous', 'master-one', 'album-1', 1, 0, 'icloud', 1),
+                ('PrimarySync', 'asset-ambiguous', 'master-two', 'album-2', 1, 0, 'icloud', 1),
+                ('PrimarySync', 'asset-null', NULL, 'album-1', 1, 0, 'icloud', 1);
+            ",
+        )
+        .unwrap();
+        set_schema_version(&conn, 14).unwrap();
+
+        migrate(&conn).unwrap();
+
+        let mappings: Vec<(String, String, String)> = conn
+            .prepare(
+                "SELECT library, asset_record_name, master_record_name \
+                 FROM asset_master_mappings \
+                 ORDER BY library, asset_record_name",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            mappings,
+            vec![
+                (
+                    "PrimarySync".to_string(),
+                    "asset-a".to_string(),
+                    "master-a".to_string()
+                ),
+                (
+                    "SharedSync-AAAA".to_string(),
+                    "asset-a".to_string(),
+                    "master-shared".to_string()
+                ),
+            ]
         );
     }
 }

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -81,7 +81,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 14;
+const HELPER_SCHEMA_VERSION: i32 = 15;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -232,6 +232,16 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
         CREATE INDEX IF NOT EXISTS idx_asset_album_memberships_container
             ON asset_album_memberships (library, container_id, is_deleted);
 
+        CREATE TABLE IF NOT EXISTS asset_master_mappings (
+            library TEXT NOT NULL,
+            asset_record_name TEXT NOT NULL,
+            master_record_name TEXT NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (library, asset_record_name)
+        );
+        CREATE INDEX IF NOT EXISTS idx_asset_master_mappings_master
+            ON asset_master_mappings (library, master_record_name);
+
         CREATE TABLE IF NOT EXISTS scoped_db_sync_tokens (
             provider TEXT NOT NULL,
             account TEXT NOT NULL,
@@ -277,7 +287,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 14). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 15). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -295,7 +305,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 14;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 15;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \
@@ -3530,6 +3540,18 @@ fn behavioral_helper_carries_every_migrated_column() {
             "v12 table {table} must exist in the behavioral helper's DDL"
         );
     }
+
+    let has_asset_master_mappings: bool = conn
+        .prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = 'asset_master_mappings'",
+        )
+        .unwrap()
+        .exists([])
+        .unwrap();
+    assert!(
+        has_asset_master_mappings,
+        "v15 table asset_master_mappings must exist in the behavioral helper's DDL"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added a v15 state table that stores `CPLAsset.recordName` -> `CPLMaster` mappings per library.
- Persist those mappings during normal full and incremental asset handling.
- Backfill safe mappings from existing album membership history during migration and before incremental delete handling.
- Use the mapping to resolve hard-delete tombstones that only carry the asset record name, while keeping token advancement blocked when the mapping is missing or ambiguous.
- Added coverage for schema creation, mapping backfill, incremental hard-delete recovery, and multi-library isolation.

## Context
Closes #626.

## Tests
- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test asset_master_mapping -- --test-threads=1`
- `cargo test test_v15_backfills_unambiguous_album_membership_mappings -- --test-threads=1`
- `cargo test asset_master_mapping_backfill_uses_unambiguous_album_history -- --test-threads=1`
- `cargo test incremental_hard_delete_recovers_mapping_from_album_history -- --test-threads=1`
- `cargo test planner_upserts_seen_and_records_album_membership -- --test-threads=1`
- `cargo test planner_uses_cross_zone_asset_library_for_state_and_membership -- --test-threads=1`
- `cargo test behavioral_helper_carries_every_migrated_column --test behavioral -- --test-threads=1`
- `cargo test behavioral_helper_schema_matches_production --test behavioral -- --test-threads=1`
- `cargo test incremental_unresolved_hard_delete_zero_rows_blocks_sync_token -- --test-threads=1`
- `just gate`
