### PR TITLE
Fix Live Photo collision skips

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3,7 +3,7 @@
     reason = "CLI subcommand whose primary purpose is to print import-existing progress to stdout"
 )]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -20,9 +20,9 @@ use crate::download::paths::{normalize_ampm, DirCache};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
-use crate::state::ImportStateStore;
+use crate::state::{ImportStateStore, VersionSizeKey};
 use crate::systemd::SystemdNotifier;
-use crate::types::FileMatchPolicy;
+use crate::types::{FileMatchPolicy, LivePhotoMovFilenamePolicy};
 
 use super::service::{
     build_collection_context, collection_libraries, init_photos_service, pass_scope_for_zone,
@@ -340,62 +340,164 @@ fn log_progress_milestone(library_label: &str, matched: u64, show_progress: bool
 }
 
 /// Find the on-disk path that satisfies the expected size: primary, then
-/// the dedup-collision shape under `NameSizeDedupWithSuffix`, then an
-/// AM/PM whitespace sibling. macOS screenshots use NARROW NO-BREAK SPACE
+/// collision-family shapes under `NameSizeDedupWithSuffix`, then AM/PM
+/// whitespace siblings. macOS screenshots use NARROW NO-BREAK SPACE
 /// (`\u{202F}`) before AM/PM; trees synced through other tools may have
 /// normalized to a regular space (or vice versa).
 async fn resolve_match_path(
-    primary: &Path,
-    expected_size: u64,
-    policy: FileMatchPolicy,
+    candidate: &ImportPathCandidate<'_>,
+    all_expected: &[ExpectedAssetPath],
+    asset_id: &str,
+    path_config: &(impl PathDerivationSource + ?Sized),
     dir_cache: &mut DirCache,
-) -> Option<(std::path::PathBuf, std::fs::Metadata)> {
-    if let Ok(m) = tokio::fs::metadata(primary).await {
-        if m.len() == expected_size {
-            return Some((primary.to_path_buf(), m));
+) -> Option<(PathBuf, std::fs::Metadata)> {
+    let mut candidates = import_match_candidates(candidate, all_expected, asset_id, path_config);
+    candidates.sort();
+    candidates.dedup();
+
+    for path in &candidates {
+        if let Some(found) =
+            match_exact_or_ampm_variant(path, candidate.expected_size, dir_cache).await
+        {
+            return Some(found);
         }
     }
-    if policy == FileMatchPolicy::NameSizeDedupWithSuffix {
-        let parent = primary.parent().unwrap_or(Path::new(""));
-        let Some(fname) = primary.file_name().and_then(|f| f.to_str()) else {
-            tracing::debug!(
-                path = %primary.display(),
-                "Skipping dedup-suffix fallback: filename is not valid UTF-8",
-            );
-            return None;
-        };
-        let suffixed_fname = download::paths::add_dedup_suffix(fname, expected_size);
-        let suffixed = parent.join(suffixed_fname);
-        if let Ok(m) = tokio::fs::metadata(&suffixed).await {
-            if m.len() == expected_size {
-                return Some((suffixed, m));
+
+    if path_config.file_match_policy() == FileMatchPolicy::NameSizeDedupWithSuffix {
+        for path in candidates {
+            if let Some(found) =
+                find_identity_ordinal_sibling(&path, asset_id, candidate.expected_size).await
+            {
+                return Some(found);
             }
         }
     }
-    // Cheap pre-check: only pay for the dir read if the filename actually
-    // has an AM/PM whitespace token to vary. `normalize_ampm` is idempotent
-    // on filenames that have no such token, so the inequality below is the
-    // exact condition under which `find_ampm_variant` could return Some.
-    let needs_probe = primary
+
+    None
+}
+
+struct ImportPathCandidate<'a> {
+    path: &'a Path,
+    expected_size: u64,
+    version_size: VersionSizeKey,
+}
+
+fn import_match_candidates(
+    candidate: &ImportPathCandidate<'_>,
+    all_expected: &[ExpectedAssetPath],
+    asset_id: &str,
+    path_config: &(impl PathDerivationSource + ?Sized),
+) -> Vec<PathBuf> {
+    let mut candidates = vec![candidate.path.to_path_buf()];
+    if path_config.file_match_policy() != FileMatchPolicy::NameSizeDedupWithSuffix {
+        return candidates;
+    }
+
+    let Some(parent) = candidate.path.parent() else {
+        return candidates;
+    };
+    let Some(fname) = candidate.path.file_name().and_then(|f| f.to_str()) else {
+        tracing::debug!(
+            path = %candidate.path.display(),
+            "Skipping collision-family fallback: filename is not valid UTF-8",
+        );
+        return candidates;
+    };
+
+    candidates.push(parent.join(download::paths::add_dedup_suffix(
+        fname,
+        candidate.expected_size,
+    )));
+    candidates.push(parent.join(download::paths::insert_suffix(fname, asset_id)));
+
+    if candidate.version_size.is_live_photo_motion() {
+        if let Some(primary) = primary_expected_path(all_expected) {
+            if let Some(primary_fname) = primary.path.file_name().and_then(|f| f.to_str()) {
+                let primary_collision_filenames = [
+                    download::paths::add_dedup_suffix(primary_fname, primary.size),
+                    download::paths::insert_suffix(primary_fname, asset_id),
+                ];
+                for primary_filename in primary_collision_filenames {
+                    let mov_filename = match path_config.live_photo_mov_filename_policy() {
+                        LivePhotoMovFilenamePolicy::Suffix => {
+                            download::paths::live_photo_mov_path_suffix(&primary_filename)
+                        }
+                        LivePhotoMovFilenamePolicy::Original => {
+                            download::paths::live_photo_mov_path_original(&primary_filename)
+                        }
+                    };
+                    candidates.push(parent.join(&mov_filename));
+                    candidates
+                        .push(parent.join(download::paths::insert_suffix(&mov_filename, asset_id)));
+                }
+            }
+        }
+    }
+
+    candidates
+}
+
+fn primary_expected_path(expected: &[ExpectedAssetPath]) -> Option<&ExpectedAssetPath> {
+    expected
+        .iter()
+        .find(|path| path.version_size.is_primary_media())
+}
+
+async fn match_exact_or_ampm_variant(
+    path: &Path,
+    expected_size: u64,
+    dir_cache: &mut DirCache,
+) -> Option<(PathBuf, std::fs::Metadata)> {
+    if let Ok(m) = tokio::fs::metadata(path).await {
+        if m.len() == expected_size {
+            return Some((path.to_path_buf(), m));
+        }
+    }
+
+    let needs_probe = path
         .file_name()
         .and_then(|f| f.to_str())
         .is_some_and(|f| normalize_ampm(f) != f);
     if !needs_probe {
         return None;
     }
-    let parent = primary.parent()?;
+    let parent = path.parent()?;
     dir_cache.ensure_dir_async(parent).await;
-    let variant = dir_cache.find_ampm_variant(primary)?;
+    let variant = dir_cache.find_ampm_variant(path)?;
     if dir_cache.file_size(&variant) != Some(expected_size) {
         return None;
     }
     let m = tokio::fs::metadata(&variant).await.ok()?;
     tracing::info!(
-        primary = %primary.display(),
+        primary = %path.display(),
         variant = %variant.display(),
         "Matched AM/PM whitespace variant on disk",
     );
     Some((variant, m))
+}
+
+async fn find_identity_ordinal_sibling(
+    base_path: &Path,
+    asset_id: &str,
+    expected_size: u64,
+) -> Option<(PathBuf, std::fs::Metadata)> {
+    let parent = base_path.parent()?;
+    let base = base_path.file_name()?.to_str()?;
+    let mut entries = tokio::fs::read_dir(parent).await.ok()?;
+    while let Some(entry) = entries.next_entry().await.ok()? {
+        let candidate_name = entry.file_name();
+        let Some(candidate_name) = candidate_name.to_str() else {
+            continue;
+        };
+        if !download::paths::filename_matches_identity_collision(base, asset_id, candidate_name) {
+            continue;
+        }
+        let metadata = entry.metadata().await.ok()?;
+        if metadata.len() == expected_size {
+            return Some((entry.path(), metadata));
+        }
+    }
+    None
 }
 
 /// Run the import-existing matching loop over a stream of `PhotoAsset`s.
@@ -537,14 +639,16 @@ where
             continue;
         }
 
-        for ExpectedAssetPath {
-            path: primary_path,
-            size: expected_size,
-            checksum,
-            url,
-            version_size,
-        } in expected
-        {
+        for expected_path in &expected {
+            let ExpectedAssetPath {
+                path: primary_path,
+                size: expected_size,
+                checksum,
+                url,
+                version_size,
+            } = expected_path;
+            let expected_size = *expected_size;
+            let version_size = *version_size;
             // For `NameSizeDedupWithSuffix`, when two iCloud assets share
             // a filename, icloudpd renames the second's download to
             // `<stem>-<size><ext>` (it stat's the existing file at
@@ -554,21 +658,22 @@ where
             // unmatched on import even though it's what kei would also
             // have written under the same collision. Try the suffix
             // shape as a fallback.
-            let (expected_path, metadata) = match resolve_match_path(
-                &primary_path,
+            let candidate = ImportPathCandidate {
+                path: primary_path,
                 expected_size,
-                path_config.file_match_policy(),
-                dir_cache,
-            )
-            .await
-            {
-                Some(found) => found,
-                None => {
-                    stats.unmatched += 1;
-                    heartbeat_state.unmatched.fetch_add(1, Ordering::Relaxed);
-                    continue;
-                }
+                version_size,
             };
+            let (expected_path, metadata) =
+                match resolve_match_path(&candidate, &expected, asset.id(), path_config, dir_cache)
+                    .await
+                {
+                    Some(found) => found,
+                    None => {
+                        stats.unmatched += 1;
+                        heartbeat_state.unmatched.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                };
 
             if let Some(verifier) = options.strict_verifier {
                 match verifier
@@ -1910,6 +2015,62 @@ mod wiremock_tests {
         assert_eq!(stats.matched, 1);
         let rows = all_downloaded(db.as_ref()).await;
         assert!(rows[0].filename.ends_with(".MOV"));
+    }
+
+    #[tokio::test]
+    async fn import_matches_live_photo_motion_from_size_suffixed_primary_stem() {
+        let server = crate::start_wiremock_or_skip!();
+        let asset = WiremockAsset::new("LIVE6", "IMG_0600.HEIC", "public.heic")
+            .orig(3000, "ck_live6", "public.heic")
+            .live_mov(2000, "ck_live6_mov");
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        let primary = expected
+            .iter()
+            .find(|e| e.version_size == VersionSizeKey::Original)
+            .expect("primary path");
+        let mov = expected
+            .iter()
+            .find(|e| e.version_size == VersionSizeKey::LiveOriginal)
+            .expect("MOV path");
+        let primary_name = primary.path.file_name().and_then(|f| f.to_str()).unwrap();
+        let primary_collision =
+            primary
+                .path
+                .with_file_name(crate::download::paths::add_dedup_suffix(
+                    primary_name,
+                    primary.size,
+                ));
+        let mov_collision_base = crate::download::paths::live_photo_mov_path_suffix(
+            primary_collision
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap(),
+        );
+        let mov_collision = mov
+            .path
+            .with_file_name(crate::download::paths::insert_suffix(
+                &mov_collision_base,
+                "LIVE6-2",
+            ));
+        stage_file(&primary_collision, primary.size);
+        stage_file(&mov_collision, mov.size);
+
+        let db = open_db(&tmp).await;
+        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+
+        assert_eq!(stats.matched, 2);
+        let rows = all_downloaded(db.as_ref()).await;
+        assert!(rows
+            .iter()
+            .any(|r| r.filename.as_ref() == "IMG_0600-3000.HEIC"));
+        assert!(rows
+            .iter()
+            .any(|r| r.filename.as_ref() == "IMG_0600-3000_HEVC-LIVE6-2.MOV"));
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1389,6 +1389,10 @@ struct DownloadContext {
     /// the expected file is already on disk instead of promoting them back to
     /// failed after the producer skips the duplicate path.
     pending_ids: LibraryAssetVersionSet,
+    /// Nested map: `library` -> `asset_id` -> (`version_size` -> filename)
+    /// for pending rows. Pending on-disk adoption uses this to avoid adopting
+    /// a same-name/same-size collision that belongs to a different asset.
+    pending_filenames: LibraryAssetVersionValueMap,
     /// All asset IDs known to the state DB (any status). Used in retry-only mode
     /// to skip new assets that were never synced. Library-blind: a known ID
     /// is "known" regardless of which zone it belongs to.
@@ -1548,15 +1552,23 @@ impl DownloadContext {
         }
 
         let mut pending_ids: LibraryAssetVersionSet = FxHashMap::default();
+        let mut pending_filenames: LibraryAssetVersionValueMap = FxHashMap::default();
         for record in pending {
             let lib = intern_id(&mut interner, record.library.to_string());
             let id = intern_id(&mut interner, record.id.to_string());
+            let version_size: Box<str> = record.version_size.as_str().into();
             pending_ids
+                .entry(Arc::clone(&lib))
+                .or_default()
+                .entry(Arc::clone(&id))
+                .or_default()
+                .insert(version_size.clone());
+            pending_filenames
                 .entry(lib)
                 .or_default()
                 .entry(id)
                 .or_default()
-                .insert(record.version_size.as_str().into());
+                .insert(version_size, record.filename.to_string().into_boxed_str());
         }
 
         let known_ids: FxHashSet<Arc<str>> = known_ids
@@ -1578,6 +1590,7 @@ impl DownloadContext {
             downloaded_metadata_hashes,
             metadata_retry_markers,
             pending_ids,
+            pending_filenames,
             known_ids,
             attempt_counts,
             downloaded_without_metadata_hash,

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -317,6 +317,39 @@ pub(crate) fn insert_suffix(path: &str, suffix: &str) -> String {
     }
 }
 
+/// Return true when `candidate` is `base` with this asset id appended before
+/// the extension, optionally followed by kei's stable collision ordinal.
+///
+/// For example, `IMG_0001-A.MOV` and `IMG_0001-A-2.MOV` are both identity
+/// collision names in the family rooted at `IMG_0001.MOV` for asset `A`.
+pub(crate) fn filename_matches_identity_collision(
+    base: &str,
+    asset_id: &str,
+    candidate: &str,
+) -> bool {
+    if candidate == insert_suffix(base, asset_id) {
+        return true;
+    }
+
+    let Some((base_stem, base_ext)) = base.rsplit_once('.') else {
+        let prefix = format!("{base}-{asset_id}-");
+        return candidate
+            .strip_prefix(&prefix)
+            .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok());
+    };
+    let Some((candidate_stem, candidate_ext)) = candidate.rsplit_once('.') else {
+        return false;
+    };
+    if candidate_ext != base_ext {
+        return false;
+    }
+
+    let prefix = format!("{base_stem}-{asset_id}-");
+    candidate_stem
+        .strip_prefix(&prefix)
+        .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok())
+}
+
 /// Add a literal suffix before the file extension.
 ///
 /// Unlike [`insert_suffix`], this does not add a hyphen. Use it for suffixes
@@ -877,6 +910,35 @@ mod tests {
         );
         assert_eq!(insert_suffix("photo", "123"), "photo-123");
         assert_eq!(insert_suffix("a.b.mov", "id"), "a.b-id.mov");
+    }
+
+    #[test]
+    fn test_filename_matches_identity_collision() {
+        assert!(filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "ASSET",
+            "IMG_0001-ASSET.MOV"
+        ));
+        assert!(filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "ASSET",
+            "IMG_0001-ASSET-2.MOV"
+        ));
+        assert!(filename_matches_identity_collision(
+            "photo",
+            "ASSET",
+            "photo-ASSET-3"
+        ));
+        assert!(!filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "ASSET",
+            "IMG_0001-OTHER-2.MOV"
+        ));
+        assert!(!filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "ASSET",
+            "IMG_0001-ASSET-x.MOV"
+        ));
     }
 
     #[test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -283,6 +283,24 @@ fn pending_versions_for_asset<'a>(
         .and_then(|assets| assets.get(asset.id()))
 }
 
+fn pending_filename_for_asset_version<'a>(
+    ctx: &'a DownloadContext,
+    library: &str,
+    asset: &PhotoAsset,
+    version_size: VersionSizeKey,
+) -> Option<&'a str> {
+    ctx.pending_filenames
+        .get(library)
+        .and_then(|assets| assets.get(asset.id()))
+        .and_then(|versions| versions.get(version_size.as_str()))
+        .map(Box::as_ref)
+}
+
+fn pending_filename_matches_derived(pending_filename: &str, derived_filename: &str) -> bool {
+    filenames_match_ampm_equivalent(pending_filename, derived_filename)
+        || pending_filename.eq_ignore_ascii_case(derived_filename)
+}
+
 async fn adopt_pending_on_disk_skip(
     state_db: Option<&dyn DownloadStore>,
     config: &DownloadConfig,
@@ -343,8 +361,19 @@ async fn adopt_pending_on_disk_task(
         return None;
     }
 
+    if let Some(adoption) = adopt_pending_task_path(db, config, asset, task_planner, task).await {
+        return Some(adoption);
+    }
+
     for derived in derive_expected_paths(asset, config) {
         if derived.version_size != task.version_size {
+            continue;
+        }
+        let pending_filename =
+            pending_filename_for_asset_version(ctx, library, asset, task.version_size);
+        if !pending_filename.is_some_and(|filename| {
+            pending_filename_matches_derived(filename, derived.filename.as_str())
+        }) {
             continue;
         }
         if let Some(adoption) =
@@ -355,6 +384,40 @@ async fn adopt_pending_on_disk_task(
     }
 
     None
+}
+
+async fn adopt_pending_task_path(
+    db: &dyn DownloadStore,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    task_planner: &mut TaskPlanner,
+    task: &DownloadTask,
+) -> Option<PendingOnDiskAdoption> {
+    let version_size = task.version_size.as_str();
+    let (existing_path, existing_size) =
+        task_planner.existing_path_with_size(&task.download_path)?;
+    if existing_size != task.size {
+        return None;
+    }
+
+    if let Err(e) = planner::upsert_seen_for_task(db, config, asset, task).await {
+        tracing::warn!(
+            asset_id = %asset.id(),
+            version_size,
+            error = %e,
+            "Failed to refresh pending asset before adopting planned on-disk file"
+        );
+        return Some(PendingOnDiskAdoption::StateWriteFailed(existing_path));
+    }
+
+    mark_pending_downloaded_from_existing_path(
+        db,
+        task.library.as_ref(),
+        asset,
+        version_size,
+        existing_path,
+    )
+    .await
 }
 
 async fn adopt_pending_derived_path(
@@ -381,6 +444,17 @@ async fn adopt_pending_derived_path(
         return Some(PendingOnDiskAdoption::StateWriteFailed(existing_path));
     }
 
+    mark_pending_downloaded_from_existing_path(db, library, asset, version_size, existing_path)
+        .await
+}
+
+async fn mark_pending_downloaded_from_existing_path(
+    db: &dyn DownloadStore,
+    library: &str,
+    asset: &PhotoAsset,
+    version_size: &str,
+    existing_path: PathBuf,
+) -> Option<PendingOnDiskAdoption> {
     let local_checksum = match super::file::compute_sha256(&existing_path).await {
         Ok(checksum) => checksum,
         Err(e) => {
@@ -447,63 +521,83 @@ fn state_path_size_allows_skip(
 fn stored_path_matches_current_collision_family(
     asset_id: &str,
     derived: &DerivedPath,
+    derived_paths: &[DerivedPath],
+    config: &DownloadConfig,
     stored_path: &Path,
 ) -> bool {
     if stored_path.parent() != derived.path.parent() {
         return false;
     }
 
-    let current_filename = derived.filename.as_str();
     let Some(stored_filename) = stored_path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
 
-    if filenames_match_ampm_equivalent(stored_filename, current_filename)
-        || filenames_match_ampm_equivalent(
-            stored_filename,
-            &super::paths::add_dedup_suffix(current_filename, derived.size),
-        )
-        || filenames_match_ampm_equivalent(
-            stored_filename,
-            &super::paths::insert_suffix(current_filename, asset_id),
-        )
-    {
-        return true;
+    collision_family_base_filenames(asset_id, derived, derived_paths, config)
+        .iter()
+        .any(|base| stored_filename_matches_base_family(stored_filename, base, asset_id))
+}
+
+fn collision_family_base_filenames(
+    asset_id: &str,
+    derived: &DerivedPath,
+    derived_paths: &[DerivedPath],
+    config: &DownloadConfig,
+) -> Vec<String> {
+    let mut bases = vec![
+        derived.filename.clone(),
+        super::paths::add_dedup_suffix(&derived.filename, derived.size),
+        super::paths::insert_suffix(&derived.filename, asset_id),
+    ];
+
+    if derived.version_size.is_live_photo_motion() {
+        if let Some(primary) = primary_derived_path(derived_paths) {
+            let primary_collision_filenames = [
+                super::paths::add_dedup_suffix(&primary.filename, primary.size),
+                super::paths::insert_suffix(&primary.filename, asset_id),
+            ];
+            for primary_filename in primary_collision_filenames {
+                bases.push(live_photo_motion_filename_for_primary(
+                    &primary_filename,
+                    config,
+                ));
+            }
+        }
     }
 
-    let Some((current_stem, current_ext)) = current_filename.rsplit_once('.') else {
-        let prefix = format!("{current_filename}-{asset_id}-");
-        if stored_filename
-            .strip_prefix(&prefix)
-            .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok())
-        {
-            return true;
+    bases.sort();
+    bases.dedup();
+    bases
+}
+
+fn primary_derived_path(derived_paths: &[DerivedPath]) -> Option<&DerivedPath> {
+    derived_paths
+        .iter()
+        .find(|derived| derived.version_size.is_primary_media())
+}
+
+fn live_photo_motion_filename_for_primary(
+    primary_filename: &str,
+    config: &DownloadConfig,
+) -> String {
+    match config.live_photo_mov_filename_policy {
+        crate::types::LivePhotoMovFilenamePolicy::Suffix => {
+            super::paths::live_photo_mov_path_suffix(primary_filename)
         }
-        let normalized_prefix = format!(
-            "{}-{asset_id}-",
-            super::paths::normalize_ampm(current_filename)
-        );
-        return super::paths::normalize_ampm(stored_filename)
-            .strip_prefix(&normalized_prefix)
-            .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok());
-    };
-    let Some((stored_stem, stored_ext)) = stored_filename.rsplit_once('.') else {
-        return false;
-    };
-    if stored_ext != current_ext {
-        return false;
+        crate::types::LivePhotoMovFilenamePolicy::Original => {
+            super::paths::live_photo_mov_path_original(primary_filename)
+        }
     }
-    let prefix = format!("{current_stem}-{asset_id}-");
-    if stored_stem
-        .strip_prefix(&prefix)
-        .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok())
-    {
-        return true;
-    }
-    let normalized_prefix = format!("{}-{asset_id}-", super::paths::normalize_ampm(current_stem));
-    super::paths::normalize_ampm(stored_stem)
-        .strip_prefix(&normalized_prefix)
-        .is_some_and(|ordinal| ordinal.parse::<u64>().is_ok())
+}
+
+fn stored_filename_matches_base_family(stored_filename: &str, base: &str, asset_id: &str) -> bool {
+    filenames_match_ampm_equivalent(stored_filename, base)
+        || super::paths::filename_matches_identity_collision(base, asset_id, stored_filename)
+        || super::paths::filename_matches_identity_collision(
+            &super::paths::normalize_ampm(base),
+            asset_id,
+            &super::paths::normalize_ampm(stored_filename),
+        )
 }
 
 fn filenames_match_ampm_equivalent(a: &str, b: &str) -> bool {
@@ -548,7 +642,13 @@ fn state_confirmed_current_path_exists(
         if derived.version_size != task.version_size {
             continue;
         }
-        if !stored_path_matches_current_collision_family(asset.id(), derived, stored_path) {
+        if !stored_path_matches_current_collision_family(
+            asset.id(),
+            derived,
+            &derived_paths,
+            config,
+            stored_path,
+        ) {
             continue;
         }
         let (existing_path, existing_size) = task_planner.existing_path_with_size(stored_path)?;
@@ -3024,7 +3124,7 @@ mod tests {
     use crate::test_helpers::TestPhotoAsset;
     use std::collections::{HashMap, HashSet};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use tempfile::TempDir;
 
@@ -5156,6 +5256,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pending_same_size_collision_does_not_adopt_other_assets_bare_file() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use crate::test_helpers::TestAssetRecord;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let asset = TestPhotoAsset::new("SAME_SIZE_B")
+            .filename("IMG_0001.JPG")
+            .orig_size(5000)
+            .orig_url("https://p01.icloud-content.com/b.jpg")
+            .orig_checksum("ck_same_size_b")
+            .build();
+
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let bare_path = crate::download::filter::expected_paths_for(&asset, config.as_ref())
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
+        let identity_path = identity_suffixed_path_for(&bare_path, asset.id());
+        fs::create_dir_all(bare_path.parent().unwrap()).unwrap();
+        fs::write(&bare_path, vec![1u8; 5000]).unwrap();
+
+        let pending = TestAssetRecord::new(asset.id())
+            .checksum("ck_same_size_b")
+            .filename(
+                identity_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .expect("identity path must have UTF-8 filename"),
+            )
+            .size(5000)
+            .build();
+        db.upsert_seen(&pending).await.unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.skip_summary.on_disk, 0,
+            "pending collision row must not adopt another asset's bare file"
+        );
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.downloaded, 0);
+        assert_eq!(summary.failed, 1);
+    }
+
+    #[tokio::test]
     async fn producer_plans_distinct_same_path_same_size_assets() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
@@ -5514,6 +5679,63 @@ mod tests {
             .build()
     }
 
+    fn live_photo_collision_asset(id: &str) -> PhotoAsset {
+        TestPhotoAsset::new(id)
+            .filename("IMG_0001.HEIC")
+            .item_type("public.heic")
+            .orig_file_type("public.heic")
+            .orig_size(2000)
+            .orig_url("https://p01.icloud-content.com/IMG_0001.HEIC")
+            .orig_checksum("heic_ck")
+            .live_photo(
+                "https://p01.icloud-content.com/IMG_0001.MOV",
+                "mov_ck",
+                3000,
+            )
+            .build()
+    }
+
+    fn path_for_filename(config: &DownloadConfig, asset: &PhotoAsset, filename: &str) -> PathBuf {
+        crate::download::paths::local_download_path(
+            &config.directory,
+            &config.folder_structure,
+            &asset.created().with_timezone(&chrono::Local),
+            filename,
+            None,
+        )
+    }
+
+    async fn record_downloaded_test_version(
+        db: &crate::state::SqliteStateDb,
+        asset: &PhotoAsset,
+        version_size: VersionSizeKey,
+        checksum: &str,
+        size: u64,
+        path: &Path,
+    ) {
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("test path must have a UTF-8 filename");
+        let record = crate::test_helpers::TestAssetRecord::new(asset.id())
+            .checksum(checksum)
+            .filename(filename)
+            .size(size)
+            .version_size(version_size)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            asset.id(),
+            version_size.as_str(),
+            path,
+            "local_checksum",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
     /// Regression for #594: a downloaded asset stored at an identity-suffixed
     /// collision path must be matched by its recorded state path, not only by
     /// the bare derived path.
@@ -5584,6 +5806,204 @@ mod tests {
         );
         let failed = db.get_failed().await.unwrap();
         assert!(failed.is_empty(), "suffixed file should remain downloaded");
+    }
+
+    #[tokio::test]
+    async fn live_photo_motion_with_size_suffixed_primary_stem_is_on_disk_skipped() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = live_photo_collision_asset("LIVE_SIZE_COLLISION");
+        let bare_primary = path_for_filename(&config, &asset, "IMG_0001.HEIC");
+        let stored_primary = path_for_filename(&config, &asset, "IMG_0001-2000.HEIC");
+        let stored_motion = path_for_filename(&config, &asset, "IMG_0001-2000_HEVC.MOV");
+        fs::create_dir_all(bare_primary.parent().unwrap()).unwrap();
+        fs::write(&bare_primary, vec![9u8; 1111]).unwrap();
+        fs::write(&stored_primary, vec![1u8; 2000]).unwrap();
+        fs::write(&stored_motion, vec![2u8; 3000]).unwrap();
+
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::Original,
+            "heic_ck",
+            2000,
+            &stored_primary,
+        )
+        .await;
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::LiveOriginal,
+            "mov_ck",
+            3000,
+            &stored_motion,
+        )
+        .await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset.clone())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(result.downloaded, 0, "Live Photo must not be re-downloaded");
+        assert_eq!(
+            result.skip_summary.on_disk, 1,
+            "asset should count as an on-disk skip when both paths are already present"
+        );
+        assert!(result.failed.is_empty());
+        assert!(
+            !path_for_filename(
+                &config,
+                &asset,
+                "IMG_0001-LIVE_SIZE_COLLISION_HEVC-LIVE_SIZE_COLLISION-2.MOV"
+            )
+            .exists(),
+            "sync must not create a compounding motion duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_photo_motion_with_identity_suffixed_primary_stem_is_on_disk_skipped() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = live_photo_collision_asset("LIVE_ID_COLLISION");
+        let bare_primary = path_for_filename(&config, &asset, "IMG_0001.HEIC");
+        let stored_primary = path_for_filename(&config, &asset, "IMG_0001-LIVE_ID_COLLISION.HEIC");
+        let stored_motion = path_for_filename(
+            &config,
+            &asset,
+            "IMG_0001-LIVE_ID_COLLISION_HEVC-LIVE_ID_COLLISION-2.MOV",
+        );
+        fs::create_dir_all(bare_primary.parent().unwrap()).unwrap();
+        fs::write(&bare_primary, vec![9u8; 2000]).unwrap();
+        fs::write(&stored_primary, vec![1u8; 2000]).unwrap();
+        fs::write(&stored_motion, vec![2u8; 3000]).unwrap();
+
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::Original,
+            "heic_ck",
+            2000,
+            &stored_primary,
+        )
+        .await;
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::LiveOriginal,
+            "mov_ck",
+            3000,
+            &stored_motion,
+        )
+        .await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(result.downloaded, 0, "Live Photo must not be re-downloaded");
+        assert_eq!(result.skip_summary.on_disk, 1);
+        assert!(result.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn live_photo_motion_original_policy_with_primary_collision_is_on_disk_skipped() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use crate::types::LivePhotoMovFilenamePolicy;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.live_photo_mov_filename_policy = LivePhotoMovFilenamePolicy::Original;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = live_photo_collision_asset("LIVE_ORIGINAL_POLICY");
+        let bare_primary = path_for_filename(&config, &asset, "IMG_0001.HEIC");
+        let stored_primary = path_for_filename(&config, &asset, "IMG_0001-2000.HEIC");
+        let stored_motion = path_for_filename(&config, &asset, "IMG_0001-2000.MOV");
+        fs::create_dir_all(bare_primary.parent().unwrap()).unwrap();
+        fs::write(&bare_primary, vec![9u8; 1111]).unwrap();
+        fs::write(&stored_primary, vec![1u8; 2000]).unwrap();
+        fs::write(&stored_motion, vec![2u8; 3000]).unwrap();
+
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::Original,
+            "heic_ck",
+            2000,
+            &stored_primary,
+        )
+        .await;
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::LiveOriginal,
+            "mov_ck",
+            3000,
+            &stored_motion,
+        )
+        .await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(result.downloaded, 0, "Live Photo must not be re-downloaded");
+        assert_eq!(result.skip_summary.on_disk, 1);
+        assert!(result.failed.is_empty());
     }
 
     /// Same state-path family as #594, with the AM/PM whitespace variant that

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -41,6 +41,19 @@ impl VersionSizeKey {
         }
     }
 
+    /// Return true for the still/video version that owns the local filename stem.
+    pub(crate) const fn is_primary_media(self) -> bool {
+        matches!(self, Self::Original | Self::Medium | Self::Thumb)
+    }
+
+    /// Return true for Live Photo motion versions derived from the primary stem.
+    pub(crate) const fn is_live_photo_motion(self) -> bool {
+        matches!(
+            self,
+            Self::LiveOriginal | Self::LiveMedium | Self::LiveThumb
+        )
+    }
+
     /// Parse from the string stored in the database.
     pub fn from_str(s: &str) -> Option<Self> {
         match s {

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -891,8 +891,8 @@ fn digits_before(hay: &str, marker: &str) -> Option<u64> {
     hay[start..idx].parse().ok()
 }
 
-/// Import-then-sync default flags. The strongest invariant: zero
-/// downloads after import.
+/// Import then sync the fixture's single library-wide pass. The strongest
+/// invariant: zero downloads after import.
 #[test]
 #[ignore]
 fn roundtrip_default_layout_sync_skips_after_import() {
@@ -902,7 +902,7 @@ fn roundtrip_default_layout_sync_skips_after_import() {
     common::with_auth_retry(|| {
         let test_data = tempdir().unwrap();
         let recent = ROUNDTRIP_RECENT.to_string();
-        let toml_path = write_kei_toml(test_data.path(), download_dir, "");
+        let toml_path = write_kei_toml(test_data.path(), download_dir, FIXTURE_FILTERS_TOML);
 
         let import = import_cmd(
             &username,
@@ -928,8 +928,13 @@ fn roundtrip_default_layout_sync_skips_after_import() {
         // (every asset rejected before the download phase) and >0 when
         // sync emits a per-asset skip tally; both are valid no-download
         // outcomes for the round-trip.
-        let (downloaded, _skipped) =
-            run_sync_against_fixture(&username, &password, download_dir, test_data.path(), "");
+        let (downloaded, _skipped) = run_sync_against_fixture(
+            &username,
+            &password,
+            download_dir,
+            test_data.path(),
+            FIXTURE_FILTERS_TOML,
+        );
         assert_eq!(
             downloaded, 0,
             "sync re-downloaded {downloaded} files after import-existing populated state DB; \
@@ -1010,7 +1015,8 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
         // import-existing doesn't expose media selection as a flag. Use TOML
         // to force it.
         let test_data = tempdir().unwrap();
-        let media_filter_toml = "[filters]\nmedia = [\"photos\", \"live-photos\"]\n";
+        let media_filter_toml =
+            "[filters]\nalbums = [\"none\"]\nunfiled = true\nmedia = [\"photos\", \"live-photos\"]\n";
         let toml_path = write_kei_toml(test_data.path(), download_dir, media_filter_toml);
 
         let recent = ROUNDTRIP_RECENT.to_string();


### PR DESCRIPTION
## Summary
- Fixes collision-family path matching for Live Photo MOV companions, including MOV names derived from size-suffixed and identity-suffixed still filenames.
- Prevents pending downloads from adopting another asset's bare same-name, same-size file when the pending row expects a collision filename.
- Extends `import-existing` so it can adopt kei-generated collision-family Live Photo MOV paths.
- Aligns the live import roundtrip tests with the single-pass fixture selection used to build the reusable fixture.

Fixes #638

## Tests
- `cargo check`
- `cargo test live_photo_motion -- --test-threads=1`
- `cargo test pending_same_size_collision_does_not_adopt_other_assets_bare_file -- --test-threads=1`
- `cargo test producer_adopts_pending_on_disk_skip_as_downloaded -- --test-threads=1`
- `cargo test import_matches_live_photo_motion_from_size_suffixed_primary_stem -- --test-threads=1`
- `cargo test test_filename_matches_identity_collision -- --test-threads=1`
- `cargo test --all-features --test import_existing_live roundtrip_default_layout_sync_skips_after_import -- --ignored --test-threads=1 --nocapture`
- `cargo test --all-features --test import_existing_live roundtrip_skip_videos_sync_skips_imported_photos -- --ignored --test-threads=1 --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `just gate`
- `just full-test`
