### PR TITLE
Fix sibling CPLAsset enumeration

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -606,7 +606,7 @@ where
         stats.total += 1;
         heartbeat_state.total.fetch_add(1, Ordering::Relaxed);
         if let Ok(mut last) = heartbeat_state.last_seen_id.lock() {
-            *last = Some(asset.id().to_string());
+            *last = Some(asset.state_id().to_string());
         }
 
         if asset.versions().is_empty() {
@@ -667,17 +667,22 @@ where
                 expected_size,
                 version_size,
             };
-            let (expected_path, metadata) =
-                match resolve_match_path(&candidate, &expected, asset.id(), path_config, dir_cache)
-                    .await
-                {
-                    Some(found) => found,
-                    None => {
-                        stats.unmatched += 1;
-                        heartbeat_state.unmatched.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
-                };
+            let (expected_path, metadata) = match resolve_match_path(
+                &candidate,
+                &expected,
+                asset.state_id(),
+                path_config,
+                dir_cache,
+            )
+            .await
+            {
+                Some(found) => found,
+                None => {
+                    stats.unmatched += 1;
+                    heartbeat_state.unmatched.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+            };
 
             if let Some(verifier) = options.strict_verifier {
                 match verifier
@@ -718,7 +723,10 @@ where
                 // (e.g. /photos on HDD).
                 let mtime_epoch = file_mtime_epoch(&metadata);
                 let already_imported = imported_index
-                    .get(&(asset.id().to_string(), version_size.as_str().to_string()))
+                    .get(&(
+                        asset.state_id().to_string(),
+                        version_size.as_str().to_string(),
+                    ))
                     .filter(|rec| {
                         rec.local_path == expected_path
                             && rec.imported_size == Some(metadata.len())
@@ -774,7 +782,7 @@ where
                     .to_string();
                 let record = state::AssetRecord::new_pending(
                     Arc::from(library_label),
-                    asset.id().to_string(),
+                    asset.state_id().to_string(),
                     version_size,
                     checksum.to_string(),
                     filename,

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -934,7 +934,7 @@ async fn collect_album_asset_ids(
     tokio::pin!(stream);
     while let Some(result) = stream.next().await {
         let asset = result?;
-        into.insert(asset.id().to_string());
+        into.insert(asset.asset_record_name().to_string());
     }
     Ok(())
 }

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -509,13 +509,13 @@ fn build_payload(
     let albums = config
         .asset_groupings
         .albums
-        .get(asset.id())
+        .get(asset.state_id())
         .map(Vec::as_slice)
         .unwrap_or(&[]);
     let people = config
         .asset_groupings
         .people
-        .get(asset.id())
+        .get(asset.state_id())
         .map(Vec::as_slice)
         .unwrap_or(&[]);
     Arc::new(MetadataPayload::from_metadata(asset.metadata()).with_asset_groupings(albums, people))
@@ -679,8 +679,16 @@ pub(crate) fn is_asset_filtered(
         tracing::warn!("Skipping malformed asset with empty CloudKit recordName");
         return Some(FilterReason::MalformedAsset);
     }
-    if config.exclude_asset_ids().contains(asset.id()) {
-        tracing::debug!(asset_id = %asset.id(), "Skipping (excluded album asset)");
+    if config
+        .exclude_asset_ids()
+        .contains(asset.asset_record_name())
+        || config.exclude_asset_ids().contains(asset.id())
+    {
+        tracing::debug!(
+            asset_id = %asset.id(),
+            asset_record_name = %asset.asset_record_name(),
+            "Skipping (excluded album asset)"
+        );
         return Some(FilterReason::ExcludedAlbum);
     }
     if asset.is_live_photo() && !config.media().live_photos {
@@ -1100,14 +1108,14 @@ pub(super) fn derive_primary(
 ) -> Option<DerivedPath> {
     let (version, effective_size) = select_primary(asset, config, ctx)?;
 
-    let mapped = mapped_version_filename(asset.id(), &ctx.base_filename, &version.asset_type);
+    let mapped = mapped_version_filename(asset.state_id(), &ctx.base_filename, &version.asset_type);
     let sized = match effective_size {
         AssetVersionSize::Medium => paths::insert_suffix(&mapped, "medium"),
         AssetVersionSize::Thumb => paths::insert_suffix(&mapped, "thumb"),
         _ => mapped,
     };
     let filename = match config.file_match_policy() {
-        FileMatchPolicy::NameId7 => paths::apply_name_id7(&sized, asset.id()),
+        FileMatchPolicy::NameId7 => paths::apply_name_id7(&sized, asset.state_id()),
         FileMatchPolicy::NameSizeDedupWithSuffix => sized,
     };
     let path = paths::local_download_path(
@@ -1144,10 +1152,10 @@ fn derive_suffixed_extra(
     suffix: &str,
     check_ampm_on_disk: bool,
 ) -> DerivedPath {
-    let mapped = mapped_version_filename(asset.id(), &ctx.base_filename, &version.asset_type);
+    let mapped = mapped_version_filename(asset.state_id(), &ctx.base_filename, &version.asset_type);
     let suffixed = paths::insert_literal_suffix(&mapped, suffix);
     let filename = match config.file_match_policy() {
-        FileMatchPolicy::NameId7 => paths::apply_name_id7(&suffixed, asset.id()),
+        FileMatchPolicy::NameId7 => paths::apply_name_id7(&suffixed, asset.state_id()),
         FileMatchPolicy::NameSizeDedupWithSuffix => suffixed,
     };
     let path = paths::local_download_path(
@@ -1250,7 +1258,7 @@ pub(super) fn derive_mov_companion(
     let live_base = match config.file_match_policy() {
         FileMatchPolicy::NameId7 => {
             let base = usable_asset_base_filename(asset, ctx);
-            paths::apply_name_id7(&base, asset.id())
+            paths::apply_name_id7(&base, asset.state_id())
         }
         FileMatchPolicy::NameSizeDedupWithSuffix => primary_effective_filename.map_or_else(
             || usable_asset_base_filename(asset, ctx),
@@ -1727,11 +1735,11 @@ pub(super) fn filter_asset_to_tasks(
             resolve_download_path(
                 &path,
                 size,
-                asset.id(),
+                asset.state_id(),
                 strategy,
                 &mut rctx,
                 check_ampm_on_disk,
-                |kind| size_or_identity_collision_filename(&filename, size, asset.id(), kind),
+                |kind| size_or_identity_collision_filename(&filename, size, asset.state_id(), kind),
                 "asset",
             )
         };
@@ -1750,7 +1758,7 @@ pub(super) fn filter_asset_to_tasks(
                 url,
                 download_path: p,
                 checksum,
-                asset_id: asset.id_arc(),
+                asset_id: asset.state_id_arc(),
                 library: Arc::clone(&task_library),
                 metadata: Arc::clone(&payload),
                 size,
@@ -1795,13 +1803,13 @@ pub(super) fn filter_asset_to_tasks(
             resolve_download_path(
                 &path,
                 size,
-                asset.id(),
+                asset.state_id(),
                 CollisionStrategy::SizeDedup {
                     skip_zero_size: true,
                 },
                 &mut rctx,
                 check_ampm_on_disk,
-                |kind| size_or_identity_collision_filename(&filename, size, asset.id(), kind),
+                |kind| size_or_identity_collision_filename(&filename, size, asset.state_id(), kind),
                 "asset extra",
             )
             .download_path()
@@ -1814,7 +1822,7 @@ pub(super) fn filter_asset_to_tasks(
                 url,
                 download_path: p,
                 checksum,
-                asset_id: asset.id_arc(),
+                asset_id: asset.state_id_arc(),
                 library: Arc::clone(&task_library),
                 metadata: Arc::clone(&payload),
                 size,
@@ -1840,7 +1848,7 @@ pub(super) fn filter_asset_to_tasks(
         if seen_urls.iter().any(|seen| seen.as_ref() == url.as_ref()) {
             return tasks;
         }
-        let asset_id = asset.id();
+        let asset_id = asset.state_id();
         let final_mov_path = {
             let mut rctx = ResolveContext {
                 config,
@@ -1870,7 +1878,7 @@ pub(super) fn filter_asset_to_tasks(
                 url,
                 download_path: p,
                 checksum,
-                asset_id: asset.id_arc(),
+                asset_id: asset.state_id_arc(),
                 library: task_library,
                 metadata: Arc::clone(&payload),
                 size,

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -306,7 +306,7 @@ pub(super) async fn tag_if_needed<D>(
     let new_hash = asset.metadata().metadata_hash.as_deref();
     let library = asset.source_zone().unwrap_or(config.library.as_ref());
     for &(vs, _) in candidates {
-        if !ctx.needs_metadata_rewrite(library, asset.id(), vs, new_hash) {
+        if !ctx.needs_metadata_rewrite(library, asset.state_id(), vs, new_hash) {
             continue;
         }
         tracing::info!(
@@ -315,7 +315,7 @@ pub(super) async fn tag_if_needed<D>(
             "Metadata-only change detected; tagging for rewrite"
         );
         if let Err(e) = db
-            .record_metadata_write_failure(library, asset.id(), vs.as_str())
+            .record_metadata_write_failure(library, asset.state_id(), vs.as_str())
             .await
         {
             tracing::warn!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2027,7 +2027,7 @@ async fn collect_pass_asset_ids(pass: &crate::commands::AlbumPass) -> Result<FxH
     let mut ids = FxHashSet::default();
     while let Some(item) = stream.next().await {
         let asset = item?;
-        ids.insert(asset.id().to_string());
+        ids.insert(asset.asset_record_name().to_string());
     }
     Ok(ids)
 }
@@ -2435,7 +2435,7 @@ async fn build_recent_frontier(
             break;
         }
         oldest_created = Some(oldest_created.map_or(created, |oldest| oldest.min(created)));
-        asset_ids.insert(asset.id().to_string());
+        asset_ids.insert(asset.asset_record_name().to_string());
     }
     Ok(Some(RecentFrontier {
         asset_ids: Arc::new(asset_ids),
@@ -2476,7 +2476,7 @@ fn filter_stream_to_enumeration_bounds(
                     Ok(asset)
                         if asset_ids
                             .as_ref()
-                            .map(|ids| ids.contains(asset.id()))
+                            .map(|ids| ids.contains(asset.asset_record_name()))
                             .unwrap_or(true) =>
                     {
                         Some(Ok(asset))
@@ -3099,6 +3099,18 @@ fn record_incremental_state_transition_result(
 }
 
 fn source_state_transition_key(event: &ChangeEvent) -> SourceStateTransitionKey<'_> {
+    if let Some(asset) = event.asset.as_ref() {
+        return SourceStateTransitionKey {
+            record_name: Cow::Borrowed(asset.state_id()),
+            record_type: if asset.state_id() == asset.id() {
+                Some("CPLMaster")
+            } else {
+                Some("CPLAsset")
+            },
+            unresolved_identity: false,
+        };
+    }
+
     if matches!(event.record_type.as_deref(), Some("CPLAsset")) {
         if let Some(master_record_name) = event.master_record_name.as_deref() {
             return SourceStateTransitionKey {
@@ -4215,7 +4227,7 @@ async fn download_photos_full_with_token(
                         let stream = stream.map(move |item| {
                             if let Ok(asset) = &item {
                                 if let Ok(mut ids) = deferred_ids.lock() {
-                                    ids.insert(asset.id().to_string());
+                                    ids.insert(asset.asset_record_name().to_string());
                                 }
                             }
                             item
@@ -4329,9 +4341,9 @@ async fn download_photos_full_with_token(
                     let stream =
                         track_deferred_unfiled_heartbeat(stream, library, stream_total_count)
                             .filter(move |item| {
-                                let keep = item
-                                    .as_ref()
-                                    .map_or(true, |asset| !excluded_ids.contains(asset.id()));
+                                let keep = item.as_ref().map_or(true, |asset| {
+                                    !excluded_ids.contains(asset.asset_record_name())
+                                });
                                 std::future::ready(keep)
                             });
                     let pass_result = run_full_pass_stream(
@@ -4756,6 +4768,44 @@ impl IncrementalDeltaSummary {
                 self.hard_deleted_count += 1;
                 tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hard-deleted record");
                 if let Some(db) = &config.state_db {
+                    if event.record_type.is_none() && event.asset.is_none() {
+                        let unresolved_tombstone_key = SourceStateTransitionKey {
+                            record_name: Cow::Borrowed(&event.record_name),
+                            record_type: None,
+                            unresolved_identity: true,
+                        };
+                        match db
+                            .mark_master_family_soft_deleted_affected(
+                                &config.library,
+                                unresolved_tombstone_key.record_name(),
+                                None,
+                            )
+                            .await
+                        {
+                            Ok(updated) if updated > 0 => {
+                                record_incremental_state_transition_result(
+                                    Ok(updated),
+                                    IncrementalStateTransition::HardDelete,
+                                    unresolved_tombstone_key,
+                                    &mut self.state_transition_failures,
+                                    &mut self.token_unsafe_reason,
+                                );
+                                return;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                record_incremental_state_transition_result(
+                                    Err(e),
+                                    IncrementalStateTransition::HardDelete,
+                                    unresolved_tombstone_key,
+                                    &mut self.state_transition_failures,
+                                    &mut self.token_unsafe_reason,
+                                );
+                                return;
+                            }
+                        }
+                    }
+
                     let state_key =
                         match hard_delete_state_transition_key(event, config, db.as_ref()).await {
                             Ok(state_key) => state_key,
@@ -4771,9 +4821,23 @@ impl IncrementalDeltaSummary {
                                 return;
                             }
                         };
-                    let result = db
-                        .mark_soft_deleted_affected(&config.library, state_key.record_name(), None)
-                        .await;
+                    let result = if matches!(state_key.record_type, Some("CPLMaster"))
+                        && !matches!(event.record_type.as_deref(), Some("CPLAsset") | None)
+                    {
+                        db.mark_master_family_soft_deleted_affected(
+                            &config.library,
+                            state_key.record_name(),
+                            None,
+                        )
+                        .await
+                    } else {
+                        db.mark_soft_deleted_affected(
+                            &config.library,
+                            state_key.record_name(),
+                            None,
+                        )
+                        .await
+                    };
                     record_incremental_state_transition_result(
                         result,
                         IncrementalStateTransition::HardDelete,
@@ -6606,7 +6670,7 @@ mod tests {
             .file_name()
             .and_then(|name| name.to_str())
             .expect("expected path has filename");
-        let record = TestAssetRecord::new(asset.id())
+        let record = TestAssetRecord::new(asset.state_id())
             .library(library)
             .checksum(&expected_path.checksum)
             .filename(filename)
@@ -6617,7 +6681,7 @@ mod tests {
         db.upsert_seen(&record).await.expect("seed state row");
         db.mark_downloaded(
             library,
-            asset.id(),
+            asset.state_id(),
             expected_path.version_size.as_str(),
             &expected_path.path,
             "seeded-local-sha256",
@@ -6628,7 +6692,7 @@ mod tests {
         assert!(
             !db.should_download(
                 library,
-                asset.id(),
+                asset.state_id(),
                 expected_path.version_size.as_str(),
                 &expected_path.checksum,
                 &expected_path.path,
@@ -6689,43 +6753,51 @@ mod tests {
 
     fn mock_photo_records_with_filename(record_name: &str, filename: &str) -> Vec<Value> {
         vec![
-            json!({
-                "recordName": record_name,
-                "recordType": "CPLMaster",
-                "fields": {
-                    "filenameEnc": {"value": filename, "type": "STRING"},
-                    "resOriginalRes": {
-                        "value": {
-                            "downloadURL": "https://p01.icloud-content.com/photo.jpg",
-                            "size": 1024,
-                            "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-                        }
-                    },
-                    "resOriginalWidth": {"value": 100, "type": "INT64"},
-                    "resOriginalHeight": {"value": 100, "type": "INT64"},
-                    "resOriginalFileType": {"value": "public.jpeg"},
-                    "itemType": {"value": "public.jpeg"},
-                    "adjustmentRenderType": {"value": 0, "type": "INT64"}
-                },
-                "recordChangeTag": "ct1"
-            }),
-            json!({
-                "recordName": format!("asset-{record_name}"),
-                "recordType": "CPLAsset",
-                "fields": {
-                    "masterRef": {
-                        "value": {
-                            "recordName": record_name,
-                            "zoneID": {"zoneName": "PrimarySync"}
-                        },
-                        "type": "REFERENCE"
-                    },
-                    "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
-                    "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
-                },
-                "recordChangeTag": "ct2"
-            }),
+            mock_master_record_with_filename(record_name, filename),
+            mock_asset_record_for(&format!("asset-{record_name}"), record_name),
         ]
+    }
+
+    fn mock_master_record_with_filename(record_name: &str, filename: &str) -> Value {
+        json!({
+            "recordName": record_name,
+            "recordType": "CPLMaster",
+            "fields": {
+                "filenameEnc": {"value": filename, "type": "STRING"},
+                "resOriginalRes": {
+                    "value": {
+                        "downloadURL": "https://p01.icloud-content.com/photo.jpg",
+                        "size": 1024,
+                        "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    }
+                },
+                "resOriginalWidth": {"value": 100, "type": "INT64"},
+                "resOriginalHeight": {"value": 100, "type": "INT64"},
+                "resOriginalFileType": {"value": "public.jpeg"},
+                "itemType": {"value": "public.jpeg"},
+                "adjustmentRenderType": {"value": 0, "type": "INT64"}
+            },
+            "recordChangeTag": "ct1"
+        })
+    }
+
+    fn mock_asset_record_for(asset_record_name: &str, master_record_name: &str) -> Value {
+        json!({
+            "recordName": asset_record_name,
+            "recordType": "CPLAsset",
+            "fields": {
+                "masterRef": {
+                    "value": {
+                        "recordName": master_record_name,
+                        "zoneID": {"zoneName": "PrimarySync"}
+                    },
+                    "type": "REFERENCE"
+                },
+                "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+            },
+            "recordChangeTag": "ct2"
+        })
     }
 
     #[tokio::test]
@@ -7675,6 +7747,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_enumeration_sibling_cplassets_do_not_count_as_duplicate_asset_ids() {
+        let records = vec![
+            mock_asset_record_for("asset-sibling-b", "MASTER_SIBLING"),
+            mock_master_record_with_filename("MASTER_SIBLING", "sibling.jpg"),
+            mock_asset_record_for("asset-sibling-a", "MASTER_SIBLING"),
+        ];
+        let session = MockPhotosFlow::new()
+            .album_count(2)
+            .query_page(records.clone(), Some("zone-token"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: mock_album("Hidden", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.file_match_policy = FileMatchPolicy::NameId7;
+
+        let pass_config = config.with_pass(&passes[0]);
+        let first_asset = PhotoAsset::new(records[1].clone(), records[2].clone());
+        let second_asset = PhotoAsset::new(records[1].clone(), records[0].clone())
+            .with_state_record_name(Arc::from("asset-sibling-b"));
+        for asset in [&first_asset, &second_asset] {
+            let expected_path = filter::expected_paths_for(asset, &pass_config)
+                .into_iter()
+                .next()
+                .expect("mock sibling asset should have an expected path");
+            tokio::fs::create_dir_all(expected_path.path.parent().expect("path has parent"))
+                .await
+                .expect("create parent dir");
+            tokio::fs::write(&expected_path.path, vec![0u8; 1024])
+                .await
+                .expect("seed existing file");
+            seed_downloaded_state_for_expected_path(
+                &mut config,
+                &pass_config,
+                asset,
+                &expected_path,
+            )
+            .await;
+        }
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("sibling CPLAssets should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.assets_seen, 2);
+        assert_eq!(result.stats.skipped.duplicates, 0);
+        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
+        assert_eq!(result.stats.pagination_shortfall_assets, 0);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
+    }
+
+    #[tokio::test]
     async fn full_sync_blank_query_sync_token_blocks_advancement() {
         let records = mock_photo_records_with_filename("MASTER_BLANK_TOKEN", "blank-token.jpg");
         let session = MockPhotosFlow::new()
@@ -8274,6 +8412,34 @@ mod tests {
         assert!(!result.stats.sync_token_blocked);
         let pending = db.get_pending().await.unwrap();
         assert_source_flags(&pending, "TRACKED_MASTER", false, false);
+    }
+
+    #[tokio::test]
+    async fn incremental_unresolved_master_hard_delete_marks_sibling_asset_rows() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        db.upsert_seen(&TestAssetRecord::new("TRACKED_MASTER").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("asset-SIBLING").build())
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-SIBLING", "TRACKED_MASTER")
+            .await
+            .unwrap();
+
+        let result = run_incremental_change_records(
+            db.clone(),
+            vec![hard_deleted_change_record("TRACKED_MASTER")],
+        )
+        .await;
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+        let pending = db.get_pending().await.unwrap();
+        assert_source_flags(&pending, "TRACKED_MASTER", true, false);
+        assert_source_flags(&pending, "asset-SIBLING", true, false);
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -261,7 +261,7 @@ fn asset_record_for_derived_path(
 ) -> AssetRecord {
     AssetRecord::new_pending(
         library,
-        asset.id().to_string(),
+        asset.state_id().to_string(),
         derived.version_size,
         derived.checksum.to_string(),
         derived.filename.clone(),
@@ -280,7 +280,7 @@ fn pending_versions_for_asset<'a>(
 ) -> Option<&'a FxHashSet<Box<str>>> {
     ctx.pending_ids
         .get(library)
-        .and_then(|assets| assets.get(asset.id()))
+        .and_then(|assets| assets.get(asset.state_id()))
 }
 
 fn pending_filename_for_asset_version<'a>(
@@ -291,7 +291,7 @@ fn pending_filename_for_asset_version<'a>(
 ) -> Option<&'a str> {
     ctx.pending_filenames
         .get(library)
-        .and_then(|assets| assets.get(asset.id()))
+        .and_then(|assets| assets.get(asset.state_id()))
         .and_then(|versions| versions.get(version_size.as_str()))
         .map(Box::as_ref)
 }
@@ -471,7 +471,7 @@ async fn mark_pending_downloaded_from_existing_path(
     if let Err(e) = db
         .mark_downloaded(
             library,
-            asset.id(),
+            asset.state_id(),
             version_size,
             &existing_path,
             &local_checksum,
@@ -645,7 +645,7 @@ fn state_confirmed_current_path_exists(
             continue;
         }
         if !stored_path_matches_current_collision_family(
-            asset.id(),
+            asset.state_id(),
             derived,
             &derived_paths,
             config,
@@ -700,14 +700,14 @@ async fn backfill_downloaded_metadata_for_on_disk_skip(
     let downloaded_versions = ctx
         .downloaded_ids
         .get(library)
-        .and_then(|assets| assets.get(asset.id()));
+        .and_then(|assets| assets.get(asset.state_id()));
     let Some(downloaded_versions) = downloaded_versions else {
         return;
     };
     let version_hashes = ctx
         .downloaded_metadata_hashes
         .get(library)
-        .and_then(|assets| assets.get(asset.id()));
+        .and_then(|assets| assets.get(asset.state_id()));
 
     for derived in derive_expected_paths(asset, config) {
         let version_size = derived.version_size.as_str();
@@ -976,7 +976,7 @@ where
                                 matches!(
                                     download_ctx.should_download_fast(
                                         library,
-                                        asset.id(),
+                                        asset.state_id(),
                                         vs,
                                         cs,
                                         true
@@ -1197,7 +1197,7 @@ where
     let handle = tokio::spawn(async move {
         let config = &producer_config;
         let mut task_planner = TaskPlanner::new();
-        let mut seen_ids: FxHashSet<Arc<str>> = FxHashSet::default();
+        let mut seen_asset_record_names: FxHashSet<Arc<str>> = FxHashSet::default();
         // Skipped-asset IDs accumulated across the producer run and
         // flushed to the DB in a single transaction at the end. This
         // collapses N UPDATE statements (one per fast-skip / on-disk
@@ -1205,8 +1205,8 @@ where
         // serialize behind an fsync-per-asset under WAL mode.
         //
         // Vec is sufficient: every push is inside a branch predicated on
-        // `seen_ids.insert(asset.id_arc())` returning true, so IDs are
-        // already unique at this point.
+        // `seen_asset_record_names.insert(asset.asset_record_name_arc())`
+        // returning true, so IDs are already unique at this point.
         let mut touched_assets: Vec<(Arc<str>, Arc<str>)> = Vec::new();
         let mut skips = ProducerSkipSummary::default();
         let mut assets_forwarded = 0u64;
@@ -1297,10 +1297,11 @@ where
             }
             match result {
                 Ok(asset) => {
-                    if !seen_ids.insert(asset.id_arc()) {
+                    if !seen_asset_record_names.insert(asset.asset_record_name_arc()) {
                         tracing::debug!(
                             asset_id = %asset.id(),
-                            "Duplicate asset ID from API, skipping"
+                            asset_record_name = %asset.asset_record_name(),
+                            "Duplicate CPLAsset record from API, skipping"
                         );
                         skips.duplicates += 1;
                         continue;
@@ -1380,7 +1381,7 @@ where
                         .await;
                         if producer_state_db.is_some() {
                             let library = effective_asset_library_arc(&asset, config);
-                            touched_assets.push((library, asset.id_arc()));
+                            touched_assets.push((library, asset.state_id_arc()));
                         }
                         skips.on_disk += 1;
                         producer_pb.inc(1);

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -138,7 +138,7 @@ where
 }
 
 /// Persist the durable CloudKit identifier bridge used to resolve future
-/// `CPLAsset` hard-delete tombstones back to the `CPLMaster` keyed state row.
+/// `CPLAsset` hard-delete tombstones back to the matching state row family.
 pub(super) async fn upsert_asset_master_mapping<D>(
     db: &D,
     library: &str,
@@ -166,7 +166,7 @@ where
         return Ok(());
     };
     let library = asset.source_zone().unwrap_or(&config.library);
-    add_asset_album_with_retry(db, library, asset.id(), album_name, "icloud").await
+    add_asset_album_with_retry(db, library, asset.state_id(), album_name, "icloud").await
 }
 
 /// Bounded retry attempts for `add_asset_album`. SQLite-busy under WAL

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -36,6 +36,18 @@ pub(crate) const QUERY_FOLDER_LIST: &str = "CPLContainerRelationLiveByAssetDate"
 /// A boxed, pinned stream of photo asset results.
 type PhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
 
+fn prune_paired_master_cache(
+    paired_masters: &mut FxHashMap<String, super::cloudkit::Record>,
+    max_records: usize,
+) {
+    if paired_masters.len() <= max_records {
+        return;
+    }
+    if let Some(key) = paired_masters.keys().next().cloned() {
+        paired_masters.remove(&key);
+    }
+}
+
 /// Keep signed CDN URLs close to the download workers that will consume them.
 ///
 /// A normal CloudKit page is optimized for fast enumeration, but each
@@ -1272,7 +1284,9 @@ impl PhotoAlbum {
             let mut saw_blank_sync_token = false;
             let mut pending_masters: FxHashMap<String, super::cloudkit::Record> =
                 FxHashMap::default();
-            let mut pending_assets: FxHashMap<String, super::cloudkit::Record> =
+            let mut pending_assets: FxHashMap<String, Vec<super::cloudkit::Record>> =
+                FxHashMap::default();
+            let mut paired_masters: FxHashMap<String, super::cloudkit::Record> =
                 FxHashMap::default();
             let mut consecutive_empty_pages: u32 = 0;
             let mut enumeration_incomplete = false;
@@ -1411,7 +1425,7 @@ impl PhotoAlbum {
 
                 // Collect current page's records, trying to pair with
                 // buffered unpaired records from previous pages.
-                let mut page_assets: FxHashMap<String, super::cloudkit::Record> =
+                let mut page_assets: FxHashMap<String, Vec<super::cloudkit::Record>> =
                     FxHashMap::default();
                 let mut page_masters: Vec<super::cloudkit::Record> = Vec::new();
                 let mut masters_seen_on_page = false;
@@ -1428,41 +1442,11 @@ impl PhotoAlbum {
                             .and_then(Value::as_str)
                         {
                             let master_id = master_id.to_string();
-                            // Try to pair with a buffered master from a previous page
-                            if let Some(master) = pending_masters.remove(&master_id) {
-                                if let Some(n) = limit {
-                                    if total_sent >= u64::from(n) {
-                                        limit_reached = true;
-                                        break;
-                                    }
-                                }
-                                let asset = PhotoAsset::from_records(master, &rec);
-                                if tx.send(Ok(asset)).await.is_err() {
-                                    return;
-                                }
-                                total_sent += 1;
-                            } else {
-                                page_assets.insert(master_id, rec);
-                            }
+                            page_assets.entry(master_id).or_default().push(rec);
                         }
                     } else if rec.record_type == "CPLMaster" {
                         masters_seen_on_page = true;
-                        if let Some(asset_rec) = pending_assets.remove(&rec.record_name) {
-                            if let Some(n) = limit {
-                                if total_sent >= u64::from(n) {
-                                    limit_reached = true;
-                                    break;
-                                }
-                            }
-                            let asset = PhotoAsset::from_records(rec, &asset_rec);
-                            if tx.send(Ok(asset)).await.is_err() {
-                                return;
-                            }
-                            total_sent += 1;
-                            offset += 1;
-                        } else {
-                            page_masters.push(rec);
-                        }
+                        page_masters.push(rec);
                     }
                 }
 
@@ -1477,7 +1461,7 @@ impl PhotoAlbum {
                     // asset count as a proxy for rank positions covered
                     // (each asset references one master/rank), with a minimum
                     // of 1 to guarantee forward progress.
-                    let advance = page_assets.len().max(1) as u64;
+                    let advance = page_assets.values().map(Vec::len).sum::<usize>().max(1) as u64;
                     offset += advance;
                     tracing::warn!(
                         album = %name,
@@ -1495,12 +1479,36 @@ impl PhotoAlbum {
                             break;
                         }
                     }
-                    if let Some(asset_rec) = page_assets.remove(&master.record_name) {
-                        let asset = PhotoAsset::from_records(master, &asset_rec);
-                        if tx.send(Ok(asset)).await.is_err() {
-                            return;
+                    let mut asset_records = pending_assets.remove(&master.record_name);
+                    if let Some(page_records) = page_assets.remove(&master.record_name) {
+                        asset_records
+                            .get_or_insert_with(Vec::new)
+                            .extend(page_records);
+                    }
+                    if let Some(mut asset_records) = asset_records {
+                        asset_records
+                            .sort_by(|left, right| left.record_name.cmp(&right.record_name));
+                        let sibling_count = asset_records.len();
+                        for (index, asset_rec) in asset_records.into_iter().enumerate() {
+                            if let Some(n) = limit {
+                                if total_sent >= u64::from(n) {
+                                    limit_reached = true;
+                                    break;
+                                }
+                            }
+                            let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
+                            if sibling_count > 1 && index > 0 {
+                                asset = asset.with_state_record_name(Arc::from(
+                                    asset_rec.record_name.as_str(),
+                                ));
+                            }
+                            if tx.send(Ok(asset)).await.is_err() {
+                                return;
+                            }
+                            total_sent += 1;
                         }
-                        total_sent += 1;
+                        paired_masters.insert(master.record_name.clone(), master);
+                        prune_paired_master_cache(&mut paired_masters, max_pending_records);
                     } else {
                         // Buffer unpaired master for pairing on subsequent pages
                         pending_masters.insert(master.record_name.clone(), master);
@@ -1520,8 +1528,58 @@ impl PhotoAlbum {
                     break;
                 }
 
-                pending_assets.extend(page_assets);
-                let pending_record_count = pending_masters.len() + pending_assets.len();
+                for (master_id, records) in page_assets {
+                    if let Some(master) = pending_masters.remove(&master_id) {
+                        let mut records = records;
+                        records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
+                        let sibling_count = records.len();
+                        for (index, asset_rec) in records.into_iter().enumerate() {
+                            if let Some(n) = limit {
+                                if total_sent >= u64::from(n) {
+                                    limit_reached = true;
+                                    break;
+                                }
+                            }
+                            let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
+                            if sibling_count > 1 && index > 0 {
+                                asset = asset.with_state_record_name(Arc::from(
+                                    asset_rec.record_name.as_str(),
+                                ));
+                            }
+                            if tx.send(Ok(asset)).await.is_err() {
+                                return;
+                            }
+                            total_sent += 1;
+                        }
+                        paired_masters.insert(master.record_name.clone(), master);
+                        prune_paired_master_cache(&mut paired_masters, max_pending_records);
+                    } else if let Some(master) = paired_masters.get(&master_id) {
+                        let mut records = records;
+                        records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
+                        for asset_rec in records {
+                            if let Some(n) = limit {
+                                if total_sent >= u64::from(n) {
+                                    limit_reached = true;
+                                    break;
+                                }
+                            }
+                            let asset = PhotoAsset::from_records(master.clone(), &asset_rec)
+                                .with_state_record_name(Arc::from(asset_rec.record_name.as_str()));
+                            if tx.send(Ok(asset)).await.is_err() {
+                                return;
+                            }
+                            total_sent += 1;
+                        }
+                    } else {
+                        pending_assets.entry(master_id).or_default().extend(records);
+                    }
+                }
+                if limit_reached {
+                    stopped_for_limit = true;
+                    break;
+                }
+                let pending_record_count =
+                    pending_masters.len() + pending_assets.values().map(Vec::len).sum::<usize>();
                 if pending_record_count > max_pending_records {
                     enumeration_incomplete = true;
                     let _ = tx
@@ -1544,20 +1602,21 @@ impl PhotoAlbum {
                 enumeration_incomplete = true;
                 tracing::warn!(
                     masters = pending_masters.len(),
-                    assets = pending_assets.len(),
+                    assets = pending_assets.values().map(Vec::len).sum::<usize>(),
                     "Unpaired CPLMaster/CPLAsset records after full enumeration"
                 );
                 for id in pending_masters.keys() {
                     tracing::debug!(master_id = %id, "Unpaired CPLMaster");
                 }
-                for id in pending_assets.keys() {
-                    tracing::debug!(master_id = %id, "Unpaired CPLAsset");
+                for (id, records) in &pending_assets {
+                    tracing::debug!(master_id = %id, count = records.len(), "Unpaired CPLAsset");
                 }
+                let pending_asset_count = pending_assets.values().map(Vec::len).sum::<usize>();
                 let _ = tx
                     .send(Err(anyhow::anyhow!(
                         "Photo enumeration is incomplete: {} unpaired CPLMaster records and {} unpaired CPLAsset records remained at the end of the stream.",
                         pending_masters.len(),
-                        pending_assets.len()
+                        pending_asset_count
                     )))
                     .await;
             }
@@ -2349,6 +2408,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_query_sibling_assets_share_master_without_clobbering() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .query_page(
+                vec![
+                    test_asset_record_for("asset-sibling-b", "master-sibling"),
+                    test_master_record("master-sibling"),
+                    test_asset_record_for("asset-sibling-a", "master-sibling"),
+                ],
+                Some("token-full"),
+            )
+            .build();
+        let album = make_album_with_session(1, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, Some(2), 1);
+        tokio::pin!(stream);
+        let mut seen = Vec::new();
+        while let Some(result) = stream.next().await {
+            let asset = result.expect("sibling asset should parse");
+            seen.push((
+                asset.id().to_string(),
+                asset.asset_record_name().to_string(),
+                asset.state_id().to_string(),
+            ));
+        }
+
+        assert_eq!(
+            seen,
+            vec![
+                (
+                    "master-sibling".to_string(),
+                    "asset-sibling-a".to_string(),
+                    "master-sibling".to_string(),
+                ),
+                (
+                    "master-sibling".to_string(),
+                    "asset-sibling-b".to_string(),
+                    "asset-sibling-b".to_string(),
+                ),
+            ]
+        );
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-full")
+        );
+    }
+
+    #[tokio::test]
+    async fn full_query_late_sibling_asset_pairs_with_recent_master() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .query_page(
+                vec![
+                    test_master_record("master-late-sibling"),
+                    test_asset_record_for("asset-late-a", "master-late-sibling"),
+                ],
+                Some("token-full"),
+            )
+            .query_page(
+                vec![test_asset_record_for("asset-late-b", "master-late-sibling")],
+                Some("token-full"),
+            )
+            .build();
+        let album = make_album_with_session(1, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, Some(2), 1);
+        tokio::pin!(stream);
+        let mut seen = Vec::new();
+        while let Some(result) = stream.next().await {
+            let asset = result.expect("late sibling asset should parse");
+            seen.push((
+                asset.id().to_string(),
+                asset.asset_record_name().to_string(),
+                asset.state_id().to_string(),
+            ));
+        }
+
+        assert_eq!(
+            seen,
+            vec![
+                (
+                    "master-late-sibling".to_string(),
+                    "asset-late-a".to_string(),
+                    "master-late-sibling".to_string(),
+                ),
+                (
+                    "master-late-sibling".to_string(),
+                    "asset-late-b".to_string(),
+                    "asset-late-b".to_string(),
+                ),
+            ]
+        );
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-full")
+        );
+    }
+
+    #[tokio::test]
     async fn full_query_unpaired_records_block_token() {
         let mock = MockPhotosFlow::new()
             .query_page(
@@ -2650,13 +2810,17 @@ mod tests {
     }
 
     fn test_asset_record(record_name: &str) -> Value {
+        test_asset_record_for(&format!("asset-{record_name}"), record_name)
+    }
+
+    fn test_asset_record_for(asset_record_name: &str, master_record_name: &str) -> Value {
         json!({
-            "recordName": format!("asset-{record_name}"),
+            "recordName": asset_record_name,
             "recordType": "CPLAsset",
             "fields": {
                 "masterRef": {
                     "value": {
-                        "recordName": record_name,
+                        "recordName": master_record_name,
                         "zoneID": {"zoneName": "PrimarySync"}
                     },
                     "type": "REFERENCE"

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -37,10 +37,10 @@ pub struct ChangeEvent {
     pub record_type: Option<Box<str>>,
     /// Master record referenced by an unpaired `CPLAsset`.
     ///
-    /// Download state is keyed by the master record name, while `CPLAsset`
-    /// soft-delete deltas can arrive without their matching `CPLMaster`. Keep
-    /// the reference so state transitions can update or no-op against the
-    /// same key that normal downloads use.
+    /// Download state normally uses the master record name, while sibling
+    /// `CPLAsset` rows can use their own asset record names. Keep the
+    /// reference so state transitions can resolve unpaired asset deltas
+    /// against the same key family that normal downloads use.
     pub master_record_name: Option<Box<str>>,
     /// Why this record changed
     pub reason: ChangeReason,
@@ -95,15 +95,15 @@ pub struct AlbumRelationDelta {
 /// - f64 primitives
 /// - Small enums last
 ///
-/// `record_name` is `Arc<str>` so downstream consumers (producer
-/// dedup set, `DownloadTask`, deferred state writes) can share the
-/// same allocation via refcount bumps instead of re-cloning the
-/// record ID at every stage boundary.
+/// Record IDs are `Arc<str>` so downstream consumers (producer dedup,
+/// `DownloadTask`, deferred state writes) can share the same allocation via
+/// refcount bumps instead of re-cloning IDs at every stage boundary.
 #[derive(Debug, Clone)]
 pub struct PhotoAsset {
     // Heap types first
     record_name: Arc<str>,
     asset_record_name: Arc<str>,
+    state_record_name: Option<Arc<str>>,
     source_zone: Option<Arc<str>>,
     filename: Option<Box<str>>,
     // Metadata behind Arc so downstream consumers (AssetRecord, the
@@ -397,6 +397,7 @@ impl PhotoAsset {
         Self {
             record_name,
             asset_record_name,
+            state_record_name: None,
             source_zone: None,
             filename,
             asset_metadata,
@@ -441,6 +442,7 @@ impl PhotoAsset {
         Self {
             record_name: Arc::from(master.record_name),
             asset_record_name: Arc::from(asset.record_name.as_str()),
+            state_record_name: None,
             source_zone,
             filename,
             asset_metadata,
@@ -485,6 +487,11 @@ impl PhotoAsset {
         self
     }
 
+    pub(crate) fn with_state_record_name(mut self, state_record_name: Arc<str>) -> Self {
+        self.state_record_name = Some(state_record_name);
+        self
+    }
+
     /// True when the CloudKit record carried a usable recordName.
     ///
     /// An empty ID cannot safely key state rows, path fingerprints, retry
@@ -494,12 +501,28 @@ impl PhotoAsset {
         !self.record_name.is_empty()
     }
 
-    /// Shared handle on the record ID. Consumers that want to store the ID
-    /// (producer dedup set, `DownloadTask`, deferred state writes) clone the
-    /// `Arc<str>` instead of allocating a fresh owned copy.
-    #[must_use]
-    pub fn id_arc(&self) -> Arc<str> {
-        Arc::clone(&self.record_name)
+    /// Local state/download identity for this asset.
+    ///
+    /// Most CloudKit assets use their `CPLMaster.recordName` as kei's durable
+    /// state ID for compatibility with existing databases. When Apple exposes
+    /// multiple sibling `CPLAsset` records that share one master, additional
+    /// siblings need their own state rows, retry accounting, and path collision
+    /// suffixes, so the enumerator can override this to the sibling
+    /// `CPLAsset.recordName`.
+    pub(crate) fn state_id(&self) -> &str {
+        self.state_record_name
+            .as_deref()
+            .unwrap_or(self.record_name.as_ref())
+    }
+
+    pub(crate) fn state_id_arc(&self) -> Arc<str> {
+        self.state_record_name
+            .as_ref()
+            .map_or_else(|| Arc::clone(&self.record_name), Arc::clone)
+    }
+
+    pub(crate) fn asset_record_name_arc(&self) -> Arc<str> {
+        Arc::clone(&self.asset_record_name)
     }
 
     pub fn filename(&self) -> Option<&str> {
@@ -705,7 +728,11 @@ pub(crate) struct DeltaRecordBuffer {
     /// Unpaired `CPLMaster` records, keyed by recordName
     pending_masters: FxHashMap<String, Record>,
     /// Unpaired `CPLAsset` records, keyed by masterRef recordName
-    pending_assets: FxHashMap<String, Record>,
+    pending_assets: FxHashMap<String, Vec<Record>>,
+    /// Masters that have already paired with at least one asset in this delta
+    /// stream. Keep them available so sibling `CPLAsset` records that share the
+    /// same `CPLMaster` do not flush as orphaned metadata-only events.
+    paired_masters: FxHashMap<String, Record>,
 }
 
 impl DeltaRecordBuffer {
@@ -747,10 +774,14 @@ impl DeltaRecordBuffer {
                 _ => match record.record_type.as_str() {
                     "CPLMaster" => {
                         let master_name = record.record_name.clone();
-                        if let Some(asset_record) = self.pending_assets.remove(&master_name) {
-                            let asset_reason = classify_change_reason(&asset_record);
-                            let final_reason = Self::reconcile_reasons(reason, asset_reason);
-                            Self::emit_paired(record, asset_record, final_reason, &mut events);
+                        if let Some(asset_records) = self.pending_assets.remove(&master_name) {
+                            Self::emit_paired_group(
+                                record.clone(),
+                                asset_records,
+                                reason,
+                                &mut events,
+                            );
+                            self.paired_masters.insert(master_name, record);
                         } else {
                             self.pending_masters.insert(master_name, record);
                         }
@@ -761,9 +792,31 @@ impl DeltaRecordBuffer {
                             if let Some(master_record) = self.pending_masters.remove(master_name) {
                                 let master_reason = classify_change_reason(&master_record);
                                 let final_reason = Self::reconcile_reasons(master_reason, reason);
-                                Self::emit_paired(master_record, record, final_reason, &mut events);
+                                Self::emit_paired(
+                                    master_record.clone(),
+                                    record,
+                                    final_reason,
+                                    false,
+                                    &mut events,
+                                );
+                                self.paired_masters
+                                    .insert(master_name.clone(), master_record);
+                            } else if let Some(master_record) = self.paired_masters.get(master_name)
+                            {
+                                let master_reason = classify_change_reason(master_record);
+                                let final_reason = Self::reconcile_reasons(master_reason, reason);
+                                Self::emit_paired(
+                                    master_record.clone(),
+                                    record,
+                                    final_reason,
+                                    true,
+                                    &mut events,
+                                );
                             } else {
-                                self.pending_assets.insert(master_name.clone(), record);
+                                self.pending_assets
+                                    .entry(master_name.clone())
+                                    .or_default()
+                                    .push(record);
                             }
                         } else {
                             // CPLAsset with no masterRef -- metadata-only change
@@ -805,15 +858,17 @@ impl DeltaRecordBuffer {
             ));
         }
 
-        for (master_ref, record) in self.pending_assets.drain() {
-            let reason = classify_change_reason(&record);
-            let mut event = ChangeEvent::new(
-                record.record_name.into_boxed_str(),
-                Some("CPLAsset".into()),
-                reason,
-            );
-            event.master_record_name = Some(master_ref.into_boxed_str());
-            events.push(event);
+        for (master_ref, records) in self.pending_assets.drain() {
+            for record in records {
+                let reason = classify_change_reason(&record);
+                let mut event = ChangeEvent::new(
+                    record.record_name.into_boxed_str(),
+                    Some("CPLAsset".into()),
+                    reason,
+                );
+                event.master_record_name = Some(master_ref.clone().into_boxed_str());
+                events.push(event);
+            }
         }
 
         events
@@ -845,15 +900,40 @@ impl DeltaRecordBuffer {
         master_record: Record,
         asset_record: Record,
         reason: ChangeReason,
+        use_asset_state_id: bool,
         events: &mut Vec<ChangeEvent>,
     ) {
         // Box::from(&str) copies only the bytes, without the String's Vec
         // capacity slack that .clone().into_boxed_str() would drag along.
         let master_name: Box<str> = Box::from(master_record.record_name.as_str());
-        let asset = PhotoAsset::from_records(master_record, &asset_record);
+        let mut asset = PhotoAsset::from_records(master_record, &asset_record);
+        if use_asset_state_id {
+            asset = asset.with_state_record_name(Arc::from(asset_record.record_name.as_str()));
+        }
         let mut event = ChangeEvent::new(master_name, Some("CPLMaster".into()), reason);
         event.asset = Some(asset);
         events.push(event);
+    }
+
+    fn emit_paired_group(
+        master_record: Record,
+        mut asset_records: Vec<Record>,
+        master_reason: ChangeReason,
+        events: &mut Vec<ChangeEvent>,
+    ) {
+        asset_records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
+        let sibling_count = asset_records.len();
+        for (index, asset_record) in asset_records.into_iter().enumerate() {
+            let reason =
+                Self::reconcile_reasons(master_reason, classify_change_reason(&asset_record));
+            Self::emit_paired(
+                master_record.clone(),
+                asset_record,
+                reason,
+                sibling_count > 1 && index > 0,
+                events,
+            );
+        }
     }
 }
 
@@ -862,7 +942,7 @@ impl Drop for DeltaRecordBuffer {
         if !self.pending_masters.is_empty() || !self.pending_assets.is_empty() {
             tracing::warn!(
                 orphaned_masters = self.pending_masters.len(),
-                orphaned_assets = self.pending_assets.len(),
+                orphaned_assets = self.pending_assets.values().map(Vec::len).sum::<usize>(),
                 "DeltaRecordBuffer dropped with orphaned records"
             );
         }
@@ -1428,6 +1508,12 @@ mod tests {
         }
     }
 
+    fn make_soft_deleted_asset_record(name: &str, master_ref: &str) -> Record {
+        let mut record = make_asset_record(name, master_ref);
+        record.fields["isDeleted"] = json!({"value": 1});
+        record
+    }
+
     #[test]
     fn test_buffer_master_then_asset_pairs() {
         let mut buffer = DeltaRecordBuffer::new();
@@ -1487,6 +1573,65 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(&*events[0].record_name, "M1");
         assert!(events[0].asset.is_some());
+    }
+
+    #[test]
+    fn test_buffer_sibling_assets_share_master_without_clobbering() {
+        let mut buffer = DeltaRecordBuffer::new();
+
+        let events = buffer.process_records(vec![
+            make_asset_record("A2", "M1"),
+            make_asset_record("A1", "M1"),
+            make_master_record("M1"),
+        ]);
+
+        assert_eq!(events.len(), 2);
+        let assets: Vec<_> = events
+            .iter()
+            .map(|event| event.asset.as_ref().expect("paired asset"))
+            .collect();
+        assert_eq!(assets[0].asset_record_name(), "A1");
+        assert_eq!(assets[0].id(), "M1");
+        assert_eq!(assets[0].state_id(), "M1");
+        assert_eq!(assets[1].asset_record_name(), "A2");
+        assert_eq!(assets[1].id(), "M1");
+        assert_eq!(assets[1].state_id(), "A2");
+    }
+
+    #[test]
+    fn test_buffer_sibling_asset_reasons_stay_per_asset() {
+        let mut buffer = DeltaRecordBuffer::new();
+
+        let events = buffer.process_records(vec![
+            make_soft_deleted_asset_record("A2", "M1"),
+            make_asset_record("A1", "M1"),
+            make_master_record("M1"),
+        ]);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].asset.as_ref().unwrap().asset_record_name(), "A1");
+        assert_eq!(events[0].reason, ChangeReason::Created);
+        assert_eq!(events[1].asset.as_ref().unwrap().asset_record_name(), "A2");
+        assert_eq!(events[1].reason, ChangeReason::SoftDeleted);
+    }
+
+    #[test]
+    fn test_buffer_late_sibling_asset_pairs_with_seen_master() {
+        let mut buffer = DeltaRecordBuffer::new();
+
+        let first = buffer.process_records(vec![
+            make_master_record("M1"),
+            make_asset_record("A1", "M1"),
+        ]);
+        assert_eq!(first.len(), 1);
+
+        let second = buffer.process_records(vec![make_asset_record("A2", "M1")]);
+        assert_eq!(second.len(), 1);
+        let asset = second[0].asset.as_ref().expect("late sibling asset");
+        assert_eq!(asset.id(), "M1");
+        assert_eq!(asset.asset_record_name(), "A2");
+        assert_eq!(asset.state_id(), "A2");
+        assert!(buffer.flush().is_empty());
     }
 
     #[test]

--- a/src/icloud/photos/cloudkit.rs
+++ b/src/icloud/photos/cloudkit.rs
@@ -58,7 +58,7 @@ pub(crate) struct BatchQueryResponse {
 
 /// A `CloudKit` record. Fields are kept as dynamic JSON because Apple's schema
 /// varies by record type and changes without notice.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Record {
     #[serde(default)]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -213,6 +213,15 @@ pub trait DownloadStateStore: Send + Sync {
             .await?;
         Ok(1)
     }
+    async fn mark_master_family_soft_deleted_affected(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        self.mark_soft_deleted_affected(library, master_record_name, deleted_at)
+            .await
+    }
     async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError>;
     async fn mark_hidden_at_source_affected(
         &self,
@@ -2782,6 +2791,34 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn mark_master_family_soft_deleted(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        let library = library.to_owned();
+        let master_record_name = master_record_name.to_owned();
+        self.with_conn("mark_master_family_soft_deleted", move |conn| {
+            let updated = conn
+                .execute(
+                    "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
+                     WHERE library = ?2 AND (id = ?3 OR id IN ( \
+                        SELECT asset_record_name FROM asset_master_mappings \
+                        WHERE library = ?2 AND master_record_name = ?3 \
+                     ))",
+                    rusqlite::params![
+                        deleted_at.map(|dt| dt.timestamp()),
+                        library,
+                        master_record_name
+                    ],
+                )
+                .map_err(|e| StateError::query("mark_master_family_soft_deleted", e))?;
+            Ok(updated)
+        })
+        .await
+    }
+
     pub(crate) async fn mark_hidden_at_source(
         &self,
         library: &str,
@@ -3136,6 +3173,21 @@ impl DownloadStateStore for SqliteStateDb {
         deleted_at: Option<DateTime<Utc>>,
     ) -> Result<usize, StateError> {
         SqliteStateDb::mark_soft_deleted(self, library, asset_id, deleted_at).await
+    }
+
+    async fn mark_master_family_soft_deleted_affected(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        SqliteStateDb::mark_master_family_soft_deleted(
+            self,
+            library,
+            master_record_name,
+            deleted_at,
+        )
+        .await
     }
 
     async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError> {
@@ -3826,6 +3878,34 @@ mod tests {
                 .unwrap(),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn master_family_soft_delete_marks_sibling_asset_state_rows() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let master = TestAssetRecord::new("master-a").build();
+        let sibling = TestAssetRecord::new("asset-b").build();
+        let unrelated = TestAssetRecord::new("asset-c").build();
+
+        db.upsert_seen(&master).await.unwrap();
+        db.upsert_seen(&sibling).await.unwrap();
+        db.upsert_seen(&unrelated).await.unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-b", "master-a")
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-c", "master-other")
+            .await
+            .unwrap();
+
+        let updated = db
+            .mark_master_family_soft_deleted("PrimarySync", "master-a", None)
+            .await
+            .unwrap();
+
+        assert_eq!(updated, 2);
+        assert!(read_asset_writer_contract_row(&db, "master-a").is_deleted);
+        assert!(read_asset_writer_contract_row(&db, "asset-b").is_deleted);
+        assert!(!read_asset_writer_contract_row(&db, "asset-c").is_deleted);
     }
 
     #[derive(Debug)]

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -407,8 +407,9 @@ CREATE TABLE IF NOT EXISTS scoped_db_sync_tokens (
 /// V15 durable CPLAsset -> CPLMaster mapping.
 ///
 /// CloudKit hard-delete tombstones can arrive with only a `recordName` and no
-/// `recordType` or fields. The download state is keyed by `CPLMaster`, so keep
-/// the last observed `CPLAsset.recordName` bridge per library.
+/// `recordType` or fields. Download state normally uses `CPLMaster`, while
+/// sibling `CPLAsset` rows can use their own asset record names, so keep the
+/// last observed `CPLAsset.recordName` bridge per library.
 const SCHEMA_V15: &str = r"
 CREATE TABLE IF NOT EXISTS asset_master_mappings (
     library TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- Pair every sibling `CPLAsset` that shares a `CPLMaster` during full and incremental enumeration.
- Use the `CPLAsset.recordName` for duplicate detection, album exclusions, recent bounds, and sibling-specific state rows.
- Keep hard-delete and soft-delete state transitions token-safe for sibling rows, including unresolved master tombstones.

Closes #643.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test sibling -- --test-threads=1`
- `cargo test hard_delete -- --test-threads=1`
- `cargo test --quiet`
- `just gate`
