### PR TITLE
Fix identity-family sync-token blockers

### DIFF
--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -5151,8 +5151,14 @@ mod tests {
         // In retry-only mode, the producer checks known_ids before sending
         // tasks. Simulate that filtering logic here.
         let mut ctx = super::super::DownloadContext::default();
-        ctx.known_ids.insert("PREV_SYNCED_001".into());
-        ctx.known_ids.insert("PREV_SYNCED_002".into());
+        ctx.known_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("PREV_SYNCED_001".into());
+        ctx.known_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("PREV_SYNCED_002".into());
 
         let known_asset = TestPhotoAsset::new("TEST_1").build(); // recordName "TEST_1"
         let config = test_config();
@@ -5161,7 +5167,7 @@ mod tests {
         // Simulate the retry_only check from the producer loop
         let retry_filtered: Vec<_> = tasks
             .into_iter()
-            .filter(|task| ctx.known_ids.contains(task.asset_id.as_ref()))
+            .filter(|task| ctx.is_known(&task.library, &task.asset_id))
             .collect();
 
         // "TEST_1" is NOT in known_ids, so retry_only would skip it
@@ -5171,11 +5177,14 @@ mod tests {
         );
 
         // Now add "TEST_1" to known_ids and verify it passes
-        ctx.known_ids.insert("TEST_1".into());
+        ctx.known_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("TEST_1".into());
         let tasks2 = filter_asset_fresh(&known_asset, &config);
         let retry_filtered2: Vec<_> = tasks2
             .into_iter()
-            .filter(|task| ctx.known_ids.contains(task.asset_id.as_ref()))
+            .filter(|task| ctx.is_known(&task.library, &task.asset_id))
             .collect();
         assert_eq!(
             retry_filtered2.len(),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -4851,6 +4851,14 @@ impl IncrementalDeltaSummary {
         let Some(asset) = &event.asset else {
             return;
         };
+        self.persist_asset_mapping_for_asset(asset, config).await;
+    }
+
+    async fn persist_asset_mapping_for_asset(
+        &mut self,
+        asset: &PhotoAsset,
+        config: &DownloadConfig,
+    ) {
         let Some(db) = &config.state_db else {
             return;
         };
@@ -5087,6 +5095,38 @@ async fn apply_incremental_relation_delta(
         return;
     };
 
+    let mut master_record_name = asset_to_master
+        .get(relation.asset_record_name.as_ref())
+        .cloned();
+    if !relation.is_deleted && master_record_name.is_none() {
+        match db
+            .get_master_record_name_for_asset(&config.library, &relation.asset_record_name)
+            .await
+        {
+            Ok(Some(master)) => {
+                tracing::debug!(
+                    container_id = %relation.container_id,
+                    asset_record_name = %relation.asset_record_name,
+                    master_record_name = %master,
+                    library = %config.library,
+                    "Resolved album relation asset through persisted asset/master mapping"
+                );
+                master_record_name = Some(master);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    container_id = %relation.container_id,
+                    asset_record_name = %relation.asset_record_name,
+                    library = %config.library,
+                    error = %e,
+                    "Failed to look up persisted asset/master mapping for album relation delta"
+                );
+                token_unsafe_reason.get_or_insert(ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON);
+            }
+        }
+    }
+
     if let Some(album_name) = planned_album_containers.get(relation.container_id.as_ref()) {
         let container_id = relation.container_id.as_ref();
         if !ensured_planned_containers.contains(container_id) {
@@ -5126,9 +5166,7 @@ async fn apply_incremental_relation_delta(
             &config.library,
             &relation.container_id,
             &relation.asset_record_name,
-            asset_to_master
-                .get(relation.asset_record_name.as_ref())
-                .map(String::as_str),
+            master_record_name.as_deref(),
             "icloud",
         )
         .await
@@ -5142,7 +5180,12 @@ async fn apply_incremental_relation_delta(
                 asset_record_name = %relation.asset_record_name,
                 "Album relation delta referenced an unknown album container"
             );
-            token_unsafe_reason.get_or_insert(UNKNOWN_ALBUM_RELATION_CONTAINER_REASON);
+            if routing
+                .album_passes_for_container(&relation.container_id)
+                .is_some()
+            {
+                token_unsafe_reason.get_or_insert(UNKNOWN_ALBUM_RELATION_CONTAINER_REASON);
+            }
         }
         Err(e) => {
             tracing::warn!(
@@ -5159,7 +5202,7 @@ async fn apply_incremental_relation_delta(
         && routing
             .album_passes_for_container(&relation.container_id)
             .is_some()
-        && !asset_to_master.contains_key(relation.asset_record_name.as_ref())
+        && master_record_name.is_none()
     {
         tracing::warn!(
             container_id = %relation.container_id,
@@ -5167,6 +5210,94 @@ async fn apply_incremental_relation_delta(
             "Selected album relation add referenced an asset not present in the delta page set"
         );
         token_unsafe_reason.get_or_insert(UNKNOWN_ALBUM_RELATION_ASSET_REASON);
+    }
+}
+
+async fn hydrate_missing_selected_relation_assets(
+    change_events: &[ChangeEvent],
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    routing: &IncrementalPassRouting,
+    asset_to_master: &mut FxHashMap<String, String>,
+    downloadable_assets: &mut Vec<(PhotoAsset, usize)>,
+    delta_summary: &mut IncrementalDeltaSummary,
+) {
+    let mut missing_by_hydrator: FxHashMap<usize, FxHashSet<String>> = FxHashMap::default();
+    let mut pass_indices_by_asset: FxHashMap<String, FxHashSet<usize>> = FxHashMap::default();
+
+    for event in change_events {
+        let Some(relation) = &event.relation else {
+            continue;
+        };
+        if relation.is_deleted {
+            continue;
+        }
+        let Some(pass_indices) = routing.album_passes_for_container(&relation.container_id) else {
+            continue;
+        };
+        let Some(pass_index) = pass_indices.first().copied() else {
+            continue;
+        };
+
+        if asset_to_master.contains_key(relation.asset_record_name.as_ref()) {
+            continue;
+        }
+
+        pass_indices_by_asset
+            .entry(relation.asset_record_name.to_string())
+            .or_default()
+            .extend(pass_indices.iter().copied());
+        missing_by_hydrator
+            .entry(pass_index)
+            .or_default()
+            .insert(relation.asset_record_name.to_string());
+    }
+
+    let mut hydrated_asset_record_names = FxHashSet::default();
+    for (pass_index, mut missing) in missing_by_hydrator {
+        missing.retain(|asset_record_name| {
+            !asset_to_master.contains_key(asset_record_name.as_str())
+                && !hydrated_asset_record_names.contains(asset_record_name.as_str())
+        });
+        if missing.is_empty() {
+            continue;
+        }
+        let Some(pass) = passes.get(pass_index) else {
+            continue;
+        };
+
+        let assets = match pass
+            .album
+            .hydrate_matching_assets_from_changes(&mut missing)
+            .await
+        {
+            Ok(assets) => assets,
+            Err(e) => {
+                tracing::warn!(
+                    pass_index,
+                    error = %e,
+                    "Failed to hydrate missing selected album relation assets"
+                );
+                delta_summary
+                    .token_unsafe_reason
+                    .get_or_insert(ALBUM_RELATION_HYDRATION_INCOMPLETE_REASON);
+                continue;
+            }
+        };
+
+        for asset in assets {
+            let asset_record_name = asset.asset_record_name().to_string();
+            hydrated_asset_record_names.insert(asset_record_name.clone());
+            asset_to_master.insert(asset_record_name.clone(), asset.id().to_string());
+            delta_summary
+                .persist_asset_mapping_for_asset(&asset, config)
+                .await;
+            if let Some(pass_indices) = pass_indices_by_asset.get(asset_record_name.as_str()) {
+                for pass_index in pass_indices {
+                    downloadable_assets.push((asset.clone(), *pass_index));
+                }
+            }
+        }
     }
 }
 
@@ -5430,6 +5561,17 @@ async fn download_photos_incremental_collecting(
     for event in &change_events {
         apply_incremental_album_delta(event, config, &mut delta_summary.token_unsafe_reason).await;
     }
+
+    hydrate_missing_selected_relation_assets(
+        &change_events,
+        passes,
+        config,
+        &routing,
+        &mut asset_to_master,
+        &mut downloadable_assets,
+        &mut delta_summary,
+    )
+    .await;
 
     for event in &change_events {
         apply_incremental_relation_delta(
@@ -6152,6 +6294,56 @@ mod tests {
     #[derive(Clone)]
     struct BackfillAndChangesSession {
         changes_zone_calls: Arc<AtomicUsize>,
+    }
+
+    #[derive(Clone)]
+    struct RelationHydrationSession {
+        incremental_calls: Arc<AtomicUsize>,
+        hydrate_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for RelationHydrationSession {
+        async fn post(
+            &self,
+            url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if !url.contains("/changes/zone?") {
+                return Ok(json!({"records": []}));
+            }
+
+            let request: Value = serde_json::from_str(&body)?;
+            let sync_token = request["zones"]
+                .as_array()
+                .and_then(|zones| zones.first())
+                .and_then(|zone| zone.get("syncToken"))
+                .and_then(Value::as_str);
+            let records = if sync_token == Some("zone-token-prev") {
+                self.incremental_calls.fetch_add(1, Ordering::SeqCst);
+                vec![relation_delta_record(
+                    "container-vacation",
+                    "asset-MASTER_HYDRATED",
+                )]
+            } else {
+                self.hydrate_calls.fetch_add(1, Ordering::SeqCst);
+                incremental_photo_records("MASTER_HYDRATED")
+            };
+
+            Ok(json!({
+                "zones": [{
+                    "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                    "syncToken": "zone-token-next",
+                    "moreComing": false,
+                    "records": records,
+                }]
+            }))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
     }
 
     #[async_trait::async_trait]
@@ -10154,7 +10346,117 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_relation_add_unknown_container_blocks_sync_token() {
+    async fn selected_relation_add_without_photo_uses_persisted_asset_master_mapping() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        seed_complete_album_snapshot(&db, "container-vacation", "Vacation", &[]).await;
+        db.upsert_asset_master_mapping("PrimarySync", "asset-MASTER_KNOWN", "MASTER_KNOWN")
+            .await
+            .unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let session = changes_zone_session(
+            Arc::clone(&calls),
+            vec![relation_delta_record(
+                "container-vacation",
+                "asset-MASTER_KNOWN",
+            )],
+        );
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: changes_album_with_container("Vacation", Some("container-vacation"), session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::Download, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("known selected relation add should not fall back to full here");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        assert!(!result.stats.sync_token_blocked);
+        let memberships = db
+            .get_live_selected_album_memberships_for_asset(
+                "PrimarySync",
+                "asset-MASTER_KNOWN",
+                &["container-vacation"],
+            )
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(
+            memberships[0].master_record_name.as_deref(),
+            Some("MASTER_KNOWN")
+        );
+    }
+
+    #[tokio::test]
+    async fn selected_relation_add_without_photo_hydrates_missing_asset() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        seed_complete_album_snapshot(&db, "container-vacation", "Vacation", &[]).await;
+        let session = RelationHydrationSession {
+            incremental_calls: Arc::new(AtomicUsize::new(0)),
+            hydrate_calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: changes_album_with_container(
+                "Vacation",
+                Some("container-vacation"),
+                session.clone(),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        let result = download_photos_incremental(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::new(DownloadRunMode::PrintFilenames, DownloadReporting::hidden()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("missing selected relation asset should hydrate");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(
+            session.incremental_calls.load(Ordering::SeqCst),
+            1,
+            "incremental changes should be read once"
+        );
+        assert_eq!(
+            session.hydrate_calls.load(Ordering::SeqCst),
+            1,
+            "missing relation asset should trigger one bounded hydrate scan"
+        );
+        let memberships = db
+            .get_live_selected_album_memberships_for_asset(
+                "PrimarySync",
+                "asset-MASTER_HYDRATED",
+                &["container-vacation"],
+            )
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(
+            memberships[0].master_record_name.as_deref(),
+            Some("MASTER_HYDRATED")
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_relation_add_unknown_unselected_container_advances_sync_token() {
         let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
         let calls = Arc::new(AtomicUsize::new(0));
         let session = changes_zone_session(
@@ -10184,12 +10486,8 @@ mod tests {
         .expect("unknown relation container should not fall back to full here");
 
         assert!(matches!(result.outcome, DownloadOutcome::Success));
-        assert_eq!(result.sync_token, None);
-        assert!(result.stats.sync_token_blocked);
-        assert_eq!(
-            result.stats.sync_token_blocked_reason,
-            Some(UNKNOWN_ALBUM_RELATION_CONTAINER_REASON)
-        );
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        assert!(!result.stats.sync_token_blocked);
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1347,6 +1347,14 @@ fn intern_id(interner: &mut FxHashSet<Arc<str>>, s: String) -> Arc<str> {
 /// `DownloadContext::downloaded_ids` and `metadata_retry_markers`.
 type LibraryAssetVersionSet = FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashSet<Box<str>>>>;
 
+/// `library -> asset_id`. Used by retry-only mode to decide whether an asset is
+/// already known in the same CloudKit zone.
+type LibraryAssetSet = FxHashMap<Arc<str>, FxHashSet<Arc<str>>>;
+
+/// `library -> asset_id -> attempt count`. Used by max-attempt gating without
+/// leaking failures across libraries that happen to share an id.
+type LibraryAssetAttemptCounts = FxHashMap<Arc<str>, FxHashMap<Arc<str>, u32>>;
+
 /// `library -> asset_id -> (version_size -> value)`. Used by
 /// `DownloadContext::downloaded_checksums` and
 /// `downloaded_metadata_hashes`.
@@ -1393,15 +1401,13 @@ struct DownloadContext {
     /// for pending rows. Pending on-disk adoption uses this to avoid adopting
     /// a same-name/same-size collision that belongs to a different asset.
     pending_filenames: LibraryAssetVersionValueMap,
-    /// All asset IDs known to the state DB (any status). Used in retry-only mode
-    /// to skip new assets that were never synced. Library-blind: a known ID
-    /// is "known" regardless of which zone it belongs to.
-    known_ids: FxHashSet<Arc<str>>,
-    /// Per-asset maximum download attempt count (from failed assets).
+    /// Nested map: `library` -> set of asset IDs known to the state DB (any
+    /// status). Used in retry-only mode to skip new assets that were never
+    /// synced in the same CloudKit zone.
+    known_ids: LibraryAssetSet,
+    /// Per-library/asset maximum download attempt count (from failed assets).
     /// Used to skip assets that have exceeded `max_download_attempts`.
-    /// Library-blind: an asset shared across libraries shares its attempt
-    /// budget (mirrors how `get_attempt_counts` aggregates by id alone).
-    attempt_counts: FxHashMap<Arc<str>, u32>,
+    attempt_counts: LibraryAssetAttemptCounts,
     /// True when at least one downloaded asset-version lacks a metadata hash.
     /// Cached because the producer checks this on hot on-disk skip paths.
     downloaded_without_metadata_hash: bool,
@@ -1425,7 +1431,7 @@ impl DownloadContext {
                 Default::default()
             }
         };
-        let (ids, checksums, paths, hashes, markers, pending, attempts, known_ids) = tokio::join!(
+        let (ids, checksums, paths, hashes, markers, pending, attempts, known_id_rows) = tokio::join!(
             async {
                 db.get_downloaded_ids().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load downloaded IDs from state DB");
@@ -1571,15 +1577,19 @@ impl DownloadContext {
                 .insert(version_size, record.filename.to_string().into_boxed_str());
         }
 
-        let known_ids: FxHashSet<Arc<str>> = known_ids
-            .into_iter()
-            .map(|id| intern_id(&mut interner, id))
-            .collect();
+        let mut known_ids: LibraryAssetSet = FxHashMap::default();
+        for (library, asset_id) in known_id_rows {
+            let lib = intern_id(&mut interner, library);
+            let id = intern_id(&mut interner, asset_id);
+            known_ids.entry(lib).or_default().insert(id);
+        }
 
-        let attempt_counts: FxHashMap<Arc<str>, u32> = attempts
-            .into_iter()
-            .map(|(id, count)| (intern_id(&mut interner, id), count))
-            .collect();
+        let mut attempt_counts: LibraryAssetAttemptCounts = FxHashMap::default();
+        for ((library, asset_id), count) in attempts {
+            let lib = intern_id(&mut interner, library);
+            let id = intern_id(&mut interner, asset_id);
+            attempt_counts.entry(lib).or_default().insert(id, count);
+        }
         let downloaded_without_metadata_hash = count_version_set_entries(&downloaded_ids)
             > count_value_map_entries(&downloaded_metadata_hashes);
 
@@ -1595,6 +1605,19 @@ impl DownloadContext {
             attempt_counts,
             downloaded_without_metadata_hash,
         }
+    }
+
+    fn is_known(&self, library: &str, asset_id: &str) -> bool {
+        self.known_ids
+            .get(library)
+            .is_some_and(|ids| ids.contains(asset_id))
+    }
+
+    fn attempt_count(&self, library: &str, asset_id: &str) -> Option<u32> {
+        self.attempt_counts
+            .get(library)
+            .and_then(|assets| assets.get(asset_id))
+            .copied()
     }
 
     /// Whether a downloaded asset-version needs a metadata-only rewrite:
@@ -3055,6 +3078,21 @@ impl IncrementalStateTransition {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SourceStateUpdate {
+    SoftDeleted { deleted_at: Option<DateTime<Utc>> },
+    Hidden,
+}
+
+impl SourceStateUpdate {
+    const fn transition(self) -> IncrementalStateTransition {
+        match self {
+            Self::SoftDeleted { .. } => IncrementalStateTransition::SoftDelete,
+            Self::Hidden => IncrementalStateTransition::Hidden,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SourceStateTransitionKey<'a> {
     record_name: Cow<'a, str>,
@@ -3130,6 +3168,102 @@ fn source_state_transition_key(event: &ChangeEvent) -> SourceStateTransitionKey<
         record_name: Cow::Borrowed(&event.record_name),
         record_type: event.record_type.as_deref(),
         unresolved_identity: event.record_type.is_none(),
+    }
+}
+
+fn unpaired_cplasset_state_key(event: &ChangeEvent) -> Option<SourceStateTransitionKey<'_>> {
+    if event.asset.is_none() && matches!(event.record_type.as_deref(), Some("CPLAsset")) {
+        return Some(SourceStateTransitionKey {
+            record_name: Cow::Borrowed(&event.record_name),
+            record_type: Some("CPLAsset"),
+            unresolved_identity: false,
+        });
+    }
+    None
+}
+
+async fn cplasset_master_fallback_state_key<'a>(
+    event: &'a ChangeEvent,
+    config: &DownloadConfig,
+    db: &dyn DownloadStore,
+) -> std::result::Result<Option<SourceStateTransitionKey<'a>>, crate::state::error::StateError> {
+    if !matches!(event.record_type.as_deref(), Some("CPLAsset")) {
+        return Ok(None);
+    }
+
+    if let Some(master_record_name) = event.master_record_name.as_deref() {
+        return Ok(Some(SourceStateTransitionKey {
+            record_name: Cow::Borrowed(master_record_name),
+            record_type: Some("CPLMaster"),
+            unresolved_identity: false,
+        }));
+    }
+
+    let Some(master_record_name) = db
+        .get_master_record_name_for_asset(&config.library, &event.record_name)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    tracing::debug!(
+        asset_record_name = %event.record_name,
+        master_record_name = %master_record_name,
+        library = %config.library,
+        "Resolved source-state CPLAsset event through asset/master mapping"
+    );
+    Ok(Some(SourceStateTransitionKey {
+        record_name: Cow::Owned(master_record_name),
+        record_type: Some("CPLMaster"),
+        unresolved_identity: false,
+    }))
+}
+
+async fn run_source_state_update(
+    db: &dyn DownloadStore,
+    config: &DownloadConfig,
+    key: &SourceStateTransitionKey<'_>,
+    update: SourceStateUpdate,
+) -> Result<usize, crate::state::error::StateError> {
+    match update {
+        SourceStateUpdate::SoftDeleted { deleted_at } => {
+            db.mark_soft_deleted_affected(&config.library, key.record_name(), deleted_at)
+                .await
+        }
+        SourceStateUpdate::Hidden => {
+            db.mark_hidden_at_source_affected(&config.library, key.record_name())
+                .await
+        }
+    }
+}
+
+async fn apply_source_state_update<'a>(
+    db: &dyn DownloadStore,
+    config: &DownloadConfig,
+    event: &'a ChangeEvent,
+    update: SourceStateUpdate,
+) -> (
+    Result<usize, crate::state::error::StateError>,
+    SourceStateTransitionKey<'a>,
+) {
+    let Some(asset_key) = unpaired_cplasset_state_key(event) else {
+        let state_key = source_state_transition_key(event);
+        let result = run_source_state_update(db, config, &state_key, update).await;
+        return (result, state_key);
+    };
+
+    let result = run_source_state_update(db, config, &asset_key, update).await;
+    match result {
+        Ok(0) => match cplasset_master_fallback_state_key(event, config, db).await {
+            Ok(Some(fallback_key)) => {
+                let fallback_result =
+                    run_source_state_update(db, config, &fallback_key, update).await;
+                (fallback_result, fallback_key)
+            }
+            Ok(None) => (Ok(0), asset_key),
+            Err(e) => (Err(e), asset_key),
+        },
+        other => (other, asset_key),
     }
 }
 
@@ -4747,17 +4881,12 @@ impl IncrementalDeltaSummary {
                 tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping soft-deleted record");
                 if let Some(db) = &config.state_db {
                     let deleted_at = event.asset.as_ref().and_then(|a| a.metadata().deleted_at);
-                    let state_key = source_state_transition_key(event);
-                    let result = db
-                        .mark_soft_deleted_affected(
-                            &config.library,
-                            state_key.record_name(),
-                            deleted_at,
-                        )
-                        .await;
+                    let update = SourceStateUpdate::SoftDeleted { deleted_at };
+                    let (result, state_key) =
+                        apply_source_state_update(db.as_ref(), config, event, update).await;
                     record_incremental_state_transition_result(
                         result,
-                        IncrementalStateTransition::SoftDelete,
+                        update.transition(),
                         state_key,
                         &mut self.state_transition_failures,
                         &mut self.token_unsafe_reason,
@@ -4851,13 +4980,12 @@ impl IncrementalDeltaSummary {
                 self.hidden_count += 1;
                 tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hidden record");
                 if let Some(db) = &config.state_db {
-                    let state_key = source_state_transition_key(event);
-                    let result = db
-                        .mark_hidden_at_source_affected(&config.library, state_key.record_name())
-                        .await;
+                    let update = SourceStateUpdate::Hidden;
+                    let (result, state_key) =
+                        apply_source_state_update(db.as_ref(), config, event, update).await;
                     record_incremental_state_transition_result(
                         result,
-                        IncrementalStateTransition::Hidden,
+                        update.transition(),
                         state_key,
                         &mut self.state_transition_failures,
                         &mut self.token_unsafe_reason,
@@ -8361,6 +8489,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incremental_cplasset_soft_delete_marks_sibling_state_row_before_master_ref() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        db.upsert_seen(&TestAssetRecord::new("TRACKED_MASTER").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("asset-TRACKED_SIBLING").build())
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-TRACKED_SIBLING", "TRACKED_MASTER")
+            .await
+            .unwrap();
+
+        let result = run_incremental_change_records(
+            db.clone(),
+            vec![soft_deleted_cpl_asset_record(
+                "asset-TRACKED_SIBLING",
+                "TRACKED_MASTER",
+            )],
+        )
+        .await;
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+        let pending = db.get_pending().await.unwrap();
+        assert_source_flags(&pending, "TRACKED_MASTER", false, false);
+        assert_source_flags(&pending, "asset-TRACKED_SIBLING", true, false);
+    }
+
+    #[tokio::test]
+    async fn incremental_cplasset_hidden_marks_sibling_state_row_before_master_ref() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
+        db.upsert_seen(&TestAssetRecord::new("TRACKED_HIDDEN_MASTER").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("asset-TRACKED_HIDDEN_SIBLING").build())
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-TRACKED_HIDDEN_SIBLING",
+            "TRACKED_HIDDEN_MASTER",
+        )
+        .await
+        .unwrap();
+
+        let result = run_incremental_change_records(
+            db.clone(),
+            vec![hidden_cpl_asset_record(
+                "asset-TRACKED_HIDDEN_SIBLING",
+                "TRACKED_HIDDEN_MASTER",
+            )],
+        )
+        .await;
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(!result.stats.sync_token_blocked);
+        let pending = db.get_pending().await.unwrap();
+        assert_source_flags(&pending, "TRACKED_HIDDEN_MASTER", false, false);
+        assert_source_flags(&pending, "asset-TRACKED_HIDDEN_SIBLING", false, true);
+    }
+
+    #[tokio::test]
     async fn incremental_change_persists_asset_master_mapping() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
         let result = run_incremental_change_records(
@@ -10364,7 +10558,10 @@ mod tests {
     fn test_download_context_known_ids_populated_for_retry_only() {
         // Simulate retry-only mode: known_ids is populated
         let mut ctx = DownloadContext::default();
-        ctx.known_ids.insert("known_asset".into());
+        ctx.known_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("known_asset".into());
 
         // A known asset that's not in downloaded_ids needs download
         assert_eq!(
@@ -10379,8 +10576,12 @@ mod tests {
         );
         // The known_ids set is used externally to decide whether to skip new assets;
         // verify the set membership works
-        assert!(ctx.known_ids.contains("known_asset"));
-        assert!(!ctx.known_ids.contains("new_asset"));
+        assert!(ctx.is_known("PrimarySync", "known_asset"));
+        assert!(!ctx.is_known("PrimarySync", "new_asset"));
+        assert!(
+            !ctx.is_known("SharedSync-AAAA", "known_asset"),
+            "retry-only known IDs are library-scoped"
+        );
     }
 
     #[test]
@@ -11162,25 +11363,39 @@ mod tests {
     #[test]
     fn download_context_attempt_counts_track_per_asset() {
         let mut ctx = DownloadContext::default();
-        ctx.attempt_counts.insert("asset_high".into(), 15);
-        ctx.attempt_counts.insert("asset_low".into(), 2);
+        ctx.attempt_counts
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("asset_high".into(), 15);
+        ctx.attempt_counts
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("asset_low".into(), 2);
+        ctx.attempt_counts
+            .entry("SharedSync-AAAA".into())
+            .or_default()
+            .insert("asset_high".into(), 1);
 
         // Simulate the producer's retry-exhaustion check
         let max_attempts = 10u32;
         assert!(
-            ctx.attempt_counts
-                .get("asset_high")
-                .is_some_and(|&c| c >= max_attempts),
+            ctx.attempt_count("PrimarySync", "asset_high")
+                .is_some_and(|c| c >= max_attempts),
             "asset_high should exceed max_download_attempts"
         );
         assert!(
-            ctx.attempt_counts
-                .get("asset_low")
-                .is_none_or(|&c| c < max_attempts),
+            ctx.attempt_count("PrimarySync", "asset_low")
+                .is_none_or(|c| c < max_attempts),
             "asset_low should not exceed max_download_attempts"
         );
         assert!(
-            !ctx.attempt_counts.contains_key("asset_never_failed"),
+            ctx.attempt_count("SharedSync-AAAA", "asset_high")
+                .is_none_or(|c| c < max_attempts),
+            "same asset id in another library should not inherit primary attempts"
+        );
+        assert!(
+            ctx.attempt_count("PrimarySync", "asset_never_failed")
+                .is_none(),
             "unknown asset should not be in attempt_counts"
         );
     }
@@ -11352,7 +11567,10 @@ mod tests {
     #[test]
     fn download_context_retry_only_known_ids_filtering() {
         let mut ctx = DownloadContext::default();
-        ctx.known_ids.insert("previously_synced".into());
+        ctx.known_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("previously_synced".into());
 
         // Known asset: should_download_fast returns Some(true) (it needs
         // download because it's not in downloaded_ids)
@@ -11367,10 +11585,14 @@ mod tests {
             Some(true)
         );
         // The producer checks known_ids separately before forwarding:
-        assert!(ctx.known_ids.contains("previously_synced"));
+        assert!(ctx.is_known("PrimarySync", "previously_synced"));
         assert!(
-            !ctx.known_ids.contains("brand_new_asset"),
+            !ctx.is_known("PrimarySync", "brand_new_asset"),
             "new asset should not be in known_ids in retry_only mode"
+        );
+        assert!(
+            !ctx.is_known("SharedSync-AAAA", "previously_synced"),
+            "same asset id in another library should stay retry-only-new"
         );
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1390,8 +1390,8 @@ where
 
                         for task in plan.tasks {
                             // Mark assets that have exceeded the retry limit as failed.
-                            if let Some(&attempts) =
-                                download_ctx.attempt_counts.get(task.asset_id.as_ref())
+                            if let Some(attempts) =
+                                download_ctx.attempt_count(&task.library, &task.asset_id)
                             {
                                 if config.max_download_attempts > 0
                                     && attempts >= config.max_download_attempts
@@ -1428,7 +1428,7 @@ where
                             }
 
                             if config.retry_only
-                                && !download_ctx.known_ids.contains(task.asset_id.as_ref())
+                                && !download_ctx.is_known(&task.library, &task.asset_id)
                             {
                                 tracing::debug!(
                                     asset_id = %task.asset_id,
@@ -4067,7 +4067,7 @@ mod tests {
             Ok(HashSet::new())
         }
 
-        async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+        async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
             Ok(HashSet::new())
         }
 
@@ -4077,7 +4077,7 @@ mod tests {
             Ok(HashMap::new())
         }
 
-        async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+        async fn get_attempt_counts(&self) -> Result<HashMap<(String, String), u32>, StateError> {
             Ok(HashMap::new())
         }
 

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -827,7 +827,7 @@ impl PhotoAlbum {
                 .filter(|id| !seen_asset_records.contains(id))
                 .collect();
             if missing.is_empty() {
-                let _ = token_tx.send(None);
+                let _ = token_tx.send(base_token);
                 return;
             }
 
@@ -844,12 +844,15 @@ impl PhotoAlbum {
                     break;
                 }
                 let missing_before = missing.len();
-                match source
-                    .send_matching_assets_from_changes(&mut missing, &tx)
-                    .await
-                {
-                    Ok(()) => {
+                match source.matching_assets_from_changes(&mut missing).await {
+                    Ok(assets) => {
                         hydrated += missing_before.saturating_sub(missing.len());
+                        for asset in assets {
+                            if tx.send(Ok(asset)).await.is_err() {
+                                let _ = token_tx.send(None);
+                                return;
+                            }
+                        }
                     }
                     Err(e) => {
                         let _ = tx.send(Err(e)).await;
@@ -879,10 +882,7 @@ impl PhotoAlbum {
                 );
             }
 
-            // Cross-zone hydration currently replays full relation/source-zone
-            // scans. Suppress the owner zone token until incremental relation
-            // semantics are implemented.
-            let _ = token_tx.send(None);
+            let _ = token_tx.send(if missing.is_empty() { base_token } else { None });
         });
 
         (
@@ -986,11 +986,31 @@ impl PhotoAlbum {
         Ok(ids)
     }
 
-    async fn send_matching_assets_from_changes(
+    pub(crate) async fn hydrate_matching_assets_from_changes(
         &self,
         missing_asset_record_names: &mut FxHashSet<String>,
-        tx: &mpsc::Sender<anyhow::Result<PhotoAsset>>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<PhotoAsset>> {
+        let mut matched = self
+            .clone_for_task_without_sources()
+            .matching_assets_from_changes(missing_asset_record_names)
+            .await?;
+        for source in self.cross_zone_sources_for_task() {
+            if missing_asset_record_names.is_empty() {
+                break;
+            }
+            matched.extend(
+                source
+                    .matching_assets_from_changes(missing_asset_record_names)
+                    .await?,
+            );
+        }
+        Ok(matched)
+    }
+
+    async fn matching_assets_from_changes(
+        &self,
+        missing_asset_record_names: &mut FxHashSet<String>,
+    ) -> anyhow::Result<Vec<PhotoAsset>> {
         let source_zone: Arc<str> = Arc::from(self.zone_name());
         let mut buffer = DeltaRecordBuffer::new();
         let mut matched = Vec::new();
@@ -1017,10 +1037,7 @@ impl PhotoAlbum {
                 matched.push(asset);
             }
         }
-        for asset in matched {
-            tx.send(Ok(asset)).await?;
-        }
-        Ok(())
+        Ok(matched)
     }
 
     async fn scan_changes_zone<F>(&self, mut on_record: F) -> anyhow::Result<()>
@@ -3086,9 +3103,9 @@ mod tests {
             && asset.asset_record_name() == "asset-master-shared"
             && asset.source_zone() == Some("SharedSync-abc")));
         assert_eq!(
-            token_rx.await.expect("sync token sender"),
-            None,
-            "cross-zone hydration suppresses owner-zone token advancement"
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("owner-token"),
+            "fully resolved cross-zone hydration can keep the owner-zone token"
         );
         assert_eq!(
             owner_query_calls.load(std::sync::atomic::Ordering::SeqCst),

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1485,9 +1485,7 @@ impl PhotoAlbum {
                             .get_or_insert_with(Vec::new)
                             .extend(page_records);
                     }
-                    if let Some(mut asset_records) = asset_records {
-                        asset_records
-                            .sort_by(|left, right| left.record_name.cmp(&right.record_name));
+                    if let Some(asset_records) = asset_records {
                         let sibling_count = asset_records.len();
                         for (index, asset_rec) in asset_records.into_iter().enumerate() {
                             if let Some(n) = limit {
@@ -1530,8 +1528,6 @@ impl PhotoAlbum {
 
                 for (master_id, records) in page_assets {
                     if let Some(master) = pending_masters.remove(&master_id) {
-                        let mut records = records;
-                        records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
                         let sibling_count = records.len();
                         for (index, asset_rec) in records.into_iter().enumerate() {
                             if let Some(n) = limit {
@@ -1554,8 +1550,6 @@ impl PhotoAlbum {
                         paired_masters.insert(master.record_name.clone(), master);
                         prune_paired_master_cache(&mut paired_masters, max_pending_records);
                     } else if let Some(master) = paired_masters.get(&master_id) {
-                        let mut records = records;
-                        records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
                         for asset_rec in records {
                             if let Some(n) = limit {
                                 if total_sent >= u64::from(n) {
@@ -2440,13 +2434,65 @@ mod tests {
             vec![
                 (
                     "master-sibling".to_string(),
-                    "asset-sibling-a".to_string(),
+                    "asset-sibling-b".to_string(),
                     "master-sibling".to_string(),
                 ),
                 (
                     "master-sibling".to_string(),
-                    "asset-sibling-b".to_string(),
-                    "asset-sibling-b".to_string(),
+                    "asset-sibling-a".to_string(),
+                    "asset-sibling-a".to_string(),
+                ),
+            ]
+        );
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-full")
+        );
+    }
+
+    #[tokio::test]
+    async fn full_query_late_earlier_sibling_keeps_first_seen_master_state_id() {
+        use tokio_stream::StreamExt;
+
+        let mock = MockPhotosFlow::new()
+            .query_page(
+                vec![
+                    test_asset_record_for("asset-late-b", "master-late-earlier"),
+                    test_master_record("master-late-earlier"),
+                ],
+                Some("token-full"),
+            )
+            .query_page(
+                vec![test_asset_record_for("asset-late-a", "master-late-earlier")],
+                Some("token-full"),
+            )
+            .build();
+        let album = make_album_with_session(1, Box::new(mock));
+
+        let (stream, token_rx) = album.photo_stream_with_token(None, Some(2), 1);
+        tokio::pin!(stream);
+        let mut seen = Vec::new();
+        while let Some(result) = stream.next().await {
+            let asset = result.expect("late sibling asset should parse");
+            seen.push((
+                asset.id().to_string(),
+                asset.asset_record_name().to_string(),
+                asset.state_id().to_string(),
+            ));
+        }
+
+        assert_eq!(
+            seen,
+            vec![
+                (
+                    "master-late-earlier".to_string(),
+                    "asset-late-b".to_string(),
+                    "master-late-earlier".to_string(),
+                ),
+                (
+                    "master-late-earlier".to_string(),
+                    "asset-late-a".to_string(),
+                    "asset-late-a".to_string(),
                 ),
             ]
         );

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -917,11 +917,10 @@ impl DeltaRecordBuffer {
 
     fn emit_paired_group(
         master_record: Record,
-        mut asset_records: Vec<Record>,
+        asset_records: Vec<Record>,
         master_reason: ChangeReason,
         events: &mut Vec<ChangeEvent>,
     ) {
-        asset_records.sort_by(|left, right| left.record_name.cmp(&right.record_name));
         let sibling_count = asset_records.len();
         for (index, asset_record) in asset_records.into_iter().enumerate() {
             let reason =
@@ -1590,12 +1589,12 @@ mod tests {
             .iter()
             .map(|event| event.asset.as_ref().expect("paired asset"))
             .collect();
-        assert_eq!(assets[0].asset_record_name(), "A1");
+        assert_eq!(assets[0].asset_record_name(), "A2");
         assert_eq!(assets[0].id(), "M1");
         assert_eq!(assets[0].state_id(), "M1");
-        assert_eq!(assets[1].asset_record_name(), "A2");
+        assert_eq!(assets[1].asset_record_name(), "A1");
         assert_eq!(assets[1].id(), "M1");
-        assert_eq!(assets[1].state_id(), "A2");
+        assert_eq!(assets[1].state_id(), "A1");
     }
 
     #[test]
@@ -1609,10 +1608,10 @@ mod tests {
         ]);
 
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].asset.as_ref().unwrap().asset_record_name(), "A1");
-        assert_eq!(events[0].reason, ChangeReason::Created);
-        assert_eq!(events[1].asset.as_ref().unwrap().asset_record_name(), "A2");
-        assert_eq!(events[1].reason, ChangeReason::SoftDeleted);
+        assert_eq!(events[0].asset.as_ref().unwrap().asset_record_name(), "A2");
+        assert_eq!(events[0].reason, ChangeReason::SoftDeleted);
+        assert_eq!(events[1].asset.as_ref().unwrap().asset_record_name(), "A1");
+        assert_eq!(events[1].reason, ChangeReason::Created);
     }
 
     #[test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -156,7 +156,7 @@ pub trait DownloadStateStore: Send + Sync {
         Ok(0)
     }
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError>;
-    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError>;
+    async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError>;
     async fn get_downloaded_checksums(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError>;
@@ -165,7 +165,7 @@ pub trait DownloadStateStore: Send + Sync {
     ) -> Result<HashMap<(String, String, String), PathBuf>, StateError> {
         Ok(HashMap::new())
     }
-    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError>;
+    async fn get_attempt_counts(&self) -> Result<HashMap<(String, String), u32>, StateError>;
     async fn touch_last_seen_many(
         &self,
         library: &str,
@@ -1927,14 +1927,16 @@ impl SqliteStateDb {
         .await
     }
 
-    pub(crate) async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+    pub(crate) async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
         self.with_conn("get_all_known_ids", move |conn| {
             let mut stmt = conn
-                .prepare_cached("SELECT DISTINCT id FROM assets")
+                .prepare_cached("SELECT DISTINCT library, id FROM assets")
                 .map_err(|e| StateError::query("get_all_known_ids", e))?;
 
             let ids = stmt
-                .query_map([], |row| row.get::<_, String>(0))
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
                 .map_err(|e| StateError::query("get_all_known_ids", e))?
                 .collect::<Result<HashSet<_>, _>>()
                 .map_err(|e| StateError::query("get_all_known_ids", e))?;
@@ -2034,20 +2036,23 @@ impl SqliteStateDb {
         .await
     }
 
-    pub(crate) async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+    pub(crate) async fn get_attempt_counts(
+        &self,
+    ) -> Result<HashMap<(String, String), u32>, StateError> {
         self.with_conn("get_attempt_counts", move |conn| {
             let mut stmt = conn
                 .prepare_cached(
-                    "SELECT id, MAX(download_attempts) FROM assets \
-                     WHERE download_attempts > 0 GROUP BY id",
+                    "SELECT library, id, MAX(download_attempts) FROM assets \
+                     WHERE download_attempts > 0 GROUP BY library, id",
                 )
                 .map_err(|e| StateError::query("get_attempt_counts", e))?;
 
             let counts = stmt
                 .query_map([], |row| {
-                    let id: String = row.get(0)?;
-                    let count: i64 = row.get(1)?;
-                    Ok((id, u32::try_from(count).unwrap_or(u32::MAX)))
+                    let library: String = row.get(0)?;
+                    let id: String = row.get(1)?;
+                    let count: i64 = row.get(2)?;
+                    Ok(((library, id), u32::try_from(count).unwrap_or(u32::MAX)))
                 })
                 .map_err(|e| StateError::query("get_attempt_counts", e))?
                 .collect::<Result<HashMap<_, _>, _>>()
@@ -3098,7 +3103,7 @@ impl DownloadStateStore for SqliteStateDb {
         SqliteStateDb::get_downloaded_ids(self).await
     }
 
-    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+    async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
         SqliteStateDb::get_all_known_ids(self).await
     }
 
@@ -3114,7 +3119,7 @@ impl DownloadStateStore for SqliteStateDb {
         SqliteStateDb::get_downloaded_local_paths(self).await
     }
 
-    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+    async fn get_attempt_counts(&self) -> Result<HashMap<(String, String), u32>, StateError> {
         SqliteStateDb::get_attempt_counts(self).await
     }
 
@@ -5376,14 +5381,22 @@ mod tests {
         db.mark_failed("PrimarySync", "FAILED_1", "original", "test error")
             .await
             .unwrap();
+        let shared_same_id = TestAssetRecord::new("FAILED_1")
+            .library("SharedSync-AAAA")
+            .checksum("shared_failed_ck")
+            .filename("shared_failed.jpg")
+            .size(1000)
+            .build();
+        db.upsert_seen(&shared_same_id).await.unwrap();
 
         let known_ids = db.get_all_known_ids().await.unwrap();
-        // Should include all 4 assets regardless of status
-        assert_eq!(known_ids.len(), 4);
-        assert!(known_ids.contains("DL_0"));
-        assert!(known_ids.contains("DL_1"));
-        assert!(known_ids.contains("PENDING_1"));
-        assert!(known_ids.contains("FAILED_1"));
+        // Should include all assets regardless of status, scoped by library.
+        assert_eq!(known_ids.len(), 5);
+        assert!(known_ids.contains(&("PrimarySync".to_string(), "DL_0".to_string())));
+        assert!(known_ids.contains(&("PrimarySync".to_string(), "DL_1".to_string())));
+        assert!(known_ids.contains(&("PrimarySync".to_string(), "PENDING_1".to_string())));
+        assert!(known_ids.contains(&("PrimarySync".to_string(), "FAILED_1".to_string())));
+        assert!(known_ids.contains(&("SharedSync-AAAA".to_string(), "FAILED_1".to_string())));
 
         // get_downloaded_ids should only return 2
         let downloaded_ids = db.get_downloaded_ids().await.unwrap();
@@ -5451,8 +5464,8 @@ mod tests {
         // After reset, the failed asset should be in known_ids but not downloaded_ids
         let known = db.get_all_known_ids().await.unwrap();
         assert_eq!(known.len(), 2);
-        assert!(known.contains("DL_1"));
-        assert!(known.contains("FAIL_1"));
+        assert!(known.contains(&("PrimarySync".to_string(), "DL_1".to_string())));
+        assert!(known.contains(&("PrimarySync".to_string(), "FAIL_1".to_string())));
 
         let downloaded = db.get_downloaded_ids().await.unwrap();
         assert_eq!(downloaded.len(), 1);
@@ -6463,8 +6476,13 @@ mod tests {
     async fn test_get_attempt_counts() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        for id in ["A", "B"] {
+        for (library, id) in [
+            ("PrimarySync", "A"),
+            ("PrimarySync", "B"),
+            ("SharedSync-AAAA", "A"),
+        ] {
             let record = TestAssetRecord::new(id)
+                .library(library)
                 .checksum(&format!("ck_{id}"))
                 .filename(&format!("{id}.jpg"))
                 .size(1000)
@@ -6484,10 +6502,23 @@ mod tests {
         db.mark_failed("PrimarySync", "B", "original", "error 1")
             .await
             .unwrap();
+        db.mark_failed("SharedSync-AAAA", "A", "original", "shared error 1")
+            .await
+            .unwrap();
 
         let counts = db.get_attempt_counts().await.unwrap();
-        assert_eq!(counts.get("A"), Some(&3));
-        assert_eq!(counts.get("B"), Some(&1));
+        assert_eq!(
+            counts.get(&("PrimarySync".to_string(), "A".to_string())),
+            Some(&3)
+        );
+        assert_eq!(
+            counts.get(&("PrimarySync".to_string(), "B".to_string())),
+            Some(&1)
+        );
+        assert_eq!(
+            counts.get(&("SharedSync-AAAA".to_string(), "A".to_string())),
+            Some(&1)
+        );
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4115,7 +4115,7 @@ mod tests {
 
         async fn get_all_known_ids(
             &self,
-        ) -> Result<std::collections::HashSet<String>, state::error::StateError> {
+        ) -> Result<std::collections::HashSet<(String, String)>, state::error::StateError> {
             self.inner.get_all_known_ids().await
         }
 
@@ -4139,7 +4139,8 @@ mod tests {
 
         async fn get_attempt_counts(
             &self,
-        ) -> Result<std::collections::HashMap<String, u32>, state::error::StateError> {
+        ) -> Result<std::collections::HashMap<(String, String), u32>, state::error::StateError>
+        {
             self.inner.get_attempt_counts().await
         }
 


### PR DESCRIPTION
## Summary
- Fixed identity-family sync-token blockers when iCloud sends selected-album relation deltas before the matching asset record.
- Added bounded relation hydration and persisted asset/master mapping recovery for selected album members.
- Scoped retry-only state, attempt counts, and source-state deltas to the correct iCloud library.

## Context
Closes #640.

## Tests
- `cargo test relation_add -- --test-threads=1`
- `cargo test photo_stream_hydrates_named_album_members_from_other_zones -- --test-threads=1`
- `cargo test photo_stream_warns_but_continues_for_unresolved_relation_members -- --test-threads=1`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate`
