### PR TITLE
Fix Docker entrypoint routing for all kei subcommands

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,7 @@ elif [ "${1#-}" != "$1" ]; then
     set -- kei "$@"
 else
     case "$1" in
-        sync|login|list|password|reset|config|status|verify|import-existing|reconcile|service)
+        sync|login|list|password|reset|config|status|doctor|manifest|verify|reconcile|import-existing|install|uninstall|service|help)
             set -- kei "$@"
             ;;
         *)

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -74,6 +74,35 @@ fn docker_packaging_defaults_to_service_run() {
     );
 
     let entrypoint = repo_file("docker/entrypoint.sh");
+    let whitelist = entrypoint
+        .lines()
+        .find(|line| line.contains("sync|login|list|password"))
+        .expect("entrypoint must keep an explicit kei subcommand whitelist");
+    for subcommand in [
+        "sync",
+        "login",
+        "list",
+        "password",
+        "reset",
+        "config",
+        "status",
+        "doctor",
+        "manifest",
+        "verify",
+        "reconcile",
+        "import-existing",
+        "install",
+        "uninstall",
+        "service",
+        "help",
+    ] {
+        assert!(
+            whitelist
+                .split(['|', ')', ' ', '\t'])
+                .any(|token| token == subcommand),
+            "entrypoint whitelist must include the kei `{subcommand}` subcommand"
+        );
+    }
     let service_index = entrypoint
         .find("|service)")
         .or_else(|| entrypoint.find("|service|"))


### PR DESCRIPTION
## Summary
- Route all current kei subcommands through the Docker entrypoint before falling back to system commands.
- Add a static guard so new or renamed CLI subcommands don't drift out of the Docker whitelist.

## Tests
- `cargo fmt --check`
- `cargo test --test branch_static docker_packaging_defaults_to_service_run`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `KEI_DOCKER_IMAGE=kei:bughunt-a565d66-fixed just test docker`
- `just gate`
