### PR TITLE
Fix sanitized Live Photo collision suffixes

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -408,14 +408,16 @@ fn import_match_candidates(
         fname,
         candidate.expected_size,
     )));
-    candidates.push(parent.join(download::paths::insert_suffix(fname, asset_id)));
+    candidates.push(parent.join(download::paths::insert_asset_identity_suffix(
+        fname, asset_id,
+    )));
 
     if candidate.version_size.is_live_photo_motion() {
         if let Some(primary) = primary_expected_path(all_expected) {
             if let Some(primary_fname) = primary.path.file_name().and_then(|f| f.to_str()) {
                 let primary_collision_filenames = [
                     download::paths::add_dedup_suffix(primary_fname, primary.size),
-                    download::paths::insert_suffix(primary_fname, asset_id),
+                    download::paths::insert_asset_identity_suffix(primary_fname, asset_id),
                 ];
                 for primary_filename in primary_collision_filenames {
                     let mov_filename = match path_config.live_photo_mov_filename_policy() {
@@ -427,8 +429,10 @@ fn import_match_candidates(
                         }
                     };
                     candidates.push(parent.join(&mov_filename));
-                    candidates
-                        .push(parent.join(download::paths::insert_suffix(&mov_filename, asset_id)));
+                    candidates.push(parent.join(download::paths::insert_asset_identity_suffix(
+                        &mov_filename,
+                        asset_id,
+                    )));
                 }
             }
         }
@@ -2071,6 +2075,63 @@ mod wiremock_tests {
         assert!(rows
             .iter()
             .any(|r| r.filename.as_ref() == "IMG_0600-3000_HEVC-LIVE6-2.MOV"));
+    }
+
+    #[tokio::test]
+    async fn import_matches_live_photo_motion_from_sanitized_identity_suffixed_primary_stem() {
+        let server = crate::start_wiremock_or_skip!();
+        let asset = WiremockAsset::new("LIVE/SLASH6", "IMG_0610.HEIC", "public.heic")
+            .orig(3000, "ck_live_slash6", "public.heic")
+            .live_mov(2000, "ck_live_slash6_mov");
+        let tmp = TempDir::new().unwrap();
+        let dl = tmp.path().join("photos");
+        std::fs::create_dir_all(&dl).unwrap();
+        let config = base_config(&dl);
+
+        let expected = expected_paths_for(&asset.to_photo_asset(), &config);
+        let primary = expected
+            .iter()
+            .find(|e| e.version_size == VersionSizeKey::Original)
+            .expect("primary path");
+        let mov = expected
+            .iter()
+            .find(|e| e.version_size == VersionSizeKey::LiveOriginal)
+            .expect("MOV path");
+        let primary_name = primary.path.file_name().and_then(|f| f.to_str()).unwrap();
+        let primary_collision =
+            primary
+                .path
+                .with_file_name(crate::download::paths::insert_asset_identity_suffix(
+                    primary_name,
+                    "LIVE/SLASH6",
+                ));
+        let mov_collision_base = crate::download::paths::live_photo_mov_path_suffix(
+            primary_collision
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap(),
+        );
+        let mov_collision = mov.path.with_file_name(
+            crate::download::paths::insert_asset_identity_ordinal_suffix(
+                &mov_collision_base,
+                "LIVE/SLASH6",
+                22,
+            ),
+        );
+        stage_file(&primary_collision, primary.size);
+        stage_file(&mov_collision, mov.size);
+
+        let db = open_db(&tmp).await;
+        let stats = run_import(&server, &[asset], db.as_ref(), &config, false).await;
+
+        assert_eq!(stats.matched, 2);
+        let rows = all_downloaded(db.as_ref()).await;
+        assert!(rows
+            .iter()
+            .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6.HEIC"));
+        assert!(rows
+            .iter()
+            .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6_HEVC-LIVE_SLASH6-22.MOV"));
     }
 
     #[tokio::test]

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -1456,9 +1456,11 @@ fn size_or_identity_collision_filename(
 ) -> String {
     match kind {
         CollisionFilenameKind::Default => paths::add_dedup_suffix(filename, size),
-        CollisionFilenameKind::AssetIdentity => paths::insert_suffix(filename, asset_id),
+        CollisionFilenameKind::AssetIdentity => {
+            paths::insert_asset_identity_suffix(filename, asset_id)
+        }
         CollisionFilenameKind::AssetIdentityOrdinal(n) => {
-            paths::insert_suffix(filename, &format!("{asset_id}-{n}"))
+            paths::insert_asset_identity_ordinal_suffix(filename, asset_id, n)
         }
     }
 }
@@ -1470,10 +1472,10 @@ fn identity_collision_filename(
 ) -> String {
     match kind {
         CollisionFilenameKind::Default | CollisionFilenameKind::AssetIdentity => {
-            paths::insert_suffix(filename, asset_id)
+            paths::insert_asset_identity_suffix(filename, asset_id)
         }
         CollisionFilenameKind::AssetIdentityOrdinal(n) => {
-            paths::insert_suffix(filename, &format!("{asset_id}-{n}"))
+            paths::insert_asset_identity_ordinal_suffix(filename, asset_id, n)
         }
     }
 }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -317,6 +317,28 @@ pub(crate) fn insert_suffix(path: &str, suffix: &str) -> String {
     }
 }
 
+/// Filesystem-safe asset id suffix for kei-generated identity collision names.
+///
+/// CloudKit record names can contain characters such as `/` that are invalid
+/// inside one filename component. Download path construction sanitizes the
+/// final filename, so every path that reconstructs or recognizes the generated
+/// suffix must sanitize the asset id the same way.
+pub(crate) fn asset_identity_suffix(asset_id: &str) -> String {
+    clean_filename(asset_id).into_owned()
+}
+
+/// Insert a filesystem-safe asset id before the file extension.
+pub(crate) fn insert_asset_identity_suffix(path: &str, asset_id: &str) -> String {
+    insert_suffix(path, &asset_identity_suffix(asset_id))
+}
+
+/// Insert a filesystem-safe asset id plus a stable collision ordinal before
+/// the file extension.
+pub(crate) fn insert_asset_identity_ordinal_suffix(path: &str, asset_id: &str, n: u64) -> String {
+    let suffix = format!("{}-{n}", asset_identity_suffix(asset_id));
+    insert_suffix(path, &suffix)
+}
+
 /// Return true when `candidate` is `base` with this asset id appended before
 /// the extension, optionally followed by kei's stable collision ordinal.
 ///
@@ -327,7 +349,11 @@ pub(crate) fn filename_matches_identity_collision(
     asset_id: &str,
     candidate: &str,
 ) -> bool {
-    if candidate == insert_suffix(base, asset_id) {
+    let base = clean_filename(base);
+    let asset_id = asset_identity_suffix(asset_id);
+    let base = base.as_ref();
+
+    if candidate == insert_suffix(base, &asset_id) {
         return true;
     }
 
@@ -913,6 +939,18 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_asset_identity_suffix_sanitizes_asset_id() {
+        assert_eq!(
+            insert_asset_identity_suffix("IMG_0001.MOV", "AcGO2/cr6V"),
+            "IMG_0001-AcGO2_cr6V.MOV"
+        );
+        assert_eq!(
+            insert_asset_identity_ordinal_suffix("IMG_0001.MOV", "AcGO2/cr6V", 22),
+            "IMG_0001-AcGO2_cr6V-22.MOV"
+        );
+    }
+
+    #[test]
     fn test_filename_matches_identity_collision() {
         assert!(filename_matches_identity_collision(
             "IMG_0001.MOV",
@@ -938,6 +976,20 @@ mod tests {
             "IMG_0001.MOV",
             "ASSET",
             "IMG_0001-ASSET-x.MOV"
+        ));
+    }
+
+    #[test]
+    fn test_filename_matches_identity_collision_sanitizes_asset_id() {
+        assert!(filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "AcGO2/cr6V",
+            "IMG_0001-AcGO2_cr6V.MOV"
+        ));
+        assert!(filename_matches_identity_collision(
+            "IMG_0001.MOV",
+            "AcGO2/cr6V",
+            "IMG_0001-AcGO2_cr6V-22.MOV"
         ));
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -547,14 +547,14 @@ fn collision_family_base_filenames(
     let mut bases = vec![
         derived.filename.clone(),
         super::paths::add_dedup_suffix(&derived.filename, derived.size),
-        super::paths::insert_suffix(&derived.filename, asset_id),
+        super::paths::insert_asset_identity_suffix(&derived.filename, asset_id),
     ];
 
     if derived.version_size.is_live_photo_motion() {
         if let Some(primary) = primary_derived_path(derived_paths) {
             let primary_collision_filenames = [
                 super::paths::add_dedup_suffix(&primary.filename, primary.size),
-                super::paths::insert_suffix(&primary.filename, asset_id),
+                super::paths::insert_asset_identity_suffix(&primary.filename, asset_id),
             ];
             for primary_filename in primary_collision_filenames {
                 bases.push(live_photo_motion_filename_for_primary(
@@ -591,6 +591,8 @@ fn live_photo_motion_filename_for_primary(
 }
 
 fn stored_filename_matches_base_family(stored_filename: &str, base: &str, asset_id: &str) -> bool {
+    let base = super::paths::clean_filename(base);
+    let base = base.as_ref();
     filenames_match_ampm_equivalent(stored_filename, base)
         || super::paths::filename_matches_identity_collision(base, asset_id, stored_filename)
         || super::paths::filename_matches_identity_collision(
@@ -5654,7 +5656,9 @@ mod tests {
             .file_name()
             .and_then(|name| name.to_str())
             .expect("test path must have a UTF-8 filename");
-        bare_path.with_file_name(crate::download::paths::insert_suffix(filename, asset_id))
+        bare_path.with_file_name(crate::download::paths::insert_asset_identity_suffix(
+            filename, asset_id,
+        ))
     }
 
     fn suffixed_collision_asset(id: &str, checksum: &str) -> PhotoAsset {
@@ -5942,6 +5946,82 @@ mod tests {
         assert_eq!(result.downloaded, 0, "Live Photo must not be re-downloaded");
         assert_eq!(result.skip_summary.on_disk, 1);
         assert!(result.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn live_photo_motion_with_sanitized_identity_suffix_is_on_disk_skipped() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = live_photo_collision_asset("LIVE/ID_COLLISION");
+        let bare_primary = path_for_filename(&config, &asset, "IMG_0001.HEIC");
+        let stored_primary = path_for_filename(&config, &asset, "IMG_0001-LIVE_ID_COLLISION.HEIC");
+        let stored_motion = path_for_filename(
+            &config,
+            &asset,
+            "IMG_0001-LIVE_ID_COLLISION_HEVC-LIVE_ID_COLLISION-22.MOV",
+        );
+        fs::create_dir_all(bare_primary.parent().unwrap()).unwrap();
+        fs::write(&bare_primary, vec![9u8; 2000]).unwrap();
+        fs::write(&stored_primary, vec![1u8; 2000]).unwrap();
+        fs::write(&stored_motion, vec![2u8; 3000]).unwrap();
+
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::Original,
+            "heic_ck",
+            2000,
+            &stored_primary,
+        )
+        .await;
+        record_downloaded_test_version(
+            db.as_ref(),
+            &asset,
+            VersionSizeKey::LiveOriginal,
+            "mov_ck",
+            3000,
+            &stored_motion,
+        )
+        .await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset.clone())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.downloaded, 0,
+            "Live Photo with sanitized asset-id suffix must not be re-downloaded"
+        );
+        assert_eq!(result.skip_summary.on_disk, 1);
+        assert!(result.failed.is_empty());
+        assert!(
+            !path_for_filename(
+                &config,
+                &asset,
+                "IMG_0001-LIVE_ID_COLLISION_HEVC-LIVE_ID_COLLISION-23.MOV"
+            )
+            .exists(),
+            "sync must not create the next sanitized ordinal duplicate"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes #638.
- Sanitizes asset IDs before using them in generated collision suffixes for sync, state-path recognition, and import-existing.
- Keeps Live Photo MOV collision-family paths with CloudKit IDs containing `/` from being re-downloaded with a new ordinal each sync.
- Adds regressions for path matching, sync skip, and import adoption.

## Tests
- `cargo check`
- `cargo test live_photo_motion_with_sanitized_identity_suffix_is_on_disk_skipped --lib`
- `cargo test import_matches_live_photo_motion_from_sanitized_identity_suffixed_primary_stem --lib`
- `cargo test sanitizes_asset_id --lib`
- `cargo test identity_suffixed --lib`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate` (rerun outside the sandbox after the sandbox run hit Wiremock localhost bind `PermissionDenied`)
