### PR TITLE
Fix pending retry URL refresh

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2009,6 +2009,72 @@ mod tests {
     use super::*;
     use crate::cli::SyncArgs;
 
+    fn documented_config_options() -> BTreeSet<&'static str> {
+        [
+            "data_dir",
+            "log_level",
+            "auth.username",
+            "auth.password_file",
+            "auth.password_command",
+            "auth.domain",
+            "download.directory",
+            "download.folder_structure",
+            "download.folder_structure_albums",
+            "download.folder_structure_smart_folders",
+            "download.threads",
+            "download.bandwidth_limit",
+            "download.temp_suffix",
+            "download.retry.per_transfer",
+            "download.retry.per_asset",
+            "filters.libraries",
+            "filters.albums",
+            "filters.smart_folders",
+            "filters.unfiled",
+            "filters.media",
+            "filters.filename_exclude",
+            "filters.recent",
+            "filters.recent_scope",
+            "filters.skip_created_before",
+            "filters.skip_created_after",
+            "photos.resolution",
+            "photos.live_resolution",
+            "photos.live_photo_mode",
+            "photos.live_photo_mov_filename_policy",
+            "photos.edited",
+            "photos.alternative",
+            "photos.raw_policy",
+            "photos.file_match_policy",
+            "photos.force_resolution",
+            "photos.keep_unicode_in_filenames",
+            "metadata.set_exif_datetime",
+            "metadata.set_exif_rating",
+            "metadata.set_exif_gps",
+            "metadata.set_exif_description",
+            "metadata.embed_xmp",
+            "metadata.xmp_sidecar",
+            "watch.interval",
+            "watch.notify_systemd",
+            "watch.pid_file",
+            "watch.reconcile_every_n_cycles",
+            "notifications.script",
+            "report.json",
+            "server.bind",
+            "server.port",
+            "ui.friendly",
+            "ui.progress_bar",
+            "import.strict",
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn example_config_option_markers(raw: &str) -> BTreeSet<&str> {
+        raw.lines()
+            .filter_map(|line| line.trim().strip_prefix("# Option: "))
+            .map(str::trim)
+            .collect()
+    }
+
     #[test]
     fn example_config_toml_parses() {
         let raw = include_str!("../example.config.toml");
@@ -2040,6 +2106,25 @@ mod tests {
         ] {
             assert!(present, "example config should include [{section}]");
         }
+    }
+
+    #[test]
+    fn example_config_documents_supported_options() {
+        let raw = include_str!("../example.config.toml");
+        let documented = example_config_option_markers(raw);
+        let expected = documented_config_options();
+        assert_eq!(
+            documented, expected,
+            "example.config.toml # Option markers must stay in sync with supported TOML options"
+        );
+        assert!(
+            !documented.contains("auth.password"),
+            "plaintext [auth].password must not be listed as a supported option"
+        );
+        assert!(
+            raw.contains("Plaintext [auth].password is not a supported config option"),
+            "example config must keep the plaintext password migration note"
+        );
     }
 
     // ── validate_template_tokens ─────────────────────────────────────

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use limiter::BandwidthLimiter;
 
 use pipeline::{
     build_download_outcome, format_duration, log_sync_summary, run_download_pass,
-    stream_and_download_from_stream, MetadataFlags, PassConfig, StreamRuntime, StreamingResult,
-    AUTH_ERROR_THRESHOLD,
+    stream_and_download_from_stream, MetadataFlags, PassConfig, PassResult, StreamRuntime,
+    StreamingResult, AUTH_ERROR_THRESHOLD,
 };
 
 pub(crate) use filter::determine_media_type;
@@ -2617,7 +2617,7 @@ struct RetryTaskKey {
 }
 
 #[derive(Debug, Clone)]
-struct IncrementalRetrySource {
+struct UrlRetrySource {
     asset_record_name: Arc<str>,
     pass_index: usize,
 }
@@ -2712,6 +2712,8 @@ fn take_matching_retry_tasks<I>(
 #[derive(Debug, Default)]
 struct PendingRetryPlan {
     tasks: Vec<DownloadTask>,
+    retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource>,
+    pass_configs: Vec<Arc<DownloadConfig>>,
     unmatched_targets: Vec<PendingRetryTarget>,
     requested: usize,
 }
@@ -2738,6 +2740,7 @@ async fn build_pending_retry_download_tasks(
     let requested = pending_targets.len();
     let pass_configs = build_pass_configs_resolving_deferred_excludes(passes, config).await?;
     let mut tasks: Vec<DownloadTask> = Vec::with_capacity(requested);
+    let mut retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource> = FxHashMap::default();
     let mut task_planner = planner::TaskPlanner::new();
 
     for (pass_index, pass) in passes.iter().enumerate() {
@@ -2761,7 +2764,17 @@ async fn build_pending_retry_download_tasks(
             if plan.filter_reason.is_some() {
                 continue;
             }
+            let first_new_task = tasks.len();
             take_matching_pending_retry_tasks(plan.tasks, &mut pending_targets, &mut tasks);
+            for task in tasks.iter().skip(first_new_task) {
+                retry_sources.insert(
+                    RetryTaskKey::from(task),
+                    UrlRetrySource {
+                        asset_record_name: asset.asset_record_name_arc(),
+                        pass_index,
+                    },
+                );
+            }
         }
     }
 
@@ -2777,6 +2790,8 @@ async fn build_pending_retry_download_tasks(
 
     Ok(PendingRetryPlan {
         tasks,
+        retry_sources,
+        pass_configs,
         unmatched_targets: pending_targets.into_iter().collect(),
         requested,
     })
@@ -2906,7 +2921,7 @@ async fn build_retry_download_tasks(
 async fn build_incremental_expired_url_retry_tasks(
     passes: &[crate::commands::AlbumPass],
     pass_configs: &[Arc<DownloadConfig>],
-    retry_sources: &FxHashMap<RetryTaskKey, IncrementalRetrySource>,
+    retry_sources: &FxHashMap<RetryTaskKey, UrlRetrySource>,
     failed_tasks: &[DownloadTask],
     shutdown_token: CancellationToken,
 ) -> Result<Vec<DownloadTask>> {
@@ -3018,10 +3033,40 @@ async fn build_incremental_expired_url_retry_tasks(
     Ok(tasks)
 }
 
+fn merge_expired_url_retry_result(
+    pass_result: &mut PassResult,
+    expired_retry_candidates: Vec<DownloadTask>,
+    refreshed_keys: FxHashSet<RetryTaskKey>,
+    retry_result: PassResult,
+) {
+    let mut still_failed: Vec<DownloadTask> = expired_retry_candidates
+        .into_iter()
+        .filter(|task| !refreshed_keys.contains(&RetryTaskKey::from(task)))
+        .collect();
+    let unrefreshed_expired_failures = still_failed.len();
+    still_failed.extend(retry_result.failed);
+    pass_result.failed = still_failed;
+    pass_result.downloaded += retry_result.downloaded;
+    pass_result
+        .downloaded_tasks
+        .extend(retry_result.downloaded_tasks);
+    pass_result.auth_errors += retry_result.auth_errors;
+    pass_result.exif_failures += retry_result.exif_failures;
+    pass_result.state_write_failures += retry_result.state_write_failures;
+    pass_result.bytes_downloaded += retry_result.bytes_downloaded;
+    pass_result.disk_bytes_written += retry_result.disk_bytes_written;
+    pass_result.rate_limit_observations += retry_result.rate_limit_observations;
+    pass_result.photos_downloaded += retry_result.photos_downloaded;
+    pass_result.videos_downloaded += retry_result.videos_downloaded;
+    pass_result.recap.merge(retry_result.recap);
+    pass_result.url_expired_abort =
+        retry_result.url_expired_abort || unrefreshed_expired_failures > 0;
+}
+
 async fn refresh_stale_incremental_tasks_before_download(
     passes: &[crate::commands::AlbumPass],
     pass_configs: &[Arc<DownloadConfig>],
-    retry_sources: &FxHashMap<RetryTaskKey, IncrementalRetrySource>,
+    retry_sources: &FxHashMap<RetryTaskKey, UrlRetrySource>,
     tasks: Vec<DownloadTask>,
     urls_obtained_at: Option<Instant>,
     refresh_after: Duration,
@@ -3821,6 +3866,8 @@ async fn run_pending_retry_pass(
     let plan = build_pending_retry_download_tasks(passes, config, shutdown_token.clone()).await?;
     let PendingRetryPlan {
         tasks,
+        retry_sources,
+        pass_configs,
         unmatched_targets,
         requested,
     } = plan;
@@ -3896,7 +3943,72 @@ async fn run_pending_retry_pass(
         bandwidth_limiter: config.bandwidth_limiter.clone(),
         library: Arc::clone(&config.library),
     };
-    let pass_result = run_download_pass(pass_config, tasks).await;
+    let planned_tasks = tasks.clone();
+    let mut pass_result = run_download_pass(pass_config, tasks).await;
+    if pass_result.url_expired_abort
+        && pass_result.auth_errors < AUTH_ERROR_THRESHOLD
+        && !shutdown_token.is_cancelled()
+    {
+        let downloaded_keys: FxHashSet<RetryTaskKey> = pass_result
+            .downloaded_tasks
+            .iter()
+            .map(RetryTaskKey::from)
+            .collect();
+        let expired_retry_candidates: Vec<DownloadTask> = planned_tasks
+            .iter()
+            .filter(|task| !downloaded_keys.contains(&RetryTaskKey::from(*task)))
+            .cloned()
+            .collect();
+        let retry_tasks = match build_incremental_expired_url_retry_tasks(
+            passes,
+            &pass_configs,
+            &retry_sources,
+            &expired_retry_candidates,
+            shutdown_token.clone(),
+        )
+        .await
+        {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Could not refresh expired pending-retry download URLs; leaving failures for replay"
+                );
+                Vec::new()
+            }
+        };
+        if !retry_tasks.is_empty() {
+            let retry_task_count = retry_tasks.len();
+            tracing::info!(
+                count = retry_task_count,
+                "Refreshing expired pending-retry download URLs and retrying failed tasks"
+            );
+            let refreshed_keys: FxHashSet<RetryTaskKey> =
+                retry_tasks.iter().map(RetryTaskKey::from).collect();
+            let retry_pass_config = PassConfig {
+                client: download_client,
+                retry_config: &config.retry,
+                metadata: MetadataFlags::from(config.as_ref()),
+                concurrency: config.concurrent_downloads,
+                reporting: controls.reporting,
+                temp_suffix: Arc::clone(&config.temp_suffix),
+                shutdown_token: shutdown_token.clone(),
+                state_db: config.state_db.clone(),
+                rate_limit_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                bandwidth_limiter: config.bandwidth_limiter.clone(),
+                library: Arc::clone(&config.library),
+            };
+            let retry_result = run_download_pass(retry_pass_config, retry_tasks).await;
+            merge_expired_url_retry_result(
+                &mut pass_result,
+                expired_retry_candidates,
+                refreshed_keys,
+                retry_result,
+            );
+        } else if !expired_retry_candidates.is_empty() {
+            pass_result.failed = expired_retry_candidates;
+        }
+    }
     let failed = pass_result.failed.len();
     if failed > 0 {
         for task in &pass_result.failed {
@@ -6034,7 +6146,7 @@ async fn download_photos_incremental_collecting_inner(
     // start on large album sets.
     let phase_started = Instant::now();
     let pass_configs = build_pass_configs(passes, config);
-    let mut retry_sources: FxHashMap<RetryTaskKey, IncrementalRetrySource> = FxHashMap::default();
+    let mut retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource> = FxHashMap::default();
 
     for (asset, pass_index) in &downloadable_assets {
         #[allow(
@@ -6063,7 +6175,7 @@ async fn download_photos_incremental_collecting_inner(
         for task in &plan.tasks {
             retry_sources.insert(
                 RetryTaskKey::from(task),
-                IncrementalRetrySource {
+                UrlRetrySource {
                     asset_record_name: asset.asset_record_name_arc(),
                     pass_index: *pass_index,
                 },
@@ -6283,29 +6395,12 @@ async fn download_photos_incremental_collecting_inner(
                 library: Arc::clone(&config.library),
             };
             let retry_result = run_download_pass(retry_pass_config, retry_tasks).await;
-
-            let mut still_failed: Vec<DownloadTask> = expired_retry_candidates
-                .into_iter()
-                .filter(|task| !refreshed_keys.contains(&RetryTaskKey::from(task)))
-                .collect();
-            let unrefreshed_expired_failures = still_failed.len();
-            still_failed.extend(retry_result.failed);
-            pass_result.failed = still_failed;
-            pass_result.downloaded += retry_result.downloaded;
-            pass_result
-                .downloaded_tasks
-                .extend(retry_result.downloaded_tasks);
-            pass_result.auth_errors += retry_result.auth_errors;
-            pass_result.exif_failures += retry_result.exif_failures;
-            pass_result.state_write_failures += retry_result.state_write_failures;
-            pass_result.bytes_downloaded += retry_result.bytes_downloaded;
-            pass_result.disk_bytes_written += retry_result.disk_bytes_written;
-            pass_result.rate_limit_observations += retry_result.rate_limit_observations;
-            pass_result.photos_downloaded += retry_result.photos_downloaded;
-            pass_result.videos_downloaded += retry_result.videos_downloaded;
-            pass_result.recap.merge(retry_result.recap);
-            pass_result.url_expired_abort =
-                retry_result.url_expired_abort || unrefreshed_expired_failures > 0;
+            merge_expired_url_retry_result(
+                &mut pass_result,
+                expired_retry_candidates,
+                refreshed_keys,
+                retry_result,
+            );
         } else if !expired_retry_candidates.is_empty() {
             pass_result.failed = expired_retry_candidates;
         }
@@ -10452,6 +10547,95 @@ mod tests {
             tokio::fs::metadata(local_path).await.is_ok(),
             "targeted retry should finalize the downloaded file"
         );
+    }
+
+    #[tokio::test]
+    async fn pending_retry_expired_url_hydrates_current_records() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = crate::start_wiremock_or_skip!();
+        Mock::given(method("GET"))
+            .and(path("/expired-pending.jpg"))
+            .respond_with(ResponseTemplate::new(410))
+            .mount(&server)
+            .await;
+
+        let body = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&body));
+        Mock::given(method("GET"))
+            .and(path("/fresh-pending.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = crate::test_helpers::TestAssetRecord::new("PENDING_EXPIRED_URL")
+            .filename("pending-expired-url.jpg")
+            .checksum("ck_pending_expired_url")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let expired_url = format!("{}/expired-pending.jpg", server.uri());
+        let fresh_url = format!("{}/fresh-pending.jpg", server.uri());
+        let mut expired_records = incremental_photo_records_with_url(
+            "PENDING_EXPIRED_URL",
+            "pending-expired-url.jpg",
+            &expired_url,
+            8,
+        );
+        expired_records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] =
+            json!(checksum.clone());
+        let mut fresh_records = incremental_photo_records_with_url(
+            "PENDING_EXPIRED_URL",
+            "pending-expired-url.jpg",
+            &fresh_url,
+            8,
+        );
+        fresh_records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] = json!(checksum);
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(Vec::new(), "zone-token-next", false)
+            .query_page(expired_records, Some("ignored-query-token"))
+            .changes_zone_page(fresh_records, "zone-token-hydrated", false)
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("expired pending retry URL should hydrate and retry");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(!result.stats.interrupted);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.downloaded, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 0);
     }
 
     #[tokio::test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -10603,6 +10603,14 @@ mod tests {
         let session = MockPhotosFlow::new()
             .changes_zone_page(Vec::new(), "zone-token-next", false)
             .query_page(expired_records, Some("ignored-query-token"))
+            // Full-query pending retry probes through consecutive empty pages
+            // after the match; keep the hydration response queued for the
+            // same-cycle expired-URL retry.
+            .empty_query_page(Some("ignored-query-token"))
+            .empty_query_page(Some("ignored-query-token"))
+            .empty_query_page(Some("ignored-query-token"))
+            .empty_query_page(Some("ignored-query-token"))
+            .empty_query_page(Some("ignored-query-token"))
             .changes_zone_page(fresh_records, "zone-token-hydrated", false)
             .build();
         let passes = vec![AlbumPass {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -7454,6 +7454,67 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug)]
+    struct PendingRetryExpiredUrlSession {
+        query_calls: Arc<AtomicUsize>,
+        expired_records: Arc<Vec<Value>>,
+        fresh_records: Arc<Vec<Value>>,
+    }
+
+    impl PendingRetryExpiredUrlSession {
+        fn new(expired_records: Vec<Value>, fresh_records: Vec<Value>) -> Self {
+            Self {
+                query_calls: Arc::new(AtomicUsize::new(0)),
+                expired_records: Arc::new(expired_records),
+                fresh_records: Arc::new(fresh_records),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for PendingRetryExpiredUrlSession {
+        async fn post(
+            &self,
+            url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/changes/zone?") {
+                let request: Value = serde_json::from_str(&body)?;
+                let has_sync_token = request["zones"]
+                    .as_array()
+                    .and_then(|zones| zones.first())
+                    .and_then(|zone| zone.get("syncToken"))
+                    .and_then(Value::as_str)
+                    .is_some();
+                let records = if has_sync_token {
+                    Vec::new()
+                } else {
+                    self.fresh_records.as_ref().clone()
+                };
+                return Ok(changes_zone_response(records, "zone-token-next"));
+            }
+
+            if url.contains("/records/query?") {
+                let call = self.query_calls.fetch_add(1, Ordering::SeqCst);
+                return Ok(if call == 0 {
+                    json!({
+                        "records": self.expired_records.as_ref().clone(),
+                        "syncToken": "ignored-query-token"
+                    })
+                } else {
+                    json!({"records": [], "syncToken": "ignored-query-token"})
+                });
+            }
+
+            Ok(json!({"records": []}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
     fn changes_zone_response(records: Vec<Value>, sync_token: &str) -> Value {
         json!({
             "zones": [{
@@ -10600,22 +10661,10 @@ mod tests {
             8,
         );
         fresh_records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] = json!(checksum);
-        let session = MockPhotosFlow::new()
-            .changes_zone_page(Vec::new(), "zone-token-next", false)
-            .query_page(expired_records, Some("ignored-query-token"))
-            // Full-query pending retry probes through consecutive empty pages
-            // after the match; keep the hydration response queued for the
-            // same-cycle expired-URL retry.
-            .empty_query_page(Some("ignored-query-token"))
-            .empty_query_page(Some("ignored-query-token"))
-            .empty_query_page(Some("ignored-query-token"))
-            .empty_query_page(Some("ignored-query-token"))
-            .empty_query_page(Some("ignored-query-token"))
-            .changes_zone_page(fresh_records, "zone-token-hydrated", false)
-            .build();
+        let session = PendingRetryExpiredUrlSession::new(expired_records, fresh_records);
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
-            album: mock_album("", session),
+            album: album_with_session("PrimarySync", "", Box::new(session)),
             exclude_ids: Arc::new(FxHashSet::default()),
         }];
 
@@ -10637,7 +10686,10 @@ mod tests {
         .await
         .expect("expired pending retry URL should hydrate and retry");
 
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "result: {result:?}"
+        );
         assert!(!result.stats.interrupted);
         assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
         let summary = db.get_summary().await.expect("summary");


### PR DESCRIPTION
## Summary
- Refresh pending-retry downloads after an expired signed URL by hydrating current CloudKit records and retrying only the affected task tuples.
- Share expired-URL retry result merging with the incremental path so pending retry and incremental retry keep the same accounting.
- Add a config reference guard for `example.config.toml` `# Option:` markers, with `[auth].password` kept as an unsupported migration note.

## Tests
- `cargo check` => pass
- `cargo test pending_retry -- --test-threads=1` => pass
- `cargo test incremental_expired_url -- --test-threads=1` => pass
- `cargo test example_config_documents_supported_options -- --test-threads=1` => pass
- `cargo test example_config_toml_parses -- --test-threads=1` => pass
- `cargo test pending_retry_expired_url_hydrates_current_records -- --test-threads=1` unrestricted => pass
- `cargo fmt --check` => pass
- `cargo clippy --all-targets --all-features -- -D warnings` => pass
- `cargo test -- --test-threads=1` unrestricted => pass, 2790 passed, 0 failed, 1 ignored in lib plus integration/doc suites pass
