### PR TITLE
Prune source-deleted pending retries

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3514,7 +3514,7 @@ async fn run_source_state_update(
 ) -> Result<usize, crate::state::error::StateError> {
     match update {
         SourceStateUpdate::SoftDeleted { deleted_at } => {
-            db.mark_soft_deleted_affected(&config.library, key.record_name(), deleted_at)
+            db.resolve_source_deleted_affected(&config.library, key.record_name(), deleted_at)
                 .await
         }
         SourceStateUpdate::Hidden => {
@@ -4191,6 +4191,18 @@ pub async fn download_photos_with_sync(
     // failed -> pending (with attempts reset), and stale attempt counts on
     // pending assets cleared so the per-sync cap starts from zero.
     let (_retry_failed_count, total_pending) = if let Some(db) = &config.state_db {
+        match db.prune_source_deleted_retries(Some(&config.library)).await {
+            Ok(0) => {}
+            Ok(count) => {
+                tracing::info!(
+                    count,
+                    "Pruned source-deleted pending/failed assets from retry queue"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to prune source-deleted retry assets");
+            }
+        }
         match db.prepare_for_retry(Some(&config.library)).await {
             Ok((failed, stale, total_pending)) => {
                 if failed > 0 {
@@ -5299,7 +5311,7 @@ impl IncrementalDeltaSummary {
                             unresolved_identity: true,
                         };
                         match db
-                            .mark_master_family_soft_deleted_affected(
+                            .resolve_master_family_source_deleted_affected(
                                 &config.library,
                                 unresolved_tombstone_key.record_name(),
                                 None,
@@ -5348,14 +5360,14 @@ impl IncrementalDeltaSummary {
                     let result = if matches!(state_key.record_type, Some("CPLMaster"))
                         && !matches!(event.record_type.as_deref(), Some("CPLAsset") | None)
                     {
-                        db.mark_master_family_soft_deleted_affected(
+                        db.resolve_master_family_source_deleted_affected(
                             &config.library,
                             state_key.record_name(),
                             None,
                         )
                         .await
                     } else {
-                        db.mark_soft_deleted_affected(
+                        db.resolve_source_deleted_affected(
                             &config.library,
                             state_key.record_name(),
                             None,
@@ -6500,6 +6512,7 @@ mod tests {
         mock_photo_records_for_zone_with_filename_and_asset_date, DynamicRecentPhotosSession,
         MockPhotosFlow, TestAssetRecord, TracingCapture,
     };
+    use chrono::TimeZone;
     use serde_json::{json, Value};
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -9250,8 +9263,13 @@ mod tests {
             "print-only incremental runs must not advance the sync token"
         );
         let pending = db.get_pending().await.unwrap();
-        assert_source_flags(&pending, "SOFT_DELETE", true, false);
-        assert_source_flags(&pending, "HARD_DELETE", true, false);
+        assert!(
+            pending
+                .iter()
+                .all(|record| record.id.as_ref() != "SOFT_DELETE"
+                    && record.id.as_ref() != "HARD_DELETE"),
+            "source-deleted pending rows must be pruned: {pending:?}"
+        );
         assert_source_flags(&pending, "HIDDEN_ASSET", false, true);
     }
 
@@ -9365,7 +9383,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_cplasset_soft_delete_marks_master_ref_row() {
+    async fn incremental_cplasset_soft_delete_prunes_master_ref_pending_row() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
         db.upsert_seen(&TestAssetRecord::new("TRACKED_MASTER").build())
             .await
@@ -9383,8 +9401,10 @@ mod tests {
         assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
         assert_eq!(result.stats.state_write_failures, 0);
         assert!(!result.stats.sync_token_blocked);
-        let pending = db.get_pending().await.unwrap();
-        assert_source_flags(&pending, "TRACKED_MASTER", true, false);
+        assert!(
+            db.get_pending().await.unwrap().is_empty(),
+            "source-deleted pending row should be removed"
+        );
     }
 
     #[tokio::test]
@@ -9411,7 +9431,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_cplasset_soft_delete_marks_sibling_state_row_before_master_ref() {
+    async fn incremental_cplasset_soft_delete_prunes_sibling_pending_row_before_master_ref() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
         db.upsert_seen(&TestAssetRecord::new("TRACKED_MASTER").build())
             .await
@@ -9438,7 +9458,12 @@ mod tests {
         assert!(!result.stats.sync_token_blocked);
         let pending = db.get_pending().await.unwrap();
         assert_source_flags(&pending, "TRACKED_MASTER", false, false);
-        assert_source_flags(&pending, "asset-TRACKED_SIBLING", true, false);
+        assert!(
+            pending
+                .iter()
+                .all(|record| record.id.as_ref() != "asset-TRACKED_SIBLING"),
+            "source-deleted sibling pending row should be removed: {pending:?}"
+        );
     }
 
     #[tokio::test]
@@ -9531,7 +9556,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_unresolved_master_hard_delete_marks_sibling_asset_rows() {
+    async fn incremental_unresolved_master_hard_delete_prunes_sibling_pending_rows() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().unwrap());
         db.upsert_seen(&TestAssetRecord::new("TRACKED_MASTER").build())
             .await
@@ -9553,9 +9578,10 @@ mod tests {
         assert_eq!(result.sync_token.as_deref(), Some("zone-token-after"));
         assert_eq!(result.stats.state_write_failures, 0);
         assert!(!result.stats.sync_token_blocked);
-        let pending = db.get_pending().await.unwrap();
-        assert_source_flags(&pending, "TRACKED_MASTER", true, false);
-        assert_source_flags(&pending, "asset-SIBLING", true, false);
+        assert!(
+            db.get_pending().await.unwrap().is_empty(),
+            "master-family hard delete should remove pending retry rows"
+        );
     }
 
     #[tokio::test]
@@ -9594,19 +9620,16 @@ mod tests {
         assert!(!result.stats.sync_token_blocked);
 
         let pending = db.get_pending().await.unwrap();
-        let primary = pending
-            .iter()
-            .find(|record| record.library.as_ref() == "PrimarySync")
-            .expect("primary row");
+        assert!(
+            pending
+                .iter()
+                .all(|record| record.library.as_ref() != "PrimarySync"),
+            "primary source-deleted pending row should be removed: {pending:?}"
+        );
         let shared = pending
             .iter()
             .find(|record| record.library.as_ref() == "SharedSync-AAAA")
             .expect("shared row");
-        assert_eq!(primary.id.as_ref(), "PRIMARY_MASTER");
-        assert!(
-            primary.metadata.is_deleted,
-            "PrimarySync mapping should resolve and mark the master row deleted"
-        );
         assert_eq!(shared.id.as_ref(), "SHARED_MASTER");
         assert!(
             !shared.metadata.is_deleted,
@@ -10756,7 +10779,7 @@ mod tests {
     #[tokio::test]
     async fn incremental_with_unmatched_pending_rows_prunes_after_targeted_retry() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
-        let record = crate::test_helpers::TestAssetRecord::new("PENDING_DELETED_UPSTREAM")
+        let record = TestAssetRecord::new("PENDING_DELETED_UPSTREAM")
             .filename("pending-deleted-upstream.jpg")
             .checksum("ck_pending_deleted_upstream")
             .size(1024)
@@ -10801,6 +10824,91 @@ mod tests {
         assert_eq!(result.stats.stale_pending_pruned, 1);
         let summary = db.get_summary().await.expect("summary");
         assert_eq!(summary.pending, 0);
+        assert!(db.get_pending().await.expect("pending page").is_empty());
+    }
+
+    async fn run_bounded_incremental_sync(
+        db: Arc<crate::state::SqliteStateDb>,
+        records: Vec<Value>,
+    ) -> SyncResult {
+        let session = MockPhotosFlow::new()
+            .changes_zone_page(records, "zone-token-next", false)
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+        config.recent = Some(300);
+        config.skip_created_before = Some(Utc.timestamp_opt(1_746_994_800, 0).unwrap());
+
+        download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("bounded incremental sync should complete")
+    }
+
+    #[tokio::test]
+    async fn incremental_source_delete_prunes_pending_row_in_bounded_sync() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("PENDING_SOURCE_DELETED")
+            .filename("pending-source-deleted.jpg")
+            .checksum("ck_pending_source_deleted")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let result = run_bounded_incremental_sync(
+            db.clone(),
+            vec![hard_deleted_change_record("PENDING_SOURCE_DELETED")],
+        )
+        .await;
+
+        assert!(
+            !result.full_enumeration_ran,
+            "source delete cleanup should not force full enumeration"
+        );
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        assert!(!result.stats.sync_token_blocked);
+        assert!(db.get_pending().await.expect("pending page").is_empty());
+    }
+
+    #[tokio::test]
+    async fn incremental_prunes_existing_source_deleted_pending_row_without_wide_sync() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("STALE_SOURCE_DELETED")
+            .filename("stale-source-deleted.jpg")
+            .checksum("ck_stale_source_deleted")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        db.mark_soft_deleted("PrimarySync", "STALE_SOURCE_DELETED", None)
+            .await
+            .expect("simulate old source-deleted pending row");
+
+        let result = run_bounded_incremental_sync(db.clone(), Vec::new()).await;
+
+        assert!(
+            !result.full_enumeration_ran,
+            "cleanup should not force full enumeration"
+        );
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        assert!(!result.stats.sync_token_blocked);
         assert!(db.get_pending().await.expect("pending page").is_empty());
     }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -140,6 +140,12 @@ pub trait DownloadStateStore: Send + Sync {
     async fn reset_failed(&self) -> Result<u64, StateError>;
     async fn prepare_for_retry(&self, library: Option<&str>)
         -> Result<(u64, u64, u64), StateError>;
+    async fn prune_source_deleted_retries(
+        &self,
+        _library: Option<&str>,
+    ) -> Result<u64, StateError> {
+        Ok(0)
+    }
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError>;
     async fn prune_stale_pending_not_seen_since(
         &self,
@@ -213,6 +219,21 @@ pub trait DownloadStateStore: Send + Sync {
             .await?;
         Ok(1)
     }
+    /// Resolve a provider delete while respecting local download state.
+    ///
+    /// Downloaded rows stay in the catalog with a source tombstone so kei can
+    /// keep reporting locally protected files. Pending/failed rows are removed:
+    /// there is no source left to retry, and keeping them would create stale
+    /// unresolved work.
+    async fn resolve_source_deleted_affected(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        self.mark_soft_deleted_affected(library, asset_id, deleted_at)
+            .await
+    }
     async fn mark_master_family_soft_deleted_affected(
         &self,
         library: &str,
@@ -220,6 +241,15 @@ pub trait DownloadStateStore: Send + Sync {
         deleted_at: Option<DateTime<Utc>>,
     ) -> Result<usize, StateError> {
         self.mark_soft_deleted_affected(library, master_record_name, deleted_at)
+            .await
+    }
+    async fn resolve_master_family_source_deleted_affected(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        self.mark_master_family_soft_deleted_affected(library, master_record_name, deleted_at)
             .await
     }
     async fn mark_hidden_at_source(&self, library: &str, asset_id: &str) -> Result<(), StateError>;
@@ -1806,6 +1836,33 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn prune_source_deleted_retries(
+        &self,
+        library: Option<&str>,
+    ) -> Result<u64, StateError> {
+        let library = library.map(ToOwned::to_owned);
+        self.with_conn("prune_source_deleted_retries", move |conn| {
+            let pruned = if let Some(library) = library.as_deref() {
+                conn.execute(
+                    "DELETE FROM assets \
+                     WHERE library = ?1 AND is_deleted = 1 AND status IN ('pending', 'failed')",
+                    rusqlite::params![library],
+                )
+            } else {
+                conn.execute(
+                    "DELETE FROM assets \
+                     WHERE is_deleted = 1 AND status IN ('pending', 'failed')",
+                    [],
+                )
+            }
+            .map_err(|e| StateError::query("prune_source_deleted_retries", e))?
+                as u64;
+
+            Ok(pruned)
+        })
+        .await
+    }
+
     pub(crate) async fn promote_pending_to_failed(
         &self,
         seen_since: i64,
@@ -2788,10 +2845,43 @@ impl SqliteStateDb {
                 .execute(
                     "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
                  WHERE library = ?2 AND id = ?3",
-                    rusqlite::params![deleted_at.map(|dt| dt.timestamp()), library, asset_id],
+                    rusqlite::params![deleted_at.map(|dt| dt.timestamp()), &library, &asset_id],
                 )
                 .map_err(|e| StateError::query("mark_soft_deleted", e))?;
             Ok(updated)
+        })
+        .await
+    }
+
+    pub(crate) async fn resolve_source_deleted(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        let library = library.to_owned();
+        let asset_id = asset_id.to_owned();
+        self.with_conn_mut("resolve_source_deleted", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("resolve_source_deleted::begin", e))?;
+            let marked = tx
+                .execute(
+                    "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
+                     WHERE library = ?2 AND id = ?3 AND status = 'downloaded'",
+                    rusqlite::params![deleted_at.map(|dt| dt.timestamp()), library, asset_id],
+                )
+                .map_err(|e| StateError::query("resolve_source_deleted::mark", e))?;
+            let pruned = tx
+                .execute(
+                    "DELETE FROM assets \
+                     WHERE library = ?1 AND id = ?2 AND status IN ('pending', 'failed')",
+                    rusqlite::params![&library, &asset_id],
+                )
+                .map_err(|e| StateError::query("resolve_source_deleted::prune", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("resolve_source_deleted::commit", e))?;
+            Ok(marked + pruned)
         })
         .await
     }
@@ -2814,12 +2904,55 @@ impl SqliteStateDb {
                      ))",
                     rusqlite::params![
                         deleted_at.map(|dt| dt.timestamp()),
-                        library,
-                        master_record_name
+                        &library,
+                        &master_record_name
                     ],
                 )
                 .map_err(|e| StateError::query("mark_master_family_soft_deleted", e))?;
             Ok(updated)
+        })
+        .await
+    }
+
+    pub(crate) async fn resolve_master_family_source_deleted(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        let library = library.to_owned();
+        let master_record_name = master_record_name.to_owned();
+        self.with_conn_mut("resolve_master_family_source_deleted", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("resolve_master_family_source_deleted::begin", e))?;
+            let marked = tx
+                .execute(
+                    "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
+                     WHERE library = ?2 AND status = 'downloaded' AND (id = ?3 OR id IN ( \
+                        SELECT asset_record_name FROM asset_master_mappings \
+                        WHERE library = ?2 AND master_record_name = ?3 \
+                     ))",
+                    rusqlite::params![
+                        deleted_at.map(|dt| dt.timestamp()),
+                        library,
+                        master_record_name
+                    ],
+                )
+                .map_err(|e| StateError::query("resolve_master_family_source_deleted::mark", e))?;
+            let pruned = tx
+                .execute(
+                    "DELETE FROM assets \
+                     WHERE library = ?1 AND status IN ('pending', 'failed') AND (id = ?2 OR id IN ( \
+                        SELECT asset_record_name FROM asset_master_mappings \
+                        WHERE library = ?1 AND master_record_name = ?2 \
+                     ))",
+                    rusqlite::params![&library, &master_record_name],
+                )
+                .map_err(|e| StateError::query("resolve_master_family_source_deleted::prune", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("resolve_master_family_source_deleted::commit", e))?;
+            Ok(marked + pruned)
         })
         .await
     }
@@ -3079,6 +3212,10 @@ impl DownloadStateStore for SqliteStateDb {
         SqliteStateDb::prepare_for_retry(self, library).await
     }
 
+    async fn prune_source_deleted_retries(&self, library: Option<&str>) -> Result<u64, StateError> {
+        SqliteStateDb::prune_source_deleted_retries(self, library).await
+    }
+
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
         SqliteStateDb::promote_pending_to_failed(self, seen_since).await
     }
@@ -3180,6 +3317,15 @@ impl DownloadStateStore for SqliteStateDb {
         SqliteStateDb::mark_soft_deleted(self, library, asset_id, deleted_at).await
     }
 
+    async fn resolve_source_deleted_affected(
+        &self,
+        library: &str,
+        asset_id: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        SqliteStateDb::resolve_source_deleted(self, library, asset_id, deleted_at).await
+    }
+
     async fn mark_master_family_soft_deleted_affected(
         &self,
         library: &str,
@@ -3187,6 +3333,21 @@ impl DownloadStateStore for SqliteStateDb {
         deleted_at: Option<DateTime<Utc>>,
     ) -> Result<usize, StateError> {
         SqliteStateDb::mark_master_family_soft_deleted(
+            self,
+            library,
+            master_record_name,
+            deleted_at,
+        )
+        .await
+    }
+
+    async fn resolve_master_family_source_deleted_affected(
+        &self,
+        library: &str,
+        master_record_name: &str,
+        deleted_at: Option<DateTime<Utc>>,
+    ) -> Result<usize, StateError> {
+        SqliteStateDb::resolve_master_family_source_deleted(
             self,
             library,
             master_record_name,
@@ -7678,6 +7839,169 @@ mod tests {
             );
             assert_eq!(rec.metadata.deleted_at, Some(when));
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_source_deleted_prunes_pending_and_failed_but_preserves_downloaded() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let pending = TestAssetRecord::new("SRC_DEL")
+            .version_size(VersionSizeKey::Original)
+            .checksum("pending")
+            .build();
+        let failed = TestAssetRecord::new("SRC_DEL")
+            .version_size(VersionSizeKey::Medium)
+            .checksum("failed")
+            .build();
+        let downloaded = TestAssetRecord::new("SRC_DEL")
+            .version_size(VersionSizeKey::Thumb)
+            .checksum("downloaded")
+            .build();
+        db.upsert_seen(&pending).await.unwrap();
+        db.upsert_seen(&failed).await.unwrap();
+        db.upsert_seen(&downloaded).await.unwrap();
+        db.mark_failed(
+            "PrimarySync",
+            "SRC_DEL",
+            VersionSizeKey::Medium.as_str(),
+            "prior failure",
+        )
+        .await
+        .unwrap();
+        let dir = test_dir();
+        let path = dir.path().join("source-deleted-thumb.jpg");
+        std::fs::write(&path, b"x").unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "SRC_DEL",
+            VersionSizeKey::Thumb.as_str(),
+            &path,
+            "local_hash",
+            Some("download_hash"),
+        )
+        .await
+        .unwrap();
+
+        let deleted_at = Utc.timestamp_opt(1_700_000_003, 0).unwrap();
+        let updated = db
+            .resolve_source_deleted("PrimarySync", "SRC_DEL", Some(deleted_at))
+            .await
+            .unwrap();
+
+        assert_eq!(updated, 3);
+        assert!(db.get_pending().await.unwrap().is_empty());
+        assert!(db.get_failed().await.unwrap().is_empty());
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 1);
+        assert_eq!(downloaded[0].version_size, VersionSizeKey::Thumb);
+        assert!(downloaded[0].metadata.is_deleted);
+        assert_eq!(downloaded[0].metadata.deleted_at, Some(deleted_at));
+        assert_eq!(downloaded[0].local_path.as_deref(), Some(path.as_path()));
+    }
+
+    #[tokio::test]
+    async fn resolve_master_family_source_deleted_prunes_pending_siblings() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.upsert_seen(&TestAssetRecord::new("MASTER_FAMILY").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("asset-FAMILY-SIBLING").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("OTHER_MASTER").build())
+            .await
+            .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-FAMILY-SIBLING", "MASTER_FAMILY")
+            .await
+            .unwrap();
+
+        let updated = db
+            .resolve_master_family_source_deleted("PrimarySync", "MASTER_FAMILY", None)
+            .await
+            .unwrap();
+
+        assert_eq!(updated, 2);
+        let pending = db.get_pending().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id.as_ref(), "OTHER_MASTER");
+    }
+
+    #[tokio::test]
+    async fn prune_source_deleted_retries_removes_only_retry_tombstones() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.upsert_seen(&TestAssetRecord::new("PENDING_DELETED").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("FAILED_DELETED").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("DOWNLOADED_DELETED").build())
+            .await
+            .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("PENDING_LIVE").build())
+            .await
+            .unwrap();
+        db.upsert_seen(
+            &TestAssetRecord::new("SHARED_DELETED")
+                .library("SharedSync-AAAA")
+                .build(),
+        )
+        .await
+        .unwrap();
+        db.mark_failed(
+            "PrimarySync",
+            "FAILED_DELETED",
+            VersionSizeKey::Original.as_str(),
+            "prior failure",
+        )
+        .await
+        .unwrap();
+        let dir = test_dir();
+        let path = dir.path().join("downloaded-deleted.jpg");
+        std::fs::write(&path, b"x").unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "DOWNLOADED_DELETED",
+            VersionSizeKey::Original.as_str(),
+            &path,
+            "local_hash",
+            Some("download_hash"),
+        )
+        .await
+        .unwrap();
+        for asset_id in [
+            "PENDING_DELETED",
+            "FAILED_DELETED",
+            "DOWNLOADED_DELETED",
+            "SHARED_DELETED",
+        ] {
+            let library = if asset_id == "SHARED_DELETED" {
+                "SharedSync-AAAA"
+            } else {
+                "PrimarySync"
+            };
+            db.mark_soft_deleted(library, asset_id, None).await.unwrap();
+        }
+
+        let pruned = db
+            .prune_source_deleted_retries(Some("PrimarySync"))
+            .await
+            .unwrap();
+
+        assert_eq!(pruned, 2);
+        assert!(db.get_failed().await.unwrap().is_empty());
+        let pending = db.get_pending().await.unwrap();
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|record| {
+            record.library.as_ref() == "PrimarySync" && record.id.as_ref() == "PENDING_LIVE"
+        }));
+        assert!(pending.iter().any(|record| {
+            record.library.as_ref() == "SharedSync-AAAA" && record.id.as_ref() == "SHARED_DELETED"
+        }));
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 1);
+        assert_eq!(downloaded[0].id.as_ref(), "DOWNLOADED_DELETED");
+        assert!(downloaded[0].metadata.is_deleted);
+        assert_eq!(downloaded[0].local_path.as_deref(), Some(path.as_path()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Resolve iCloud source deletes by pruning pending/failed retry rows while preserving downloaded rows as source-deleted tombstones.
- Prune already-tombstoned pending/failed rows at sync startup so older consumed delete events self-heal on a normal sync.
- Added incremental and SQLite coverage for bounded sync cleanup, master-family deletes, and library-scoped pruning.

## Tests
- `cargo fmt --check` => passed
- `cargo check` => passed
- `cargo test incremental_source_delete_prunes_pending_row_in_bounded_sync -- --test-threads=1` => passed
- `cargo test incremental_prunes_existing_source_deleted_pending_row_without_wide_sync -- --test-threads=1` => passed
- `cargo test prune_source_deleted -- --test-threads=1` => passed
- `cargo test --lib -- --test-threads=1` => passed, 2798 passed, 1 ignored
- `cargo clippy --all-targets --all-features -- -D warnings` => passed
