### PR TITLE
Make sync checkpoints recovery-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- State databases now use schema version 16 to track inconclusive provider verification. Older kei versions reject a version 16 database instead of opening it. To downgrade, restore a state DB backup made before the upgrade; downloaded media files are unchanged.
+
+### Fixed
+
+- Full sync now proves natural EOF past iCloud count hints and repairs missing, blank, dropped, or incomplete pass-token evidence once in the same cycle. The previous provider checkpoint stays active when repair doesn't complete.
+- Pending retries now revalidate stored record identities directly. Confirmed source deletions remain in catalog history but leave actionable pending totals, while omitted or transient lookup results stay pending with a verification reason.
+- Provider checkpoints can advance after transfer failures when retry work is durable, without marking the local backup complete. Eligibility config reconciliation preserves the prior token through inventory and delta bridging, and path-only config drift keeps source tracking incremental.
+
 ## [0.22.11] - 2026-07-06
 
 ### Fixed

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -37,7 +37,29 @@ pub(crate) async fn run_status(
     println!("  Downloaded: {}", summary.downloaded);
     println!("  Pending:    {}", summary.pending);
     println!("  Failed:     {}", summary.failed);
+    println!("  Source deleted: {}", summary.source_deleted);
+    println!(
+        "  Awaiting provider verification: {}",
+        summary.awaiting_provider_verification
+    );
     println!();
+    println!(
+        "Provider checkpoint: {}",
+        summary
+            .provider_checkpoint_status
+            .as_deref()
+            .unwrap_or("unavailable")
+    );
+    if let Some(reason) = &summary.last_full_enumeration_reason {
+        println!("Last full-enumeration reason: {reason}");
+    }
+    if let Some(action) = summary
+        .last_recovery_action
+        .as_deref()
+        .filter(|action| *action != "none")
+    {
+        println!("Last recovery action: {action}");
+    }
     println!("{}", backup_status_line(&summary));
     println!();
 
@@ -168,6 +190,12 @@ fn backup_status_line(summary: &state::types::SyncSummary) -> String {
             "{} {}",
             count_phrase(summary.pending, "pending asset"),
             remain_verb(summary.pending)
+        ));
+    }
+    if summary.awaiting_provider_verification > 0 {
+        reasons.push(format!(
+            "{} awaiting provider verification",
+            count_phrase(summary.awaiting_provider_verification, "asset")
         ));
     }
     if summary.last_inventory_drop_detected {

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -532,6 +532,48 @@ enum PublishResult {
     DestinationExists,
 }
 
+/// Copy an existing catalog file to a new derived path without replacing any
+/// file already present at the destination. The copy is verified before the
+/// same no-overwrite `.part` publication used by provider downloads.
+pub(crate) async fn copy_local_file_no_replace(
+    source: &Path,
+    destination: &Path,
+    temp_suffix: &str,
+) -> anyhow::Result<Option<String>> {
+    if fs::try_exists(destination).await? {
+        let source_hash = compute_sha256(source).await?;
+        let destination_hash = compute_sha256(destination).await?;
+        return Ok((source_hash == destination_hash).then_some(destination_hash));
+    }
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    let filename = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("reconciled");
+    let part_path = destination.with_file_name(format!("{filename}{temp_suffix}-reconcile"));
+    crate::fs_util::log_remove_async(&part_path).await;
+    fs::copy(source, &part_path).await?;
+    let source_hash = compute_sha256(source).await?;
+    let copied_hash = compute_sha256(&part_path).await?;
+    if source_hash != copied_hash {
+        crate::fs_util::log_remove_async(&part_path).await;
+        anyhow::bail!("local path reconciliation checksum mismatch");
+    }
+    match publish_part_no_replace(&part_path, destination).await? {
+        PublishResult::Published => {
+            crate::fs_util::fsync_parent_dir_async_best_effort(destination).await;
+            Ok(Some(copied_hash))
+        }
+        PublishResult::DestinationExists => {
+            crate::fs_util::log_remove_async(&part_path).await;
+            let destination_hash = compute_sha256(destination).await?;
+            Ok((source_hash == destination_hash).then_some(destination_hash))
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 async fn publish_part_no_replace(
     part_path: &Path,
@@ -1022,6 +1064,28 @@ mod tests {
     use tempfile::TempDir;
 
     const ISSUE_507_JPEG_HEADER: [u8; 8] = [0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x80, 0x45, 0x78];
+
+    #[tokio::test]
+    async fn local_reconciliation_copy_preserves_source_and_refuses_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jpg");
+        let destination = dir.path().join("nested/destination.jpg");
+        std::fs::write(&source, b"catalog bytes").unwrap();
+
+        let copied = copy_local_file_no_replace(&source, &destination, ".part")
+            .await
+            .unwrap();
+        assert!(copied.is_some());
+        assert_eq!(std::fs::read(&source).unwrap(), b"catalog bytes");
+        assert_eq!(std::fs::read(&destination).unwrap(), b"catalog bytes");
+
+        std::fs::write(&destination, b"user bytes").unwrap();
+        let conflict = copy_local_file_no_replace(&source, &destination, ".part")
+            .await
+            .unwrap();
+        assert_eq!(conflict, None);
+        assert_eq!(std::fs::read(&destination).unwrap(), b"user bytes");
+    }
 
     #[test]
     fn test_base32_encode() {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2810,6 +2810,25 @@ pub(crate) struct PathReconciliationResult {
     pub(crate) stats: SyncStats,
 }
 
+async fn requeue_missing_catalog_file(
+    db: &dyn DownloadStore,
+    task: &DownloadTask,
+    stats: &mut SyncStats,
+) {
+    if let Err(error) = db
+        .mark_failed(
+            &task.library,
+            &task.asset_id,
+            task.version_size.as_str(),
+            crate::commands::reconcile::FILE_MISSING_REASON,
+        )
+        .await
+    {
+        stats.state_write_failures += 1;
+        tracing::warn!(asset_id = %task.asset_id, %error, "Path reconciliation could not requeue a missing catalog file");
+    }
+}
+
 pub(crate) async fn reconcile_catalog_paths(
     passes: &[crate::commands::AlbumPass],
     config: Arc<DownloadConfig>,
@@ -2988,6 +3007,7 @@ pub(crate) async fn reconcile_catalog_paths(
         };
         let Some(source_path) = record.local_path.as_deref() else {
             deferred_to_pending_retry = true;
+            requeue_missing_catalog_file(db.as_ref(), &task, &mut stats).await;
             tracing::debug!(asset_id = %task.asset_id, "Path reconciliation deferred catalog row without a local file to targeted retry");
             continue;
         };
@@ -2995,6 +3015,7 @@ pub(crate) async fn reconcile_catalog_paths(
             Ok(true) => {}
             Ok(false) => {
                 deferred_to_pending_retry = true;
+                requeue_missing_catalog_file(db.as_ref(), &task, &mut stats).await;
                 tracing::debug!(asset_id = %task.asset_id, path = %source_path.display(), "Path reconciliation deferred missing local file to targeted retry");
                 continue;
             }
@@ -11191,7 +11212,7 @@ mod tests {
             Arc::new({
                 let mut config = test_config();
                 config.directory = Arc::from(new_dir.path());
-                config.state_db = Some(db);
+                config.state_db = Some(db.clone());
                 config
             }),
             CancellationToken::new(),
@@ -11200,6 +11221,9 @@ mod tests {
         .expect("missing local file should defer to targeted retry");
         assert!(!deferred.complete);
         assert_eq!(deferred.stats.failed, 0);
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 1);
     }
 
     #[tokio::test]
@@ -11655,6 +11679,54 @@ mod tests {
         assert_eq!(summary.failed, 0);
         assert_eq!(summary.awaiting_provider_verification, 0);
         assert_eq!(summary.source_deleted, 1);
+    }
+
+    #[tokio::test]
+    async fn pending_retry_deleted_sibling_does_not_tombstone_present_master_state() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("MASTER_WITH_SIBLINGS")
+            .filename("master-with-siblings.jpg")
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        db.upsert_asset_master_mapping("PrimarySync", "asset-a-deleted", "MASTER_WITH_SIBLINGS")
+            .await
+            .expect("seed deleted sibling mapping");
+        db.upsert_asset_master_mapping("PrimarySync", "asset-b-present", "MASTER_WITH_SIBLINGS")
+            .await
+            .expect("seed present sibling mapping");
+
+        let session = PendingLookupSession {
+            records: Arc::new(vec![
+                json!({
+                    "recordName": "asset-a-deleted",
+                    "serverErrorCode": "UNKNOWN_ITEM",
+                    "reason": "record not found"
+                }),
+                mock_master_record_with_filename(
+                    "MASTER_WITH_SIBLINGS",
+                    "master-with-siblings.jpg",
+                ),
+                mock_asset_record_for("asset-b-present", "MASTER_WITH_SIBLINGS"),
+            ]),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+
+        let plan = build_pending_retry_download_tasks(&passes, &config, CancellationToken::new())
+            .await
+            .expect("build pending retry plan");
+
+        assert_eq!(plan.unmatched_targets.len(), 0);
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.source_deleted, 0);
+        assert_eq!(summary.pending, 1);
     }
 
     async fn run_bounded_incremental_sync(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -16,6 +16,7 @@ pub mod paths;
 pub(crate) mod pipeline;
 pub(crate) mod planner;
 pub(crate) mod recap;
+mod retry;
 
 pub(crate) use limiter::BandwidthLimiter;
 
@@ -28,6 +29,9 @@ use pipeline::{
 pub(crate) use filter::determine_media_type;
 pub(crate) use filter::AssetGroupings;
 use filter::DownloadTask;
+#[cfg(test)]
+use retry::take_matching_pending_retry_tasks;
+use retry::{build_pending_retry_download_tasks, PendingRetryPlan, PendingRetryTarget};
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
@@ -49,7 +53,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::asset::ChangeEvent;
-use crate::icloud::photos::{PhotoAsset, SyncTokenError};
+use crate::icloud::photos::{
+    PhotoAsset, ProviderRecordId, RecordLookupRequest, RecordResolution, SyncTokenError,
+};
 use crate::retry::RetryConfig;
 use crate::state::{
     DownloadStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore, SyncTokenStore,
@@ -108,6 +114,10 @@ pub enum FullEnumerationReason {
     AlbumRelationHydrationIncomplete,
     EnumConfigHashDrift,
     DownloadConfigHashDrift,
+    #[allow(
+        dead_code,
+        reason = "serialized public reason retained for report compatibility after retry work moved off full enumeration"
+    )]
     ExplicitRetryFailed,
     OtherStaticReason,
 }
@@ -289,6 +299,10 @@ pub struct SyncStats {
     pub pagination_shortfall_warnings: usize,
     /// Sum of missing assets reported by diagnostic pagination shortfalls.
     pub pagination_shortfall_assets: u64,
+    /// Count-backed tail owners opened to prove natural EOF.
+    pub tail_probes: usize,
+    /// Assets discovered beyond the provider's pre-enumeration count hint.
+    pub count_undercount_assets: u64,
     /// True when the asset producer stopped before naturally exhausting the
     /// iCloud stream for a reason other than an external interrupt.
     pub enumeration_incomplete: bool,
@@ -358,6 +372,10 @@ pub struct SyncStats {
     /// `sync_token_blocked` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_token_unique_values: Option<usize>,
+    /// Bounded pass-token recovery rounds attempted in this cycle.
+    pub same_cycle_recovery_attempts: usize,
+    /// Pass-token recovery rounds that completed checkpoint proof.
+    pub same_cycle_recovery_successes: usize,
     pub elapsed_secs: f64,
     pub interrupted: bool,
     /// Number of tasks that observed at least one HTTP 429 / 503 response
@@ -419,6 +437,8 @@ impl SyncStats {
         self.stale_pending_pruned += other.stale_pending_pruned;
         self.pagination_shortfall_warnings += other.pagination_shortfall_warnings;
         self.pagination_shortfall_assets += other.pagination_shortfall_assets;
+        self.tail_probes += other.tail_probes;
+        self.count_undercount_assets += other.count_undercount_assets;
         self.enumeration_incomplete = self.enumeration_incomplete || other.enumeration_incomplete;
         self.inventory_drop_warnings += other.inventory_drop_warnings;
         if other.inventory_drop_assets > self.inventory_drop_assets {
@@ -462,6 +482,8 @@ impl SyncStats {
         if self.sync_token_unique_values.is_none() {
             self.sync_token_unique_values = other.sync_token_unique_values;
         }
+        self.same_cycle_recovery_attempts += other.same_cycle_recovery_attempts;
+        self.same_cycle_recovery_successes += other.same_cycle_recovery_successes;
         self.elapsed_secs += other.elapsed_secs;
         self.interrupted = self.interrupted || other.interrupted;
         self.rate_limited += other.rate_limited;
@@ -521,20 +543,6 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
         | UNKNOWN_ALBUM_RELATION_ASSET_REASON
         | UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => "icloud",
         _ => "unknown",
-    }
-}
-
-pub(crate) fn sync_token_blocked_bounded_log_message(reason: &str) -> Option<&'static str> {
-    match reason {
-        RECENT_LIMITED_FULL_ENUMERATION_REASON => Some(
-            "--recent mode is bounded and does not persist a full enumeration sync token. Run \
-             without --recent for checkpointed incremental token flow.",
-        ),
-        DATE_BOUNDED_FULL_ENUMERATION_REASON => Some(
-            "Date-bounded mode is bounded and does not persist a full enumeration sync token. \
-             Run without the lower date bound for checkpointed incremental token flow.",
-        ),
-        _ => None,
     }
 }
 
@@ -600,7 +608,7 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
             "a targeted album backfill did not complete safely"
         }
         PENDING_RETRY_UNMATCHED_REASON => {
-            "kei could not refresh every pending retry target, so token advancement stayed blocked"
+            "kei could not refresh every pending retry target; the rows remain durable for a later cycle"
         }
         "sync_token_unavailable" | "sync_token_missing" => {
             "no usable sync token was available at the end of the cycle"
@@ -2093,12 +2101,119 @@ async fn build_pass_configs_resolving_deferred_excludes(
 
 #[derive(Debug)]
 struct PerPassStreamingResult {
+    pass_index: usize,
     kind: crate::commands::PassKind,
     label: String,
     count: u64,
     elapsed: std::time::Duration,
     token_rx: tokio::sync::oneshot::Receiver<Option<String>>,
     result: StreamingResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PassKey {
+    index: usize,
+    kind: crate::commands::PassKind,
+    label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PassTokenResult {
+    Present(String),
+    Missing,
+    Blank,
+    ReceiverDropped,
+    EnumerationIncomplete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PassTokenObservation {
+    pass: PassKey,
+    result: PassTokenResult,
+}
+
+struct PassTokenReceiver {
+    pass: PassKey,
+    receiver: tokio::sync::oneshot::Receiver<Option<String>>,
+    enumeration_complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenGap {
+    Missing,
+    Blank,
+    ReceiverDropped,
+    EnumerationIncomplete,
+    Mismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ZoneTokenEvidence {
+    Complete {
+        token: String,
+    },
+    Recoverable {
+        passes: Vec<PassKey>,
+        reason: TokenGap,
+    },
+    Incomplete {
+        reason: TokenGap,
+    },
+}
+
+fn classify_zone_token_evidence(observations: &[PassTokenObservation]) -> ZoneTokenEvidence {
+    let passes_without_tokens = || {
+        observations
+            .iter()
+            .filter(|observation| !matches!(observation.result, PassTokenResult::Present(_)))
+            .map(|observation| observation.pass.clone())
+            .collect()
+    };
+
+    for (result, reason) in [
+        (
+            PassTokenResult::EnumerationIncomplete,
+            TokenGap::EnumerationIncomplete,
+        ),
+        (PassTokenResult::ReceiverDropped, TokenGap::ReceiverDropped),
+        (PassTokenResult::Blank, TokenGap::Blank),
+        (PassTokenResult::Missing, TokenGap::Missing),
+    ] {
+        if observations.iter().any(|observation| {
+            std::mem::discriminant(&observation.result) == std::mem::discriminant(&result)
+        }) {
+            return ZoneTokenEvidence::Recoverable {
+                passes: passes_without_tokens(),
+                reason,
+            };
+        }
+    }
+
+    let tokens: Vec<&str> = observations
+        .iter()
+        .filter_map(|observation| match &observation.result {
+            PassTokenResult::Present(token) => Some(token.as_str()),
+            _ => None,
+        })
+        .collect();
+    let Some(first) = tokens.first() else {
+        return ZoneTokenEvidence::Incomplete {
+            reason: TokenGap::Missing,
+        };
+    };
+    if tokens.iter().all(|token| token == first) {
+        ZoneTokenEvidence::Complete {
+            token: (*first).to_string(),
+        }
+    } else {
+        ZoneTokenEvidence::Recoverable {
+            passes: observations
+                .iter()
+                .map(|observation| observation.pass.clone())
+                .collect(),
+            reason: TokenGap::Mismatch,
+        }
+    }
 }
 
 type DownloadPhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
@@ -2232,6 +2347,7 @@ struct RecentFrontier {
 }
 
 struct FullPassStreamOptions {
+    pass_index: usize,
     controls: DownloadControls,
     count: u64,
     kind: crate::commands::PassKind,
@@ -2586,6 +2702,7 @@ where
     let elapsed = pass_start.elapsed();
     pass_pb.finish_and_clear();
     Ok(PerPassStreamingResult {
+        pass_index: options.pass_index,
         kind: options.kind,
         label: pass_config.pass_label().to_string(),
         count: options.count,
@@ -2609,6 +2726,27 @@ fn merge_streaming_result(combined: &mut StreamingResult, result: StreamingResul
     combined.enumeration_complete = combined.enumeration_complete && result.enumeration_complete;
 }
 
+fn merge_token_recovery_result(combined: &mut StreamingResult, result: StreamingResult) {
+    // A token-recovery pass replays an already observed pass through the real
+    // planner and state pipeline. Preserve the original inventory/progress
+    // counts rather than double-counting every replayed asset, but retain all
+    // transfer, durability, and error outcomes produced by the repair.
+    combined.downloaded += result.downloaded;
+    combined.exif_failures += result.exif_failures;
+    combined.failed.extend(result.failed);
+    combined.auth_errors += result.auth_errors;
+    combined.state_write_failures += result.state_write_failures;
+    combined.enumeration_errors += result.enumeration_errors;
+    combined.bytes_downloaded += result.bytes_downloaded;
+    combined.disk_bytes_written += result.disk_bytes_written;
+    combined.rate_limit_observations += result.rate_limit_observations;
+    combined.url_expired_abort = combined.url_expired_abort || result.url_expired_abort;
+    combined.photos_downloaded += result.photos_downloaded;
+    combined.videos_downloaded += result.videos_downloaded;
+    combined.recap.merge(result.recap);
+    combined.enumeration_complete = combined.enumeration_complete && result.enumeration_complete;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct RetryTaskKey {
     asset_id: Arc<str>,
@@ -2620,31 +2758,6 @@ struct RetryTaskKey {
 struct UrlRetrySource {
     asset_record_name: Arc<str>,
     pass_index: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct PendingRetryTarget {
-    library: Arc<str>,
-    asset_id: Arc<str>,
-    version_size: VersionSizeKey,
-}
-
-impl PendingRetryTarget {
-    fn from_record(record: &crate::state::AssetRecord) -> Self {
-        Self {
-            library: Arc::clone(&record.library),
-            asset_id: Arc::from(record.id.as_ref()),
-            version_size: record.version_size,
-        }
-    }
-
-    fn from_task(task: &DownloadTask) -> Self {
-        Self {
-            library: Arc::clone(&task.library),
-            asset_id: Arc::clone(&task.asset_id),
-            version_size: task.version_size,
-        }
-    }
 }
 
 impl From<&DownloadTask> for RetryTaskKey {
@@ -2673,24 +2786,6 @@ fn retry_hydrator_pass_index(
         .or_else(|| (!passes.is_empty()).then_some(0))
 }
 
-fn take_matching_pending_retry_tasks<I>(
-    tasks: I,
-    pending_targets: &mut FxHashSet<PendingRetryTarget>,
-    out: &mut Vec<DownloadTask>,
-) where
-    I: IntoIterator<Item = DownloadTask>,
-{
-    for task in tasks {
-        let target = PendingRetryTarget::from_task(&task);
-        if pending_targets.remove(&target) {
-            out.push(task);
-            if pending_targets.is_empty() {
-                break;
-            }
-        }
-    }
-}
-
 fn take_matching_retry_tasks<I>(
     tasks: I,
     pending_keys: &mut FxHashSet<RetryTaskKey>,
@@ -2710,144 +2805,259 @@ fn take_matching_retry_tasks<I>(
 }
 
 #[derive(Debug, Default)]
-struct PendingRetryPlan {
-    tasks: Vec<DownloadTask>,
-    retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource>,
-    pass_configs: Vec<Arc<DownloadConfig>>,
-    unmatched_targets: Vec<PendingRetryTarget>,
-    requested: usize,
+pub(crate) struct PathReconciliationResult {
+    pub(crate) complete: bool,
+    pub(crate) stats: SyncStats,
 }
 
-async fn build_pending_retry_download_tasks(
+pub(crate) async fn reconcile_catalog_paths(
     passes: &[crate::commands::AlbumPass],
-    config: &DownloadConfig,
+    config: Arc<DownloadConfig>,
     shutdown_token: CancellationToken,
-) -> Result<PendingRetryPlan> {
+) -> Result<PathReconciliationResult> {
     let Some(db) = &config.state_db else {
-        return Ok(PendingRetryPlan::default());
+        return Ok(PathReconciliationResult::default());
+    };
+    let Some(provider_pass) = passes.first() else {
+        return Ok(PathReconciliationResult::default());
     };
 
-    let pending = db.get_pending().await?;
-    let mut pending_targets: FxHashSet<PendingRetryTarget> = pending
-        .iter()
-        .filter(|record| record.library.as_ref() == config.library.as_ref())
-        .map(PendingRetryTarget::from_record)
-        .collect();
-    if pending_targets.is_empty() {
-        return Ok(PendingRetryPlan::default());
-    }
-
-    let requested = pending_targets.len();
-    let pass_configs = build_pass_configs_resolving_deferred_excludes(passes, config).await?;
-    let mut tasks: Vec<DownloadTask> = Vec::with_capacity(requested);
-    let mut retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource> = FxHashMap::default();
-    let mut task_planner = planner::TaskPlanner::new();
-
-    for (pass_index, pass) in passes.iter().enumerate() {
-        if pending_targets.is_empty() || shutdown_token.is_cancelled() {
+    let mut records = Vec::new();
+    let mut offset = 0u64;
+    const PAGE_SIZE: u32 = 1_000;
+    loop {
+        let page = db.get_downloaded_page(offset, PAGE_SIZE).await?;
+        let page_len = page.len();
+        records.extend(page.into_iter().filter(|record| {
+            record.library.as_ref() == config.library.as_ref() && !record.metadata.is_deleted
+        }));
+        if page_len < PAGE_SIZE as usize {
             break;
         }
+        offset = offset.saturating_add(u64::from(PAGE_SIZE));
+    }
+    if records.is_empty() {
+        return Ok(PathReconciliationResult {
+            complete: true,
+            stats: SyncStats::default(),
+        });
+    }
 
-        let assets = pass.album.photos(config.recent).await?;
-        #[allow(
-            clippy::indexing_slicing,
-            reason = "pass_index comes from enumerate() over `passes`; pass_configs is \
-                      built 1:1 from the same slice"
-        )]
-        let pass_config = &pass_configs[pass_index];
-
-        for asset in &assets {
-            if pending_targets.is_empty() || shutdown_token.is_cancelled() {
-                break;
+    let mut targets: FxHashSet<PendingRetryTarget> = records
+        .iter()
+        .map(PendingRetryTarget::from_record)
+        .collect();
+    let mut requests = Vec::new();
+    let mut seen_requests = FxHashSet::default();
+    let mut master_by_state_id = FxHashMap::default();
+    for record in &records {
+        let mapped_master = db
+            .get_master_record_name_for_asset(&config.library, &record.id)
+            .await?;
+        let master = mapped_master
+            .as_deref()
+            .unwrap_or(record.id.as_ref())
+            .to_owned();
+        let asset_record_names = if mapped_master.is_some() {
+            vec![record.id.to_string()]
+        } else {
+            db.get_asset_record_names_for_master(&config.library, &master)
+                .await?
+        };
+        master_by_state_id.insert(record.id.to_string(), master.clone());
+        for asset_record_name in asset_record_names {
+            let key = (
+                record.id.to_string(),
+                master.clone(),
+                asset_record_name.clone(),
+            );
+            if seen_requests.insert(key.clone()) {
+                requests.push(RecordLookupRequest {
+                    state_id: ProviderRecordId::new(key.0),
+                    master_record_name: ProviderRecordId::new(key.1),
+                    asset_record_name: ProviderRecordId::new(key.2),
+                });
             }
-            let plan = task_planner.plan_asset(asset, pass_config).await;
-            if plan.filter_reason.is_some() {
+        }
+    }
+
+    let pass_configs: Vec<Arc<DownloadConfig>> = passes
+        .iter()
+        .map(|pass| Arc::new(config.with_pass(pass)))
+        .collect();
+    let mut albums_by_asset: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+    for (asset_id, album_name) in db.get_all_asset_albums(&config.library).await? {
+        albums_by_asset
+            .entry(asset_id)
+            .or_default()
+            .insert(album_name);
+    }
+    let album_container_ids: Vec<String> = passes
+        .iter()
+        .filter(|pass| pass.kind == crate::commands::PassKind::Album)
+        .filter_map(|pass| pass.album.container_id().map(ToOwned::to_owned))
+        .collect();
+    let album_pass_count = passes
+        .iter()
+        .filter(|pass| pass.kind == crate::commands::PassKind::Album)
+        .count();
+    let album_container_refs: Vec<&str> = album_container_ids.iter().map(String::as_str).collect();
+    let album_membership_complete = album_container_ids.len() == album_pass_count
+        && (album_container_refs.is_empty()
+            || db
+                .selected_album_containers_have_complete_snapshots(
+                    &config.library,
+                    &album_container_refs,
+                )
+                .await?);
+    let selection_complete = album_membership_complete
+        && !passes
+            .iter()
+            .any(|pass| pass.kind == crate::commands::PassKind::SmartFolder);
+    let batch = provider_pass.album.resolve_records(&requests).await;
+    let mut task_planner = planner::TaskPlanner::new();
+    let mut tasks = Vec::new();
+    let mut task_keys = FxHashSet::default();
+    for (state_id, resolution) in batch.results {
+        if shutdown_token.is_cancelled() {
+            break;
+        }
+        match resolution {
+            RecordResolution::Present(asset) => {
+                targets.retain(|target| target.asset_id.as_ref() != state_id.as_str());
+                let known_albums = albums_by_asset.get(state_id.as_str());
+                for (pass, pass_config) in passes.iter().zip(&pass_configs) {
+                    let selected = match pass.kind {
+                        crate::commands::PassKind::Album => known_albums
+                            .is_some_and(|albums| albums.contains(pass.album.name.as_ref())),
+                        crate::commands::PassKind::Unfiled => {
+                            known_albums.is_none_or(FxHashSet::is_empty)
+                        }
+                        crate::commands::PassKind::SmartFolder => false,
+                    };
+                    if !selected {
+                        continue;
+                    }
+                    let plan = task_planner.plan_asset(&asset, pass_config).await;
+                    if plan.filter_reason.is_some() {
+                        continue;
+                    }
+                    for task in plan.tasks {
+                        let key = RetryTaskKey::from(&task);
+                        if task_keys.insert(key) {
+                            tasks.push(task);
+                        }
+                    }
+                }
+            }
+            RecordResolution::Deleted {
+                deleted_at,
+                master_family,
+            } => {
+                let id = state_id.as_str();
+                if master_family {
+                    let master = master_by_state_id.get(id).map(String::as_str).unwrap_or(id);
+                    db.resolve_master_family_source_deleted_affected(
+                        &config.library,
+                        master,
+                        deleted_at,
+                    )
+                    .await?;
+                } else {
+                    db.resolve_source_deleted_affected(&config.library, id, deleted_at)
+                        .await?;
+                }
+                targets.retain(|target| target.asset_id.as_ref() != id);
+            }
+            RecordResolution::Unknown | RecordResolution::TransientFailure(_) => {}
+        }
+    }
+
+    let records_by_target: FxHashMap<PendingRetryTarget, &crate::state::AssetRecord> = records
+        .iter()
+        .map(|record| (PendingRetryTarget::from_record(record), record))
+        .collect();
+    let mut stats = SyncStats::default();
+    let mut deferred_to_pending_retry = false;
+    for task in tasks {
+        let target = PendingRetryTarget::from_task(&task);
+        let Some(record) = records_by_target.get(&target) else {
+            stats.failed += 1;
+            tracing::warn!(asset_id = %task.asset_id, "Path reconciliation task had no catalog row");
+            continue;
+        };
+        let Some(source_path) = record.local_path.as_deref() else {
+            deferred_to_pending_retry = true;
+            tracing::debug!(asset_id = %task.asset_id, "Path reconciliation deferred catalog row without a local file to targeted retry");
+            continue;
+        };
+        match tokio::fs::try_exists(source_path).await {
+            Ok(true) => {}
+            Ok(false) => {
+                deferred_to_pending_retry = true;
+                tracing::debug!(asset_id = %task.asset_id, path = %source_path.display(), "Path reconciliation deferred missing local file to targeted retry");
                 continue;
             }
-            let first_new_task = tasks.len();
-            take_matching_pending_retry_tasks(plan.tasks, &mut pending_targets, &mut tasks);
-            for task in tasks.iter().skip(first_new_task) {
-                retry_sources.insert(
-                    RetryTaskKey::from(task),
-                    UrlRetrySource {
-                        asset_record_name: asset.asset_record_name_arc(),
-                        pass_index,
-                    },
-                );
+            Err(error) => {
+                stats.failed += 1;
+                tracing::warn!(asset_id = %task.asset_id, path = %source_path.display(), %error, "Path reconciliation could not inspect the catalog file");
+                continue;
             }
         }
-    }
-
-    if !pending_targets.is_empty() {
-        tracing::warn!(
-            requested,
-            refreshed = tasks.len(),
-            missing = pending_targets.len(),
-            diagnostic = PENDING_RETRY_UNMATCHED_REASON,
-            "Targeted retry could not refresh every pending asset; blocking sync token advancement"
-        );
-    }
-
-    Ok(PendingRetryPlan {
-        tasks,
-        retry_sources,
-        pass_configs,
-        unmatched_targets: pending_targets.into_iter().collect(),
-        requested,
-    })
-}
-
-async fn prune_unmatched_pending_retry_targets(
-    config: &DownloadConfig,
-    shutdown_token: &CancellationToken,
-    unmatched_targets: &[PendingRetryTarget],
-) -> usize {
-    if unmatched_targets.is_empty()
-        || config.recent.is_some()
-        || config.skip_created_before.is_some()
-        || shutdown_token.is_cancelled()
-    {
-        return 0;
-    }
-
-    let Some(db) = &config.state_db else {
-        return 0;
-    };
-
-    let asset_versions: Vec<(String, String)> = unmatched_targets
-        .iter()
-        .map(|target| {
-            (
-                target.asset_id.to_string(),
-                target.version_size.as_str().to_string(),
-            )
-        })
-        .collect();
-    match db
-        .prune_pending_asset_versions(&config.library, &asset_versions)
+        match file::copy_local_file_no_replace(
+            source_path,
+            &task.download_path,
+            &config.temp_suffix,
+        )
         .await
-    {
-        Ok(pruned) => {
-            if pruned > 0 {
-                tracing::warn!(
-                    count = pruned,
-                    library = %config.library,
-                    diagnostic = "targeted_retry_stale_pending_pruned",
-                    "Pruned pending state rows absent from targeted retry enumeration"
-                );
+        {
+            Ok(Some(local_checksum)) => {
+                if let Err(error) = db
+                    .mark_downloaded(
+                        &task.library,
+                        &task.asset_id,
+                        task.version_size.as_str(),
+                        &task.download_path,
+                        &local_checksum,
+                        None,
+                    )
+                    .await
+                {
+                    stats.state_write_failures += 1;
+                    tracing::warn!(asset_id = %task.asset_id, %error, "Failed to persist reconciled local path");
+                } else {
+                    stats.downloaded += 1;
+                    if matches!(
+                        task.media_type,
+                        crate::state::MediaType::Photo | crate::state::MediaType::LivePhotoImage
+                    ) {
+                        stats.photos_downloaded += 1;
+                    } else {
+                        stats.videos_downloaded += 1;
+                    }
+                    stats.disk_bytes_written =
+                        stats.disk_bytes_written.saturating_add(record.size_bytes);
+                }
             }
-            usize::try_from(pruned).unwrap_or(usize::MAX)
-        }
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                library = %config.library,
-                diagnostic = PENDING_RETRY_UNMATCHED_REASON,
-                "Failed to prune pending rows absent from targeted retry enumeration"
-            );
-            0
+            Ok(None) => {
+                stats.failed += 1;
+                tracing::warn!(asset_id = %task.asset_id, path = %task.download_path.display(), "Path reconciliation found conflicting destination bytes");
+            }
+            Err(error) => {
+                stats.failed += 1;
+                tracing::warn!(asset_id = %task.asset_id, %error, "Failed to copy existing media into reconciled path");
+            }
         }
     }
+    stats.interrupted = shutdown_token.is_cancelled();
+    let complete = batch.complete
+        && selection_complete
+        && targets.is_empty()
+        && !deferred_to_pending_retry
+        && stats.failed == 0
+        && stats.state_write_failures == 0
+        && !stats.interrupted;
+    Ok(PathReconciliationResult { complete, stats })
 }
 
 /// Re-enumerate iCloud and rebuild only the failed tasks with fresh CDN URLs.
@@ -3306,24 +3516,6 @@ async fn has_metadata_backfill_work(config: &DownloadConfig) -> bool {
             false
         }
     }
-}
-
-fn should_prune_stale_pending_after_full_enumeration(
-    sync_result: &SyncResult,
-    config: &DownloadConfig,
-    controls: DownloadControls,
-    shutdown_token: &CancellationToken,
-) -> bool {
-    sync_result.full_enumeration_ran
-        && matches!(sync_result.outcome, DownloadOutcome::Success)
-        && sync_result.stats.enumeration_errors == 0
-        && !sync_result.stats.enumeration_incomplete
-        && !sync_result.stats.interrupted
-        && config.recent.is_none()
-        && config.skip_created_before.is_none()
-        && !controls.run_mode.is_dry_run()
-        && !controls.run_mode.only_print_filenames()
-        && !shutdown_token.is_cancelled()
 }
 
 fn set_full_enumeration_reason(result: &mut SyncResult, reason: FullEnumerationReason) {
@@ -3803,12 +3995,13 @@ async fn download_photos_incremental_with_smart_folder_refresh(
             Arc::clone(config)
         };
 
-    let mut smart_folder_result = download_photos_full_with_token(
+    let mut smart_folder_result = download_photos_full_with_token_policy(
         download_client,
         &smart_folder_passes,
         &smart_folder_config,
         controls,
         shutdown_token,
+        false,
     )
     .await?;
 
@@ -3879,7 +4072,6 @@ async fn run_pending_retry_pass(
             &shutdown_token,
             0,
             0,
-            0,
         ));
     }
 
@@ -3903,7 +4095,6 @@ async fn run_pending_retry_pass(
             &shutdown_token,
             unmatched,
             0,
-            0,
         ));
     }
 
@@ -3913,20 +4104,15 @@ async fn run_pending_retry_pass(
             &shutdown_token,
             unmatched,
             tasks.len(),
-            0,
         ));
     }
 
     if tasks.is_empty() {
-        let pruned =
-            prune_unmatched_pending_retry_targets(config, &shutdown_token, &unmatched_targets)
-                .await;
         return Ok(pending_retry_no_download_result(
             &started,
             &shutdown_token,
             unmatched,
             0,
-            pruned,
         ));
     }
 
@@ -4015,14 +4201,11 @@ async fn run_pending_retry_pass(
             tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Targeted retry failed");
         }
     }
-    let pruned =
-        prune_unmatched_pending_retry_targets(config, &shutdown_token, &unmatched_targets).await;
-    let remaining_unmatched = unmatched.saturating_sub(pruned);
+    let remaining_unmatched = unmatched;
 
-    let mut stats = SyncStats {
+    let stats = SyncStats {
         downloaded: pass_result.downloaded,
-        failed,
-        stale_pending_pruned: pruned as u64,
+        failed: failed.saturating_add(remaining_unmatched),
         bytes_downloaded: pass_result.bytes_downloaded,
         disk_bytes_written: pass_result.disk_bytes_written,
         exif_failures: pass_result.exif_failures,
@@ -4037,10 +4220,6 @@ async fn run_pending_retry_pass(
         recap: pass_result.recap.clone(),
         ..SyncStats::default()
     };
-    if remaining_unmatched > 0 {
-        block_sync_token_for_incremental_delta(&mut stats, PENDING_RETRY_UNMATCHED_REASON);
-    }
-
     if pass_result.auth_errors >= AUTH_ERROR_THRESHOLD {
         return Ok(SyncResult {
             outcome: DownloadOutcome::SessionExpired {
@@ -4071,19 +4250,15 @@ fn pending_retry_no_download_result(
     shutdown_token: &CancellationToken,
     unmatched: usize,
     downloaded: usize,
-    pruned: usize,
 ) -> SyncResult {
-    let remaining_unmatched = unmatched.saturating_sub(pruned);
-    let mut stats = SyncStats {
+    let remaining_unmatched = unmatched;
+    let stats = SyncStats {
         downloaded,
-        stale_pending_pruned: pruned as u64,
+        failed: remaining_unmatched,
         elapsed_secs: started.elapsed().as_secs_f64(),
         interrupted: shutdown_token.is_cancelled(),
         ..SyncStats::default()
     };
-    if remaining_unmatched > 0 {
-        block_sync_token_for_incremental_delta(&mut stats, PENDING_RETRY_UNMATCHED_REASON);
-    }
     SyncResult {
         outcome: if remaining_unmatched > 0 {
             DownloadOutcome::PartialFailure {
@@ -4126,15 +4301,15 @@ async fn append_pending_retry_to_incremental_result(
     {
         Ok(result) => result,
         Err(e) => {
-            let mut stats = SyncStats {
+            let stats = SyncStats {
+                failed: 1,
                 elapsed_secs: 0.0,
                 ..SyncStats::default()
             };
-            block_sync_token_for_incremental_delta(&mut stats, PENDING_RETRY_UNMATCHED_REASON);
             tracing::warn!(
                 error = %e,
                 diagnostic = PENDING_RETRY_UNMATCHED_REASON,
-                "Targeted pending retry failed before downloads; blocking sync token advancement"
+                "Targeted pending retry failed before downloads; retaining durable work for a later cycle"
             );
             SyncResult {
                 outcome: DownloadOutcome::PartialFailure { failed_count: 1 },
@@ -4153,8 +4328,7 @@ async fn append_pending_retry_to_incremental_result(
     } = incremental_result;
     let outcome = merge_download_outcomes(&incremental_outcome, &retry_result.outcome);
     combined_stats.accumulate(&retry_result.stats);
-    let sync_token = if matches!(outcome, DownloadOutcome::Success)
-        && !combined_stats.sync_token_blocked
+    let sync_token = if !combined_stats.sync_token_blocked
         && !combined_stats.interrupted
         && !controls.run_mode.is_dry_run()
         && !controls.run_mode.only_print_filenames()
@@ -4367,39 +4541,6 @@ pub async fn download_photos_with_sync(
         }
     };
 
-    let mut result = result;
-    if let (Ok(sync_result), Some(db)) = (&mut result, config.state_db.as_ref()) {
-        if should_prune_stale_pending_after_full_enumeration(
-            sync_result,
-            config.as_ref(),
-            controls,
-            &shutdown_token,
-        ) {
-            match db
-                .prune_stale_pending_not_seen_since(&config.library, sync_started_at)
-                .await
-            {
-                Ok(pruned) if pruned > 0 => {
-                    sync_result.stats.stale_pending_pruned = pruned;
-                    tracing::warn!(
-                        count = pruned,
-                        library = %config.library,
-                        diagnostic = "stale_pending_pruned",
-                        "Pruned stale pending state rows after clean full enumeration"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        library = %config.library,
-                        "Failed to prune stale pending rows"
-                    );
-                }
-                _ => {}
-            }
-        }
-    }
-
     // Pending is transient — anything still pending after a complete sync either
     // wasn't enumerated or failed silently. Skip on interrupt where pending is expected.
     if let Some(db) = &config.state_db {
@@ -4570,25 +4711,6 @@ fn classify_pagination_shortfall(
 /// one. All passes for a zone must agree before the token can advance; picking
 /// the first completed pass would hide snapshot drift between album-scoped
 /// enumerations.
-fn unanimous_pass_sync_token(tokens: &[String]) -> Option<String> {
-    let first = tokens.first()?;
-    if tokens.iter().all(|token| token == first) {
-        return Some(first.clone());
-    }
-
-    let mut unique_tokens = FxHashSet::default();
-    for token in tokens {
-        unique_tokens.insert(token.as_str());
-    }
-    tracing::warn!(
-        token_count = tokens.len(),
-        unique_token_count = unique_tokens.len(),
-        "Full enumeration syncToken mismatch across passes; blocking sync \
-         token advancement"
-    );
-    None
-}
-
 /// Full enumeration with syncToken capture.
 ///
 /// Uses `photo_stream_with_token` to capture the zone-level syncToken
@@ -4600,6 +4722,25 @@ async fn download_photos_full_with_token(
     config: &Arc<DownloadConfig>,
     controls: DownloadControls,
     shutdown_token: CancellationToken,
+) -> Result<SyncResult> {
+    download_photos_full_with_token_policy(
+        download_client,
+        passes,
+        config,
+        controls,
+        shutdown_token,
+        true,
+    )
+    .await
+}
+
+async fn download_photos_full_with_token_policy(
+    download_client: &Client,
+    passes: &[crate::commands::AlbumPass],
+    config: &Arc<DownloadConfig>,
+    controls: DownloadControls,
+    shutdown_token: CancellationToken,
+    repair_token_gaps: bool,
 ) -> Result<SyncResult> {
     let started = Instant::now();
     let record_album_snapshots = should_record_album_snapshots(passes, config, controls);
@@ -4645,7 +4786,7 @@ async fn download_photos_full_with_token(
     // instead of serializing round trips across albums. Download workers are
     // divided across active pass pipelines so real downloads do not multiply
     // the user-selected `[download].threads` by the number of albums.
-    let (streaming_result, token_receivers) = if needs_per_pass {
+    let (mut streaming_result, token_receivers) = if needs_per_pass {
         let mut combined_result = StreamingResult {
             // Enumeration is "complete" only when every pass finished
             // its stream cleanly. Start optimistic; flip to false on the
@@ -4702,85 +4843,89 @@ async fn download_photos_full_with_token(
                     Some(*index) != deferred_unfiled
                 }),
         )
-        .map(|((((_index, pass), &count), total_count), pass_config)| {
-            let shutdown_token = shutdown_token.clone();
-            let download_client = download_client.clone();
-            let deferred_ids = deferred_ids.clone();
-            let recent_frontier = recent_frontier.as_ref();
-            let download_ctx = shared_download_ctx.clone();
-            let bounds_truncated = Arc::clone(&bounds_truncated);
-            async move {
-                let album_snapshot = if record_album_snapshots {
-                    AlbumSnapshotRecorder::start_for_pass(
-                        config.state_db.clone(),
-                        pass,
-                        config.enum_config_hash.as_deref(),
+        .map(
+            |((((pass_index, pass), &count), total_count), pass_config)| {
+                let shutdown_token = shutdown_token.clone();
+                let download_client = download_client.clone();
+                let deferred_ids = deferred_ids.clone();
+                let recent_frontier = recent_frontier.as_ref();
+                let download_ctx = shared_download_ctx.clone();
+                let bounds_truncated = Arc::clone(&bounds_truncated);
+                async move {
+                    let album_snapshot = if record_album_snapshots {
+                        AlbumSnapshotRecorder::start_for_pass(
+                            config.state_db.clone(),
+                            pass,
+                            config.enum_config_hash.as_deref(),
+                        )
+                        .await
+                    } else {
+                        None
+                    };
+                    let (stream, token_rx) = open_photo_stream_for_controls(
+                        &pass.album,
+                        scope_frontier_limit(config, recent_frontier),
+                        *total_count,
+                        config.concurrent_downloads,
+                        pass_config.concurrent_downloads,
+                        controls,
+                        strict_empty_tail_errors,
+                    );
+                    let stream = filter_stream_to_enumeration_bounds(
+                        stream,
+                        config,
+                        recent_frontier,
+                        Arc::clone(&bounds_truncated),
+                    );
+
+                    if pass.kind == crate::commands::PassKind::Album {
+                        if let Some(deferred_ids) = deferred_ids {
+                            let stream = stream.map(move |item| {
+                                if let Ok(asset) = &item {
+                                    if let Ok(mut ids) = deferred_ids.lock() {
+                                        ids.insert(asset.asset_record_name().to_string());
+                                    }
+                                }
+                                item
+                            });
+                            return run_full_pass_stream(
+                                download_client,
+                                stream,
+                                token_rx,
+                                pass_config,
+                                FullPassStreamOptions {
+                                    pass_index,
+                                    controls,
+                                    count,
+                                    kind: pass.kind,
+                                    shutdown_token,
+                                    download_ctx: download_ctx.clone(),
+                                    album_snapshot,
+                                },
+                            )
+                            .await;
+                        }
+                    }
+
+                    run_full_pass_stream(
+                        download_client,
+                        stream,
+                        token_rx,
+                        pass_config,
+                        FullPassStreamOptions {
+                            pass_index,
+                            controls,
+                            count,
+                            kind: pass.kind,
+                            shutdown_token,
+                            download_ctx,
+                            album_snapshot,
+                        },
                     )
                     .await
-                } else {
-                    None
-                };
-                let (stream, token_rx) = open_photo_stream_for_controls(
-                    &pass.album,
-                    scope_frontier_limit(config, recent_frontier),
-                    *total_count,
-                    config.concurrent_downloads,
-                    pass_config.concurrent_downloads,
-                    controls,
-                    strict_empty_tail_errors,
-                );
-                let stream = filter_stream_to_enumeration_bounds(
-                    stream,
-                    config,
-                    recent_frontier,
-                    Arc::clone(&bounds_truncated),
-                );
-
-                if pass.kind == crate::commands::PassKind::Album {
-                    if let Some(deferred_ids) = deferred_ids {
-                        let stream = stream.map(move |item| {
-                            if let Ok(asset) = &item {
-                                if let Ok(mut ids) = deferred_ids.lock() {
-                                    ids.insert(asset.asset_record_name().to_string());
-                                }
-                            }
-                            item
-                        });
-                        return run_full_pass_stream(
-                            download_client,
-                            stream,
-                            token_rx,
-                            pass_config,
-                            FullPassStreamOptions {
-                                controls,
-                                count,
-                                kind: pass.kind,
-                                shutdown_token,
-                                download_ctx: download_ctx.clone(),
-                                album_snapshot,
-                            },
-                        )
-                        .await;
-                    }
                 }
-
-                run_full_pass_stream(
-                    download_client,
-                    stream,
-                    token_rx,
-                    pass_config,
-                    FullPassStreamOptions {
-                        controls,
-                        count,
-                        kind: pass.kind,
-                        shutdown_token,
-                        download_ctx,
-                        album_snapshot,
-                    },
-                )
-                .await
-            }
-        })
+            },
+        )
         .buffer_unordered(pass_parallelism)
         .collect::<Vec<Result<PerPassStreamingResult>>>();
 
@@ -4790,6 +4935,7 @@ async fn download_photos_full_with_token(
         let mut deferred_exclusions_complete = true;
         for pass_result in pass_results {
             let PerPassStreamingResult {
+                pass_index,
                 kind,
                 label,
                 count,
@@ -4820,7 +4966,15 @@ async fn download_photos_full_with_token(
                 pagination_count_deduction = pagination_count_deduction.saturating_add(count);
             }
 
-            token_receivers.push(token_rx);
+            token_receivers.push(PassTokenReceiver {
+                pass: PassKey {
+                    index: pass_index,
+                    kind,
+                    label: label.clone(),
+                },
+                receiver: token_rx,
+                enumeration_complete: result.enumeration_complete && result.enumeration_errors == 0,
+            });
             let downloaded_u64 = u64::try_from(result.downloaded).unwrap_or(u64::MAX);
             divider.mark_done(&label, downloaded_u64, count, elapsed);
 
@@ -4867,6 +5021,7 @@ async fn download_photos_full_with_token(
                         token_rx,
                         pass_config,
                         FullPassStreamOptions {
+                            pass_index: index,
                             controls,
                             count: pass_counts.get(index).copied().unwrap_or(0),
                             kind: crate::commands::PassKind::Unfiled,
@@ -4888,7 +5043,16 @@ async fn download_photos_full_with_token(
                         pass_result.count,
                         pass_result.elapsed,
                     );
-                    token_receivers.push(pass_result.token_rx);
+                    token_receivers.push(PassTokenReceiver {
+                        pass: PassKey {
+                            index: pass_result.pass_index,
+                            kind: pass_result.kind,
+                            label: pass_result.label.clone(),
+                        },
+                        receiver: pass_result.token_rx,
+                        enumeration_complete: pass_result.result.enumeration_complete
+                            && pass_result.result.enumeration_errors == 0,
+                    });
                     merge_streaming_result(&mut combined_result, pass_result.result);
                 }
             } else {
@@ -4911,8 +5075,9 @@ async fn download_photos_full_with_token(
         let mut token_receivers = Vec::with_capacity(passes.len());
         let streams: Vec<_> = passes
             .iter()
+            .enumerate()
             .zip(&pass_stream_counts)
-            .map(|(pass, total_count)| {
+            .map(|((pass_index, pass), total_count)| {
                 let (stream, token_rx) = open_photo_stream_for_controls(
                     &pass.album,
                     scope_frontier_limit(config, recent_frontier.as_ref()),
@@ -4922,7 +5087,20 @@ async fn download_photos_full_with_token(
                     controls,
                     strict_empty_tail_errors,
                 );
-                token_receivers.push(token_rx);
+                let label = if pass.album.name.is_empty() {
+                    "unfiled".to_string()
+                } else {
+                    pass.album.name.to_string()
+                };
+                token_receivers.push(PassTokenReceiver {
+                    pass: PassKey {
+                        index: pass_index,
+                        kind: pass.kind,
+                        label,
+                    },
+                    receiver: token_rx,
+                    enumeration_complete: true,
+                });
                 filter_stream_to_enumeration_bounds(
                     stream,
                     config,
@@ -5031,10 +5209,8 @@ async fn download_photos_full_with_token(
     // stream suppresses its token when it hits the cap, and lower-date-bound /
     // global-recent filtering marks `bounds_truncated` when it stops before
     // natural EOF.
-    let token_eligible = !controls.run_mode.only_print_filenames()
-        && !controls.run_mode.is_dry_run()
-        && streaming_result.enumeration_complete
-        && streaming_result.enumeration_errors == 0;
+    let token_attempt_allowed =
+        !controls.run_mode.only_print_filenames() && !controls.run_mode.is_dry_run();
     let mut token_block_reason: Option<&'static str> = None;
     let mut token_expected_receivers: Option<usize> = None;
     let mut token_receivers_with_token: Option<usize> = None;
@@ -5042,73 +5218,292 @@ async fn download_photos_full_with_token(
     let mut token_receivers_blank: Option<usize> = None;
     let mut token_receivers_dropped: Option<usize> = None;
     let mut token_unique_values: Option<usize> = None;
-    let sync_token = if token_eligible {
+    let mut same_cycle_recovery_attempts = 0usize;
+    let mut same_cycle_recovery_successes = 0usize;
+    let sync_token = if token_attempt_allowed {
         let expected_token_count = token_receivers.len();
         token_expected_receivers = Some(expected_token_count);
-        let mut tokens = Vec::new();
-        let mut missing_tokens = 0usize;
-        let mut blank_tokens = 0usize;
-        let mut dropped_receivers = 0usize;
-        for rx in token_receivers {
-            match rx.await {
-                Ok(Some(token)) => {
-                    let trimmed = token.trim();
-                    if trimmed.is_empty() {
-                        blank_tokens += 1;
-                        continue;
-                    }
-                    tokens.push(trimmed.to_string());
+        let mut observations = Vec::with_capacity(expected_token_count);
+        for receiver in token_receivers {
+            let result = if !receiver.enumeration_complete {
+                let _ = receiver.receiver.await;
+                PassTokenResult::EnumerationIncomplete
+            } else {
+                match receiver.receiver.await {
+                    Ok(Some(token)) if token.trim().is_empty() => PassTokenResult::Blank,
+                    Ok(Some(token)) => PassTokenResult::Present(token.trim().to_string()),
+                    Ok(None) => PassTokenResult::Missing,
+                    Err(_) => PassTokenResult::ReceiverDropped,
                 }
-                Ok(None) => {
-                    missing_tokens += 1;
-                }
-                Err(_) => {
-                    dropped_receivers += 1;
-                }
-            }
+            };
+            observations.push(PassTokenObservation {
+                pass: receiver.pass,
+                result,
+            });
         }
+        let tokens: Vec<&str> = observations
+            .iter()
+            .filter_map(|observation| match &observation.result {
+                PassTokenResult::Present(token) => Some(token.as_str()),
+                _ => None,
+            })
+            .collect();
+        let missing_tokens = observations
+            .iter()
+            .filter(|observation| matches!(observation.result, PassTokenResult::Missing))
+            .count();
+        let blank_tokens = observations
+            .iter()
+            .filter(|observation| matches!(observation.result, PassTokenResult::Blank))
+            .count();
+        let dropped_receivers = observations
+            .iter()
+            .filter(|observation| matches!(observation.result, PassTokenResult::ReceiverDropped))
+            .count();
+        let unique_token_count = tokens.iter().copied().collect::<FxHashSet<_>>().len();
         token_receivers_with_token = Some(tokens.len());
         token_receivers_missing = Some(missing_tokens);
         token_receivers_blank = Some(blank_tokens);
         token_receivers_dropped = Some(dropped_receivers);
-        if blank_tokens > 0 {
-            tracing::warn!(
-                blank_tokens,
-                expected_token_count,
-                "Full enumeration returned blank syncToken values; blocking token advancement"
-            );
-        }
-        if dropped_receivers > 0 {
-            tracing::warn!(
-                dropped_receivers,
-                expected_token_count,
-                "Full enumeration syncToken receiver dropped before completion; blocking token advancement"
-            );
-        }
-        let unique_token_count = tokens
-            .iter()
-            .map(std::string::String::as_str)
-            .collect::<FxHashSet<_>>()
-            .len();
         token_unique_values = Some(unique_token_count);
-        let resolved = unanimous_pass_sync_token(&tokens);
-        if resolved.is_none() {
-            token_block_reason = Some(if dropped_receivers > 0 {
-                "kei_internal_token_receiver_dropped"
-            } else if blank_tokens > 0 {
-                "icloud_blank_sync_token"
-            } else if unique_token_count > 1 {
-                "icloud_sync_token_mismatch"
-            } else if missing_tokens > 0 {
-                "icloud_sync_token_missing"
-            } else {
-                "sync_token_unavailable"
-            });
+        let bounded_stream_truncated = bounds_truncated.load(Ordering::Relaxed);
+        let repair_entire_enumeration = (!streaming_result.enumeration_complete
+            || streaming_result.enumeration_errors > 0)
+            && !bounded_stream_truncated;
+        let initial_evidence = if bounded_stream_truncated {
+            ZoneTokenEvidence::Incomplete {
+                reason: TokenGap::EnumerationIncomplete,
+            }
+        } else if repair_entire_enumeration {
+            ZoneTokenEvidence::Recoverable {
+                passes: observations
+                    .iter()
+                    .map(|observation| observation.pass.clone())
+                    .collect(),
+                reason: TokenGap::EnumerationIncomplete,
+            }
+        } else {
+            classify_zone_token_evidence(&observations)
+        };
+        match initial_evidence {
+            ZoneTokenEvidence::Complete { token } => Some(token),
+            ZoneTokenEvidence::Recoverable { reason, .. } if !repair_token_gaps => {
+                token_block_reason = Some(match reason {
+                    TokenGap::ReceiverDropped => "kei_internal_token_receiver_dropped",
+                    TokenGap::Blank => "icloud_blank_sync_token",
+                    TokenGap::Mismatch => "icloud_sync_token_mismatch",
+                    TokenGap::Missing | TokenGap::EnumerationIncomplete => {
+                        "icloud_sync_token_missing"
+                    }
+                });
+                None
+            }
+            ZoneTokenEvidence::Recoverable {
+                reason,
+                passes: recovery_passes,
+            } => {
+                tracing::warn!(
+                    reason = ?reason,
+                    passes = ?recovery_passes,
+                    "Provider checkpoint preserved: pass proof is incomplete; retrying only affected passes now"
+                );
+                same_cycle_recovery_attempts = 1;
+                let recovery_configs =
+                    match build_pass_configs_resolving_deferred_excludes(passes, config).await {
+                        Ok(configs) => configs,
+                        Err(error) => {
+                            tracing::warn!(
+                                error = %error,
+                                "Same-cycle pass recovery could not rebuild pass exclusions"
+                            );
+                            Vec::new()
+                        }
+                    };
+                let mut recovery_enumeration_complete = true;
+                let mut recovery_enumeration_errors = 0usize;
+                let expected_recovery_passes = recovery_passes.len();
+                let mut completed_recovery_passes = 0usize;
+                for pass_key in recovery_passes {
+                    let Some(pass) = passes.get(pass_key.index) else {
+                        recovery_enumeration_complete = false;
+                        continue;
+                    };
+                    let Some(pass_config) = recovery_configs.get(pass_key.index).cloned() else {
+                        recovery_enumeration_complete = false;
+                        continue;
+                    };
+                    let total_count = pass_stream_counts.get(pass_key.index).copied().flatten();
+                    let (stream, token_rx) = open_photo_stream_for_controls(
+                        &pass.album,
+                        scope_frontier_limit(config, recent_frontier.as_ref()),
+                        total_count,
+                        config.concurrent_downloads,
+                        pass_config.concurrent_downloads,
+                        controls,
+                        strict_empty_tail_errors,
+                    );
+                    let stream = filter_stream_to_enumeration_bounds(
+                        stream,
+                        config,
+                        recent_frontier.as_ref(),
+                        Arc::clone(&bounds_truncated),
+                    );
+                    let recovered = run_full_pass_stream(
+                        download_client.clone(),
+                        stream,
+                        token_rx,
+                        pass_config,
+                        FullPassStreamOptions {
+                            pass_index: pass_key.index,
+                            controls,
+                            count: pass_counts.get(pass_key.index).copied().unwrap_or(0),
+                            kind: pass.kind,
+                            shutdown_token: shutdown_token.clone(),
+                            download_ctx: None,
+                            album_snapshot: None,
+                        },
+                    )
+                    .await;
+                    let recovered = match recovered {
+                        Ok(recovered) => recovered,
+                        Err(error) => {
+                            recovery_enumeration_complete = false;
+                            recovery_enumeration_errors =
+                                recovery_enumeration_errors.saturating_add(1);
+                            if let Some(observation) = observations
+                                .iter_mut()
+                                .find(|observation| observation.pass.index == pass_key.index)
+                            {
+                                observation.result = PassTokenResult::EnumerationIncomplete;
+                            }
+                            tracing::warn!(
+                                pass = ?pass_key,
+                                error = %error,
+                                "Same-cycle pass recovery did not complete"
+                            );
+                            continue;
+                        }
+                    };
+                    completed_recovery_passes += 1;
+                    let recovered_result = if !recovered.result.enumeration_complete
+                        || recovered.result.enumeration_errors > 0
+                    {
+                        let _ = recovered.token_rx.await;
+                        PassTokenResult::EnumerationIncomplete
+                    } else {
+                        match recovered.token_rx.await {
+                            Ok(Some(token)) if token.trim().is_empty() => PassTokenResult::Blank,
+                            Ok(Some(token)) => PassTokenResult::Present(token.trim().to_string()),
+                            Ok(None) => PassTokenResult::Missing,
+                            Err(_) => PassTokenResult::ReceiverDropped,
+                        }
+                    };
+                    recovery_enumeration_complete =
+                        recovery_enumeration_complete && recovered.result.enumeration_complete;
+                    recovery_enumeration_errors = recovery_enumeration_errors
+                        .saturating_add(recovered.result.enumeration_errors);
+                    if let Some(observation) = observations
+                        .iter_mut()
+                        .find(|observation| observation.pass.index == pass_key.index)
+                    {
+                        observation.result = recovered_result;
+                    }
+                    merge_token_recovery_result(&mut streaming_result, recovered.result);
+                }
+
+                if completed_recovery_passes != expected_recovery_passes {
+                    recovery_enumeration_complete = false;
+                    recovery_enumeration_errors = recovery_enumeration_errors.saturating_add(
+                        expected_recovery_passes.saturating_sub(completed_recovery_passes),
+                    );
+                }
+
+                if repair_entire_enumeration {
+                    streaming_result.enumeration_complete = recovery_enumeration_complete;
+                    streaming_result.enumeration_errors = recovery_enumeration_errors;
+                }
+
+                let final_tokens: Vec<&str> = observations
+                    .iter()
+                    .filter_map(|observation| match &observation.result {
+                        PassTokenResult::Present(token) => Some(token.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                token_receivers_with_token = Some(final_tokens.len());
+                token_receivers_missing = Some(
+                    observations
+                        .iter()
+                        .filter(|observation| {
+                            matches!(observation.result, PassTokenResult::Missing)
+                        })
+                        .count(),
+                );
+                token_receivers_blank = Some(
+                    observations
+                        .iter()
+                        .filter(|observation| matches!(observation.result, PassTokenResult::Blank))
+                        .count(),
+                );
+                token_receivers_dropped = Some(
+                    observations
+                        .iter()
+                        .filter(|observation| {
+                            matches!(observation.result, PassTokenResult::ReceiverDropped)
+                        })
+                        .count(),
+                );
+                token_unique_values =
+                    Some(final_tokens.iter().copied().collect::<FxHashSet<_>>().len());
+
+                match classify_zone_token_evidence(&observations) {
+                    ZoneTokenEvidence::Complete { token }
+                        if streaming_result.enumeration_complete
+                            && streaming_result.enumeration_errors == 0 =>
+                    {
+                        same_cycle_recovery_successes = 1;
+                        tracing::info!(
+                            passes = ?observations.iter().map(|observation| &observation.pass).collect::<Vec<_>>(),
+                            "Provider checkpoint proof repaired in the current cycle"
+                        );
+                        Some(token)
+                    }
+                    ZoneTokenEvidence::Complete { .. } => {
+                        token_block_reason = Some("icloud_sync_token_missing");
+                        None
+                    }
+                    ZoneTokenEvidence::Recoverable { reason, .. }
+                    | ZoneTokenEvidence::Incomplete { reason } => {
+                        token_block_reason = Some(match reason {
+                            TokenGap::ReceiverDropped => "kei_internal_token_receiver_dropped",
+                            TokenGap::Blank => "icloud_blank_sync_token",
+                            TokenGap::Mismatch => "icloud_sync_token_mismatch",
+                            TokenGap::Missing | TokenGap::EnumerationIncomplete => {
+                                "icloud_sync_token_missing"
+                            }
+                        });
+                        None
+                    }
+                }
+            }
+            ZoneTokenEvidence::Incomplete { reason } => {
+                token_block_reason = Some(match reason {
+                    TokenGap::ReceiverDropped => "kei_internal_token_receiver_dropped",
+                    TokenGap::Blank => "icloud_blank_sync_token",
+                    TokenGap::Mismatch => "icloud_sync_token_mismatch",
+                    TokenGap::Missing | TokenGap::EnumerationIncomplete => {
+                        "icloud_sync_token_missing"
+                    }
+                });
+                None
+            }
         }
-        resolved
     } else {
         None
     };
+    let token_eligible = token_attempt_allowed
+        && streaming_result.enumeration_complete
+        && streaming_result.enumeration_errors == 0;
 
     // Capture the enumeration-complete signal before
     // `build_download_outcome` consumes `streaming_result`. The marker
@@ -5116,6 +5511,17 @@ async fn download_photos_full_with_token(
     // whose enumeration phase finished still clears the marker.
     let enumeration_complete = streaming_result.enumeration_complete;
     let enumeration_errors = streaming_result.enumeration_errors;
+    let tail_probes = if config.recent.is_none() && config.skip_created_before.is_none() {
+        pass_stream_counts
+            .iter()
+            .filter(|count| count.is_some())
+            .count()
+    } else {
+        0
+    };
+    let count_undercount_assets = exact_total
+        .map(|count| streaming_result.assets_seen.saturating_sub(count))
+        .unwrap_or(0);
 
     // Build the outcome using the same logic as download_photos
     let (outcome, mut stats) = build_download_outcome(
@@ -5130,9 +5536,13 @@ async fn download_photos_full_with_token(
     .await?;
     stats.pagination_shortfall_warnings = pagination_shortfall_warnings;
     stats.pagination_shortfall_assets = pagination_shortfall_assets;
+    stats.tail_probes = tail_probes;
+    stats.count_undercount_assets = count_undercount_assets;
     stats.count_probe_failures = len_errors;
     stats.api_total_at_start = api_total_at_start;
-    if token_eligible {
+    stats.same_cycle_recovery_attempts = same_cycle_recovery_attempts;
+    stats.same_cycle_recovery_successes = same_cycle_recovery_successes;
+    if token_attempt_allowed {
         stats.sync_token_expected_receivers = token_expected_receivers;
         stats.sync_token_receivers_with_token = token_receivers_with_token;
         stats.sync_token_receivers_missing = token_receivers_missing;
@@ -6809,7 +7219,7 @@ mod tests {
                 }));
             }
 
-            if url.contains("/records/query?") {
+            if url.contains("/records/lookup?") || url.contains("/records/query?") {
                 self.records_query_calls.fetch_add(1, Ordering::SeqCst);
                 return Ok(self.query_page.clone());
             }
@@ -6874,11 +7284,17 @@ mod tests {
             }
 
             if url.contains("/records/query?") {
-                self.records_query_calls.fetch_add(1, Ordering::SeqCst);
+                let call = self.records_query_calls.fetch_add(1, Ordering::SeqCst);
                 if self.fail_records_query {
                     anyhow::bail!("smart folder refresh failed");
                 }
-                return Ok(self.page.clone());
+                if call == 0 {
+                    return Ok(self.page.clone());
+                }
+                return Ok(json!({
+                    "records": [],
+                    "syncToken": self.page.get("syncToken").cloned().unwrap_or(Value::Null)
+                }));
             }
 
             Ok(json!({"records": []}))
@@ -7428,6 +7844,91 @@ mod tests {
     }
 
     #[derive(Clone, Debug)]
+    struct RecoveringPassTokenSession {
+        query_calls: Arc<AtomicUsize>,
+        records: Arc<Vec<Value>>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecoveringIncompletePassSession {
+        query_calls: Arc<AtomicUsize>,
+        records: Arc<Vec<Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for RecoveringIncompletePassSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/internal/records/query/batch") {
+                return Ok(json!({
+                    "batch": [{"records": [{"fields": {"itemCount": {"value": 1}}}]}]
+                }));
+            }
+            if !url.contains("/records/query?") {
+                return Ok(json!({"records": []}));
+            }
+
+            let call = self.query_calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Ok(json!({"records": "malformed"}));
+            }
+            if call == 1 {
+                return Ok(json!({
+                    "records": self.records.as_ref().clone(),
+                    "syncToken": "zone-token-recovered"
+                }));
+            }
+            Ok(json!({"records": [], "syncToken": "zone-token-recovered"}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for RecoveringPassTokenSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/internal/records/query/batch") {
+                return Ok(json!({
+                    "batch": [{"records": [{"fields": {"itemCount": {"value": 1}}}]}]
+                }));
+            }
+            if !url.contains("/records/query?") {
+                return Ok(json!({"records": []}));
+            }
+
+            let call = self.query_calls.fetch_add(1, Ordering::SeqCst);
+            let recovery_round = call >= 6;
+            let first_page = call.is_multiple_of(6);
+            Ok(match (first_page, recovery_round) {
+                (true, false) => json!({"records": self.records.as_ref().clone()}),
+                (false, false) => json!({"records": []}),
+                (true, true) => json!({
+                    "records": self.records.as_ref().clone(),
+                    "syncToken": "zone-token-recovered"
+                }),
+                (false, true) => {
+                    json!({"records": [], "syncToken": "zone-token-recovered"})
+                }
+            })
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[derive(Clone, Debug)]
     struct SplitChangesZoneSession {
         delta_responses: Arc<std::sync::Mutex<std::collections::VecDeque<Value>>>,
         hydrate_responses: Arc<std::sync::Mutex<std::collections::VecDeque<Value>>>,
@@ -7508,7 +8009,7 @@ mod tests {
                 return Ok(changes_zone_response(records, "zone-token-next"));
             }
 
-            if url.contains("/records/query?") {
+            if url.contains("/records/lookup?") || url.contains("/records/query?") {
                 let call = self.query_calls.fetch_add(1, Ordering::SeqCst);
                 return Ok(if call == 0 {
                     json!({
@@ -7521,6 +8022,33 @@ mod tests {
             }
 
             Ok(json!({"records": []}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct PendingLookupSession {
+        records: Arc<Vec<Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for PendingLookupSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/changes/zone?") {
+                return Ok(changes_zone_response(Vec::new(), "zone-token-next"));
+            }
+            if url.contains("/records/lookup?") {
+                return Ok(json!({"records": self.records.as_ref().clone()}));
+            }
+            Ok(json!({"records": [], "syncToken": "ignored-query-token"}))
         }
 
         fn clone_box(&self) -> Box<dyn PhotosSession> {
@@ -7937,7 +8465,10 @@ mod tests {
         .await
         .expect("dry-run full sync should succeed");
 
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "result: {result:?}"
+        );
         assert_eq!(
             session.max_in_flight(),
             1,
@@ -8566,7 +9097,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_album_count_blocks_token_on_ambiguous_empty_tail() {
+    async fn malformed_album_count_is_diagnostic_when_tail_proves_eof() {
         let records = mock_photo_records_with_filename("MASTER_BEFORE_GAP", "before-gap.jpg");
         let later_records = mock_photo_records_with_filename("MASTER_AFTER_GAP", "after-gap.jpg");
         let session = MockPhotosFlow::new()
@@ -8606,28 +9137,22 @@ mod tests {
         .await
         .expect("malformed album count should produce a sync result");
 
-        assert!(matches!(
-            result.outcome,
-            DownloadOutcome::PartialFailure { failed_count: 1 }
-        ));
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
         assert_eq!(
             result.stats.assets_seen, 1,
-            "enumeration must not walk past the ambiguous empty-tail terminator"
+            "the finite empty-page ceiling is the natural EOF proof"
         );
-        assert_eq!(result.stats.enumeration_errors, 1);
+        assert_eq!(result.stats.enumeration_errors, 0);
         assert_eq!(result.stats.count_probe_failures, 1);
         assert_eq!(result.stats.pagination_shortfall_warnings, 0);
         assert_eq!(result.stats.pagination_shortfall_assets, 0);
-        assert!(result.stats.sync_token_blocked);
-        assert_eq!(
-            result.stats.sync_token_blocked_reason,
-            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
-        );
-        assert_eq!(result.sync_token, None);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
     }
 
     #[tokio::test]
-    async fn missing_album_count_item_count_blocks_ambiguous_empty_tail() {
+    async fn missing_album_count_is_diagnostic_when_empty_inventory_proves_eof() {
         let session = MockPhotosFlow::new()
             .album_count_response(json!({
                 "batch": [{"records": [{"fields": {}}]}]
@@ -8655,19 +9180,13 @@ mod tests {
         .await
         .expect("missing album count should produce a sync result");
 
-        assert!(matches!(
-            result.outcome,
-            DownloadOutcome::PartialFailure { failed_count: 1 }
-        ));
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
         assert_eq!(result.stats.assets_seen, 0);
-        assert_eq!(result.stats.enumeration_errors, 1);
+        assert_eq!(result.stats.enumeration_errors, 0);
         assert_eq!(result.stats.count_probe_failures, 1);
-        assert!(result.stats.sync_token_blocked);
-        assert_eq!(
-            result.stats.sync_token_blocked_reason,
-            Some(ICLOUD_ALBUM_COUNT_ERROR_REASON)
-        );
-        assert_eq!(result.sync_token, None);
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token"));
     }
 
     #[tokio::test]
@@ -8799,9 +9318,9 @@ mod tests {
             "duplicate asset IDs should be treated as producer skips, not partial failure"
         );
         assert_eq!(result.stats.assets_seen, 1);
-        assert_eq!(result.stats.skipped.duplicates, 1);
-        assert_eq!(result.stats.pagination_shortfall_warnings, 0);
-        assert_eq!(result.stats.pagination_shortfall_assets, 0);
+        assert_eq!(result.stats.skipped.duplicates, 0);
+        assert_eq!(result.stats.pagination_shortfall_warnings, 1);
+        assert_eq!(result.stats.pagination_shortfall_assets, 1);
         assert!(!result.stats.sync_token_blocked);
         assert_eq!(result.stats.sync_token_expected_receivers, Some(1));
         assert_eq!(result.stats.sync_token_receivers_with_token, Some(1));
@@ -8947,6 +9466,90 @@ mod tests {
         assert_eq!(result.stats.sync_token_receivers_dropped, Some(0));
         assert_eq!(result.stats.sync_token_unique_values, Some(0));
         assert_eq!(result.sync_token, None, "blank token must not be persisted");
+        assert_eq!(result.stats.same_cycle_recovery_attempts, 1);
+        assert_eq!(result.stats.same_cycle_recovery_successes, 0);
+    }
+
+    #[tokio::test]
+    async fn full_sync_repairs_missing_pass_token_in_same_cycle() {
+        let records = mock_photo_records_with_filename("MASTER_RECOVER", "recover.jpg");
+        let query_calls = Arc::new(AtomicUsize::new(0));
+        let session = RecoveringPassTokenSession {
+            query_calls: Arc::clone(&query_calls),
+            records: Arc::new(records.clone()),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: album_with_session("PrimarySync", "Recovery", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.file_match_policy = FileMatchPolicy::NameId7;
+
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("same-cycle token recovery should complete");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-recovered"));
+        assert_eq!(result.stats.same_cycle_recovery_attempts, 1);
+        assert_eq!(result.stats.same_cycle_recovery_successes, 1);
+        assert_eq!(result.stats.sync_token_receivers_with_token, Some(1));
+        assert_eq!(result.stats.sync_token_receivers_missing, Some(0));
+        assert_eq!(query_calls.load(Ordering::SeqCst), 12);
+    }
+
+    #[tokio::test]
+    async fn full_sync_repairs_incomplete_pass_in_same_cycle() {
+        let records = mock_photo_records_with_filename("MASTER_REPAIR", "repair.jpg");
+        let query_calls = Arc::new(AtomicUsize::new(0));
+        let session = RecoveringIncompletePassSession {
+            query_calls: Arc::clone(&query_calls),
+            records: Arc::new(records.clone()),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Album,
+            album: album_with_session("PrimarySync", "Recovery", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.concurrent_downloads = 1;
+        config.file_match_policy = FileMatchPolicy::NameId7;
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
+
+        let result = download_photos_full_with_token(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("incomplete pass should repair once in-cycle");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.enumeration_errors, 0);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-recovered"));
+        assert_eq!(result.stats.same_cycle_recovery_attempts, 1);
+        assert_eq!(result.stats.same_cycle_recovery_successes, 1);
+        assert_eq!(query_calls.load(Ordering::SeqCst), 7);
     }
 
     #[test]
@@ -10109,7 +10712,7 @@ mod tests {
         );
         assert_eq!(
             smart_session.records_query_count(),
-            1,
+            1 + crate::icloud::photos::MAX_EMPTY_PAGE_PROBES as usize,
             "smart-folder refresh should enumerate the selected smart folder"
         );
         assert!(
@@ -10152,7 +10755,10 @@ mod tests {
             1,
             "unfiled incremental changes should still be checked"
         );
-        assert_eq!(smart_session.records_query_count(), 1);
+        assert_eq!(
+            smart_session.records_query_count(),
+            crate::icloud::photos::MAX_EMPTY_PAGE_PROBES as usize
+        );
         assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
         assert!(
             !result.stats.sync_token_blocked,
@@ -10183,7 +10789,7 @@ mod tests {
         assert_eq!(changes_calls.load(Ordering::SeqCst), 1);
         assert_eq!(
             smart_session.records_query_count(),
-            1,
+            1 + crate::icloud::photos::MAX_EMPTY_PAGE_PROBES as usize,
             "smart-folder refresh must enumerate only the selected smart-folder stream"
         );
     }
@@ -10433,21 +11039,24 @@ mod tests {
         )
         .await
         .expect("mark failed");
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-FAILED_BEFORE_SYNC",
+            "FAILED_BEFORE_SYNC",
+        )
+        .await
+        .expect("seed asset/master mapping");
 
-        let session = MockPhotosFlow::new()
-            .changes_zone_page(Vec::new(), "zone-token-next", false)
-            .query_page(
-                mock_photo_records_for_zone_with_filename(
-                    "FAILED_BEFORE_SYNC",
-                    "PrimarySync",
-                    "failed-before-sync.jpg",
-                ),
-                Some("ignored-query-token"),
-            )
-            .build();
+        let session = PendingLookupSession {
+            records: Arc::new(mock_photo_records_for_zone_with_filename(
+                "FAILED_BEFORE_SYNC",
+                "PrimarySync",
+                "failed-before-sync.jpg",
+            )),
+        };
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
-            album: mock_album("", session),
+            album: album_with_session("PrimarySync", "", Box::new(session)),
             exclude_ids: Arc::new(FxHashSet::default()),
         }];
 
@@ -10474,11 +11083,123 @@ mod tests {
             "normal sync with failed rows should not force full enumeration"
         );
         assert_eq!(result.stats.full_enumeration_reason, None);
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "result: {result:?}"
+        );
         assert_eq!(
             result.sync_token, None,
             "print-only targeted retry must not advance the zone token"
         );
+    }
+
+    #[tokio::test]
+    async fn path_reconciliation_copies_catalog_file_without_provider_inventory() {
+        #[derive(Clone, Debug)]
+        struct LookupOnlySession {
+            records: Arc<Vec<Value>>,
+        }
+
+        #[async_trait::async_trait]
+        impl PhotosSession for LookupOnlySession {
+            async fn post(
+                &self,
+                url: &str,
+                _body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                if url.contains("/records/lookup?") {
+                    return Ok(json!({"records": self.records.as_ref().clone()}));
+                }
+                anyhow::bail!("path reconciliation made an unexpected provider request: {url}")
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let old_dir = TempDir::new().expect("old dir");
+        let new_dir = TempDir::new().expect("new dir");
+        let old_path = old_dir.path().join("reconcile.jpg");
+        tokio::fs::write(&old_path, b"catalog bytes").await.unwrap();
+        let local_checksum = file::compute_sha256(&old_path).await.unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new("RECONCILE")
+            .filename("reconcile.jpg")
+            .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "RECONCILE",
+            "original",
+            &old_path,
+            &local_checksum,
+            Some("provider-checksum"),
+        )
+        .await
+        .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "asset-RECONCILE", "RECONCILE")
+            .await
+            .unwrap();
+
+        let records =
+            mock_photo_records_for_zone_with_filename("RECONCILE", "PrimarySync", "reconcile.jpg");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(LookupOnlySession {
+                    records: Arc::new(records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        config.directory = Arc::from(new_dir.path());
+        config.state_db = Some(db.clone());
+        let expected_path = filter::expected_paths_for(&asset, &config)
+            .into_iter()
+            .next()
+            .unwrap()
+            .path;
+
+        let result = reconcile_catalog_paths(&passes, Arc::new(config), CancellationToken::new())
+            .await
+            .expect("path reconciliation");
+
+        assert!(result.complete);
+        assert_eq!(result.stats.downloaded, 1);
+        assert_eq!(tokio::fs::read(&old_path).await.unwrap(), b"catalog bytes");
+        assert_eq!(
+            tokio::fs::read(&expected_path).await.unwrap(),
+            b"catalog bytes"
+        );
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(
+            downloaded[0].local_path.as_deref(),
+            Some(expected_path.as_path())
+        );
+
+        tokio::fs::remove_file(&expected_path).await.unwrap();
+        let deferred = reconcile_catalog_paths(
+            &passes,
+            Arc::new({
+                let mut config = test_config();
+                config.directory = Arc::from(new_dir.path());
+                config.state_db = Some(db);
+                config
+            }),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("missing local file should defer to targeted retry");
+        assert!(!deferred.complete);
+        assert_eq!(deferred.stats.failed, 0);
     }
 
     #[tokio::test]
@@ -10490,21 +11211,20 @@ mod tests {
             .size(1024)
             .build();
         db.upsert_seen(&record).await.expect("seed pending row");
+        db.upsert_asset_master_mapping("PrimarySync", "asset-DRY_RUN_PENDING", "DRY_RUN_PENDING")
+            .await
+            .expect("seed asset/master mapping");
 
-        let session = MockPhotosFlow::new()
-            .changes_zone_page(Vec::new(), "zone-token-next", false)
-            .query_page(
-                mock_photo_records_for_zone_with_filename(
-                    "DRY_RUN_PENDING",
-                    "PrimarySync",
-                    "dry-run-pending.jpg",
-                ),
-                Some("ignored-query-token"),
-            )
-            .build();
+        let session = PendingLookupSession {
+            records: Arc::new(mock_photo_records_for_zone_with_filename(
+                "DRY_RUN_PENDING",
+                "PrimarySync",
+                "dry-run-pending.jpg",
+            )),
+        };
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
-            album: mock_album("", session),
+            album: album_with_session("PrimarySync", "", Box::new(session)),
             exclude_ids: Arc::new(FxHashSet::default()),
         }];
 
@@ -10571,6 +11291,13 @@ mod tests {
         )
         .await
         .expect("mark failed");
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-FAILED_BEFORE_SYNC",
+            "FAILED_BEFORE_SYNC",
+        )
+        .await
+        .expect("seed asset/master mapping");
 
         let download_url = format!("{}/failed-before-sync.jpg", server.uri());
         let mut records = incremental_photo_records_with_url(
@@ -10580,13 +11307,12 @@ mod tests {
             8,
         );
         records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] = json!(checksum);
-        let session = MockPhotosFlow::new()
-            .changes_zone_page(Vec::new(), "zone-token-next", false)
-            .query_page(records, Some("ignored-query-token"))
-            .build();
+        let session = PendingLookupSession {
+            records: Arc::new(records),
+        };
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
-            album: mock_album("", session),
+            album: album_with_session("PrimarySync", "", Box::new(session)),
             exclude_ids: Arc::new(FxHashSet::default()),
         }];
 
@@ -10666,6 +11392,13 @@ mod tests {
             .size(1024)
             .build();
         db.upsert_seen(&record).await.expect("seed pending row");
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-PENDING_EXPIRED_URL",
+            "PENDING_EXPIRED_URL",
+        )
+        .await
+        .expect("seed asset/master mapping");
 
         let expired_url = format!("{}/expired-pending.jpg", server.uri());
         let fresh_url = format!("{}/fresh-pending.jpg", server.uri());
@@ -10722,7 +11455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_with_unmatched_pending_rows_blocks_token_without_full_enumeration() {
+    async fn incremental_with_unmatched_pending_rows_does_not_block_source_checkpoint() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = crate::test_helpers::TestAssetRecord::new("PENDING_BEFORE_SYNC")
             .filename("pending-before-sync.jpg")
@@ -10757,7 +11490,7 @@ mod tests {
             CancellationToken::new(),
         )
         .await
-        .expect("pending rows should return a token-blocked result");
+        .expect("pending rows should remain durable without forcing provider recovery");
 
         assert!(
             !result.full_enumeration_ran,
@@ -10769,15 +11502,12 @@ mod tests {
         ));
         assert_eq!(result.sync_token, None);
         assert_eq!(result.stats.downloaded, 0);
-        assert!(result.stats.sync_token_blocked);
-        assert_eq!(
-            result.stats.sync_token_blocked_reason,
-            Some(PENDING_RETRY_UNMATCHED_REASON)
-        );
+        assert!(!result.stats.sync_token_blocked);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
     }
 
     #[tokio::test]
-    async fn incremental_with_unmatched_pending_rows_prunes_after_targeted_retry() {
+    async fn incremental_with_unmatched_pending_rows_retains_state_without_deletion_evidence() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = TestAssetRecord::new("PENDING_DELETED_UPSTREAM")
             .filename("pending-deleted-upstream.jpg")
@@ -10812,19 +11542,119 @@ mod tests {
             CancellationToken::new(),
         )
         .await
-        .expect("unmatched pending rows should be pruned after targeted retry");
+        .expect("unmatched pending rows should remain represented after targeted retry");
 
         assert!(
             !result.full_enumeration_ran,
-            "targeted retry pruning should not force full enumeration"
+            "retaining unresolved pending state should not force full enumeration"
         );
-        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
         assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
         assert!(!result.stats.sync_token_blocked);
-        assert_eq!(result.stats.stale_pending_pruned, 1);
+        assert_eq!(result.stats.sync_token_blocked_reason, None);
+        assert_eq!(result.stats.stale_pending_pruned, 0);
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.awaiting_provider_verification, 1);
+        assert_eq!(db.get_pending().await.expect("pending page").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn full_enumeration_query_absence_never_deletes_pending_state() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("ABSENT_FROM_FULL_QUERY")
+            .filename("absent-from-full-query.jpg")
+            .checksum("ck_absent_from_full_query")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let session = MockPhotosFlow::new()
+            .empty_query_page(Some("zone-token-next"))
+            .build();
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album("", session),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Full;
+
+        download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("clean full enumeration");
+
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.total_assets, 1);
+        assert_eq!(summary.source_deleted, 0);
+        assert_eq!(summary.failed, 1);
+    }
+
+    #[tokio::test]
+    async fn incremental_pending_retry_clears_only_explicit_provider_deletion() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("PENDING_CONFIRMED_DELETED")
+            .filename("confirmed-deleted.jpg")
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-PENDING_CONFIRMED_DELETED",
+            "PENDING_CONFIRMED_DELETED",
+        )
+        .await
+        .expect("seed identity mapping");
+
+        let session = PendingLookupSession {
+            records: Arc::new(vec![json!({
+                "recordName": "PENDING_CONFIRMED_DELETED",
+                "serverErrorCode": "UNKNOWN_ITEM",
+                "reason": "record not found"
+            })]),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("explicit provider deletion should resolve pending work");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
         let summary = db.get_summary().await.expect("summary");
         assert_eq!(summary.pending, 0);
-        assert!(db.get_pending().await.expect("pending page").is_empty());
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.awaiting_provider_verification, 0);
+        assert_eq!(summary.source_deleted, 1);
     }
 
     async fn run_bounded_incremental_sync(
@@ -13342,6 +14172,8 @@ mod tests {
             stale_pending_pruned: 5,
             pagination_shortfall_warnings: 1,
             pagination_shortfall_assets: 9,
+            tail_probes: 2,
+            count_undercount_assets: 3,
             enumeration_incomplete: false,
             inventory_drop_warnings: 1,
             inventory_drop_assets: 5,
@@ -13362,6 +14194,8 @@ mod tests {
             sync_token_receivers_blank: Some(0),
             sync_token_receivers_dropped: Some(0),
             sync_token_unique_values: Some(1),
+            same_cycle_recovery_attempts: 1,
+            same_cycle_recovery_successes: 1,
             full_enumeration_reason: Some(FullEnumerationReason::NoStoredToken),
             elapsed_secs: 1.5,
             interrupted: false,
@@ -13399,6 +14233,8 @@ mod tests {
             stale_pending_pruned: 8,
             pagination_shortfall_warnings: 2,
             pagination_shortfall_assets: 11,
+            tail_probes: 4,
+            count_undercount_assets: 5,
             enumeration_incomplete: true,
             inventory_drop_warnings: 2,
             inventory_drop_assets: 11,
@@ -13417,6 +14253,8 @@ mod tests {
             sync_token_receivers_blank: Some(0),
             sync_token_receivers_dropped: Some(0),
             sync_token_unique_values: Some(1),
+            same_cycle_recovery_attempts: 2,
+            same_cycle_recovery_successes: 1,
             full_enumeration_reason: Some(FullEnumerationReason::MetadataBackfill),
             elapsed_secs: 0.75,
             interrupted: true,
@@ -13463,6 +14301,11 @@ mod tests {
             acc.pagination_shortfall_assets, 20,
             "pagination shortfall assets must sum"
         );
+        assert_eq!(acc.tail_probes, 6, "tail probes must sum");
+        assert_eq!(
+            acc.count_undercount_assets, 8,
+            "count undercount assets must sum"
+        );
         assert!(acc.enumeration_incomplete, "enumeration_incomplete must OR");
         assert_eq!(
             acc.inventory_drop_warnings, 3,
@@ -13496,6 +14339,8 @@ mod tests {
         assert_eq!(acc.sync_token_receivers_blank, Some(0));
         assert_eq!(acc.sync_token_receivers_dropped, Some(0));
         assert_eq!(acc.sync_token_unique_values, Some(1));
+        assert_eq!(acc.same_cycle_recovery_attempts, 3);
+        assert_eq!(acc.same_cycle_recovery_successes, 2);
         assert_eq!(
             acc.full_enumeration_reason,
             Some(FullEnumerationReason::NoStoredToken)
@@ -14451,24 +15296,90 @@ mod tests {
     }
 
     #[test]
-    fn unanimous_pass_sync_token_returns_token_when_passes_agree() {
-        let tokens = vec!["zone-token".to_string(), "zone-token".to_string()];
+    fn zone_token_evidence_is_complete_when_all_passes_agree() {
+        let observations = [PassKind::Album, PassKind::Unfiled]
+            .into_iter()
+            .enumerate()
+            .map(|(index, kind)| PassTokenObservation {
+                pass: PassKey {
+                    index,
+                    kind,
+                    label: format!("pass-{index}"),
+                },
+                result: PassTokenResult::Present("zone-token".to_string()),
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(
-            unanimous_pass_sync_token(&tokens).as_deref(),
-            Some("zone-token")
+            classify_zone_token_evidence(&observations),
+            ZoneTokenEvidence::Complete {
+                token: "zone-token".to_string()
+            }
         );
     }
 
     #[test]
-    fn unanimous_pass_sync_token_suppresses_disagreement() {
-        let tokens = vec!["zone-token-a".to_string(), "zone-token-b".to_string()];
+    fn zone_token_evidence_retries_all_passes_after_mismatch() {
+        let observations = ["zone-token-a", "zone-token-b"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, token)| PassTokenObservation {
+                pass: PassKey {
+                    index,
+                    kind: PassKind::Album,
+                    label: format!("pass-{index}"),
+                },
+                result: PassTokenResult::Present(token.to_string()),
+            })
+            .collect::<Vec<_>>();
 
-        assert_eq!(
-            unanimous_pass_sync_token(&tokens),
-            None,
-            "mismatched full-enumeration pass tokens must block advancement"
-        );
+        let ZoneTokenEvidence::Recoverable { passes, reason } =
+            classify_zone_token_evidence(&observations)
+        else {
+            panic!("mismatched pass tokens must be recoverable once");
+        };
+        assert_eq!(reason, TokenGap::Mismatch);
+        assert_eq!(passes.len(), 2);
+    }
+
+    #[test]
+    fn zone_token_evidence_retries_only_passes_with_gaps() {
+        for (gap, expected_reason) in [
+            (PassTokenResult::Missing, TokenGap::Missing),
+            (PassTokenResult::Blank, TokenGap::Blank),
+            (PassTokenResult::ReceiverDropped, TokenGap::ReceiverDropped),
+            (
+                PassTokenResult::EnumerationIncomplete,
+                TokenGap::EnumerationIncomplete,
+            ),
+        ] {
+            let observations = vec![
+                PassTokenObservation {
+                    pass: PassKey {
+                        index: 0,
+                        kind: PassKind::Album,
+                        label: "complete".to_string(),
+                    },
+                    result: PassTokenResult::Present("zone-token".to_string()),
+                },
+                PassTokenObservation {
+                    pass: PassKey {
+                        index: 1,
+                        kind: PassKind::Unfiled,
+                        label: "gap".to_string(),
+                    },
+                    result: gap,
+                },
+            ];
+
+            let ZoneTokenEvidence::Recoverable { passes, reason } =
+                classify_zone_token_evidence(&observations)
+            else {
+                panic!("pass gap must receive one bounded recovery round");
+            };
+            assert_eq!(reason, expected_reason);
+            assert_eq!(passes, vec![observations[1].pass.clone()]);
+        }
     }
 
     /// Per-pass mode AND-folds `enumeration_complete` across passes.

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -1,0 +1,295 @@
+//! Durable pending-retry identity resolution and targeted provider revalidation.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    build_pass_configs_resolving_deferred_excludes, planner, DownloadConfig, DownloadTask,
+    RetryTaskKey, UrlRetrySource, PENDING_RETRY_UNMATCHED_REASON,
+};
+use crate::icloud::photos::{ProviderRecordId, RecordLookupRequest, RecordResolution};
+use crate::state::{AssetVerificationState, VersionSizeKey};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct PendingRetryTarget {
+    pub(super) library: Arc<str>,
+    pub(super) asset_id: Arc<str>,
+    pub(super) version_size: VersionSizeKey,
+}
+
+impl PendingRetryTarget {
+    pub(super) fn from_record(record: &crate::state::AssetRecord) -> Self {
+        Self {
+            library: Arc::clone(&record.library),
+            asset_id: Arc::from(record.id.as_ref()),
+            version_size: record.version_size,
+        }
+    }
+
+    pub(super) fn from_task(task: &DownloadTask) -> Self {
+        Self {
+            library: Arc::clone(&task.library),
+            asset_id: Arc::clone(&task.asset_id),
+            version_size: task.version_size,
+        }
+    }
+}
+
+pub(super) fn take_matching_pending_retry_tasks<I>(
+    tasks: I,
+    pending_targets: &mut FxHashSet<PendingRetryTarget>,
+    out: &mut Vec<DownloadTask>,
+) where
+    I: IntoIterator<Item = DownloadTask>,
+{
+    for task in tasks {
+        let target = PendingRetryTarget::from_task(&task);
+        if pending_targets.remove(&target) {
+            out.push(task);
+            if pending_targets.is_empty() {
+                break;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PendingRetryPlan {
+    pub(super) tasks: Vec<DownloadTask>,
+    pub(super) retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource>,
+    pub(super) pass_configs: Vec<Arc<DownloadConfig>>,
+    pub(super) unmatched_targets: Vec<PendingRetryTarget>,
+    pub(super) requested: usize,
+}
+
+pub(super) async fn build_pending_retry_download_tasks(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    shutdown_token: CancellationToken,
+) -> Result<PendingRetryPlan> {
+    let Some(db) = &config.state_db else {
+        return Ok(PendingRetryPlan::default());
+    };
+
+    let pending = db.get_pending().await?;
+    let mut pending_targets: FxHashSet<PendingRetryTarget> = pending
+        .iter()
+        .filter(|record| record.library.as_ref() == config.library.as_ref())
+        .map(PendingRetryTarget::from_record)
+        .collect();
+    if pending_targets.is_empty() {
+        return Ok(PendingRetryPlan::default());
+    }
+
+    let requested = pending_targets.len();
+    let pass_configs = build_pass_configs_resolving_deferred_excludes(passes, config).await?;
+    let mut tasks: Vec<DownloadTask> = Vec::with_capacity(requested);
+    let mut retry_sources: FxHashMap<RetryTaskKey, UrlRetrySource> = FxHashMap::default();
+    let mut task_planner = planner::TaskPlanner::new();
+    let mut lookup_requests = Vec::new();
+    let mut seen_requests = FxHashSet::default();
+    let mut master_by_state_id: FxHashMap<String, String> = FxHashMap::default();
+    for record in pending
+        .iter()
+        .filter(|record| record.library.as_ref() == config.library.as_ref())
+    {
+        let mapped_master = db
+            .get_master_record_name_for_asset(&config.library, &record.id)
+            .await?;
+        let master = mapped_master
+            .as_deref()
+            .unwrap_or(record.id.as_ref())
+            .to_string();
+        let asset_record_names = if mapped_master.is_some() {
+            vec![record.id.to_string()]
+        } else {
+            db.get_asset_record_names_for_master(&config.library, &master)
+                .await?
+        };
+        master_by_state_id.insert(record.id.to_string(), master.clone());
+        for asset_record_name in asset_record_names {
+            let request_key = (
+                record.id.to_string(),
+                master.clone(),
+                asset_record_name.clone(),
+            );
+            if seen_requests.insert(request_key.clone()) {
+                lookup_requests.push(RecordLookupRequest {
+                    state_id: ProviderRecordId::new(request_key.0),
+                    master_record_name: ProviderRecordId::new(request_key.1),
+                    asset_record_name: ProviderRecordId::new(request_key.2),
+                });
+            }
+        }
+    }
+
+    let requested_state_ids: FxHashSet<&str> = lookup_requests
+        .iter()
+        .map(|request| request.state_id.as_str())
+        .collect();
+    for target in &pending_targets {
+        if !requested_state_ids.contains(target.asset_id.as_ref()) {
+            db.set_asset_verification(
+                &target.library,
+                &target.asset_id,
+                target.version_size.as_str(),
+                AssetVerificationState::Unknown,
+                "stable provider asset/master mapping is unavailable",
+            )
+            .await?;
+        }
+    }
+
+    let resolutions = if let Some(pass) = passes.first() {
+        let batch = pass.album.resolve_records(&lookup_requests).await;
+        if !batch.complete {
+            tracing::warn!(
+                library = %config.library,
+                requested = lookup_requests.len(),
+                "Pending provider revalidation completed with inconclusive results"
+            );
+        }
+        batch.results
+    } else {
+        Vec::new()
+    };
+    for (state_id, resolution) in resolutions {
+        if pending_targets.is_empty() || shutdown_token.is_cancelled() {
+            break;
+        }
+        match resolution {
+            RecordResolution::Present(asset) => {
+                for target in pending_targets
+                    .iter()
+                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
+                {
+                    db.clear_asset_verification(
+                        &target.library,
+                        &target.asset_id,
+                        target.version_size.as_str(),
+                    )
+                    .await?;
+                }
+                for (pass_index, pass_config) in pass_configs.iter().enumerate() {
+                    let plan = task_planner.plan_asset(&asset, pass_config).await;
+                    if plan.filter_reason.is_some() {
+                        continue;
+                    }
+                    let first_new_task = tasks.len();
+                    take_matching_pending_retry_tasks(plan.tasks, &mut pending_targets, &mut tasks);
+                    for task in tasks.iter().skip(first_new_task) {
+                        retry_sources.insert(
+                            RetryTaskKey::from(task),
+                            UrlRetrySource {
+                                asset_record_name: asset.asset_record_name_arc(),
+                                pass_index,
+                            },
+                        );
+                    }
+                }
+            }
+            RecordResolution::Deleted {
+                deleted_at,
+                master_family,
+            } => {
+                let state_id = state_id.as_str();
+                let resolved = if master_family {
+                    let master = master_by_state_id
+                        .get(state_id)
+                        .map(String::as_str)
+                        .unwrap_or(state_id);
+                    db.resolve_master_family_source_deleted_affected(
+                        &config.library,
+                        master,
+                        deleted_at,
+                    )
+                    .await?
+                } else {
+                    db.resolve_source_deleted_affected(&config.library, state_id, deleted_at)
+                        .await?
+                };
+                tracing::info!(
+                    library = %config.library,
+                    state_id,
+                    resolved,
+                    master_family,
+                    "Pending asset cleared: provider confirmed source deletion"
+                );
+            }
+            RecordResolution::Unknown => {
+                for target in pending_targets
+                    .iter()
+                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
+                {
+                    db.set_asset_verification(
+                        &target.library,
+                        &target.asset_id,
+                        target.version_size.as_str(),
+                        AssetVerificationState::Unknown,
+                        "provider lookup omitted or could not parse the requested record",
+                    )
+                    .await?;
+                }
+                tracing::warn!(
+                    library = %config.library,
+                    state_id = state_id.as_str(),
+                    "Pending asset retained: provider lookup was inconclusive"
+                );
+            }
+            RecordResolution::TransientFailure(error) => {
+                for target in pending_targets
+                    .iter()
+                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
+                {
+                    db.set_asset_verification(
+                        &target.library,
+                        &target.asset_id,
+                        target.version_size.as_str(),
+                        AssetVerificationState::TransientFailure,
+                        &error.to_string(),
+                    )
+                    .await?;
+                }
+                tracing::warn!(
+                    library = %config.library,
+                    state_id = state_id.as_str(),
+                    error = %error,
+                    "Pending asset retained: provider lookup failed transiently"
+                );
+            }
+        }
+    }
+
+    // Explicit deletion tombstones leave catalog history in place but remove
+    // those rows from the actionable pending reader. Present rows remain
+    // actionable until their retry succeeds.
+    let still_pending: FxHashSet<PendingRetryTarget> = db
+        .get_pending()
+        .await?
+        .iter()
+        .filter(|record| record.library.as_ref() == config.library.as_ref())
+        .map(PendingRetryTarget::from_record)
+        .collect();
+    pending_targets.retain(|target| still_pending.contains(target));
+
+    if !pending_targets.is_empty() {
+        tracing::warn!(
+            requested,
+            refreshed = tasks.len(),
+            missing = pending_targets.len(),
+            diagnostic = PENDING_RETRY_UNMATCHED_REASON,
+            "Targeted retry could not refresh every pending asset; retaining durable retry work"
+        );
+    }
+
+    Ok(PendingRetryPlan {
+        tasks,
+        retry_sources,
+        pass_configs,
+        unmatched_targets: pending_targets.into_iter().collect(),
+        requested,
+    })
+}

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -106,6 +106,40 @@ pub(crate) struct RecordResolutionBatch {
     pub(crate) complete: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ResolutionEvidence {
+    ChildDeleted,
+    Inconclusive,
+    MasterDeleted,
+    Present,
+}
+
+fn resolution_evidence(resolution: &RecordResolution) -> ResolutionEvidence {
+    match resolution {
+        RecordResolution::Present(_) => ResolutionEvidence::Present,
+        RecordResolution::Deleted {
+            master_family: true,
+            ..
+        } => ResolutionEvidence::MasterDeleted,
+        RecordResolution::Unknown | RecordResolution::TransientFailure(_) => {
+            ResolutionEvidence::Inconclusive
+        }
+        RecordResolution::Deleted {
+            master_family: false,
+            ..
+        } => ResolutionEvidence::ChildDeleted,
+    }
+}
+
+// Multiple provider records can map to one durable state identity. Merge them
+// conservatively: a present sibling resolves the work, a missing master proves
+// family deletion, and any inconclusive sibling blocks child-only deletion.
+fn merge_record_resolution(existing: &mut RecordResolution, incoming: RecordResolution) {
+    if resolution_evidence(&incoming) > resolution_evidence(existing) {
+        *existing = incoming;
+    }
+}
+
 fn prune_paired_master_cache(
     paired_masters: &mut FxHashMap<String, super::cloudkit::Record>,
     max_records: usize,
@@ -824,7 +858,6 @@ impl PhotoAlbum {
         requests: &[RecordLookupRequest],
     ) -> RecordResolutionBatch {
         let mut results = Vec::with_capacity(requests.len());
-        let mut complete = true;
         let url = format!(
             "{}/records/lookup?{}",
             self.service_endpoint,
@@ -859,7 +892,6 @@ impl PhotoAlbum {
             {
                 Ok(response) => response,
                 Err(error) => {
-                    complete = false;
                     let error = classify_provider_lookup_error(&error);
                     crate::metrics::record_targeted_lookup("transient_failure", batch.len());
                     results.extend(batch.iter().map(|request| {
@@ -873,7 +905,6 @@ impl PhotoAlbum {
             };
 
             let Some(response_records) = response.get("records").and_then(Value::as_array) else {
-                complete = false;
                 crate::metrics::record_targeted_lookup("transient_failure", batch.len());
                 results.extend(batch.iter().map(|request| {
                     (
@@ -942,13 +973,9 @@ impl PhotoAlbum {
                             }
                             RecordResolution::Present(photo)
                         }
-                        _ => {
-                            complete = false;
-                            RecordResolution::Unknown
-                        }
+                        _ => RecordResolution::Unknown,
                     }
                 } else {
-                    complete = false;
                     RecordResolution::Unknown
                 };
                 let outcome = match &resolution {
@@ -962,7 +989,32 @@ impl PhotoAlbum {
             }
         }
 
-        RecordResolutionBatch { results, complete }
+        let mut grouped: Vec<(ProviderRecordId, RecordResolution)> =
+            Vec::with_capacity(results.len());
+        let mut positions: FxHashMap<ProviderRecordId, usize> = FxHashMap::default();
+        for (state_id, resolution) in results {
+            if let Some(existing) = positions
+                .get(&state_id)
+                .and_then(|index| grouped.get_mut(*index))
+                .map(|(_, resolution)| resolution)
+            {
+                merge_record_resolution(existing, resolution);
+            } else {
+                positions.insert(state_id.clone(), grouped.len());
+                grouped.push((state_id, resolution));
+            }
+        }
+        let complete = grouped.iter().all(|(_, resolution)| {
+            matches!(
+                resolution,
+                RecordResolution::Present(_) | RecordResolution::Deleted { .. }
+            )
+        });
+
+        RecordResolutionBatch {
+            results: grouped,
+            complete,
+        }
     }
 
     /// Stream photos page-by-page without buffering the full album in memory.
@@ -2757,6 +2809,59 @@ mod tests {
             RecordResolution::Deleted { .. }
         ));
         assert!(matches!(batch.results[2].1, RecordResolution::Unknown));
+    }
+
+    #[tokio::test]
+    async fn targeted_record_lookup_present_sibling_keeps_shared_master_state() {
+        let response = json!({
+            "records": [
+                test_master_record("master-shared"),
+                {
+                    "recordName": "asset-a-deleted",
+                    "serverErrorCode": "UNKNOWN_ITEM",
+                    "reason": "record not found"
+                },
+                test_asset_record_for("asset-b-present", "master-shared")
+            ]
+        });
+        let album = make_album_with_session(100, Box::new(MockPhotosSession::new().ok(response)));
+
+        let batch = album
+            .resolve_records(&[
+                lookup_request("master-shared", "master-shared", "asset-a-deleted"),
+                lookup_request("master-shared", "master-shared", "asset-b-present"),
+            ])
+            .await;
+
+        assert!(batch.complete);
+        assert_eq!(batch.results.len(), 1);
+        assert!(matches!(batch.results[0].1, RecordResolution::Present(_)));
+    }
+
+    #[tokio::test]
+    async fn targeted_record_lookup_omitted_sibling_keeps_shared_master_state_unknown() {
+        let response = json!({
+            "records": [
+                test_master_record("master-shared"),
+                {
+                    "recordName": "asset-a-deleted",
+                    "serverErrorCode": "UNKNOWN_ITEM",
+                    "reason": "record not found"
+                }
+            ]
+        });
+        let album = make_album_with_session(100, Box::new(MockPhotosSession::new().ok(response)));
+
+        let batch = album
+            .resolve_records(&[
+                lookup_request("master-shared", "master-shared", "asset-a-deleted"),
+                lookup_request("master-shared", "master-shared", "asset-b-omitted"),
+            ])
+            .await;
+
+        assert!(!batch.complete);
+        assert_eq!(batch.results.len(), 1);
+        assert!(matches!(batch.results[0].1, RecordResolution::Unknown));
     }
 
     #[tokio::test]

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -28,7 +28,7 @@ use crate::retry::RetryConfig;
 /// Set conservatively so a multi-page run of fully-deleted records does
 /// not silently truncate enumeration; the cost on true EOF is at most
 /// `MAX_EMPTY_PAGE_PROBES - 1` extra empty requests per fetcher.
-const MAX_EMPTY_PAGE_PROBES: u32 = 5;
+pub(crate) const MAX_EMPTY_PAGE_PROBES: u32 = 5;
 pub(crate) const DEFAULT_PAGE_SIZE: usize = 100;
 pub(crate) const QUERY_ALL_LIST: &str = "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted";
 pub(crate) const QUERY_ALL_OBJ: &str = "CPLAssetByAssetDateWithoutHiddenOrDeleted";
@@ -36,6 +36,75 @@ pub(crate) const QUERY_FOLDER_LIST: &str = "CPLContainerRelationLiveByAssetDate"
 
 /// A boxed, pinned stream of photo asset results.
 type PhotoStream = Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>>;
+
+const RECORD_LOOKUP_BATCH_SIZE: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProviderRecordId(Arc<str>);
+
+impl ProviderRecordId {
+    pub(crate) fn new(value: impl Into<Arc<str>>) -> Self {
+        Self(value.into())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecordLookupRequest {
+    pub(crate) state_id: ProviderRecordId,
+    pub(crate) master_record_name: ProviderRecordId,
+    pub(crate) asset_record_name: ProviderRecordId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ProviderLookupError {
+    #[error("provider authentication failed with HTTP {status}: {message}")]
+    Authentication { status: u16, message: String },
+    #[error("provider record lookup was rate limited with HTTP {status}: {message}")]
+    RateLimited { status: u16, message: String },
+    #[error("provider record lookup request failed: {0}")]
+    Request(String),
+    #[error("provider record lookup response was malformed: {0}")]
+    Malformed(String),
+}
+
+fn classify_provider_lookup_error(error: &anyhow::Error) -> ProviderLookupError {
+    let message = error.to_string();
+    let Some(http) = error.downcast_ref::<super::session::HttpStatusError>() else {
+        return ProviderLookupError::Request(message);
+    };
+    match http.status {
+        401 | 403 | 421 => ProviderLookupError::Authentication {
+            status: http.status,
+            message,
+        },
+        429 | 503 => ProviderLookupError::RateLimited {
+            status: http.status,
+            message,
+        },
+        _ => ProviderLookupError::Request(message),
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RecordResolution {
+    Present(PhotoAsset),
+    Deleted {
+        deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+        master_family: bool,
+    },
+    Unknown,
+    TransientFailure(ProviderLookupError),
+}
+
+#[derive(Debug)]
+pub(crate) struct RecordResolutionBatch {
+    pub(crate) results: Vec<(ProviderRecordId, RecordResolution)>,
+    pub(crate) complete: bool,
+}
 
 fn prune_paired_master_cache(
     paired_masters: &mut FxHashMap<String, super::cloudkit::Record>,
@@ -120,10 +189,31 @@ impl PhotoStreamProfile {
             Self::BackpressuredDownload { .. } => 1,
         }
     }
+}
 
-    fn allow_initial_boundary_probe(self) -> bool {
-        matches!(self, Self::FastEnumeration { .. })
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FetcherRangeRole {
+    /// Count-partitioned work that covers a known rank interval.
+    Data,
+    /// The single owner that scans past the count hint until natural EOF.
+    TailProof,
+    /// A bounded stream that must inspect one more eligible asset to prove
+    /// whether the caller's limit truncated the inventory.
+    LimitProbe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnumerationFailure {
+    FetcherError,
+    ConsumerDropped,
+    UnpairedRecords,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnumerationCompletion {
+    ProvenEof,
+    UserBoundReached,
+    Incomplete(EnumerationFailure),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,7 +221,7 @@ struct FetcherRange {
     start: u64,
     end: u64,
     limit: Option<u32>,
-    suppress_token_on_limit: bool,
+    role: FetcherRangeRole,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -197,13 +287,7 @@ fn range_limit(limit: Option<u32>, start: u64, end: u64) -> Option<u32> {
     })
 }
 
-fn push_fetcher_range(
-    ranges: &mut Vec<FetcherRange>,
-    limit: Option<u32>,
-    start: u64,
-    end: u64,
-    suppress_token_on_limit: bool,
-) {
+fn push_fetcher_range(ranges: &mut Vec<FetcherRange>, limit: Option<u32>, start: u64, end: u64) {
     if start >= end {
         return;
     }
@@ -211,7 +295,7 @@ fn push_fetcher_range(
         start,
         end,
         limit: range_limit(limit, start, end),
-        suppress_token_on_limit,
+        role: FetcherRangeRole::Data,
     });
 }
 
@@ -222,76 +306,83 @@ fn build_enumeration_plan(
     profile: PhotoStreamProfile,
 ) -> EnumerationPlan {
     let page_size = profile.request_page_size(default_page_size);
-    let Some(total) = effective_total(limit, total_count).map(|total| total.max(1)) else {
+    // A caller limit needs an ordered N+1 probe. Running count-partitioned
+    // ranges in parallel cannot prove which asset is the first item beyond
+    // the bound, and historically `limit == count` was incorrectly treated
+    // as EOF. Keep bounded streams sequential and use the count only as a
+    // scheduling hint for unbounded inventories.
+    if let Some(limit) = limit {
         return EnumerationPlan {
             page_size,
             ranges: vec![FetcherRange {
                 start: 0,
                 end: u64::MAX,
-                limit,
-                suppress_token_on_limit: limit.is_some(),
+                limit: Some(limit),
+                role: FetcherRangeRole::LimitProbe,
+            }],
+        };
+    }
+
+    let Some(total) = total_count else {
+        return EnumerationPlan {
+            page_size,
+            ranges: vec![FetcherRange {
+                start: 0,
+                end: u64::MAX,
+                limit: None,
+                role: FetcherRangeRole::TailProof,
             }],
         };
     };
 
+    // Download streams deliberately keep one ordered fetcher so signed URLs
+    // stay near their consumers. Let that fetcher own EOF proof directly
+    // rather than stopping at the count hint and starting a concurrent tail.
+    if matches!(profile, PhotoStreamProfile::BackpressuredDownload { .. })
+        || profile.fetcher_concurrency() == 1
+    {
+        return EnumerationPlan {
+            page_size,
+            ranges: vec![FetcherRange {
+                start: 0,
+                end: u64::MAX,
+                limit: None,
+                role: FetcherRangeRole::TailProof,
+            }],
+        };
+    }
+
     let concurrency = profile.fetcher_concurrency();
-    let num_fetchers = if concurrency > 1 {
+    let num_fetchers = if concurrency > 1 && total > 0 {
         determine_fetcher_count(total, page_size, concurrency * 2)
     } else {
         1
     };
-    let suppress_token_on_limit = match (limit, total_count) {
-        (Some(lim), Some(total_count)) => u64::from(lim) < total_count,
-        (Some(_), None) => true,
-        (None, _) => false,
-    };
-    let initial_boundary_probe = profile.allow_initial_boundary_probe()
-        && concurrency > 1
-        && total >= page_size as u64
-        && page_size > 1
-        && limit.is_some();
     let chunk_size_items = {
         let raw = total.div_ceil(num_fetchers as u64);
         let ps = page_size as u64;
         raw.div_ceil(ps) * ps
     };
 
-    let mut ranges = Vec::with_capacity(num_fetchers + usize::from(initial_boundary_probe) * 2);
+    let mut ranges = Vec::with_capacity(num_fetchers + 1);
     for i in 0..num_fetchers {
-        let mut start = i as u64 * chunk_size_items;
+        let start = i as u64 * chunk_size_items;
         let end = ((i as u64 + 1) * chunk_size_items).min(total);
         if start >= total {
             break;
         }
-        if initial_boundary_probe && i == 0 {
-            let boundary_start = page_size as u64 - 1;
-            let boundary_end = (page_size as u64).min(total);
-            ranges.push(FetcherRange {
-                start: boundary_start,
-                end: boundary_end,
-                limit: Some(1),
-                suppress_token_on_limit,
-            });
-            push_fetcher_range(
-                &mut ranges,
-                limit,
-                start,
-                end.min(boundary_start),
-                suppress_token_on_limit,
-            );
-            push_fetcher_range(
-                &mut ranges,
-                limit,
-                boundary_end,
-                end,
-                suppress_token_on_limit,
-            );
-            continue;
-        } else if initial_boundary_probe && i > 0 {
-            start = start.max(page_size as u64);
-        }
-        push_fetcher_range(&mut ranges, limit, start, end, suppress_token_on_limit);
+        push_fetcher_range(&mut ranges, None, start, end);
     }
+
+    // Counts are hints, not EOF proof. The final owner starts exactly where
+    // the count-partitioned ranges stop and continues until the provider's
+    // consecutive-empty-page policy proves natural EOF.
+    ranges.push(FetcherRange {
+        start: total,
+        end: u64::MAX,
+        limit: None,
+        role: FetcherRangeRole::TailProof,
+    });
 
     EnumerationPlan { page_size, ranges }
 }
@@ -306,6 +397,31 @@ fn log_fetcher_response(album: &str, response: &Value) {
         response = %response,
         "Fetcher response body",
     );
+}
+
+fn should_emit_asset_record(
+    record_name: &str,
+    range_start: u64,
+    range_role: FetcherRangeRole,
+    emitted_in_range: &mut FxHashSet<String>,
+    range_record_owners: &std::sync::Mutex<FxHashMap<String, u64>>,
+) -> bool {
+    if !matches!(range_role, FetcherRangeRole::Data)
+        && !emitted_in_range.insert(record_name.to_owned())
+    {
+        return false;
+    }
+
+    let Ok(mut owners) = range_record_owners.lock() else {
+        return true;
+    };
+    match owners.get(record_name) {
+        Some(owner) => *owner == range_start,
+        None => {
+            owners.insert(record_name.to_owned(), range_start);
+            true
+        }
+    }
 }
 
 /// Return a full-enumeration sync token only when every fetcher that reported
@@ -334,13 +450,20 @@ fn unanimous_fetcher_sync_token(album: &str, tokens: &[String]) -> Option<String
 
 #[derive(Debug, Default)]
 struct FetcherSyncTokenCapture {
-    tokens: tokio::sync::Mutex<Vec<String>>,
+    observations: tokio::sync::Mutex<Vec<(Option<String>, EnumerationCompletion)>>,
+    expected_fetchers: AtomicUsize,
+    completed_fetchers: AtomicUsize,
     suppressed: AtomicBool,
 }
 
 impl FetcherSyncTokenCapture {
-    async fn push(&self, token: String) {
-        self.tokens.lock().await.push(token);
+    fn expect(&self, fetchers: usize) {
+        self.expected_fetchers.store(fetchers, Ordering::Relaxed);
+    }
+
+    async fn complete(&self, token: Option<String>, completion: EnumerationCompletion) {
+        self.observations.lock().await.push((token, completion));
+        self.completed_fetchers.fetch_add(1, Ordering::Relaxed);
     }
 
     fn suppress(&self) {
@@ -356,8 +479,50 @@ impl FetcherSyncTokenCapture {
             return None;
         }
 
-        let tokens = self.tokens.lock().await;
-        unanimous_fetcher_sync_token(album, &tokens)
+        let expected = self.expected_fetchers.load(Ordering::Relaxed);
+        let completed = self.completed_fetchers.load(Ordering::Relaxed);
+        if completed != expected {
+            tracing::warn!(
+                album,
+                expected_fetchers = expected,
+                completed_fetchers = completed,
+                "Full enumeration did not receive completion evidence from every fetcher; blocking sync token advancement"
+            );
+            return None;
+        }
+
+        let observations = self.observations.lock().await;
+        if let Some(failure) = observations
+            .iter()
+            .find_map(|(_, completion)| match completion {
+                EnumerationCompletion::Incomplete(failure) => Some(*failure),
+                _ => None,
+            })
+        {
+            tracing::warn!(
+                album,
+                ?failure,
+                "Full enumeration was incomplete in a fetcher"
+            );
+            return None;
+        }
+        if observations
+            .iter()
+            .any(|(_, completion)| matches!(completion, EnumerationCompletion::UserBoundReached))
+        {
+            tracing::debug!(album, "Full enumeration stopped at a user bound");
+            return None;
+        }
+        let present = observations
+            .iter()
+            .filter_map(|(token, _)| token.as_ref())
+            .cloned()
+            .collect::<Vec<_>>();
+        // Completion is required from every fetcher, but CloudKit may omit a
+        // syncToken on an empty tail page. In that case the unanimous token
+        // observed by the completed data fetchers is still the pass token;
+        // an incomplete fetcher is rejected by the count above.
+        unanimous_fetcher_sync_token(album, &present)
     }
 }
 
@@ -649,6 +814,155 @@ impl PhotoAlbum {
             );
         }
         Ok(items)
+    }
+
+    /// Resolve durable pending identities without scanning the surrounding
+    /// album or library. Missing response members are inconclusive; only an
+    /// explicit CloudKit not-found result or tombstone is deletion evidence.
+    pub(crate) async fn resolve_records(
+        &self,
+        requests: &[RecordLookupRequest],
+    ) -> RecordResolutionBatch {
+        let mut results = Vec::with_capacity(requests.len());
+        let mut complete = true;
+        let url = format!(
+            "{}/records/lookup?{}",
+            self.service_endpoint,
+            encode_params(&self.params)
+        );
+
+        for batch in requests.chunks(RECORD_LOOKUP_BATCH_SIZE) {
+            let mut record_names = FxHashSet::default();
+            let mut records = Vec::with_capacity(batch.len().saturating_mul(2));
+            for request in batch {
+                for record_id in [&request.master_record_name, &request.asset_record_name] {
+                    if record_names.insert(record_id.as_str().to_string()) {
+                        records.push(json!({
+                            "recordName": record_id.as_str(),
+                        }));
+                    }
+                }
+            }
+            let body = json!({
+                "records": records,
+                "zoneID": self.zone_id.as_ref(),
+                "desiredKeys": &*DESIRED_KEYS_VALUES,
+            });
+            let response = match super::session::retry_post_allowing_record_errors(
+                self.session.as_ref(),
+                &url,
+                &body.to_string(),
+                &[("Content-type", "text/plain")],
+                &self.retry_config,
+            )
+            .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    complete = false;
+                    let error = classify_provider_lookup_error(&error);
+                    crate::metrics::record_targeted_lookup("transient_failure", batch.len());
+                    results.extend(batch.iter().map(|request| {
+                        (
+                            request.state_id.clone(),
+                            RecordResolution::TransientFailure(error.clone()),
+                        )
+                    }));
+                    continue;
+                }
+            };
+
+            let Some(response_records) = response.get("records").and_then(Value::as_array) else {
+                complete = false;
+                crate::metrics::record_targeted_lookup("transient_failure", batch.len());
+                results.extend(batch.iter().map(|request| {
+                    (
+                        request.state_id.clone(),
+                        RecordResolution::TransientFailure(ProviderLookupError::Malformed(
+                            "missing records array".to_string(),
+                        )),
+                    )
+                }));
+                continue;
+            };
+            let by_name: FxHashMap<&str, &Value> = response_records
+                .iter()
+                .filter_map(|record| {
+                    record
+                        .get("recordName")
+                        .and_then(Value::as_str)
+                        .map(|name| (name, record))
+                })
+                .collect();
+
+            for request in batch {
+                let master = by_name.get(request.master_record_name.as_str()).copied();
+                let asset = by_name.get(request.asset_record_name.as_str()).copied();
+                let explicit_not_found = |record: Option<&Value>| {
+                    record
+                        .and_then(|record| record.get("serverErrorCode"))
+                        .and_then(Value::as_str)
+                        .is_some_and(|code| matches!(code, "UNKNOWN_ITEM" | "NOT_FOUND"))
+                };
+                let tombstoned = |record: Option<&Value>| {
+                    record
+                        .and_then(|record| record.get("deleted"))
+                        .and_then(Value::as_bool)
+                        == Some(true)
+                };
+                let deleted_at = master.into_iter().chain(asset).find_map(|record| {
+                    record
+                        .get("fields")
+                        .and_then(|fields| fields.get("deletedDate"))
+                        .and_then(|field| field.get("value"))
+                        .and_then(Value::as_i64)
+                        .and_then(chrono::DateTime::<chrono::Utc>::from_timestamp_millis)
+                });
+
+                let master_deleted = explicit_not_found(master) || tombstoned(master);
+                let asset_deleted = explicit_not_found(asset) || tombstoned(asset);
+                let resolution = if master_deleted || asset_deleted {
+                    RecordResolution::Deleted {
+                        deleted_at,
+                        master_family: master_deleted,
+                    }
+                } else if let (Some(master), Some(asset)) = (master, asset) {
+                    match (
+                        serde_json::from_value::<super::cloudkit::Record>(master.clone()),
+                        serde_json::from_value::<super::cloudkit::Record>(asset.clone()),
+                    ) {
+                        (Ok(master), Ok(asset))
+                            if master.record_type == "CPLMaster"
+                                && asset.record_type == "CPLAsset" =>
+                        {
+                            let mut photo = PhotoAsset::from_records(master, &asset);
+                            if request.state_id.as_str() != request.master_record_name.as_str() {
+                                photo = photo
+                                    .with_state_record_name(Arc::from(request.state_id.as_str()));
+                            }
+                            RecordResolution::Present(photo)
+                        }
+                        _ => {
+                            complete = false;
+                            RecordResolution::Unknown
+                        }
+                    }
+                } else {
+                    complete = false;
+                    RecordResolution::Unknown
+                };
+                let outcome = match &resolution {
+                    RecordResolution::Present(_) => "present",
+                    RecordResolution::Deleted { .. } => "deleted",
+                    RecordResolution::Unknown => "unknown",
+                    RecordResolution::TransientFailure(_) => "transient_failure",
+                };
+                crate::metrics::record_targeted_lookup(outcome, 1);
+                results.push((request.state_id.clone(), resolution));
+            }
+        }
+
+        RecordResolutionBatch { results, complete }
     }
 
     /// Stream photos page-by-page without buffering the full album in memory.
@@ -1287,9 +1601,18 @@ impl PhotoAlbum {
         treat_empty_tail_as_error: bool,
     ) -> (PhotoStream, Vec<JoinHandle<()>>) {
         let plan = build_enumeration_plan(limit, total_count, self.page_size, profile);
+        if let Some(capture) = &fetcher_sync_tokens {
+            capture.expect(plan.ranges.len());
+            if matches!((limit, total_count), (Some(limit), Some(total)) if total > u64::from(limit))
+            {
+                capture.suppress();
+            }
+        }
         let (tx, rx) = mpsc::channel::<anyhow::Result<PhotoAsset>>(
             (plan.page_size * plan.channel_fetchers()).min(500),
         );
+        let range_record_owners =
+            Arc::new(std::sync::Mutex::new(FxHashMap::<String, u64>::default()));
         let mut handles = Vec::with_capacity(plan.ranges.len());
 
         if effective_total(limit, total_count).is_none() {
@@ -1306,10 +1629,8 @@ impl PhotoAlbum {
         for range in plan.ranges {
             handles.push(self.spawn_fetcher(
                 tx.clone(),
-                range.start,
-                range.end,
-                range.limit,
-                range.suppress_token_on_limit,
+                range,
+                Arc::clone(&range_record_owners),
                 fetcher_sync_tokens.clone(),
                 behavior,
             ));
@@ -1337,10 +1658,8 @@ impl PhotoAlbum {
     fn spawn_fetcher(
         &self,
         tx: mpsc::Sender<anyhow::Result<PhotoAsset>>,
-        start_offset: u64,
-        end_offset: u64,
-        limit: Option<u32>,
-        suppress_token_on_limit: bool,
+        range: FetcherRange,
+        range_record_owners: Arc<std::sync::Mutex<FxHashMap<String, u64>>>,
         fetcher_sync_tokens: Option<Arc<FetcherSyncTokenCapture>>,
         behavior: FetcherBehavior,
     ) -> JoinHandle<()> {
@@ -1354,6 +1673,12 @@ impl PhotoAlbum {
         let zone_id = Arc::clone(&self.zone_id);
 
         tokio::spawn(async move {
+            let FetcherRange {
+                start: start_offset,
+                end: end_offset,
+                limit,
+                role: range_role,
+            } = range;
             let mut offset = start_offset;
             let mut total_sent: u64 = 0;
             let mut last_sync_token: Option<String> = None;
@@ -1364,6 +1689,7 @@ impl PhotoAlbum {
                 FxHashMap::default();
             let mut paired_masters: FxHashMap<String, super::cloudkit::Record> =
                 FxHashMap::default();
+            let mut emitted_asset_records: FxHashSet<String> = FxHashSet::default();
             let mut consecutive_empty_pages: u32 = 0;
             let mut enumeration_incomplete = false;
             let mut stopped_for_limit = false;
@@ -1375,6 +1701,22 @@ impl PhotoAlbum {
             let max_pending_records = behavior.page_size.saturating_mul(4).max(1);
 
             loop {
+                // Dropping the stream is the caller's cancellation signal.
+                // Do not continue probing the provider or report checkpoint
+                // evidence after the consumer has stopped observing assets.
+                if tx.is_closed() {
+                    if let Some(shared) = &fetcher_sync_tokens {
+                        shared
+                            .complete(
+                                None,
+                                EnumerationCompletion::Incomplete(
+                                    EnumerationFailure::ConsumerDropped,
+                                ),
+                            )
+                            .await;
+                    }
+                    return;
+                }
                 if offset >= end_offset {
                     break;
                 }
@@ -1406,6 +1748,16 @@ impl PhotoAlbum {
                     Ok(r) => r,
                     Err(e) => {
                         let _ = tx.send(Err(e)).await;
+                        if let Some(shared) = &fetcher_sync_tokens {
+                            shared
+                                .complete(
+                                    None,
+                                    EnumerationCompletion::Incomplete(
+                                        EnumerationFailure::FetcherError,
+                                    ),
+                                )
+                                .await;
+                        }
                         return;
                     }
                 };
@@ -1420,6 +1772,16 @@ impl PhotoAlbum {
                             "Failed to deserialize fetcher response (body logged above at DEBUG)",
                         );
                         let _ = tx.send(Err(e.into())).await;
+                        if let Some(shared) = &fetcher_sync_tokens {
+                            shared
+                                .complete(
+                                    None,
+                                    EnumerationCompletion::Incomplete(
+                                        EnumerationFailure::FetcherError,
+                                    ),
+                                )
+                                .await;
+                        }
                         return;
                     }
                 };
@@ -1474,6 +1836,7 @@ impl PhotoAlbum {
                             "End of album (consecutive empty pages)"
                         );
                         if behavior.treat_empty_tail_as_error
+                            && matches!(range_role, FetcherRangeRole::Data)
                             && limit.is_none()
                             && end_offset == u64::MAX
                             && fetcher_sync_tokens.is_some()
@@ -1497,8 +1860,6 @@ impl PhotoAlbum {
                     offset += behavior.page_size as u64;
                     continue;
                 }
-                consecutive_empty_pages = 0;
-
                 // Collect current page's records, trying to pair with
                 // buffered unpaired records from previous pages.
                 let mut page_assets: FxHashMap<String, Vec<super::cloudkit::Record>> =
@@ -1506,6 +1867,7 @@ impl PhotoAlbum {
                 let mut page_masters: Vec<super::cloudkit::Record> = Vec::new();
                 let mut masters_seen_on_page = false;
                 let mut limit_reached = false;
+                let mut page_emitted = 0u64;
 
                 for rec in records {
                     tracing::debug!(record_type = %rec.record_type, "  record");
@@ -1527,7 +1889,7 @@ impl PhotoAlbum {
                 }
 
                 if limit_reached {
-                    stopped_for_limit = suppress_token_on_limit;
+                    stopped_for_limit = matches!(range_role, FetcherRangeRole::LimitProbe);
                     break;
                 }
 
@@ -1549,12 +1911,6 @@ impl PhotoAlbum {
                 }
 
                 for master in page_masters {
-                    if let Some(n) = limit {
-                        if total_sent >= u64::from(n) {
-                            limit_reached = true;
-                            break;
-                        }
-                    }
                     let mut asset_records = pending_assets.remove(&master.record_name);
                     if let Some(page_records) = page_assets.remove(&master.record_name) {
                         asset_records
@@ -1564,6 +1920,15 @@ impl PhotoAlbum {
                     if let Some(asset_records) = asset_records {
                         let sibling_count = asset_records.len();
                         for (index, asset_rec) in asset_records.into_iter().enumerate() {
+                            if !should_emit_asset_record(
+                                &asset_rec.record_name,
+                                start_offset,
+                                range_role,
+                                &mut emitted_asset_records,
+                                &range_record_owners,
+                            ) {
+                                continue;
+                            }
                             if let Some(n) = limit {
                                 if total_sent >= u64::from(n) {
                                     limit_reached = true;
@@ -1580,6 +1945,7 @@ impl PhotoAlbum {
                                 return;
                             }
                             total_sent += 1;
+                            page_emitted += 1;
                         }
                         paired_masters.insert(master.record_name.clone(), master);
                         prune_paired_master_cache(&mut paired_masters, max_pending_records);
@@ -1598,7 +1964,7 @@ impl PhotoAlbum {
                 );
 
                 if limit_reached {
-                    stopped_for_limit = suppress_token_on_limit;
+                    stopped_for_limit = matches!(range_role, FetcherRangeRole::LimitProbe);
                     break;
                 }
 
@@ -1606,6 +1972,15 @@ impl PhotoAlbum {
                     if let Some(master) = pending_masters.remove(&master_id) {
                         let sibling_count = records.len();
                         for (index, asset_rec) in records.into_iter().enumerate() {
+                            if !should_emit_asset_record(
+                                &asset_rec.record_name,
+                                start_offset,
+                                range_role,
+                                &mut emitted_asset_records,
+                                &range_record_owners,
+                            ) {
+                                continue;
+                            }
                             if let Some(n) = limit {
                                 if total_sent >= u64::from(n) {
                                     limit_reached = true;
@@ -1622,11 +1997,21 @@ impl PhotoAlbum {
                                 return;
                             }
                             total_sent += 1;
+                            page_emitted += 1;
                         }
                         paired_masters.insert(master.record_name.clone(), master);
                         prune_paired_master_cache(&mut paired_masters, max_pending_records);
                     } else if let Some(master) = paired_masters.get(&master_id) {
                         for asset_rec in records {
+                            if !should_emit_asset_record(
+                                &asset_rec.record_name,
+                                start_offset,
+                                range_role,
+                                &mut emitted_asset_records,
+                                &range_record_owners,
+                            ) {
+                                continue;
+                            }
                             if let Some(n) = limit {
                                 if total_sent >= u64::from(n) {
                                     limit_reached = true;
@@ -1639,13 +2024,14 @@ impl PhotoAlbum {
                                 return;
                             }
                             total_sent += 1;
+                            page_emitted += 1;
                         }
                     } else {
                         pending_assets.entry(master_id).or_default().extend(records);
                     }
                 }
                 if limit_reached {
-                    stopped_for_limit = suppress_token_on_limit;
+                    stopped_for_limit = matches!(range_role, FetcherRangeRole::LimitProbe);
                     break;
                 }
                 let pending_record_count =
@@ -1660,10 +2046,21 @@ impl PhotoAlbum {
                         .await;
                     break;
                 }
-            }
-
-            if suppress_token_on_limit && limit.is_some_and(|n| total_sent >= u64::from(n)) {
-                stopped_for_limit = true;
+                if page_emitted == 0 {
+                    consecutive_empty_pages += 1;
+                    if consecutive_empty_pages >= MAX_EMPTY_PAGE_PROBES {
+                        tracing::info!(
+                            album = %name,
+                            offset,
+                            probes = consecutive_empty_pages,
+                            total_sent,
+                            "End of album (consecutive pages without new assets)"
+                        );
+                        break;
+                    }
+                } else {
+                    consecutive_empty_pages = 0;
+                }
             }
 
             // Surface any remaining unpaired records that couldn't be paired.
@@ -1695,18 +2092,22 @@ impl PhotoAlbum {
                     .await;
             }
 
-            if !enumeration_incomplete {
-                if let Some(shared) = &fetcher_sync_tokens {
-                    if stopped_for_limit {
-                        shared.suppress();
-                    } else if let Some(token) = last_sync_token {
-                        shared.push(token).await;
-                    } else if saw_blank_sync_token
-                        && behavior.preserve_blank_sync_tokens_for_diagnostics
-                    {
-                        shared.push(String::new()).await;
-                    }
+            if let Some(shared) = &fetcher_sync_tokens {
+                if stopped_for_limit {
+                    shared.suppress();
                 }
+                let token = last_sync_token.or_else(|| {
+                    (saw_blank_sync_token && behavior.preserve_blank_sync_tokens_for_diagnostics)
+                        .then(String::new)
+                });
+                let completion = if enumeration_incomplete {
+                    EnumerationCompletion::Incomplete(EnumerationFailure::UnpairedRecords)
+                } else if stopped_for_limit {
+                    EnumerationCompletion::UserBoundReached
+                } else {
+                    EnumerationCompletion::ProvenEof
+                };
+                shared.complete(token, completion).await;
             }
         })
     }
@@ -2102,9 +2503,9 @@ mod tests {
             plan.ranges,
             vec![FetcherRange {
                 start: 0,
-                end: 1000,
+                end: u64::MAX,
                 limit: Some(1000),
-                suppress_token_on_limit: true,
+                role: FetcherRangeRole::LimitProbe,
             }]
         );
         assert!(
@@ -2114,7 +2515,7 @@ mod tests {
     }
 
     #[test]
-    fn fast_profile_parallel_plan_covers_recent_window_with_partitioned_ranges() {
+    fn fast_profile_uses_ordered_limit_probe_for_recent_window() {
         let plan = build_enumeration_plan(
             Some(1000),
             Some(5000),
@@ -2123,10 +2524,8 @@ mod tests {
         );
 
         assert_eq!(plan.page_size, 100);
-        assert!(
-            plan.ranges.len() > 1,
-            "fast profile should keep parallel fetcher ranges"
-        );
+        assert_eq!(plan.ranges.len(), 1);
+        assert_eq!(plan.ranges[0].role, FetcherRangeRole::LimitProbe);
         assert!(
             plan.covers_prefix(1000),
             "parallel fast profile must cover the same recent window"
@@ -2134,7 +2533,7 @@ mod tests {
     }
 
     #[test]
-    fn boundary_probe_is_disabled_for_single_fetcher_plans() {
+    fn limit_probe_does_not_trust_equal_count_as_eof() {
         let plan = build_enumeration_plan(
             Some(100),
             Some(100),
@@ -2146,15 +2545,15 @@ mod tests {
             plan.ranges,
             vec![FetcherRange {
                 start: 0,
-                end: 100,
+                end: u64::MAX,
                 limit: Some(100),
-                suppress_token_on_limit: false,
+                role: FetcherRangeRole::LimitProbe,
             }]
         );
     }
 
     #[test]
-    fn boundary_probe_is_explicit_in_parallel_plans_without_losing_coverage() {
+    fn parallel_recent_plan_still_uses_one_ordered_limit_probe() {
         let plan = build_enumeration_plan(
             Some(100),
             Some(100),
@@ -2162,16 +2561,17 @@ mod tests {
             PhotoStreamProfile::FastEnumeration { concurrency: 10 },
         );
 
-        let mut offsets: Vec<u64> = plan.ranges.iter().map(|range| range.start).collect();
-        offsets.sort_unstable();
-        assert_eq!(offsets, vec![0, 99]);
+        assert_eq!(plan.ranges.len(), 1);
+        assert_eq!(plan.ranges[0].start, 0);
+        assert_eq!(plan.ranges[0].end, u64::MAX);
+        assert_eq!(plan.ranges[0].role, FetcherRangeRole::LimitProbe);
         assert!(plan.covers_prefix(100));
     }
 
     #[test]
-    fn boundary_probe_keeps_rest_of_first_parallel_chunk() {
+    fn unbounded_parallel_plan_partitions_data_and_appends_tail_owner() {
         let plan = build_enumeration_plan(
-            Some(5000),
+            None,
             Some(5000),
             100,
             PhotoStreamProfile::FastEnumeration { concurrency: 10 },
@@ -2180,8 +2580,17 @@ mod tests {
         assert!(
             plan.ranges
                 .iter()
-                .any(|range| range.start == 100 && range.end == 300),
-            "the boundary probe must not drop ranks between the first page and second fetcher"
+                .any(|range| range.start == 0 && range.role == FetcherRangeRole::Data),
+            "the count prefix must keep count-partitioned data work"
+        );
+        assert_eq!(
+            plan.ranges.last(),
+            Some(&FetcherRange {
+                start: 5000,
+                end: u64::MAX,
+                limit: None,
+                role: FetcherRangeRole::TailProof,
+            })
         );
         assert!(plan.covers_prefix(5000));
     }
@@ -2261,6 +2670,139 @@ mod tests {
             },
             session,
         )
+    }
+
+    fn lookup_request(state_id: &str, master: &str, asset: &str) -> RecordLookupRequest {
+        RecordLookupRequest {
+            state_id: ProviderRecordId::new(state_id),
+            master_record_name: ProviderRecordId::new(master),
+            asset_record_name: ProviderRecordId::new(asset),
+        }
+    }
+
+    #[tokio::test]
+    async fn targeted_record_lookup_scopes_zone_at_request_level() {
+        #[derive(Clone)]
+        struct CaptureLookupSession {
+            body: Arc<Mutex<Option<Value>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl PhotosSession for CaptureLookupSession {
+            async fn post(
+                &self,
+                url: &str,
+                body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                assert!(url.contains("/records/lookup?"));
+                *self.body.lock().unwrap() = Some(serde_json::from_str(&body)?);
+                Ok(json!({"records": []}))
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(None));
+        let album = make_album_with_session(
+            100,
+            Box::new(CaptureLookupSession {
+                body: Arc::clone(&captured),
+            }),
+        );
+        album
+            .resolve_records(&[lookup_request("master", "master", "asset")])
+            .await;
+
+        let body = captured.lock().unwrap().clone().expect("lookup body");
+        assert_eq!(body["zoneID"], default_zone());
+        let records = body["records"].as_array().expect("records array");
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().all(|record| record.get("zoneID").is_none()));
+    }
+
+    #[tokio::test]
+    async fn targeted_record_lookup_distinguishes_present_deleted_and_omitted() {
+        let response = json!({
+            "records": [
+                test_master_record("master-present"),
+                test_asset_record_for("asset-present", "master-present"),
+                test_master_record("master-deleted"),
+                {
+                    "recordName": "asset-deleted",
+                    "serverErrorCode": "UNKNOWN_ITEM",
+                    "reason": "record not found"
+                }
+            ]
+        });
+        let album = make_album_with_session(100, Box::new(MockPhotosSession::new().ok(response)));
+        let batch = album
+            .resolve_records(&[
+                lookup_request("master-present", "master-present", "asset-present"),
+                lookup_request("master-deleted", "master-deleted", "asset-deleted"),
+                lookup_request("master-unknown", "master-unknown", "asset-unknown"),
+            ])
+            .await;
+
+        assert!(!batch.complete, "an omitted batch member is inconclusive");
+        assert!(
+            matches!(batch.results[0].1, RecordResolution::Present(_)),
+            "unexpected lookup results: {:?}",
+            batch.results
+        );
+        assert!(matches!(
+            batch.results[1].1,
+            RecordResolution::Deleted { .. }
+        ));
+        assert!(matches!(batch.results[2].1, RecordResolution::Unknown));
+    }
+
+    #[tokio::test]
+    async fn targeted_record_lookup_retains_transient_failure() {
+        let mut session = MockPhotosSession::new();
+        for _ in 0..8 {
+            session = session.err("temporary lookup failure");
+        }
+        let album = make_album_with_session(100, Box::new(session));
+
+        let batch = album
+            .resolve_records(&[lookup_request("master", "master", "asset")])
+            .await;
+
+        assert!(!batch.complete);
+        assert!(matches!(
+            batch.results[0].1,
+            RecordResolution::TransientFailure(ProviderLookupError::Request(_))
+        ));
+    }
+
+    #[test]
+    fn targeted_record_lookup_preserves_typed_http_failures() {
+        let error: anyhow::Error = super::super::session::HttpStatusError {
+            status: 429,
+            url: "https://example.com/records/lookup".to_string(),
+            retry_after: None,
+            body: None,
+        }
+        .into();
+        assert!(matches!(
+            classify_provider_lookup_error(&error),
+            ProviderLookupError::RateLimited { status: 429, .. }
+        ));
+
+        let error: anyhow::Error = super::super::session::HttpStatusError {
+            status: 421,
+            url: "https://example.com/records/lookup".to_string(),
+            retry_after: None,
+            body: None,
+        }
+        .into();
+        assert!(matches!(
+            classify_provider_lookup_error(&error),
+            ProviderLookupError::Authentication { status: 421, .. }
+        ));
     }
 
     #[tokio::test]
@@ -2398,6 +2940,105 @@ mod tests {
             }
         }
         (ids, errors)
+    }
+
+    #[tokio::test]
+    async fn underreported_count_tail_proof_emits_every_asset() {
+        let session = DynamicRecentPhotosSession::new(2);
+        let album = make_album_with_session(100, Box::new(session));
+
+        let (stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(None, Some(1), 1, true);
+
+        assert_eq!(
+            drain_photo_stream_ids(stream).await,
+            vec!["master-0000", "master-0001"]
+        );
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("zone-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_limit_probe_suppresses_token_only_when_extra_asset_exists() {
+        let session = DynamicRecentPhotosSession::new(2);
+        let album = make_album_with_session(100, Box::new(session));
+
+        let (stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(Some(1), Some(1), 1, true);
+
+        assert_eq!(drain_photo_stream_ids(stream).await, vec!["master-0000"]);
+        assert_eq!(
+            token_rx.await.expect("sync token sender"),
+            None,
+            "the N+1 asset proves that the user bound truncated enumeration"
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_limit_probe_keeps_token_when_natural_eof_is_proved() {
+        let session = DynamicRecentPhotosSession::new(1);
+        let album = make_album_with_session(100, Box::new(session));
+
+        let (stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(Some(1), Some(1), 1, true);
+
+        assert_eq!(drain_photo_stream_ids(stream).await, vec!["master-0000"]);
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("zone-token"),
+            "equal count and limit are eligible only after the N+1 probe proves EOF"
+        );
+    }
+
+    #[tokio::test]
+    async fn overreported_count_still_finishes_at_proved_eof() {
+        let session = DynamicRecentPhotosSession::new(1);
+        let album = make_album_with_session(100, Box::new(session));
+
+        let (stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(None, Some(10_000), 1, true);
+
+        assert_eq!(drain_photo_stream_ids(stream).await, vec!["master-0000"]);
+        assert_eq!(
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("zone-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn tail_request_failure_blocks_token_after_prefix_was_observed() {
+        let session = DynamicRecentPhotosSession::new(2).with_error_at_offset(2);
+        let album = make_album_with_session(100, Box::new(session));
+
+        let (stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(None, Some(1), 1, true);
+        let (ids, errors) = drain_photo_stream(stream).await;
+
+        assert_eq!(ids, vec!["master-0000", "master-0001"]);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(token_rx.await.expect("sync token sender"), None);
+    }
+
+    #[tokio::test]
+    async fn dropping_stream_during_tail_proof_blocks_token() {
+        use tokio_stream::StreamExt;
+
+        let session = DynamicRecentPhotosSession::new(100);
+        let album = make_album_with_session(100, Box::new(session));
+        let (mut stream, token_rx) =
+            album.photo_stream_with_token_for_download_policy(None, Some(1), 1, true);
+
+        assert!(stream
+            .next()
+            .await
+            .transpose()
+            .expect("first asset")
+            .is_some());
+        drop(stream);
+
+        assert_eq!(token_rx.await.expect("sync token sender"), None);
     }
 
     #[tokio::test]
@@ -2666,7 +3307,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn full_query_empty_page_stop_blocks_token() {
+    async fn full_query_consecutive_empty_pages_prove_eof() {
         let mock = MockPhotosFlow::new()
             .query_photo_page("master-before-empty-tail", Some("token-full"))
             .build();
@@ -2676,16 +3317,11 @@ mod tests {
         let (ids, errors) = drain_photo_stream(stream).await;
 
         assert_eq!(ids, vec!["master-before-empty-tail"]);
-        assert_eq!(errors.len(), 1);
-        assert!(
-            errors[0].contains("without confirming the end of the stream"),
-            "unexpected error: {}",
-            errors[0]
-        );
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
         assert_eq!(
-            token_rx.await.expect("sync token sender"),
-            None,
-            "ambiguous empty-page termination must suppress the sync token"
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("token-full"),
+            "the finite consecutive-empty-page policy is positive EOF proof"
         );
     }
 
@@ -2809,7 +3445,7 @@ mod tests {
                     Some("st-known"),
                 ))
             } else {
-                Ok(json!({"records": []}))
+                Ok(json!({"records": [], "syncToken": "st-known"}))
             }
         }
 
@@ -2819,7 +3455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn photo_stream_with_known_single_page_total_skips_empty_tail_probes() {
+    async fn photo_stream_with_known_single_page_total_proves_empty_tail() {
         let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let album = make_album_with_session(
             100,
@@ -2837,8 +3473,8 @@ mod tests {
         );
         assert_eq!(
             calls.load(std::sync::atomic::Ordering::Relaxed),
-            1,
-            "known single-page totals should not spend extra requests probing the empty tail"
+            6,
+            "the count is only a hint, so the final owner must prove the empty tail"
         );
     }
 
@@ -2902,8 +3538,10 @@ mod tests {
                 }
                 records.push(test_asset_record("master-99"));
                 records
-            } else {
+            } else if offset == 99 {
                 test_records("master-99")
+            } else {
+                Vec::new()
             };
             Ok(json!({"records": records, "syncToken": "st-boundary"}))
         }
@@ -3176,8 +3814,8 @@ mod tests {
         );
         assert_eq!(
             owner_query_calls.load(std::sync::atomic::Ordering::SeqCst),
-            2,
-            "base enumeration should stop after the owner page plus empty tail"
+            6,
+            "base enumeration should stop after the owner page plus finite empty-tail proof"
         );
         assert_eq!(
             owner_changes_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -3252,8 +3890,8 @@ mod tests {
         );
         assert_eq!(
             owner_query_calls.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "recent limit should stop at the requested owner-zone item"
+            6,
+            "recent limit should stop after the requested item and finite owner-zone probe"
         );
         assert_eq!(
             owner_changes_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -3268,7 +3906,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn photo_stream_initial_boundary_probe_runs_in_parallel() {
+    async fn photo_stream_limit_probe_is_ordered_and_proves_eof() {
         let session = InitialBoundarySession {
             in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             max_in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3283,16 +3921,16 @@ mod tests {
             token_rx.await.expect("sync token sender").as_deref(),
             Some("st-boundary")
         );
-        assert!(
+        assert_eq!(
             session
                 .max_in_flight
-                .load(std::sync::atomic::Ordering::SeqCst)
-                >= 2,
-            "boundary probe should overlap the first page fetch"
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the N+1 proof must remain ordered"
         );
         let mut offsets = session.offsets.lock().expect("offsets lock").clone();
         offsets.sort_unstable();
-        assert_eq!(offsets, vec![0, 99]);
+        assert_eq!(offsets, vec![0, 99, 100, 200, 300, 400, 500]);
     }
 
     #[tokio::test]
@@ -3314,8 +3952,8 @@ mod tests {
         );
         assert_eq!(
             session.offsets().as_slice(),
-            &[0, 20, 40, 60, 80],
-            "download-mode pagination should advance through every reduced page"
+            &[0, 20, 40, 60, 80, 100, 120, 140, 160, 180],
+            "download-mode pagination should advance through the data and finite EOF proof"
         );
         assert!(
             session.results_limits().iter().all(|limit| *limit == 40),
@@ -3336,14 +3974,14 @@ mod tests {
         assert_eq!(ids.first().map(String::as_str), Some("master-0000"));
         assert_eq!(ids.last().map(String::as_str), Some("master-0099"));
         assert_eq!(
-            token_rx.await.expect("sync token sender"),
-            None,
-            "unknown-total recent streams stop at the caller's cap, not a confirmed EOF"
+            token_rx.await.expect("sync token sender").as_deref(),
+            Some("zone-token"),
+            "the N+1 probe can prove EOF even when the count side-channel is unavailable"
         );
         assert_eq!(
             session.offsets().as_slice(),
-            &[0, 20, 40, 60, 80],
-            "unknown-total download-mode --recent should keep paging until the limit"
+            &[0, 20, 40, 60, 80, 100, 120, 140, 160, 180],
+            "unknown-total download-mode --recent should keep paging through the finite EOF proof"
         );
         assert!(
             session.results_limits().iter().all(|limit| *limit == 40),

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -16,6 +16,9 @@ pub mod types;
 pub use album::PhotoAlbum;
 #[cfg(test)]
 pub use album::PhotoAlbumConfig;
+#[cfg(test)]
+pub(crate) use album::MAX_EMPTY_PAGE_PROBES;
+pub(crate) use album::{ProviderRecordId, RecordLookupRequest, RecordResolution};
 pub use asset::{PhotoAsset, VersionsMap};
 pub use library::PhotoLibrary;
 pub(crate) use library::{is_shared_zone, PRIMARY_ZONE_NAME};

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -378,6 +378,23 @@ pub async fn retry_post(
     .await
 }
 
+/// Retry transport and HTTP failures while leaving record-level CloudKit
+/// errors in the response for a batch-aware caller to classify. This is used
+/// by `/records/lookup`, where one explicit `UNKNOWN_ITEM` is a successful
+/// deletion result and must not fail unrelated records in the same batch.
+pub(crate) async fn retry_post_allowing_record_errors(
+    session: &dyn PhotosSession,
+    url: &str,
+    body: &str,
+    headers: &[(&str, &str)],
+    retry_config: &RetryConfig,
+) -> anyhow::Result<Value> {
+    retry::retry_with_backoff(retry_config, classify_api_error, || async {
+        session.post(url, body.to_owned(), headers).await
+    })
+    .await
+}
+
 /// Errors from `changes/zone` when syncToken is invalid.
 #[derive(Debug, thiserror::Error)]
 pub enum SyncTokenError {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -71,6 +71,39 @@ struct FullEnumerationLabels {
     reason: &'static str,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
+struct CheckpointDecisionLabels {
+    decision: &'static str,
+    reason: &'static str,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
+struct RecordLookupLabels {
+    outcome: &'static str,
+}
+
+static CHECKPOINT_DECISIONS: LazyLock<Family<CheckpointDecisionLabels, Counter>> =
+    LazyLock::new(Family::default);
+static TARGETED_RECORD_LOOKUPS: LazyLock<Family<RecordLookupLabels, Counter>> =
+    LazyLock::new(Family::default);
+static TRANSFERS_DEFERRED_AFTER_CHECKPOINT: LazyLock<Counter> = LazyLock::new(Counter::default);
+
+pub(crate) fn record_checkpoint_decision(decision: &'static str, reason: &'static str) {
+    CHECKPOINT_DECISIONS
+        .get_or_create(&CheckpointDecisionLabels { decision, reason })
+        .inc();
+}
+
+pub(crate) fn record_targeted_lookup(outcome: &'static str, count: usize) {
+    TARGETED_RECORD_LOOKUPS
+        .get_or_create(&RecordLookupLabels { outcome })
+        .inc_by(count as u64);
+}
+
+pub(crate) fn record_deferred_transfers(count: usize) {
+    TRANSFERS_DEFERRED_AFTER_CHECKPOINT.inc_by(count as u64);
+}
+
 /// Label set for the `kei_db_assets_total` and `kei_db_assets_size_bytes` gauge families.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
 struct StatusLabels {
@@ -112,7 +145,11 @@ pub(crate) struct MetricsHandle {
     enumeration_errors: Counter,
     pagination_shortfall_warnings: Counter,
     pagination_shortfall_assets: Counter,
+    tail_probes: Counter,
+    count_undercount_assets: Counter,
     sync_token_blocked_cycles: Counter,
+    same_cycle_recovery_attempts: Counter,
+    same_cycle_recovery_successes: Counter,
     full_enumeration_reasons: Family<FullEnumerationLabels, Counter>,
     session_expirations: Counter,
     cycle_duration_seconds: Gauge<f64, AtomicU64>,
@@ -122,6 +159,7 @@ pub(crate) struct MetricsHandle {
     // DB-backed gauges (only populated when --metrics-port is set).
     db_assets_total: Family<StatusLabels, Gauge>,
     db_assets_size_bytes: Family<StatusLabels, Gauge>,
+    pending_verification_age_seconds: Gauge,
     db_last_sync_assets_seen: Gauge,
     db_summary_read_failures: Counter,
 }
@@ -215,11 +253,52 @@ impl MetricsHandle {
             sync_token_blocked_cycles.clone(),
         );
 
+        let tail_probes = Counter::default();
+        registry.register(
+            "kei_sync_tail_probes",
+            "Total number of count-backed tail probes opened to prove natural EOF",
+            tail_probes.clone(),
+        );
+        let count_undercount_assets = Counter::default();
+        registry.register(
+            "kei_sync_count_undercount_assets",
+            "Total assets discovered beyond provider count hints",
+            count_undercount_assets.clone(),
+        );
+
+        let same_cycle_recovery_attempts = Counter::default();
+        registry.register(
+            "kei_sync_same_cycle_recovery_attempts",
+            "Total number of bounded same-cycle checkpoint recovery rounds attempted",
+            same_cycle_recovery_attempts.clone(),
+        );
+        let same_cycle_recovery_successes = Counter::default();
+        registry.register(
+            "kei_sync_same_cycle_recovery_successes",
+            "Total number of same-cycle checkpoint recovery rounds that completed proof",
+            same_cycle_recovery_successes.clone(),
+        );
+
         let full_enumeration_reasons: Family<FullEnumerationLabels, Counter> = Family::default();
         registry.register(
             "kei_sync_full_enumeration_reason",
             "Total number of full-enumeration sync cycles, by bounded reason",
             full_enumeration_reasons.clone(),
+        );
+        registry.register(
+            "kei_sync_checkpoint_decisions",
+            "Total provider checkpoint decisions by outcome and bounded reason",
+            CHECKPOINT_DECISIONS.clone(),
+        );
+        registry.register(
+            "kei_sync_targeted_record_lookups",
+            "Total targeted provider record lookup results by outcome",
+            TARGETED_RECORD_LOOKUPS.clone(),
+        );
+        registry.register(
+            "kei_sync_transfers_deferred_after_checkpoint",
+            "Total local transfers deferred after provider checkpoint advancement",
+            TRANSFERS_DEFERRED_AFTER_CHECKPOINT.clone(),
         );
 
         let session_expirations = Counter::default();
@@ -271,6 +350,13 @@ impl MetricsHandle {
             db_assets_size_bytes.clone(),
         );
 
+        let pending_verification_age_seconds: Gauge = Gauge::default();
+        registry.register(
+            "kei_pending_provider_verification_age_seconds",
+            "Age in seconds of the oldest unresolved targeted provider verification",
+            pending_verification_age_seconds.clone(),
+        );
+
         let db_last_sync_assets_seen: Gauge = Gauge::default();
         registry.register(
             "kei_db_last_sync_assets_seen",
@@ -319,7 +405,11 @@ impl MetricsHandle {
             enumeration_errors,
             pagination_shortfall_warnings,
             pagination_shortfall_assets,
+            tail_probes,
+            count_undercount_assets,
             sync_token_blocked_cycles,
+            same_cycle_recovery_attempts,
+            same_cycle_recovery_successes,
             full_enumeration_reasons,
             session_expirations,
             cycle_duration_seconds,
@@ -328,6 +418,7 @@ impl MetricsHandle {
             interrupted_cycles,
             db_assets_total,
             db_assets_size_bytes,
+            pending_verification_age_seconds,
             db_last_sync_assets_seen,
             db_summary_read_failures,
         }
@@ -353,9 +444,16 @@ impl MetricsHandle {
             .inc_by(stats.pagination_shortfall_warnings as u64);
         self.pagination_shortfall_assets
             .inc_by(stats.pagination_shortfall_assets);
+        self.tail_probes.inc_by(stats.tail_probes as u64);
+        self.count_undercount_assets
+            .inc_by(stats.count_undercount_assets);
         if stats.sync_token_blocked {
             self.sync_token_blocked_cycles.inc();
         }
+        self.same_cycle_recovery_attempts
+            .inc_by(stats.same_cycle_recovery_attempts as u64);
+        self.same_cycle_recovery_successes
+            .inc_by(stats.same_cycle_recovery_successes as u64);
         if let Some(reason) = stats.full_enumeration_reason {
             self.full_enumeration_reasons
                 .get_or_create(&FullEnumerationLabels {
@@ -421,6 +519,26 @@ impl MetricsHandle {
         self.db_assets_total
             .get_or_create(&StatusLabels { status: "failed" })
             .set(i64::try_from(summary.failed).unwrap_or(i64::MAX));
+        self.db_assets_total
+            .get_or_create(&StatusLabels {
+                status: "awaiting_provider_verification",
+            })
+            .set(i64::try_from(summary.awaiting_provider_verification).unwrap_or(i64::MAX));
+        self.db_assets_total
+            .get_or_create(&StatusLabels {
+                status: "source_deleted",
+            })
+            .set(i64::try_from(summary.source_deleted).unwrap_or(i64::MAX));
+        let verification_age = summary
+            .oldest_provider_verification_at
+            .map(|checked_at| {
+                Utc::now()
+                    .signed_duration_since(checked_at)
+                    .num_seconds()
+                    .max(0)
+            })
+            .unwrap_or(0);
+        self.pending_verification_age_seconds.set(verification_age);
         self.db_assets_size_bytes
             .get_or_create(&StatusLabels {
                 status: "downloaded",
@@ -760,6 +878,35 @@ mod tests {
             ),
             "output:\n{output}"
         );
+    }
+
+    #[tokio::test]
+    async fn recovery_metrics_export_counters_and_bounded_decisions() {
+        let handle = MetricsHandle::new(None);
+        let stats = SyncStats {
+            tail_probes: 2,
+            count_undercount_assets: 3,
+            same_cycle_recovery_attempts: 1,
+            same_cycle_recovery_successes: 1,
+            ..SyncStats::default()
+        };
+        record_checkpoint_decision("preserved", "pass_token_missing");
+        record_targeted_lookup("present", 4);
+        record_deferred_transfers(5);
+        handle.update(&stats, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        for expected in [
+            "kei_sync_tail_probes_total 2",
+            "kei_sync_count_undercount_assets_total 3",
+            "kei_sync_same_cycle_recovery_attempts_total 1",
+            "kei_sync_same_cycle_recovery_successes_total 1",
+            "kei_sync_checkpoint_decisions_total{decision=\"preserved\",reason=\"pass_token_missing\"}",
+            "kei_sync_targeted_record_lookups_total{outcome=\"present\"}",
+            "kei_sync_transfers_deferred_after_checkpoint_total",
+        ] {
+            assert!(output.contains(expected), "missing {expected}:\n{output}");
+        }
     }
 
     #[tokio::test]
@@ -1148,6 +1295,12 @@ mod tests {
             downloaded,
             pending,
             failed,
+            awaiting_provider_verification: 0,
+            source_deleted: 0,
+            oldest_provider_verification_at: None,
+            provider_checkpoint_status: None,
+            last_recovery_action: None,
+            last_full_enumeration_reason: None,
             downloaded_bytes,
             active_sync_started: None,
             active_enumeration_zones: Vec::new(),
@@ -1185,6 +1338,35 @@ mod tests {
             output.contains(r#"kei_db_assets_total{status="failed"} 2"#),
             "failed count missing or wrong:\n{output}"
         );
+    }
+
+    #[tokio::test]
+    async fn update_db_stats_exports_verification_and_source_deleted_gauges() {
+        let handle = MetricsHandle::new(None);
+        let mut summary = make_summary(10, 2, 1, 1_000);
+        summary.awaiting_provider_verification = 2;
+        summary.source_deleted = 7;
+        summary.oldest_provider_verification_at = Some(Utc::now() - chrono::Duration::seconds(60));
+        handle.update_db_stats(&summary, 13);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains(r#"kei_db_assets_total{status="awaiting_provider_verification"} 2"#),
+            "output:\n{output}"
+        );
+        assert!(
+            output.contains(r#"kei_db_assets_total{status="source_deleted"} 7"#),
+            "output:\n{output}"
+        );
+        let age_line = output
+            .lines()
+            .find(|line| line.starts_with("kei_pending_provider_verification_age_seconds "))
+            .expect("verification age gauge");
+        let age = age_line
+            .split_once(' ')
+            .and_then(|(_, value)| value.parse::<i64>().ok())
+            .expect("integer verification age");
+        assert!((60..=65).contains(&age), "age line: {age_line}");
     }
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -96,6 +96,27 @@ pub(crate) struct ScopedDbSyncToken {
     pub(crate) token: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CheckpointTransition {
+    pub(crate) metadata_updates: Vec<(String, String)>,
+    pub(crate) metadata_deletes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AssetVerificationState {
+    Unknown,
+    TransientFailure,
+}
+
+impl AssetVerificationState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::TransientFailure => "transient_failure",
+        }
+    }
+}
+
 /// State operations used by the download producer and finalizer.
 #[allow(
     dead_code,
@@ -192,6 +213,31 @@ pub trait DownloadStateStore: Send + Sync {
     ) -> Result<Option<String>, StateError> {
         Ok(None)
     }
+    async fn get_asset_record_names_for_master(
+        &self,
+        _library: &str,
+        _master_record_name: &str,
+    ) -> Result<Vec<String>, StateError> {
+        Ok(Vec::new())
+    }
+    async fn set_asset_verification(
+        &self,
+        _library: &str,
+        _id: &str,
+        _version_size: &str,
+        _state: AssetVerificationState,
+        _reason: &str,
+    ) -> Result<(), StateError> {
+        Ok(())
+    }
+    async fn clear_asset_verification(
+        &self,
+        _library: &str,
+        _id: &str,
+        _version_size: &str,
+    ) -> Result<(), StateError> {
+        Ok(())
+    }
     async fn backfill_asset_master_mappings_from_album_memberships(
         &self,
     ) -> Result<u64, StateError> {
@@ -221,10 +267,9 @@ pub trait DownloadStateStore: Send + Sync {
     }
     /// Resolve a provider delete while respecting local download state.
     ///
-    /// Downloaded rows stay in the catalog with a source tombstone so kei can
-    /// keep reporting locally protected files. Pending/failed rows are removed:
-    /// there is no source left to retry, and keeping them would create stale
-    /// unresolved work.
+    /// Every row stays in the catalog with a source tombstone so kei retains
+    /// provider history and local-file evidence. Actionable retry and status
+    /// readers exclude tombstoned pending/failed rows.
     async fn resolve_source_deleted_affected(
         &self,
         library: &str,
@@ -322,6 +367,15 @@ pub trait SyncTokenStore: Send + Sync {
     async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError>;
     async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError>;
     async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError>;
+    async fn commit_checkpoint_transition(
+        &self,
+        _transition: CheckpointTransition,
+    ) -> Result<(), StateError> {
+        Err(StateError::Invariant {
+            operation: "commit_checkpoint_transition",
+            detail: "atomic checkpoint transitions are not implemented by this state store".into(),
+        })
+    }
     async fn get_scoped_db_sync_token(
         &self,
         _provider: &str,
@@ -852,7 +906,7 @@ fn update_status_to_downloaded(
     let mut stmt = conn
         .prepare_cached(
             "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
-             local_checksum = ?3, download_checksum = ?4, last_error = NULL \
+             local_checksum = ?3, download_checksum = COALESCE(?4, download_checksum), last_error = NULL \
              WHERE library = ?5 AND id = ?6 AND version_size = ?7",
         )
         .map_err(|e| StateError::query("mark_downloaded::prepare", e))?;
@@ -1202,7 +1256,7 @@ impl SqliteStateDb {
     pub(crate) async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_failed", move |conn| {
             let sql = format!(
-                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' AND is_deleted = 0 \
                  ORDER BY last_seen_at DESC",
             );
             let mut stmt = conn
@@ -1227,14 +1281,14 @@ impl SqliteStateDb {
         self.with_conn("get_failed_sample", move |conn| {
             let total: i64 = conn
                 .query_row(
-                    "SELECT COUNT(*) FROM assets WHERE status = 'failed'",
+                    "SELECT COUNT(*) FROM assets WHERE status = 'failed' AND is_deleted = 0",
                     [],
                     |row| row.get(0),
                 )
                 .map_err(|e| StateError::query("get_failed_sample", e))?;
 
             let sql = format!(
-                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' AND is_deleted = 0 \
                  ORDER BY last_seen_at DESC LIMIT ?1",
             );
             let mut stmt = conn
@@ -1261,7 +1315,7 @@ impl SqliteStateDb {
     pub(crate) async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_pending", move |conn| {
             let sql = format!(
-                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' \
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' AND is_deleted = 0 \
                  ORDER BY last_seen_at DESC",
             );
             let mut stmt = conn
@@ -1286,7 +1340,7 @@ impl SqliteStateDb {
     ) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_failed_page", move |conn| {
             let sql = format!(
-                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' AND is_deleted = 0 \
                  ORDER BY last_seen_at DESC LIMIT ?1 OFFSET ?2",
             );
             let mut stmt = conn
@@ -1319,7 +1373,7 @@ impl SqliteStateDb {
     ) -> Result<Vec<AssetRecord>, StateError> {
         self.with_conn("get_pending_page", move |conn| {
             let sql = format!(
-                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' \
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' AND is_deleted = 0 \
                  ORDER BY last_seen_at DESC LIMIT ?1 OFFSET ?2",
             );
             let mut stmt = conn
@@ -1347,13 +1401,14 @@ impl SqliteStateDb {
 
     pub(crate) async fn get_summary(&self) -> Result<SyncSummary, StateError> {
         self.with_conn("get_summary", move |conn| {
-            let (total_assets, downloaded, pending, failed, downloaded_bytes) = conn
+            let (total_assets, downloaded, pending, failed, source_deleted, downloaded_bytes) = conn
                 .query_row(
                     "SELECT \
                          COUNT(*), \
                          COUNT(CASE WHEN status = 'downloaded' THEN 1 END), \
-                         COUNT(CASE WHEN status = 'pending' THEN 1 END), \
-                         COUNT(CASE WHEN status = 'failed' THEN 1 END), \
+                         COUNT(CASE WHEN status = 'pending' AND is_deleted = 0 THEN 1 END), \
+                         COUNT(CASE WHEN status = 'failed' AND is_deleted = 0 THEN 1 END), \
+                         COUNT(CASE WHEN is_deleted = 1 THEN 1 END), \
                          COALESCE(SUM(CASE WHEN status = 'downloaded' THEN size_bytes ELSE 0 END), 0) \
                      FROM assets",
                     [],
@@ -1364,19 +1419,66 @@ impl SqliteStateDb {
                             row.get::<_, i64>(2)?,
                             row.get::<_, i64>(3)?,
                             row.get::<_, i64>(4)?,
+                            row.get::<_, i64>(5)?,
                         ))
                     },
                 )
-                .map(|(t, d, p, f, b)| {
+                .map(|(t, d, p, f, s, b)| {
                     (
                         u64::try_from(t).unwrap_or(0),
                         u64::try_from(d).unwrap_or(0),
                         u64::try_from(p).unwrap_or(0),
                         u64::try_from(f).unwrap_or(0),
+                        u64::try_from(s).unwrap_or(0),
                         u64::try_from(b).unwrap_or(0),
                     )
                 })
                 .map_err(|e| StateError::query("get_summary", e))?;
+            let awaiting_provider_verification: u64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM asset_verifications AS verification \
+                     JOIN assets \
+                       ON assets.library = verification.library \
+                      AND assets.id = verification.id \
+                      AND assets.version_size = verification.version_size \
+                     WHERE assets.status IN ('pending', 'failed') AND assets.is_deleted = 0",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map(|count| u64::try_from(count).unwrap_or(0))
+                .map_err(|e| StateError::query("get_summary::provider_verification", e))?;
+            let oldest_provider_verification_at = conn
+                .query_row(
+                    "SELECT MIN(verification.checked_at) FROM asset_verifications AS verification \
+                     JOIN assets \
+                       ON assets.library = verification.library \
+                      AND assets.id = verification.id \
+                      AND assets.version_size = verification.version_size \
+                     WHERE assets.status IN ('pending', 'failed') AND assets.is_deleted = 0",
+                    [],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .map_err(|e| StateError::query("get_summary::oldest_provider_verification", e))?
+                .and_then(|timestamp| Utc.timestamp_opt(timestamp, 0).single());
+            let metadata_value = |key: &str| {
+                conn.query_row("SELECT value FROM metadata WHERE key = ?1", [key], |row| {
+                    row.get::<_, String>(0)
+                })
+                .optional()
+            };
+            let mut provider_checkpoint_status = metadata_value("last_checkpoint_status")
+                .map_err(|e| StateError::query("get_summary::checkpoint_status", e))?;
+            if provider_checkpoint_status.is_none() {
+                let token_exists = conn
+                    .prepare("SELECT 1 FROM metadata WHERE key LIKE 'sync_token:%' LIMIT 1")
+                    .and_then(|mut stmt| stmt.exists([]))
+                    .map_err(|e| StateError::query("get_summary::checkpoint_exists", e))?;
+                provider_checkpoint_status = token_exists.then(|| "current".to_owned());
+            }
+            let last_recovery_action = metadata_value("last_recovery_action")
+                .map_err(|e| StateError::query("get_summary::recovery_action", e))?;
+            let last_full_enumeration_reason = metadata_value("last_full_enumeration_reason")
+                .map_err(|e| StateError::query("get_summary::full_enumeration_reason", e))?;
 
             type LastSyncRow = (
                 Option<i64>,
@@ -1498,6 +1600,12 @@ impl SqliteStateDb {
                 downloaded,
                 pending,
                 failed,
+                awaiting_provider_verification,
+                source_deleted,
+                oldest_provider_verification_at,
+                provider_checkpoint_status,
+                last_recovery_action,
+                last_full_enumeration_reason,
                 downloaded_bytes,
                 active_sync_started,
                 active_enumeration_zones,
@@ -1785,13 +1893,13 @@ impl SqliteStateDb {
             let failed = if let Some(library) = library.as_deref() {
                 conn.execute(
                     "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL \
-                     WHERE status = 'failed' AND library = ?1",
+                     WHERE status = 'failed' AND is_deleted = 0 AND library = ?1",
                     rusqlite::params![library],
                 )
             } else {
                 conn.execute(
                     "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL \
-                     WHERE status = 'failed'",
+                     WHERE status = 'failed' AND is_deleted = 0",
                     [],
                 )
             }
@@ -1801,13 +1909,13 @@ impl SqliteStateDb {
             let pending = if let Some(library) = library.as_deref() {
                 conn.execute(
                     "UPDATE assets SET download_attempts = 0, last_error = NULL \
-                     WHERE status = 'pending' AND download_attempts > 0 AND library = ?1",
+                     WHERE status = 'pending' AND is_deleted = 0 AND download_attempts > 0 AND library = ?1",
                     rusqlite::params![library],
                 )
             } else {
                 conn.execute(
                     "UPDATE assets SET download_attempts = 0, last_error = NULL \
-                     WHERE status = 'pending' AND download_attempts > 0",
+                     WHERE status = 'pending' AND is_deleted = 0 AND download_attempts > 0",
                     [],
                 )
             }
@@ -1816,13 +1924,13 @@ impl SqliteStateDb {
 
             let total_pending: i64 = if let Some(library) = library.as_deref() {
                 conn.query_row(
-                    "SELECT COUNT(*) FROM assets WHERE status = 'pending' AND library = ?1",
+                    "SELECT COUNT(*) FROM assets WHERE status = 'pending' AND is_deleted = 0 AND library = ?1",
                     rusqlite::params![library],
                     |row| row.get(0),
                 )
             } else {
                 conn.query_row(
-                    "SELECT COUNT(*) FROM assets WHERE status = 'pending'",
+                    "SELECT COUNT(*) FROM assets WHERE status = 'pending' AND is_deleted = 0",
                     [],
                     |row| row.get(0),
                 )
@@ -1838,29 +1946,9 @@ impl SqliteStateDb {
 
     pub(crate) async fn prune_source_deleted_retries(
         &self,
-        library: Option<&str>,
+        _library: Option<&str>,
     ) -> Result<u64, StateError> {
-        let library = library.map(ToOwned::to_owned);
-        self.with_conn("prune_source_deleted_retries", move |conn| {
-            let pruned = if let Some(library) = library.as_deref() {
-                conn.execute(
-                    "DELETE FROM assets \
-                     WHERE library = ?1 AND is_deleted = 1 AND status IN ('pending', 'failed')",
-                    rusqlite::params![library],
-                )
-            } else {
-                conn.execute(
-                    "DELETE FROM assets \
-                     WHERE is_deleted = 1 AND status IN ('pending', 'failed')",
-                    [],
-                )
-            }
-            .map_err(|e| StateError::query("prune_source_deleted_retries", e))?
-                as u64;
-
-            Ok(pruned)
-        })
-        .await
+        Ok(0)
     }
 
     pub(crate) async fn promote_pending_to_failed(
@@ -1875,7 +1963,13 @@ impl SqliteStateDb {
             let promoted = conn
                 .execute(
                     "UPDATE assets SET status = 'failed', last_error = 'Not resolved during sync' \
-                     WHERE status = 'pending' AND last_seen_at >= ?1",
+                     WHERE status = 'pending' AND last_seen_at >= ?1 \
+                       AND NOT EXISTS ( \
+                         SELECT 1 FROM asset_verifications AS verification \
+                         WHERE verification.library = assets.library \
+                           AND verification.id = assets.id \
+                           AND verification.version_size = assets.version_size \
+                       )",
                     rusqlite::params![seen_since],
                 )
                 .map_err(|e| StateError::query("promote_pending_to_failed", e))?
@@ -2161,6 +2255,33 @@ impl SqliteStateDb {
                 .map_err(|e| StateError::query("delete_metadata_by_prefix", e))?;
 
             Ok(deleted as u64)
+        })
+        .await
+    }
+
+    pub(crate) async fn commit_checkpoint_transition(
+        &self,
+        transition: CheckpointTransition,
+    ) -> Result<(), StateError> {
+        self.with_conn_mut("commit_checkpoint_transition", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("commit_checkpoint_transition::begin", e))?;
+            for (key, value) in transition.metadata_updates {
+                tx.execute(
+                    "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    rusqlite::params![key, value],
+                )
+                .map_err(|e| StateError::query("commit_checkpoint_transition::update", e))?;
+            }
+            for key in transition.metadata_deletes {
+                tx.execute("DELETE FROM metadata WHERE key = ?1", [key])
+                    .map_err(|e| StateError::query("commit_checkpoint_transition::delete", e))?;
+            }
+            tx.commit()
+                .map_err(|e| StateError::query("commit_checkpoint_transition::commit", e))?;
+            Ok(())
         })
         .await
     }
@@ -2790,6 +2911,89 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn get_asset_record_names_for_master(
+        &self,
+        library: &str,
+        master_record_name: &str,
+    ) -> Result<Vec<String>, StateError> {
+        let library = library.to_owned();
+        let master_record_name = master_record_name.to_owned();
+        self.with_conn("get_asset_record_names_for_master", move |conn| {
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT asset_record_name FROM asset_master_mappings \
+                     WHERE library = ?1 AND master_record_name = ?2 \
+                     ORDER BY asset_record_name",
+                )
+                .map_err(|e| StateError::query("get_asset_record_names_for_master::prepare", e))?;
+            let rows = stmt
+                .query_map(rusqlite::params![library, master_record_name], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(|e| StateError::query("get_asset_record_names_for_master::query", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| StateError::query("get_asset_record_names_for_master::row", e))?;
+            Ok(rows)
+        })
+        .await
+    }
+
+    pub(crate) async fn set_asset_verification(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        state: AssetVerificationState,
+        reason: &str,
+    ) -> Result<(), StateError> {
+        let library = library.to_owned();
+        let id = id.to_owned();
+        let version_size = version_size.to_owned();
+        let reason = reason.to_owned();
+        self.with_conn("set_asset_verification", move |conn| {
+            conn.execute(
+                "INSERT INTO asset_verifications \
+                    (library, id, version_size, state, reason, checked_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT(library, id, version_size) DO UPDATE SET \
+                    state = excluded.state, reason = excluded.reason, \
+                    checked_at = excluded.checked_at",
+                rusqlite::params![
+                    library,
+                    id,
+                    version_size,
+                    state.as_str(),
+                    reason,
+                    Utc::now().timestamp()
+                ],
+            )
+            .map_err(|e| StateError::query("set_asset_verification", e))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn clear_asset_verification(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        let library = library.to_owned();
+        let id = id.to_owned();
+        let version_size = version_size.to_owned();
+        self.with_conn("clear_asset_verification", move |conn| {
+            conn.execute(
+                "DELETE FROM asset_verifications \
+                 WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+                rusqlite::params![library, id, version_size],
+            )
+            .map_err(|e| StateError::query("clear_asset_verification", e))?;
+            Ok(())
+        })
+        .await
+    }
+
     pub(crate) async fn backfill_asset_master_mappings_from_album_memberships(
         &self,
     ) -> Result<u64, StateError> {
@@ -2868,20 +3072,18 @@ impl SqliteStateDb {
             let marked = tx
                 .execute(
                     "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
-                     WHERE library = ?2 AND id = ?3 AND status = 'downloaded'",
+                     WHERE library = ?2 AND id = ?3",
                     rusqlite::params![deleted_at.map(|dt| dt.timestamp()), library, asset_id],
                 )
                 .map_err(|e| StateError::query("resolve_source_deleted::mark", e))?;
-            let pruned = tx
-                .execute(
-                    "DELETE FROM assets \
-                     WHERE library = ?1 AND id = ?2 AND status IN ('pending', 'failed')",
-                    rusqlite::params![&library, &asset_id],
-                )
-                .map_err(|e| StateError::query("resolve_source_deleted::prune", e))?;
+            tx.execute(
+                "DELETE FROM asset_verifications WHERE library = ?1 AND id = ?2",
+                rusqlite::params![&library, &asset_id],
+            )
+            .map_err(|e| StateError::query("resolve_source_deleted::clear_verification", e))?;
             tx.commit()
                 .map_err(|e| StateError::query("resolve_source_deleted::commit", e))?;
-            Ok(marked + pruned)
+            Ok(marked)
         })
         .await
     }
@@ -2929,7 +3131,7 @@ impl SqliteStateDb {
             let marked = tx
                 .execute(
                     "UPDATE assets SET is_deleted = 1, deleted_at = COALESCE(?1, deleted_at) \
-                     WHERE library = ?2 AND status = 'downloaded' AND (id = ?3 OR id IN ( \
+                     WHERE library = ?2 AND (id = ?3 OR id IN ( \
                         SELECT asset_record_name FROM asset_master_mappings \
                         WHERE library = ?2 AND master_record_name = ?3 \
                      ))",
@@ -2940,19 +3142,24 @@ impl SqliteStateDb {
                     ],
                 )
                 .map_err(|e| StateError::query("resolve_master_family_source_deleted::mark", e))?;
-            let pruned = tx
-                .execute(
-                    "DELETE FROM assets \
-                     WHERE library = ?1 AND status IN ('pending', 'failed') AND (id = ?2 OR id IN ( \
-                        SELECT asset_record_name FROM asset_master_mappings \
-                        WHERE library = ?1 AND master_record_name = ?2 \
-                     ))",
-                    rusqlite::params![&library, &master_record_name],
+            tx.execute(
+                "DELETE FROM asset_verifications \
+                 WHERE library = ?1 AND (id = ?2 OR id IN ( \
+                    SELECT asset_record_name FROM asset_master_mappings \
+                    WHERE library = ?1 AND master_record_name = ?2 \
+                 ))",
+                rusqlite::params![&library, &master_record_name],
+            )
+            .map_err(|e| {
+                StateError::query(
+                    "resolve_master_family_source_deleted::clear_verification",
+                    e,
                 )
-                .map_err(|e| StateError::query("resolve_master_family_source_deleted::prune", e))?;
-            tx.commit()
-                .map_err(|e| StateError::query("resolve_master_family_source_deleted::commit", e))?;
-            Ok(marked + pruned)
+            })?;
+            tx.commit().map_err(|e| {
+                StateError::query("resolve_master_family_source_deleted::commit", e)
+            })?;
+            Ok(marked)
         })
         .await
     }
@@ -3291,6 +3498,34 @@ impl DownloadStateStore for SqliteStateDb {
         SqliteStateDb::get_master_record_name_for_asset(self, library, asset_record_name).await
     }
 
+    async fn get_asset_record_names_for_master(
+        &self,
+        library: &str,
+        master_record_name: &str,
+    ) -> Result<Vec<String>, StateError> {
+        SqliteStateDb::get_asset_record_names_for_master(self, library, master_record_name).await
+    }
+
+    async fn set_asset_verification(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        state: AssetVerificationState,
+        reason: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::set_asset_verification(self, library, id, version_size, state, reason).await
+    }
+
+    async fn clear_asset_verification(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::clear_asset_verification(self, library, id, version_size).await
+    }
+
     async fn backfill_asset_master_mappings_from_album_memberships(
         &self,
     ) -> Result<u64, StateError> {
@@ -3467,6 +3702,13 @@ impl SyncTokenStore for SqliteStateDb {
 
     async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
         SqliteStateDb::delete_metadata_by_prefix(self, prefix).await
+    }
+
+    async fn commit_checkpoint_transition(
+        &self,
+        transition: CheckpointTransition,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::commit_checkpoint_transition(self, transition).await
     }
 
     async fn get_scoped_db_sync_token(
@@ -5660,6 +5902,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn checkpoint_transition_is_atomic() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.set_metadata("sync_token:zone", "old-token")
+            .await
+            .unwrap();
+        db.set_metadata("enum_config_hash", "old-hash")
+            .await
+            .unwrap();
+        db.set_metadata("pending_enum_config_hash", "new-hash")
+            .await
+            .unwrap();
+
+        db.with_conn("install_test_trigger", |conn| {
+            conn.execute_batch(
+                "CREATE TRIGGER fail_enum_hash_update \
+                 BEFORE UPDATE ON metadata \
+                 WHEN NEW.key = 'enum_config_hash' \
+                 BEGIN SELECT RAISE(ABORT, 'simulated promotion failure'); END;",
+            )
+            .map_err(|e| StateError::query("install_test_trigger", e))?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let result = db
+            .commit_checkpoint_transition(CheckpointTransition {
+                metadata_updates: vec![
+                    ("sync_token:zone".into(), "new-token".into()),
+                    ("enum_config_hash".into(), "new-hash".into()),
+                ],
+                metadata_deletes: vec!["pending_enum_config_hash".into()],
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            db.get_metadata("sync_token:zone").await.unwrap().as_deref(),
+            Some("old-token")
+        );
+        assert_eq!(
+            db.get_metadata("enum_config_hash")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("old-hash")
+        );
+        assert_eq!(
+            db.get_metadata("pending_enum_config_hash")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("new-hash")
+        );
+    }
+
+    #[tokio::test]
     async fn test_delete_metadata_by_prefix() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
@@ -6487,6 +6786,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn provider_verification_marker_keeps_inconclusive_row_pending() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new("VERIFY_UNKNOWN").build();
+        db.upsert_seen(&record).await.unwrap();
+        db.set_asset_verification(
+            "PrimarySync",
+            "VERIFY_UNKNOWN",
+            "original",
+            AssetVerificationState::Unknown,
+            "lookup omitted record",
+        )
+        .await
+        .unwrap();
+
+        let promoted = db.promote_pending_to_failed(0).await.unwrap();
+        assert_eq!(promoted, 0);
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.awaiting_provider_verification, 1);
+
+        db.clear_asset_verification("PrimarySync", "VERIFY_UNKNOWN", "original")
+            .await
+            .unwrap();
+        assert_eq!(db.promote_pending_to_failed(0).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
     async fn open_corrupt_db_returns_error() {
         let dir = test_dir();
         let path = dir.path().join("corrupt.db");
@@ -7195,6 +7521,16 @@ mod tests {
         )
         .await
         .unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "DL_CK",
+            "original",
+            Path::new("/photos/reconciled/photo.jpg"),
+            "reconciled_local_sha256",
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify via get_downloaded_page that the asset is downloaded
         let page = db.get_downloaded_page(0, 10).await.unwrap();
@@ -7202,8 +7538,8 @@ mod tests {
         assert_eq!(&*page[0].id, "DL_CK");
         assert_eq!(
             page[0].local_checksum.as_deref(),
-            Some("local_sha256"),
-            "local_checksum should be stored"
+            Some("reconciled_local_sha256"),
+            "the latest local checksum should be stored"
         );
         let conn = db.acquire_lock("verify download checksum").unwrap();
         let download_checksum: Option<String> = conn
@@ -7217,7 +7553,7 @@ mod tests {
         assert_eq!(
             download_checksum.as_deref(),
             Some("pre_exif_sha256"),
-            "download_checksum should preserve the pre-EXIF downloaded bytes hash"
+            "path reconciliation without downloaded-byte evidence must preserve the prior hash"
         );
     }
 
@@ -7830,19 +8166,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(updated, 2);
-        let pending = db.get_pending().await.unwrap();
-        assert_eq!(pending.len(), 2);
-        for rec in &pending {
-            assert!(
-                rec.metadata.is_deleted,
-                "is_deleted should be set for all versions"
-            );
-            assert_eq!(rec.metadata.deleted_at, Some(when));
-        }
+        assert!(db.get_pending().await.unwrap().is_empty());
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.total_assets, 2);
+        assert_eq!(summary.source_deleted, 2);
     }
 
     #[tokio::test]
-    async fn resolve_source_deleted_prunes_pending_and_failed_but_preserves_downloaded() {
+    async fn resolve_source_deleted_retains_history_and_preserves_downloaded() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let pending = TestAssetRecord::new("SRC_DEL")
             .version_size(VersionSizeKey::Original)
@@ -7896,10 +8227,13 @@ mod tests {
         assert!(downloaded[0].metadata.is_deleted);
         assert_eq!(downloaded[0].metadata.deleted_at, Some(deleted_at));
         assert_eq!(downloaded[0].local_path.as_deref(), Some(path.as_path()));
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.total_assets, 3);
+        assert_eq!(summary.source_deleted, 3);
     }
 
     #[tokio::test]
-    async fn resolve_master_family_source_deleted_prunes_pending_siblings() {
+    async fn resolve_master_family_source_deleted_excludes_pending_siblings() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         db.upsert_seen(&TestAssetRecord::new("MASTER_FAMILY").build())
             .await
@@ -7923,10 +8257,11 @@ mod tests {
         let pending = db.get_pending().await.unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id.as_ref(), "OTHER_MASTER");
+        assert_eq!(db.get_summary().await.unwrap().source_deleted, 2);
     }
 
     #[tokio::test]
-    async fn prune_source_deleted_retries_removes_only_retry_tombstones() {
+    async fn source_deleted_retries_are_retained_but_not_actionable() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         db.upsert_seen(&TestAssetRecord::new("PENDING_DELETED").build())
             .await
@@ -7987,21 +8322,21 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(pruned, 2);
+        assert_eq!(pruned, 0);
         assert!(db.get_failed().await.unwrap().is_empty());
         let pending = db.get_pending().await.unwrap();
-        assert_eq!(pending.len(), 2);
+        assert_eq!(pending.len(), 1);
         assert!(pending.iter().any(|record| {
             record.library.as_ref() == "PrimarySync" && record.id.as_ref() == "PENDING_LIVE"
-        }));
-        assert!(pending.iter().any(|record| {
-            record.library.as_ref() == "SharedSync-AAAA" && record.id.as_ref() == "SHARED_DELETED"
         }));
         let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
         assert_eq!(downloaded.len(), 1);
         assert_eq!(downloaded[0].id.as_ref(), "DOWNLOADED_DELETED");
         assert!(downloaded[0].metadata.is_deleted);
         assert_eq!(downloaded[0].local_path.as_deref(), Some(path.as_path()));
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.total_assets, 5);
+        assert_eq!(summary.source_deleted, 4);
     }
 
     #[tokio::test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -14,7 +14,7 @@ pub mod types;
 
 #[cfg(test)]
 pub use db::ImportedRecord;
-pub(crate) use db::ScopedDbSyncToken;
+pub(crate) use db::{AssetVerificationState, CheckpointTransition, ScopedDbSyncToken};
 pub use db::{
     DownloadStateStore, ImportStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore,
     SqliteStateDb, SyncTokenStore,

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 15;
+pub(crate) const SCHEMA_VERSION: i32 = 16;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -447,6 +447,23 @@ GROUP BY membership.library, membership.asset_record_name
 HAVING COUNT(DISTINCT membership.master_record_name) = 1;
 ";
 
+/// V16 durable provider-verification state for unresolved retry rows.
+const SCHEMA_V16: &str = r"
+CREATE TABLE IF NOT EXISTS asset_verifications (
+    library TEXT NOT NULL,
+    id TEXT NOT NULL,
+    version_size TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('unknown', 'transient_failure')),
+    reason TEXT NOT NULL,
+    checked_at INTEGER NOT NULL,
+    PRIMARY KEY (library, id, version_size),
+    FOREIGN KEY (library, id, version_size)
+        REFERENCES assets (library, id, version_size) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_asset_verifications_state
+    ON asset_verifications (state, checked_at);
+";
+
 /// Apply migration for a specific version.
 ///
 /// `start_version` is the schema version the DB carried when `migrate()`
@@ -599,6 +616,7 @@ fn migrate_to_version(
         }
         14 => conn.execute_batch(SCHEMA_V14)?,
         15 => conn.execute_batch(SCHEMA_V15)?,
+        16 => conn.execute_batch(SCHEMA_V16)?,
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -1806,6 +1824,32 @@ mod tests {
             exists, 1,
             "v15 must create idx_asset_master_mappings_master"
         );
+    }
+
+    #[test]
+    fn test_v16_creates_asset_verifications_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'table' AND name = 'asset_verifications'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1);
+        for column in [
+            "library",
+            "id",
+            "version_size",
+            "state",
+            "reason",
+            "checked_at",
+        ] {
+            assert!(column_exists(&conn, "asset_verifications", column).unwrap());
+        }
     }
 
     #[test]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -489,6 +489,18 @@ pub struct SyncSummary {
     pub pending: u64,
     /// Number of assets that failed to download.
     pub failed: u64,
+    /// Pending or failed rows whose targeted provider lookup was inconclusive.
+    pub awaiting_provider_verification: u64,
+    /// Provider-confirmed deletions retained as catalog history.
+    pub source_deleted: u64,
+    /// Oldest unresolved targeted provider verification.
+    pub oldest_provider_verification_at: Option<DateTime<Utc>>,
+    /// Last provider checkpoint decision recorded by the cycle owner.
+    pub provider_checkpoint_status: Option<String>,
+    /// Last bounded recovery action selected by the cycle owner.
+    pub last_recovery_action: Option<String>,
+    /// Last reason that selected full provider enumeration.
+    pub last_full_enumeration_reason: Option<String>,
     /// Total size in bytes of downloaded assets.
     pub downloaded_bytes: u64,
     /// Time of the newest sync run that is still marked running.

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -45,10 +45,13 @@ pub(crate) struct LibraryState {
 /// both would cause each cycle to overwrite the other's value and
 /// permanently invalidate incremental sync.
 pub(crate) const ENUM_CONFIG_HASH_KEY: &str = "enum_config_hash";
+pub(crate) const PENDING_ENUM_CONFIG_HASH_KEY: &str = "pending_enum_config_hash";
+pub(crate) const PENDING_DOWNLOAD_CONFIG_HASH_KEY: &str = "pending_download_config_hash";
+const LAST_CHECKPOINT_STATUS_KEY: &str = "last_checkpoint_status";
+const LAST_RECOVERY_ACTION_KEY: &str = "last_recovery_action";
+const LAST_FULL_ENUMERATION_REASON_KEY: &str = "last_full_enumeration_reason";
 
-/// Prefix for every per-zone CloudKit sync token row in the metadata
-/// table. Cleared en masse when [`ENUM_CONFIG_HASH_KEY`] changes so the
-/// next cycle falls back to full enumeration.
+/// Prefix for every per-zone CloudKit sync token row in the metadata table.
 pub(crate) const SYNC_TOKEN_PREFIX: &str = "sync_token:";
 const INVENTORY_ANCHOR_PREFIX: &str = "inventory_anchor:";
 const INVENTORY_DROP_THRESHOLD_PERCENT: f64 = 5.0;
@@ -109,6 +112,190 @@ pub(crate) struct CycleResult {
     pub(crate) db_sync_token_advance_safe: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckpointBasis {
+    IncrementalDelta,
+    CompleteInventory,
+    InventoryWithDeltaBridge,
+}
+
+impl CheckpointBasis {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::IncrementalDelta => "incremental_delta",
+            Self::CompleteInventory => "complete_inventory",
+            Self::InventoryWithDeltaBridge => "inventory_with_delta_bridge",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckpointHoldReason {
+    DryRun,
+    StalePassPlan,
+    Interrupted,
+    SessionExpired,
+    EnumerationIncomplete,
+    StateNotDurable,
+    TokenProofIncomplete,
+}
+
+impl CheckpointHoldReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::DryRun => "dry_run",
+            Self::StalePassPlan => "stale_pass_plan",
+            Self::Interrupted => "interrupted",
+            Self::SessionExpired => "session_expired",
+            Self::EnumerationIncomplete => "enumeration_incomplete",
+            Self::StateNotDurable => "state_not_durable",
+            Self::TokenProofIncomplete => "token_proof_incomplete",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RecoveryAction {
+    ContinueTail,
+    RetryPasses(Vec<download::PassKey>),
+    RevalidateRecords(Vec<crate::icloud::photos::ProviderRecordId>),
+    ReplayFromPriorToken,
+    #[allow(
+        dead_code,
+        reason = "typed recovery vocabulary includes the final fallback even when current branches select narrower actions"
+    )]
+    ReconcileInventory(download::FullEnumerationReason),
+    Reauthenticate,
+    Stop,
+}
+
+impl RecoveryAction {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ContinueTail => "continue_tail",
+            Self::RetryPasses(_) => "retry_passes",
+            Self::RevalidateRecords(_) => "revalidate_records",
+            Self::ReplayFromPriorToken => "replay_from_prior_token",
+            Self::ReconcileInventory(_) => "reconcile_inventory",
+            Self::Reauthenticate => "reauthenticate",
+            Self::Stop => "stop",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceCheckpointDecision {
+    Advance {
+        token: String,
+        basis: CheckpointBasis,
+    },
+    Preserve {
+        reason: CheckpointHoldReason,
+        recovery: RecoveryAction,
+    },
+}
+
+fn source_checkpoint_decision(
+    result: &download::SyncResult,
+    dry_run: bool,
+    stale_pass_plan: bool,
+    basis: CheckpointBasis,
+) -> SourceCheckpointDecision {
+    let preserve = |reason, recovery| SourceCheckpointDecision::Preserve { reason, recovery };
+    if dry_run {
+        return preserve(CheckpointHoldReason::DryRun, RecoveryAction::Stop);
+    }
+    if stale_pass_plan {
+        return preserve(
+            CheckpointHoldReason::StalePassPlan,
+            RecoveryAction::ReplayFromPriorToken,
+        );
+    }
+    if matches!(
+        result.outcome,
+        download::DownloadOutcome::SessionExpired { .. }
+    ) {
+        return preserve(
+            CheckpointHoldReason::SessionExpired,
+            RecoveryAction::Reauthenticate,
+        );
+    }
+    if result.stats.interrupted {
+        return preserve(
+            CheckpointHoldReason::Interrupted,
+            RecoveryAction::ReplayFromPriorToken,
+        );
+    }
+    if result.stats.enumeration_errors > 0 || result.stats.enumeration_incomplete {
+        return preserve(
+            CheckpointHoldReason::EnumerationIncomplete,
+            RecoveryAction::ContinueTail,
+        );
+    }
+    if result.stats.state_write_failures > 0 {
+        return preserve(
+            CheckpointHoldReason::StateNotDurable,
+            RecoveryAction::ReplayFromPriorToken,
+        );
+    }
+    let Some(token) = result
+        .sync_token
+        .as_ref()
+        .filter(|token| !token.trim().is_empty())
+    else {
+        let recovery = if result.stats.sync_token_blocked_reason == Some("pending_retry_unmatched")
+        {
+            RecoveryAction::RevalidateRecords(Vec::new())
+        } else {
+            RecoveryAction::RetryPasses(Vec::new())
+        };
+        return preserve(CheckpointHoldReason::TokenProofIncomplete, recovery);
+    };
+    if result.stats.sync_token_blocked {
+        return preserve(
+            CheckpointHoldReason::TokenProofIncomplete,
+            RecoveryAction::RetryPasses(Vec::new()),
+        );
+    }
+    SourceCheckpointDecision::Advance {
+        token: token.clone(),
+        basis,
+    }
+}
+
+fn merge_download_outcomes(
+    first: &download::DownloadOutcome,
+    second: &download::DownloadOutcome,
+) -> download::DownloadOutcome {
+    match (first, second) {
+        (download::DownloadOutcome::SessionExpired { auth_error_count }, _)
+        | (_, download::DownloadOutcome::SessionExpired { auth_error_count }) => {
+            download::DownloadOutcome::SessionExpired {
+                auth_error_count: *auth_error_count,
+            }
+        }
+        (
+            download::DownloadOutcome::PartialFailure {
+                failed_count: first,
+            },
+            download::DownloadOutcome::PartialFailure {
+                failed_count: second,
+            },
+        ) => download::DownloadOutcome::PartialFailure {
+            failed_count: first.saturating_add(*second),
+        },
+        (download::DownloadOutcome::PartialFailure { failed_count }, _)
+        | (_, download::DownloadOutcome::PartialFailure { failed_count }) => {
+            download::DownloadOutcome::PartialFailure {
+                failed_count: *failed_count,
+            }
+        }
+        (download::DownloadOutcome::Success, download::DownloadOutcome::Success) => {
+            download::DownloadOutcome::Success
+        }
+    }
+}
+
 /// Decide whether the per-zone `sync_token` should be persisted to the state
 /// DB after a download pass.
 ///
@@ -124,6 +311,7 @@ pub(crate) struct CycleResult {
 ///
 /// The returned bool is the gate: callers still check that `sync_token` is
 /// `Some(_)` and that a state DB is configured before persisting.
+#[cfg(test)]
 pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_run: bool) -> bool {
     matches!(outcome, download::DownloadOutcome::Success) && !dry_run
 }
@@ -135,6 +323,7 @@ pub(crate) fn should_store_sync_token(outcome: &download::DownloadOutcome, dry_r
 /// the wrong pass, so the affected zone must not advance. Unaffected zones
 /// can still store their own zone tokens; the broader database pre-check
 /// token remains conservative until every selected zone is clean.
+#[cfg(test)]
 pub(crate) fn should_store_sync_token_for_cycle(
     outcome: &download::DownloadOutcome,
     dry_run: bool,
@@ -262,12 +451,11 @@ pub(crate) enum EnumConfigHashOutcome {
     /// have written.
     Initial,
     Unchanged,
-    /// Hash drifted; sync tokens cleared and new hash persisted so this
-    /// cycle falls back to full enumeration.
+    /// Hash drifted; the candidate hash was staged while active tokens and
+    /// the active hash remain unchanged until reconciliation succeeds.
     Changed,
-    /// Hash drift was detected, but the stale sync-token rows could not be
-    /// cleared. The new hash was not persisted, and the current cycle must
-    /// force full enumeration rather than trusting any surviving tokens.
+    /// Hash drift was detected, but the pending reconciliation hash could
+    /// not be staged.
     ChangedTokenPurgeFailed,
     /// The stored hash could not be read, so the cycle cannot prove whether
     /// existing sync tokens still match the current config.
@@ -294,7 +482,7 @@ pub(crate) enum DownloadConfigHashOutcome {
 
 impl DownloadConfigHashOutcome {
     const fn must_force_full_sync(self) -> bool {
-        !matches!(self, Self::Unchanged)
+        matches!(self, Self::ReadFailed | Self::TokenPurgeFailed)
     }
 
     const fn token_purge_failed(self) -> bool {
@@ -308,11 +496,8 @@ pub(crate) struct SyncModeDecision {
     pub(crate) full_enumeration_reason: Option<download::FullEnumerationReason>,
 }
 
-/// Compare the current download-config hash against the one stored in
-/// the state DB and react to drift. Storage failures are logged at warn
-/// and swallowed, but the new hash is never persisted unless stale sync
-/// tokens were cleared first. Otherwise a failed purge could leave old
-/// tokens behind while the updated hash makes later cycles trust them.
+/// Compare the current enumeration-config hash against the active value.
+/// Drift is staged without deleting the last safe provider checkpoint.
 pub(crate) async fn check_and_persist_enum_config_hash<D>(
     db: &D,
     current_hash: &str,
@@ -328,34 +513,38 @@ where
         }
     };
     let outcome = match stored_hash.as_deref() {
-        Some(h) if h == current_hash => return EnumConfigHashOutcome::Unchanged,
+        Some(h) if h == current_hash => {
+            if let Err(e) = db
+                .delete_metadata_by_prefix(PENDING_ENUM_CONFIG_HASH_KEY)
+                .await
+            {
+                tracing::debug!(error = %e, "Failed to clear reverted pending enum config hash");
+            }
+            return EnumConfigHashOutcome::Unchanged;
+        }
         Some(_) => EnumConfigHashOutcome::Changed,
         None => EnumConfigHashOutcome::Initial,
     };
 
-    if matches!(outcome, EnumConfigHashOutcome::Changed) {
-        tracing::info!("Download config changed since last sync, clearing sync tokens");
-        match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
-            Ok(n) if n > 0 => {
-                tracing::debug!(cleared = n, "Cleared stale sync tokens");
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to clear sync tokens; enum_config_hash will not advance"
-                );
-                return EnumConfigHashOutcome::ChangedTokenPurgeFailed;
-            }
-            _ => {}
+    let key = if matches!(outcome, EnumConfigHashOutcome::Changed) {
+        tracing::info!(
+            "Enumeration config changed since last sync; preserving active checkpoints and staging reconciliation"
+        );
+        PENDING_ENUM_CONFIG_HASH_KEY
+    } else {
+        ENUM_CONFIG_HASH_KEY
+    };
+    if let Err(e) = db.set_metadata(key, current_hash).await {
+        tracing::warn!(error = %e, key, "Failed to persist enum config hash state");
+        if matches!(outcome, EnumConfigHashOutcome::Changed) {
+            return EnumConfigHashOutcome::ChangedTokenPurgeFailed;
         }
-    }
-    if let Err(e) = db.set_metadata(ENUM_CONFIG_HASH_KEY, current_hash).await {
-        tracing::warn!(error = %e, "Failed to persist enum_config_hash");
     }
     outcome
 }
 
-/// Check the path-affecting download config hash.
+/// Check the path-affecting download config hash without deleting provider
+/// cursors. Reconciliation promotes the pending hash only after it succeeds.
 ///
 /// This hash does not prove CloudKit cursor safety. It proves local
 /// path/state trust: after a directory or filename-template change, an
@@ -369,7 +558,15 @@ where
     D: state::SyncTokenStore + ?Sized,
 {
     match db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY).await {
-        Ok(Some(stored)) if stored == current_hash => DownloadConfigHashOutcome::Unchanged,
+        Ok(Some(stored)) if stored == current_hash => {
+            if let Err(e) = db
+                .delete_metadata_by_prefix(PENDING_DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+            {
+                tracing::debug!(error = %e, "Failed to clear reverted pending download config hash");
+            }
+            DownloadConfigHashOutcome::Unchanged
+        }
         Ok(None) => {
             if let Err(e) = db
                 .set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, current_hash)
@@ -381,31 +578,23 @@ where
             DownloadConfigHashOutcome::Unchanged
         }
         Ok(Some(_stored)) => {
-            tracing::info!("Download config changed since last sync, verifying all files");
-            match db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX).await {
-                Ok(n) => {
-                    if n > 0 {
-                        tracing::debug!(
-                            cleared = n,
-                            "Cleared sync tokens after download config hash drift"
-                        );
-                    }
-                    if let Err(e) = db
-                        .set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, current_hash)
-                        .await
-                    {
-                        tracing::warn!(error = %e, "Failed to persist download config_hash");
-                        return DownloadConfigHashOutcome::TokenPurgeFailed;
-                    }
-                    DownloadConfigHashOutcome::Changed
+            tracing::info!(
+                "Download path config changed since last sync; preserving provider checkpoints and staging local reconciliation"
+            );
+            if let Err(e) = db
+                .set_metadata(PENDING_DOWNLOAD_CONFIG_HASH_KEY, current_hash)
+                .await
+            {
+                tracing::warn!(error = %e, "Failed to stage pending download config_hash");
+                DownloadConfigHashOutcome::TokenPurgeFailed
+            } else {
+                if let Err(e) = db
+                    .set_metadata(LAST_RECOVERY_ACTION_KEY, "reconcile_local_paths")
+                    .await
+                {
+                    tracing::debug!(error = %e, "Failed to persist local path reconciliation state");
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Failed to clear sync tokens after download config hash drift"
-                    );
-                    DownloadConfigHashOutcome::TokenPurgeFailed
-                }
+                DownloadConfigHashOutcome::Changed
             }
         }
         Err(e) => {
@@ -440,6 +629,11 @@ pub(crate) async fn run_cycle(
     let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
     let mut force_full_for_config_hash = false;
     let mut force_full_for_download_config_hash = false;
+    let mut checkpoint_transition_state_safe = true;
+    let mut enum_config_hash_outcome = EnumConfigHashOutcome::Unchanged;
+    let mut pending_download_config_hash = None;
+    let mut path_reconciliation_complete = true;
+    let mut candidate_zone_tokens = Vec::new();
     let enum_config_hash = download::compute_config_hash(config);
 
     // Check if token-unsafe eligibility config changed since last sync. If
@@ -456,13 +650,14 @@ pub(crate) async fn run_cycle(
     // each other every cycle, permanently preventing incremental sync.
     if !config.runtime.dry_run {
         if let Some(db) = state_db {
-            let config_hash_outcome =
+            enum_config_hash_outcome =
                 check_and_persist_enum_config_hash(db, &enum_config_hash).await;
-            force_full_for_config_hash = config_hash_outcome.must_force_full_sync();
+            force_full_for_config_hash = enum_config_hash_outcome.must_force_full_sync();
             if matches!(
-                config_hash_outcome,
+                enum_config_hash_outcome,
                 EnumConfigHashOutcome::ChangedTokenPurgeFailed | EnumConfigHashOutcome::ReadFailed
             ) {
+                checkpoint_transition_state_safe = false;
                 db_sync_token_advance_safe = false;
             }
         }
@@ -472,7 +667,8 @@ pub(crate) async fn run_cycle(
     // unsafe, but it does make an incremental cycle insufficient: with no
     // changed assets, `/changes/zone` would never re-plan already-known media
     // into the new directory/template. Detect that before choosing
-    // incremental mode and force a full reconciliation for this cycle.
+    // incremental mode. Path-only drift keeps source tracking incremental;
+    // the pending marker drives separate catalog/targeted rehydration work.
     if !config.runtime.dry_run {
         if let (Some(db), Some(first_library)) = (state_db, library_states.first()) {
             let probe_config = build_download_config(
@@ -484,21 +680,28 @@ pub(crate) async fn run_cycle(
             let download_config_hash = download::hash_download_config(&probe_config);
             let outcome = check_download_config_hash_for_cycle(db, &download_config_hash).await;
             force_full_for_download_config_hash = outcome.must_force_full_sync();
+            if matches!(outcome, DownloadConfigHashOutcome::Changed) {
+                pending_download_config_hash = Some(download_config_hash);
+            }
             if outcome.token_purge_failed() {
+                checkpoint_transition_state_safe = false;
                 db_sync_token_advance_safe = false;
             }
         }
     }
 
-    for lib_state in library_states {
+    for lib_state in library_states
+        .iter()
+        .copied()
+        .filter(|state| has_active_passes(state))
+    {
         if shutdown_token.is_cancelled() {
             break;
         }
 
-        // Determine sync mode per-library
-        // retry-failed must always use full enumeration: incremental
-        // sync only returns NEW iCloud changes, missing previously-
-        // failed assets that were already enumerated but not downloaded.
+        // Determine source-enumeration mode per library. Failed transfers are
+        // rehydrated from durable pending state by the download engine and do
+        // not require replaying the provider inventory.
         let sync_mode_decision = if force_full_for_config_hash {
             let reason = download::FullEnumerationReason::EnumConfigHashDrift;
             tracing::debug!(
@@ -538,6 +741,14 @@ pub(crate) async fn run_cycle(
             download::SyncMode::Incremental { .. } => "incremental",
         };
         if let Some(reason) = sync_mode_decision.full_enumeration_reason {
+            if let Some(db) = state_db {
+                if let Err(e) = db
+                    .set_metadata(LAST_FULL_ENUMERATION_REASON_KEY, reason.as_str())
+                    .await
+                {
+                    tracing::debug!(error = %e, "Failed to persist full-enumeration reason");
+                }
+            }
             tracing::info!(
                 sync_mode = sync_mode_label,
                 zone = %lib_state.zone_name,
@@ -563,10 +774,24 @@ pub(crate) async fn run_cycle(
         let download_config = build_download_config(
             sync_mode,
             Arc::new(rustc_hash::FxHashSet::default()),
-            asset_groupings,
+            Arc::clone(&asset_groupings),
             Arc::from(lib_state.zone_name.as_str()),
         );
         let download_client = shared_session.read().await.download_client().clone();
+        if pending_download_config_hash.is_some() {
+            let reconciliation = download::reconcile_catalog_paths(
+                &lib_state.plan.passes,
+                Arc::clone(&download_config),
+                shutdown_token.clone(),
+            )
+            .await?;
+            path_reconciliation_complete = path_reconciliation_complete && reconciliation.complete;
+            cycle_failed_count = cycle_failed_count
+                .saturating_add(reconciliation.stats.failed)
+                .saturating_add(reconciliation.stats.exif_failures)
+                .saturating_add(reconciliation.stats.state_write_failures);
+            cycle_stats.accumulate(&reconciliation.stats);
+        }
         let mut sync_result = download::download_photos_with_sync(
             &download_client,
             &lib_state.plan.passes,
@@ -575,6 +800,92 @@ pub(crate) async fn run_cycle(
             shutdown_token.clone(),
         )
         .await?;
+
+        let mut checkpoint_basis = if sync_result.full_enumeration_ran {
+            CheckpointBasis::CompleteInventory
+        } else {
+            CheckpointBasis::IncrementalDelta
+        };
+
+        // Eligibility reconciliation begins from a trusted prior cursor when
+        // one exists. The inventory covers unchanged newly eligible assets;
+        // replaying the prior cursor then bridges changes that occurred while
+        // that inventory was running. Only the bridged token may replace the
+        // active checkpoint.
+        if matches!(enum_config_hash_outcome, EnumConfigHashOutcome::Changed)
+            && sync_result.full_enumeration_ran
+            && checkpoint_transition_state_safe
+        {
+            let prior_token = if let Some(db) = state_db {
+                db.get_metadata(&lib_state.sync_token_key).await?
+            } else {
+                None
+            };
+            if let Some(prior_token) = prior_token.filter(|token| !token.trim().is_empty()) {
+                let inventory_decision = source_checkpoint_decision(
+                    &sync_result,
+                    config.runtime.dry_run,
+                    lib_state.plan_is_stale,
+                    CheckpointBasis::CompleteInventory,
+                );
+                if matches!(inventory_decision, SourceCheckpointDecision::Advance { .. }) {
+                    let bridge_config = build_download_config(
+                        download::SyncMode::Incremental {
+                            zone_sync_token: prior_token,
+                        },
+                        Arc::new(rustc_hash::FxHashSet::default()),
+                        Arc::clone(&asset_groupings),
+                        Arc::from(lib_state.zone_name.as_str()),
+                    );
+                    tracing::info!(
+                        zone = %lib_state.zone_name,
+                        "Inventory reconciliation complete; bridging changes from the preserved provider checkpoint"
+                    );
+                    let bridge_result = download::download_photos_with_sync(
+                        &download_client,
+                        &lib_state.plan.passes,
+                        bridge_config,
+                        download_controls,
+                        shutdown_token.clone(),
+                    )
+                    .await?;
+                    let bridge_decision = source_checkpoint_decision(
+                        &bridge_result,
+                        config.runtime.dry_run,
+                        lib_state.plan_is_stale,
+                        CheckpointBasis::IncrementalDelta,
+                    );
+                    let bridge_outcome =
+                        merge_download_outcomes(&sync_result.outcome, &bridge_result.outcome);
+                    sync_result.stats.accumulate(&bridge_result.stats);
+                    sync_result.outcome = bridge_outcome;
+                    if !bridge_result.full_enumeration_ran {
+                        if let SourceCheckpointDecision::Advance { token, .. } = bridge_decision {
+                            sync_result.sync_token = Some(token);
+                            checkpoint_basis = CheckpointBasis::InventoryWithDeltaBridge;
+                        } else {
+                            sync_result.sync_token = None;
+                            sync_result.stats.sync_token_blocked = true;
+                            sync_result.stats.sync_token_blocked_reason =
+                                Some("inventory_delta_bridge_failed");
+                            sync_result.stats.sync_token_blocked_source = Some("kei");
+                            sync_result.stats.sync_token_blocked_explanation = Some(
+                                "the inventory completed, but replay from the preserved provider checkpoint did not finish safely",
+                            );
+                        }
+                    } else {
+                        sync_result.sync_token = None;
+                        sync_result.stats.sync_token_blocked = true;
+                        sync_result.stats.sync_token_blocked_reason =
+                            Some("inventory_delta_bridge_failed");
+                        sync_result.stats.sync_token_blocked_source = Some("kei");
+                        sync_result.stats.sync_token_blocked_explanation = Some(
+                            "the prior provider checkpoint could not be replayed incrementally after inventory reconciliation",
+                        );
+                    }
+                }
+            }
+        }
 
         if sync_result.full_enumeration_ran && sync_result.stats.full_enumeration_reason.is_none() {
             sync_result.stats.full_enumeration_reason = sync_mode_decision.full_enumeration_reason;
@@ -615,105 +926,124 @@ pub(crate) async fn run_cycle(
             }
         }
 
-        // CONTRACT: SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE - store the zone
-        // token only after the download engine has returned a clean result and
-        // flushed all batch state writes. `Success` excludes partial failures;
-        // the extra interrupted and shutdown gates below catch cancellation
-        // paths that can still carry a token. A crash before this metadata
-        // write leaves the old token in place, so the zone replays next cycle
-        // instead of skipping unfinalized work.
-        let should_store_token = should_store_sync_token_for_cycle(
-            &sync_result.outcome,
-            config.runtime.dry_run,
-            lib_state.plan_is_stale,
-        ) && !sync_result.stats.interrupted
-            && !shutdown_token.is_cancelled();
-        if should_store_token {
-            match (&sync_result.sync_token, state_db) {
-                (Some(token), Some(db)) => {
-                    if let Err(e) = db.set_metadata(&lib_state.sync_token_key, token).await {
+        // Provider cursor safety is independent from transfer completion.
+        // The download pipeline persists every planned work item before this
+        // boundary, so failed transfers may advance while state, identity,
+        // enumeration, auth, and token-proof failures preserve the old cursor.
+        let checkpoint_decision =
+            if checkpoint_transition_state_safe && !shutdown_token.is_cancelled() {
+                source_checkpoint_decision(
+                    &sync_result,
+                    config.runtime.dry_run,
+                    lib_state.plan_is_stale,
+                    checkpoint_basis,
+                )
+            } else if shutdown_token.is_cancelled() {
+                SourceCheckpointDecision::Preserve {
+                    reason: CheckpointHoldReason::Interrupted,
+                    recovery: RecoveryAction::ReplayFromPriorToken,
+                }
+            } else {
+                SourceCheckpointDecision::Preserve {
+                    reason: CheckpointHoldReason::StateNotDurable,
+                    recovery: RecoveryAction::ReplayFromPriorToken,
+                }
+            };
+
+        match checkpoint_decision {
+            SourceCheckpointDecision::Advance { token, basis } => {
+                crate::metrics::record_checkpoint_decision("advanced", basis.as_str());
+                crate::metrics::record_deferred_transfers(
+                    sync_result
+                        .stats
+                        .failed
+                        .saturating_add(sync_result.stats.exif_failures),
+                );
+                if let Some(db) = state_db {
+                    let reconciliation_active = force_full_for_config_hash;
+                    if reconciliation_active {
+                        candidate_zone_tokens.push((lib_state.sync_token_key.clone(), token));
+                    } else if let Err(e) = db
+                        .commit_checkpoint_transition(state::CheckpointTransition {
+                            metadata_updates: vec![
+                                (lib_state.sync_token_key.clone(), token),
+                                (LAST_CHECKPOINT_STATUS_KEY.to_owned(), "current".to_owned()),
+                                (LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()),
+                            ],
+                            metadata_deletes: Vec::new(),
+                        })
+                        .await
+                    {
                         db_sync_token_advance_safe = false;
-                        tracing::warn!(error = %e, "Failed to store sync token");
+                        tracing::warn!(error = %e, "Failed to store provider checkpoint");
                     } else {
                         if cycle_has_stale_plan && !lib_state.plan_is_stale {
                             tracing::warn!(
                                 zone = %lib_state.zone_name,
                                 diagnostic = "stale_plan_unaffected_zone",
-                                "Stored clean zone sync token despite another selected zone's stale plan"
+                                "Stored clean zone checkpoint despite another selected zone's stale plan"
                             );
                         }
-                        tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
+                        if sync_result.stats.failed > 0 || sync_result.stats.exif_failures > 0 {
+                            tracing::info!(
+                                zone = %lib_state.zone_name,
+                                basis = ?basis,
+                                deferred_transfers = sync_result.stats.failed,
+                                metadata_failures = sync_result.stats.exif_failures,
+                                "Provider checkpoint advanced: incomplete local work is durably queued for targeted retry"
+                            );
+                        } else {
+                            tracing::debug!(zone = %lib_state.zone_name, basis = ?basis, "Stored provider checkpoint for next incremental sync");
+                        }
                     }
-                }
-                (Some(_), None) => {
+                } else {
                     db_sync_token_advance_safe = false;
                     tracing::debug!(
                         zone = %lib_state.zone_name,
-                        "Sync token available but no state DB is configured"
+                        "Provider checkpoint available but no state DB is configured"
                     );
                 }
-                (None, _) => {
-                    db_sync_token_advance_safe = false;
-                    let reason = sync_result
-                        .stats
-                        .sync_token_blocked_reason
-                        .unwrap_or("sync_token_missing");
-                    let source = sync_result
-                        .stats
-                        .sync_token_blocked_source
-                        .unwrap_or_else(|| download::sync_token_blocked_source(reason));
-                    let explanation = sync_result
-                        .stats
-                        .sync_token_blocked_explanation
-                        .as_ref()
-                        .copied()
-                        .unwrap_or_else(|| download::sync_token_blocked_explanation(reason));
-                    let observation = match (
-                        sync_result.stats.sync_token_expected_receivers,
-                        sync_result.stats.sync_token_receivers_with_token,
-                    ) {
-                        (Some(expected), Some(with_token)) => {
-                            let missing = sync_result.stats.sync_token_receivers_missing.unwrap_or(0);
-                            let blank = sync_result.stats.sync_token_receivers_blank.unwrap_or(0);
-                            let dropped = sync_result.stats.sync_token_receivers_dropped.unwrap_or(0);
-                            let unique = sync_result.stats.sync_token_unique_values.unwrap_or(0);
-                            format!(
-                                "Observed usable sync tokens on {with_token}/{expected} passes (missing: {missing}, blank: {blank}, dropped: {dropped}, unique values: {unique})"
-                            )
-                        }
-                        _ => "No per-pass sync token observation details were collected for this reason"
-                            .to_string(),
-                    };
-                    if let Some(message) = download::sync_token_blocked_bounded_log_message(reason)
+            }
+            SourceCheckpointDecision::Preserve { reason, recovery } => {
+                crate::metrics::record_checkpoint_decision("preserved", reason.as_str());
+                db_sync_token_advance_safe = false;
+                if let Some(db) = state_db {
+                    if let Err(e) = db
+                        .commit_checkpoint_transition(state::CheckpointTransition {
+                            metadata_updates: vec![
+                                (
+                                    LAST_CHECKPOINT_STATUS_KEY.to_owned(),
+                                    "preserved".to_owned(),
+                                ),
+                                (
+                                    LAST_RECOVERY_ACTION_KEY.to_owned(),
+                                    recovery.as_str().to_owned(),
+                                ),
+                            ],
+                            metadata_deletes: Vec::new(),
+                        })
+                        .await
                     {
-                        tracing::info!(
-                            zone = %lib_state.zone_name,
-                            reason,
-                            source,
-                            explanation,
-                            observation,
-                            "{message}"
-                        );
-                    } else {
-                        tracing::warn!(
-                            zone = %lib_state.zone_name,
-                            reason,
-                            source,
-                            explanation,
-                            observation,
-                            "Sync token did not advance after this successful sync. Here's why: {}. {}. Next cycle will run full enumeration",
-                            explanation,
-                            observation
-                        );
+                        tracing::debug!(error = %e, "Failed to persist checkpoint hold status");
                     }
                 }
+                let diagnostic = sync_result
+                    .stats
+                    .sync_token_blocked_reason
+                    .unwrap_or("provider_checkpoint_preserved");
+                let explanation = sync_result
+                    .stats
+                    .sync_token_blocked_explanation
+                    .unwrap_or_else(|| download::sync_token_blocked_explanation(diagnostic));
+                tracing::warn!(
+                    zone = %lib_state.zone_name,
+                    reason = ?reason,
+                    recovery = ?recovery,
+                    diagnostic,
+                    explanation,
+                    "Provider checkpoint preserved; recovery will use the narrowest safe action"
+                );
             }
-        } else if sync_result.sync_token.is_some() {
-            db_sync_token_advance_safe = false;
-            tracing::info!(
-                zone = %lib_state.zone_name,
-                "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
-            );
         }
 
         if sync_result.stats.sync_token_blocked
@@ -738,6 +1068,51 @@ pub(crate) async fn run_cycle(
             }
             download::DownloadOutcome::PartialFailure { failed_count } => {
                 cycle_failed_count += failed_count;
+            }
+        }
+    }
+
+    let reconciliation_active = force_full_for_config_hash;
+    if reconciliation_active
+        && db_sync_token_advance_safe
+        && !cycle_session_expired
+        && !shutdown_token.is_cancelled()
+    {
+        if let Some(db) = state_db {
+            let mut metadata_updates = candidate_zone_tokens;
+            let mut metadata_deletes = Vec::new();
+            if force_full_for_config_hash {
+                metadata_updates.push((ENUM_CONFIG_HASH_KEY.to_owned(), enum_config_hash));
+                metadata_deletes.push(PENDING_ENUM_CONFIG_HASH_KEY.to_owned());
+            }
+            metadata_updates.push((LAST_CHECKPOINT_STATUS_KEY.to_owned(), "current".to_owned()));
+            metadata_updates.push((LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()));
+            if let Err(e) = db
+                .commit_checkpoint_transition(state::CheckpointTransition {
+                    metadata_updates,
+                    metadata_deletes,
+                })
+                .await
+            {
+                db_sync_token_advance_safe = false;
+                tracing::warn!(error = %e, "Failed to atomically promote checkpoint reconciliation");
+            }
+        }
+    }
+
+    if path_reconciliation_complete && !cycle_session_expired && !shutdown_token.is_cancelled() {
+        if let (Some(db), Some(download_config_hash)) = (state_db, pending_download_config_hash) {
+            if let Err(e) = db
+                .commit_checkpoint_transition(state::CheckpointTransition {
+                    metadata_updates: vec![(
+                        download::DOWNLOAD_CONFIG_HASH_KEY.to_owned(),
+                        download_config_hash,
+                    )],
+                    metadata_deletes: vec![PENDING_DOWNLOAD_CONFIG_HASH_KEY.to_owned()],
+                })
+                .await
+            {
+                tracing::warn!(error = %e, "Failed to promote completed local path reconciliation");
             }
         }
     }
@@ -790,8 +1165,8 @@ where
 
 /// Determine the sync mode for a library: full enumeration or incremental.
 pub(crate) async fn determine_sync_mode_decision<D>(
-    is_retry_failed: bool,
-    library_count: usize,
+    _is_retry_failed: bool,
+    _library_count: usize,
     state_db: Option<&D>,
     sync_token_key: &str,
     zone_name: &str,
@@ -799,19 +1174,7 @@ pub(crate) async fn determine_sync_mode_decision<D>(
 where
     D: state::SyncTokenStore + ?Sized,
 {
-    if is_retry_failed {
-        let reason = download::FullEnumerationReason::ExplicitRetryFailed;
-        if library_count == 1 {
-            tracing::info!(
-                full_enumeration_reason = reason.as_str(),
-                "Retry-failed always runs full enumeration because incremental sync only returns new iCloud changes and can miss older failed assets"
-            );
-        }
-        SyncModeDecision {
-            mode: download::SyncMode::Full,
-            full_enumeration_reason: Some(reason),
-        }
-    } else if let Some(db) = state_db {
+    if let Some(db) = state_db {
         match db.get_metadata(sync_token_key).await {
             Ok(Some(ref token)) if !token.is_empty() => {
                 tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
@@ -955,6 +1318,49 @@ mod tests {
     }
 
     #[test]
+    fn durable_transfer_failure_can_advance_source_checkpoint() {
+        let result = download::SyncResult {
+            outcome: download::DownloadOutcome::PartialFailure { failed_count: 1 },
+            sync_token: Some("zone-token-next".to_string()),
+            stats: download::SyncStats {
+                failed: 1,
+                ..download::SyncStats::default()
+            },
+            full_enumeration_ran: false,
+        };
+
+        assert_eq!(
+            source_checkpoint_decision(&result, false, false, CheckpointBasis::IncrementalDelta,),
+            SourceCheckpointDecision::Advance {
+                token: "zone-token-next".to_string(),
+                basis: CheckpointBasis::IncrementalDelta,
+            }
+        );
+    }
+
+    #[test]
+    fn failed_retry_state_write_preserves_source_checkpoint() {
+        let result = download::SyncResult {
+            outcome: download::DownloadOutcome::PartialFailure { failed_count: 1 },
+            sync_token: Some("zone-token-next".to_string()),
+            stats: download::SyncStats {
+                failed: 1,
+                state_write_failures: 1,
+                ..download::SyncStats::default()
+            },
+            full_enumeration_ran: false,
+        };
+
+        assert_eq!(
+            source_checkpoint_decision(&result, false, false, CheckpointBasis::IncrementalDelta,),
+            SourceCheckpointDecision::Preserve {
+                reason: CheckpointHoldReason::StateNotDurable,
+                recovery: RecoveryAction::ReplayFromPriorToken,
+            }
+        );
+    }
+
+    #[test]
     fn inventory_drop_classifier_uses_five_percent_threshold() {
         assert_eq!(classify_inventory_drop(100, 96), None);
         assert_eq!(
@@ -1071,11 +1477,12 @@ mod tests {
 
         let retry =
             determine_sync_mode_decision(true, 1, Some(&db), &sync_token_key, "PrimarySync").await;
-        assert!(matches!(retry.mode, download::SyncMode::Full));
-        assert_eq!(
-            retry.full_enumeration_reason,
-            Some(download::FullEnumerationReason::ExplicitRetryFailed)
-        );
+        assert!(matches!(
+            retry.mode,
+            download::SyncMode::Incremental { ref zone_sync_token }
+                if zone_sync_token == "stored-token-abc"
+        ));
+        assert_eq!(retry.full_enumeration_reason, None);
 
         db.delete_metadata_by_prefix(SYNC_TOKEN_PREFIX)
             .await

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -634,6 +634,7 @@ pub(crate) async fn run_cycle(
     let mut pending_download_config_hash = None;
     let mut path_reconciliation_complete = true;
     let mut candidate_zone_tokens = Vec::new();
+    let mut checkpoint_hold_action: Option<&'static str> = None;
     let enum_config_hash = download::compute_config_hash(config);
 
     // Check if token-unsafe eligibility config changed since last sync. If
@@ -963,37 +964,55 @@ pub(crate) async fn run_cycle(
                     let reconciliation_active = force_full_for_config_hash;
                     if reconciliation_active {
                         candidate_zone_tokens.push((lib_state.sync_token_key.clone(), token));
-                    } else if let Err(e) = db
-                        .commit_checkpoint_transition(state::CheckpointTransition {
-                            metadata_updates: vec![
-                                (lib_state.sync_token_key.clone(), token),
-                                (LAST_CHECKPOINT_STATUS_KEY.to_owned(), "current".to_owned()),
-                                (LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()),
-                            ],
-                            metadata_deletes: Vec::new(),
-                        })
-                        .await
-                    {
-                        db_sync_token_advance_safe = false;
-                        tracing::warn!(error = %e, "Failed to store provider checkpoint");
                     } else {
-                        if cycle_has_stale_plan && !lib_state.plan_is_stale {
-                            tracing::warn!(
-                                zone = %lib_state.zone_name,
-                                diagnostic = "stale_plan_unaffected_zone",
-                                "Stored clean zone checkpoint despite another selected zone's stale plan"
-                            );
-                        }
-                        if sync_result.stats.failed > 0 || sync_result.stats.exif_failures > 0 {
-                            tracing::info!(
-                                zone = %lib_state.zone_name,
-                                basis = ?basis,
-                                deferred_transfers = sync_result.stats.failed,
-                                metadata_failures = sync_result.stats.exif_failures,
-                                "Provider checkpoint advanced: incomplete local work is durably queued for targeted retry"
-                            );
+                        let mut metadata_updates = vec![(lib_state.sync_token_key.clone(), token)];
+                        if let Some(recovery_action) = checkpoint_hold_action {
+                            metadata_updates.push((
+                                LAST_CHECKPOINT_STATUS_KEY.to_owned(),
+                                "preserved".to_owned(),
+                            ));
+                            metadata_updates.push((
+                                LAST_RECOVERY_ACTION_KEY.to_owned(),
+                                recovery_action.to_owned(),
+                            ));
                         } else {
-                            tracing::debug!(zone = %lib_state.zone_name, basis = ?basis, "Stored provider checkpoint for next incremental sync");
+                            metadata_updates.push((
+                                LAST_CHECKPOINT_STATUS_KEY.to_owned(),
+                                "current".to_owned(),
+                            ));
+                            metadata_updates
+                                .push((LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()));
+                        }
+                        if let Err(e) = db
+                            .commit_checkpoint_transition(state::CheckpointTransition {
+                                metadata_updates,
+                                metadata_deletes: Vec::new(),
+                            })
+                            .await
+                        {
+                            checkpoint_hold_action =
+                                Some(RecoveryAction::ReplayFromPriorToken.as_str());
+                            db_sync_token_advance_safe = false;
+                            tracing::warn!(error = %e, "Failed to store provider checkpoint");
+                        } else {
+                            if cycle_has_stale_plan && !lib_state.plan_is_stale {
+                                tracing::warn!(
+                                    zone = %lib_state.zone_name,
+                                    diagnostic = "stale_plan_unaffected_zone",
+                                    "Stored clean zone checkpoint despite another selected zone's stale plan"
+                                );
+                            }
+                            if sync_result.stats.failed > 0 || sync_result.stats.exif_failures > 0 {
+                                tracing::info!(
+                                    zone = %lib_state.zone_name,
+                                    basis = ?basis,
+                                    deferred_transfers = sync_result.stats.failed,
+                                    metadata_failures = sync_result.stats.exif_failures,
+                                    "Provider checkpoint advanced: incomplete local work is durably queued for targeted retry"
+                                );
+                            } else {
+                                tracing::debug!(zone = %lib_state.zone_name, basis = ?basis, "Stored provider checkpoint for next incremental sync");
+                            }
                         }
                     }
                 } else {
@@ -1005,6 +1024,7 @@ pub(crate) async fn run_cycle(
                 }
             }
             SourceCheckpointDecision::Preserve { reason, recovery } => {
+                checkpoint_hold_action = Some(recovery.as_str());
                 crate::metrics::record_checkpoint_decision("preserved", reason.as_str());
                 db_sync_token_advance_safe = false;
                 if let Some(db) = state_db {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -33,7 +33,8 @@ use crate::sync_cycle::{run_cycle, sync_token_key as make_sync_token_key, Librar
 use crate::sync_cycle::{
     check_and_persist_enum_config_hash, check_download_config_hash_for_cycle, determine_sync_mode,
     should_store_sync_token, should_store_sync_token_for_cycle, CycleResult,
-    DownloadConfigHashOutcome, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY, SYNC_TOKEN_PREFIX,
+    DownloadConfigHashOutcome, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY,
+    PENDING_DOWNLOAD_CONFIG_HASH_KEY, PENDING_ENUM_CONFIG_HASH_KEY, SYNC_TOKEN_PREFIX,
 };
 
 #[cfg(all(test, feature = "xmp"))]
@@ -3272,6 +3273,58 @@ mod tests {
         )
     }
 
+    #[derive(Clone)]
+    struct ConfigBridgeSession {
+        zone: Arc<str>,
+        inventory_token: Arc<str>,
+        bridge_token: Arc<str>,
+    }
+
+    impl ConfigBridgeSession {
+        fn new(zone: &str, inventory_token: &str, bridge_token: &str) -> Self {
+            Self {
+                zone: Arc::from(zone),
+                inventory_token: Arc::from(inventory_token),
+                bridge_token: Arc::from(bridge_token),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::icloud::photos::PhotosSession for ConfigBridgeSession {
+        async fn post(
+            &self,
+            url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<serde_json::Value> {
+            if url.contains("/internal/records/query/batch") {
+                return Ok(album_count_response(0));
+            }
+            if url.contains("/records/query?") {
+                return Ok(serde_json::json!({
+                    "records": [],
+                    "syncToken": self.inventory_token.as_ref()
+                }));
+            }
+            if url.contains("/changes/zone?") {
+                return Ok(serde_json::json!({
+                    "zones": [{
+                        "zoneID": {"zoneName": self.zone.as_ref(), "ownerRecordName": "_defaultOwner"},
+                        "syncToken": self.bridge_token.as_ref(),
+                        "moreComing": false,
+                        "records": []
+                    }]
+                }));
+            }
+            Ok(serde_json::json!({"records": []}))
+        }
+
+        fn clone_box(&self) -> Box<dyn crate::icloud::photos::PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
     fn make_one_photo_incremental_album_for_zone(
         zone: &str,
         zone_sync_token: &str,
@@ -3679,7 +3732,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_cycle_recent_full_download_does_not_store_zone_token() {
+    async fn run_cycle_recent_exact_inventory_stores_zone_token() {
         let (capture, _guard) = crate::test_helpers::TracingCapture::install();
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(40);
@@ -3722,20 +3775,15 @@ mod tests {
             db.get_metadata("sync_token:PrimarySync")
                 .await
                 .expect("read zone token"),
-            None,
-            "recent-limited full cycle must not persist a zone token"
+            Some("zone-tok-recent".to_owned()),
+            "an N+1 probe that proves exact EOF may persist the zone token"
         );
         let events = capture.events();
         assert!(
-            events.iter().any(|event| {
-                event.level == tracing::Level::INFO
-                    && event.field("reason") == Some("recent_limited_full_enumeration")
-                    && event.message().is_some_and(|message| {
-                        message.contains("--recent mode is bounded")
-                            && message.contains("does not persist a full enumeration sync token")
-                    })
-            }),
-            "recent-limited token suppression should log at info: {events:?}"
+            !events
+                .iter()
+                .any(|event| { event.field("reason") == Some("recent_limited_full_enumeration") }),
+            "an exact recent inventory must not report truncation: {events:?}"
         );
         assert!(
             !events.iter().any(|event| {
@@ -3767,17 +3815,17 @@ mod tests {
         assert!(
             events.iter().any(|event| {
                 event.level == tracing::Level::WARN
-                    && event.field("reason") == Some("icloud_blank_sync_token")
+                    && event.field("diagnostic") == Some("icloud_blank_sync_token")
                     && event
                         .message()
-                        .is_some_and(|message| message.contains("Sync token did not advance"))
+                        .is_some_and(|message| message.contains("Provider checkpoint preserved"))
             }),
             "true token-unsafe sync-token suppression should still warn: {events:?}"
         );
     }
 
     #[tokio::test]
-    async fn watch_recent_first_cycle_does_not_seed_incremental_token() {
+    async fn watch_recent_exact_first_cycle_seeds_incremental_token() {
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(20);
         let db = make_state_db();
@@ -3818,7 +3866,7 @@ mod tests {
             db.get_metadata("sync_token:PrimarySync")
                 .await
                 .expect("read zone token"),
-            None
+            Some("zone-tok-watch".to_owned())
         );
         let next_mode = determine_sync_mode(
             false,
@@ -3829,13 +3877,13 @@ mod tests {
         )
         .await;
         assert!(
-            matches!(next_mode, download::SyncMode::Full),
-            "a later watch cycle must not switch to incremental from a recent-limited token"
+            matches!(next_mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "zone-tok-watch"),
+            "a later watch cycle should use the token from proved recent EOF"
         );
     }
 
     #[tokio::test]
-    async fn run_cycle_recent_multiple_libraries_downloads_each_zone_without_token_advance() {
+    async fn run_cycle_recent_exact_multiple_libraries_advance_each_zone() {
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(20);
         let db = make_state_db();
@@ -3890,13 +3938,13 @@ mod tests {
             db.get_metadata("sync_token:PrimarySync")
                 .await
                 .expect("read primary token"),
-            None
+            Some("zone-tok-primary".to_owned())
         );
         assert_eq!(
             db.get_metadata("sync_token:SharedSync-TEST")
                 .await
                 .expect("read shared token"),
-            None
+            Some("zone-tok-shared".to_owned())
         );
     }
 
@@ -4124,11 +4172,6 @@ mod tests {
 
         fn with_get_failure(mut self, failure: MetadataSetFailure) -> Self {
             self.get_failure = Some(failure);
-            self
-        }
-
-        fn with_delete_prefix_failure(mut self, prefix: &'static str) -> Self {
-            self.delete_prefix_failure = Some(prefix);
             self
         }
 
@@ -4411,6 +4454,25 @@ mod tests {
             }
         }
 
+        async fn commit_checkpoint_transition(
+            &self,
+            transition: state::CheckpointTransition,
+        ) -> Result<(), state::error::StateError> {
+            if transition
+                .metadata_updates
+                .iter()
+                .any(|(key, _)| self.failure.matches(key))
+                || transition
+                    .metadata_deletes
+                    .iter()
+                    .any(|key| self.delete_prefix_failure == Some(key.as_str()))
+            {
+                Err(state::error::StateError::LockPoisoned(self.message.into()))
+            } else {
+                self.inner.commit_checkpoint_transition(transition).await
+            }
+        }
+
         async fn get_scoped_db_sync_token(
             &self,
             provider: &str,
@@ -4685,12 +4747,10 @@ mod tests {
         }
     }
 
-    /// `is_retry_failed=true` MUST force `SyncMode::Full` even when a
-    /// sync token is stored. A regression that picked Incremental during
-    /// retry-failed would silently skip the previously-failed assets the
-    /// user explicitly asked to retry — silent data loss.
+    /// Retry work is rehydrated independently from source enumeration, so a
+    /// stored provider checkpoint remains usable during `--retry-failed`.
     #[tokio::test]
-    async fn determine_sync_mode_retry_failed_with_token_returns_full() {
+    async fn determine_sync_mode_retry_failed_with_token_returns_incremental() {
         let db = make_state_db();
         let sync_token_key = "sync_token:PrimarySync";
         // Pre-populate a stored token so we can verify it is ignored.
@@ -4708,14 +4768,12 @@ mod tests {
         .await;
 
         assert!(
-            matches!(mode, download::SyncMode::Full),
-            "retry-failed must force Full, got {mode:?}"
+            matches!(mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "stored-token-abc"),
+            "retry-failed should keep source tracking incremental, got {mode:?}"
         );
     }
 
-    /// Retry-failed should ignore a stored token for its own run, but it must
-    /// not clear that token. A subsequent normal sync should still use
-    /// incremental mode from the previously stored token.
+    /// Retry-failed must neither consume nor clear the stored provider token.
     #[tokio::test]
     async fn determine_sync_mode_retry_failed_does_not_consume_or_clear_stored_token() {
         let db = make_state_db();
@@ -4727,8 +4785,8 @@ mod tests {
         let retry_mode =
             determine_sync_mode(true, 1, Some(db.as_ref()), sync_token_key, "PrimarySync").await;
         assert!(
-            matches!(retry_mode, download::SyncMode::Full),
-            "retry-failed must force Full, got {retry_mode:?}"
+            matches!(retry_mode, download::SyncMode::Incremental { ref zone_sync_token } if zone_sync_token == "stored-token-abc"),
+            "retry-failed should use the stored token, got {retry_mode:?}"
         );
 
         let normal_mode =
@@ -5863,7 +5921,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_cycle_config_hash_purge_failure_forces_full_without_persisting_hash() {
+    async fn run_cycle_config_hash_stage_failure_forces_full_without_replacing_checkpoint() {
         let config = make_run_cycle_config();
         let current_hash = download::compute_config_hash(&config);
         assert_ne!(current_hash, "old-hash");
@@ -5877,13 +5935,11 @@ mod tests {
             .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
             .await
             .expect("seed zone token");
-        let db: Arc<dyn download::DownloadStore> = Arc::new(
-            FailingMetadataSetDb::without_set_failure(
-                Arc::clone(&inner),
-                "simulated token purge failure",
-            )
-            .with_delete_prefix_failure(SYNC_TOKEN_PREFIX),
-        );
+        let db: Arc<dyn download::DownloadStore> = Arc::new(FailingMetadataSetDb::new(
+            Arc::clone(&inner),
+            MetadataSetFailure::Exact(PENDING_ENUM_CONFIG_HASH_KEY),
+            "simulated pending hash write failure",
+        ));
         let download_dir = tempfile::tempdir().expect("download tempdir");
         let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
 
@@ -5936,7 +5992,7 @@ mod tests {
                 .expect("read enum hash")
                 .as_deref(),
             Some("old-hash"),
-            "new hash must not be persisted when the stale-token purge failed"
+            "new hash must not become active when reconciliation could not be staged"
         );
         assert_eq!(
             inner
@@ -5944,13 +6000,205 @@ mod tests {
                 .await
                 .expect("read zone token")
                 .as_deref(),
-            Some("zone-tok-new"),
-            "the forced full pass should still refresh the selected zone token after success"
+            Some("zone-tok-prev"),
+            "failed reconciliation staging must preserve the last safe zone token"
         );
     }
 
     #[tokio::test]
-    async fn run_cycle_download_config_hash_drift_forces_full_reconciliation() {
+    async fn run_cycle_enum_config_drift_atomically_promotes_bridged_checkpoint() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "old-enum-hash")
+            .await
+            .expect("seed active enum hash");
+        db.set_metadata("sync_token:PrimarySync", "prior-token")
+            .await
+            .expect("seed prior token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let album = make_full_album_with_boxed_session(
+            "PrimarySync",
+            Box::new(ConfigBridgeSession::new(
+                "PrimarySync",
+                "inventory-token",
+                "bridge-token",
+            )),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("inventory plus delta bridge should complete");
+
+        assert!(result.db_sync_token_advance_safe);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("bridge-token")
+        );
+        let expected_hash = download::compute_config_hash(&config);
+        assert_eq!(
+            db.get_metadata(ENUM_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(expected_hash.as_str())
+        );
+        assert_eq!(
+            db.get_metadata(PENDING_ENUM_CONFIG_HASH_KEY).await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_failed_token_repair_preserves_prior_sqlite_checkpoint() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "old-enum-hash")
+            .await
+            .unwrap();
+        db.set_metadata("sync_token:PrimarySync", "prior-token")
+            .await
+            .unwrap();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let lib_state = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_empty_full_album(""),
+        );
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("failed token repair should preserve the active state");
+
+        assert!(!result.db_sync_token_advance_safe);
+        assert_eq!(result.stats.same_cycle_recovery_attempts, 1);
+        assert_eq!(result.stats.same_cycle_recovery_successes, 0);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("prior-token")
+        );
+        assert_eq!(
+            db.get_metadata(ENUM_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("old-enum-hash")
+        );
+        assert!(db
+            .get_metadata(PENDING_ENUM_CONFIG_HASH_KEY)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn run_cycle_multi_zone_reconciliation_preserves_all_active_tokens_on_partial_failure() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "old-enum-hash")
+            .await
+            .unwrap();
+        db.set_metadata("sync_token:PrimarySync", "primary-prior")
+            .await
+            .unwrap();
+        db.set_metadata("sync_token:SharedSync-TEST", "shared-prior")
+            .await
+            .unwrap();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let primary = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_full_album_with_boxed_session(
+                "PrimarySync",
+                Box::new(ConfigBridgeSession::new(
+                    "PrimarySync",
+                    "primary-inventory",
+                    "primary-bridge",
+                )),
+            ),
+        );
+        let shared = make_run_cycle_library_state_with_album(
+            "SharedSync-TEST",
+            "sync_token:SharedSync-TEST",
+            make_full_album_with_boxed_session(
+                "SharedSync-TEST",
+                Box::new(ConfigBridgeSession::new("SharedSync-TEST", "", "unused")),
+            ),
+        );
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &[&primary, &shared],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("partial multi-zone reconciliation should preserve active state");
+
+        assert!(!result.db_sync_token_advance_safe);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("primary-prior")
+        );
+        assert_eq!(
+            db.get_metadata("sync_token:SharedSync-TEST")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("shared-prior")
+        );
+        assert_eq!(
+            db.get_metadata(ENUM_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("old-enum-hash")
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_download_config_hash_drift_keeps_source_incremental() {
         let config = make_run_cycle_config();
         let db = make_state_db();
         let old_download_dir = tempfile::tempdir().expect("old download tempdir");
@@ -5976,7 +6224,7 @@ mod tests {
         let lib_state = make_run_cycle_library_state_with_album(
             "PrimarySync",
             &format!("{SYNC_TOKEN_PREFIX}PrimarySync"),
-            make_empty_full_album("zone-tok-new"),
+            make_incremental_album("zone-tok-new"),
         );
         let states = vec![&lib_state];
         let observed_modes = Arc::new(std::sync::Mutex::new(Vec::<download::SyncMode>::new()));
@@ -5985,6 +6233,12 @@ mod tests {
             Arc::clone(&db),
             Arc::clone(&observed_modes),
         );
+        let new_hash = download::hash_download_config(&build_download_config(
+            download::SyncMode::Full,
+            Arc::new(rustc_hash::FxHashSet::default()),
+            Arc::new(download::AssetGroupings::default()),
+            Arc::from("PrimarySync"),
+        ));
 
         let result = run_cycle(
             &states,
@@ -6000,16 +6254,15 @@ mod tests {
         .expect("run cycle");
 
         assert_eq!(result.failed_count, 0);
-        assert_eq!(
-            result.stats.full_enumeration_reason,
-            Some(download::FullEnumerationReason::DownloadConfigHashDrift)
-        );
+        assert_eq!(result.stats.full_enumeration_reason, None);
         let observed_modes = observed_modes.lock().expect("recorded modes lock").clone();
         assert!(
-            observed_modes
-                .iter()
-                .all(|mode| matches!(mode, download::SyncMode::Full)),
-            "path drift must not run an empty incremental pass against the old cursor: {observed_modes:?}"
+            matches!(
+                observed_modes.last(),
+                Some(download::SyncMode::Incremental { zone_sync_token })
+                    if zone_sync_token == "zone-tok-prev"
+            ),
+            "path-only drift must preserve incremental source tracking: {observed_modes:?}"
         );
         assert_eq!(
             db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
@@ -6017,7 +6270,21 @@ mod tests {
                 .expect("read zone token")
                 .as_deref(),
             Some("zone-tok-new"),
-            "the forced full pass should refresh the selected zone token after success"
+            "the incremental source pass should refresh the selected zone token after success"
+        );
+        assert_eq!(
+            db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .expect("read active download hash")
+                .as_deref(),
+            Some(new_hash.as_str()),
+            "an empty catalog completes local path reconciliation immediately"
+        );
+        assert_eq!(
+            db.get_metadata(PENDING_DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .expect("read pending download hash"),
+            None
         );
     }
 
@@ -6314,15 +6581,15 @@ mod tests {
         assert_eq!(result.stats.failed, 1);
         assert_eq!(result.stats.downloaded, 0);
         assert!(
-            !result.db_sync_token_advance_safe,
-            "database precheck token must not advance after a download failure"
+            result.db_sync_token_advance_safe,
+            "durably queued transfer failure must not replay the provider delta"
         );
         assert_eq!(
             db.get_metadata("sync_token:PrimarySync")
                 .await
                 .expect("read zone token"),
-            None,
-            "partial sync must not store the post-fault zone token"
+            Some("zone-tok-after-fault".to_string()),
+            "source checkpoint may advance once failed transfer work is durable"
         );
 
         let failed = db.get_failed().await.expect("read failed assets");
@@ -6389,7 +6656,7 @@ mod tests {
         assert_eq!(result.stats.assets_seen, 0);
         assert_eq!(
             result.stats.full_enumeration_reason,
-            Some(download::FullEnumerationReason::ExplicitRetryFailed)
+            Some(download::FullEnumerationReason::NoStoredToken)
         );
         assert!(
             !logs_contain(ZERO_ASSET_WARNING_PREFIX),
@@ -6798,7 +7065,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enum_config_hash_drift_clears_tokens_and_persists() {
+    async fn enum_config_hash_drift_stages_reconciliation_and_preserves_tokens() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
         db.set_metadata(ENUM_CONFIG_HASH_KEY, "old-hash")
             .await
@@ -6821,23 +7088,33 @@ mod tests {
                 .await
                 .unwrap()
                 .as_deref(),
-            Some("new-hash"),
+            Some("old-hash"),
         );
-        // Every sync_token:* row must clear, including shared zones.
-        assert!(db
-            .get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
-            .await
-            .unwrap()
-            .is_none());
-        assert!(db
-            .get_metadata(&format!("{SYNC_TOKEN_PREFIX}SharedSync-AAAA1111"))
-            .await
-            .unwrap()
-            .is_none());
+        assert_eq!(
+            db.get_metadata(PENDING_ENUM_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("new-hash")
+        );
+        assert_eq!(
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("tok-primary")
+        );
+        assert_eq!(
+            db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}SharedSync-AAAA1111"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("tok-shared")
+        );
     }
 
     #[tokio::test]
-    async fn enum_config_hash_purge_failure_keeps_old_hash_and_tokens() {
+    async fn enum_config_hash_stage_failure_keeps_old_hash_and_tokens() {
         let inner = make_state_db();
         inner
             .set_metadata(ENUM_CONFIG_HASH_KEY, "old-hash")
@@ -6847,13 +7124,11 @@ mod tests {
             .set_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"), "old-zone-token")
             .await
             .expect("seed zone token");
-        let db: Arc<dyn download::DownloadStore> = Arc::new(
-            FailingMetadataSetDb::without_set_failure(
-                Arc::clone(&inner),
-                "simulated token purge failure",
-            )
-            .with_delete_prefix_failure(SYNC_TOKEN_PREFIX),
-        );
+        let db: Arc<dyn download::DownloadStore> = Arc::new(FailingMetadataSetDb::new(
+            Arc::clone(&inner),
+            MetadataSetFailure::Exact(PENDING_ENUM_CONFIG_HASH_KEY),
+            "simulated pending hash write failure",
+        ));
 
         let outcome = check_and_persist_enum_config_hash(db.as_ref(), "new-hash").await;
 
@@ -6865,7 +7140,7 @@ mod tests {
                 .expect("read enum hash")
                 .as_deref(),
             Some("old-hash"),
-            "new hash must not be persisted while old sync tokens may still exist"
+            "new hash must not become active before reconciliation"
         );
         assert_eq!(
             inner
@@ -6874,7 +7149,7 @@ mod tests {
                 .expect("read zone token")
                 .as_deref(),
             Some("old-zone-token"),
-            "the test must prove the stale token survived the failed purge"
+            "the last safe token must survive a failed reconciliation-stage write"
         );
     }
 
@@ -6901,7 +7176,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_config_hash_drift_clears_token() {
+    async fn enum_config_revert_clears_pending_reconciliation() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "active-hash")
+            .await
+            .unwrap();
+        db.set_metadata(PENDING_ENUM_CONFIG_HASH_KEY, "abandoned-hash")
+            .await
+            .unwrap();
+
+        let outcome = check_and_persist_enum_config_hash(&db, "active-hash").await;
+
+        assert_eq!(outcome, EnumConfigHashOutcome::Unchanged);
+        assert_eq!(
+            db.get_metadata(PENDING_ENUM_CONFIG_HASH_KEY).await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn download_config_hash_drift_stages_reconciliation_without_clearing_token() {
         let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
         db.set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, "old-download-hash")
             .await
@@ -6917,15 +7211,22 @@ mod tests {
             db.get_metadata(&format!("{SYNC_TOKEN_PREFIX}PrimarySync"))
                 .await
                 .unwrap(),
-            None,
-            "path hash drift cannot leave an old incremental cursor in place"
+            Some("tok-keep".to_string()),
+            "path drift must preserve the active provider cursor"
         );
         assert_eq!(
             db.get_metadata(download::DOWNLOAD_CONFIG_HASH_KEY)
                 .await
                 .unwrap(),
+            Some("old-download-hash".to_string()),
+            "the active path hash changes only after reconciliation"
+        );
+        assert_eq!(
+            db.get_metadata(PENDING_DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .unwrap(),
             Some("current-download-hash".to_string()),
-            "the cycle owner must persist the stable run-level path hash"
+            "the candidate path hash must be durable while reconciliation runs"
         );
     }
 
@@ -6954,6 +7255,27 @@ mod tests {
                 .as_deref(),
             Some("tok-keep"),
             "initial hash persistence must not purge existing tokens"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_config_revert_clears_pending_reconciliation() {
+        let db = state::SqliteStateDb::open_in_memory().expect("open in-memory state DB");
+        db.set_metadata(download::DOWNLOAD_CONFIG_HASH_KEY, "active-hash")
+            .await
+            .unwrap();
+        db.set_metadata(PENDING_DOWNLOAD_CONFIG_HASH_KEY, "abandoned-hash")
+            .await
+            .unwrap();
+
+        let outcome = check_download_config_hash_for_cycle(&db, "active-hash").await;
+
+        assert_eq!(outcome, DownloadConfigHashOutcome::Unchanged);
+        assert_eq!(
+            db.get_metadata(PENDING_DOWNLOAD_CONFIG_HASH_KEY)
+                .await
+                .unwrap(),
+            None
         );
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -6198,6 +6198,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_cycle_multi_zone_status_preserves_an_earlier_checkpoint_hold() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+        let held = make_run_cycle_library_state_with_album(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            make_empty_full_album(""),
+        );
+        let advanced = make_run_cycle_library_state_with_album(
+            "SharedSync-TEST",
+            "sync_token:SharedSync-TEST",
+            make_empty_full_album("shared-token"),
+        );
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+
+        let result = run_cycle(
+            &[&held, &advanced],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert!(!result.db_sync_token_advance_safe);
+        assert_eq!(
+            db.get_metadata("last_checkpoint_status")
+                .await
+                .expect("read checkpoint status")
+                .as_deref(),
+            Some("preserved")
+        );
+        assert_eq!(
+            db.get_metadata("last_recovery_action")
+                .await
+                .expect("read recovery action")
+                .as_deref(),
+            Some("retry_passes")
+        );
+    }
+
+    #[tokio::test]
     async fn run_cycle_download_config_hash_drift_keeps_source_incremental() {
         let config = make_run_cycle_config();
         let db = make_state_db();

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -81,7 +81,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 15;
+const HELPER_SCHEMA_VERSION: i32 = 16;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -242,6 +242,20 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
         CREATE INDEX IF NOT EXISTS idx_asset_master_mappings_master
             ON asset_master_mappings (library, master_record_name);
 
+        CREATE TABLE IF NOT EXISTS asset_verifications (
+            library TEXT NOT NULL,
+            id TEXT NOT NULL,
+            version_size TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('unknown', 'transient_failure')),
+            reason TEXT NOT NULL,
+            checked_at INTEGER NOT NULL,
+            PRIMARY KEY (library, id, version_size),
+            FOREIGN KEY (library, id, version_size)
+                REFERENCES assets (library, id, version_size) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_asset_verifications_state
+            ON asset_verifications (state, checked_at);
+
         CREATE TABLE IF NOT EXISTS scoped_db_sync_tokens (
             provider TEXT NOT NULL,
             account TEXT NOT NULL,
@@ -287,7 +301,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 15). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 16). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -305,7 +319,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 15;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 16;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \
@@ -3551,6 +3565,18 @@ fn behavioral_helper_carries_every_migrated_column() {
     assert!(
         has_asset_master_mappings,
         "v15 table asset_master_mappings must exist in the behavioral helper's DDL"
+    );
+
+    let has_asset_verifications: bool = conn
+        .prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = 'asset_verifications'",
+        )
+        .unwrap()
+        .exists([])
+        .unwrap();
+    assert!(
+        has_asset_verifications,
+        "v16 table asset_verifications must exist in the behavioral helper's DDL"
     );
 }
 

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -690,6 +690,7 @@ fn typed_error_downcasts_stay_in_named_classifier_boundaries() {
         "classify_download_task_error",
         "classify_exit_error",
         "classify_incremental_error",
+        "classify_provider_lookup_error",
         "classify_srp_post_error",
         "classify_sync_auth_error",
         "is_session_error",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,7 @@
 // Shared test utilities -- not all functions are used by every test file.
 #![allow(dead_code)]
 
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -14,6 +15,57 @@ const CLOUDKIT_STALE_SESSION_MARKER: &str = "HTTP 401 for https://";
 
 /// Cached auth credentials for reactive session refresh mid-run.
 static AUTH_CREDS: OnceLock<(String, String, PathBuf)> = OnceLock::new();
+
+thread_local! {
+    /// Keep each live test's isolated state directory alive for the lifetime
+    /// of its test thread. Auth material is copied in, while the SQLite state
+    /// DB starts empty so one test's download/config choices cannot leave
+    /// durable pending work that changes another test's result.
+    static ISOLATED_DATA_DIR: RefCell<Option<tempfile::TempDir>> = const { RefCell::new(None) };
+}
+
+fn copy_auth_material(username: &str, source: &Path, destination: &Path) {
+    let sanitized: String = username
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+    for name in [
+        sanitized.clone(),
+        format!("{sanitized}.session"),
+        format!("{sanitized}.cache"),
+    ] {
+        let source_path = source.join(&name);
+        if source_path.is_file() {
+            std::fs::copy(&source_path, destination.join(&name)).unwrap_or_else(|error| {
+                panic!(
+                    "copy live-test auth material {}: {error}",
+                    source_path.display()
+                )
+            });
+        }
+    }
+}
+
+fn isolated_data_dir(username: &str, shared_cookie_dir: &Path) -> PathBuf {
+    ISOLATED_DATA_DIR.with(|slot| {
+        let dir = tempfile::Builder::new()
+            .prefix("kei-live-state-")
+            .tempdir()
+            .expect("create isolated live-test data dir");
+        copy_auth_material(username, shared_cookie_dir, dir.path());
+        let path = dir.path().to_path_buf();
+        *slot.borrow_mut() = Some(dir);
+        path
+    })
+}
+
+fn refresh_isolated_auth_material(username: &str, shared_cookie_dir: &Path) {
+    ISOLATED_DATA_DIR.with(|slot| {
+        if let Some(dir) = slot.borrow().as_ref() {
+            copy_auth_material(username, shared_cookie_dir, dir.path());
+        }
+    });
+}
 
 /// Load `.env` exactly once across all test functions.
 fn init_env() {
@@ -230,6 +282,7 @@ fn refresh_auth() {
         .expect("failed to run login");
 
     if output.status.success() {
+        refresh_isolated_auth_material(username, cookie_dir);
         eprintln!("Session refreshed OK.");
         return;
     }
@@ -304,8 +357,9 @@ pub(crate) fn is_retryable_auth_failure(msg: &str) -> bool {
 
 /// Require a pre-authenticated session. Returns `(username, password, cookie_dir)`.
 ///
-/// All tests share the same cookie directory so only one Apple API session
-/// is used per test run. **Auth-requiring tests must run single-threaded:**
+/// All tests share one pre-authenticated session source, then copy its auth
+/// material into an isolated data directory so SQLite state does not leak
+/// between tests. **Auth-requiring tests must run single-threaded:**
 ///
 /// ```sh
 /// cargo test --test sync -- --ignored --test-threads=1
@@ -326,7 +380,8 @@ pub fn require_preauth() -> (String, String, PathBuf) {
     let dir = cookie_dir();
     AUTH_CREDS.get_or_init(|| (username.clone(), password.clone(), dir.clone()));
     ensure_session(&username, &password, &dir);
-    (username, password, dir)
+    let isolated_dir = isolated_data_dir(&username, &dir);
+    (username, password, isolated_dir)
 }
 
 /// Strip ANSI escape sequences from a string (for log assertions).


### PR DESCRIPTION
## Summary

- Treat iCloud count responses as scheduling hints and prove natural EOF with bounded tail scans before accepting a full-enumeration checkpoint.
- Require token evidence from every selected pass, with one same-cycle recovery round for missing, blank, dropped, mismatched, or incomplete evidence.
- Revalidate pending assets by stable CloudKit record identity instead of broad enumeration. Only explicit provider deletion creates a source-deleted tombstone; omitted or malformed results remain durable pending work.
- Separate provider checkpoint safety from transfer completion. A checkpoint may advance after a failed transfer when the provider event and retry work are durable, while status continues to report the backup as incomplete.
- Preserve active tokens during eligibility and path configuration drift. Eligibility changes use inventory plus a delta bridge; path-only changes reconcile catalog paths without a provider-wide inventory.
- Add schema version 16 provider-verification state, atomic checkpoint transitions, recovery metrics, and separate provider-checkpoint and backup-safety status reporting.
- Isolate live-test state databases so one test's durable pending work cannot affect later tests.

## Behavior and compatibility

- Existing media and catalog rows are retained when provider lookup is inconclusive.
- Confirmed source deletions remain in catalog history but are excluded from actionable pending and failed totals.
- Local path reconciliation never overwrites conflicting destination bytes and preserves the previous local file.
- Schema version 16 is not readable by older kei versions. Downgrading requires restoring a pre-upgrade state DB backup; downloaded media is unchanged.

## Review notes

Suggested review order:

1. `src/icloud/photos/album.rs` for EOF proof, token capture, and targeted record lookup.
2. `src/download/retry.rs` and `src/state/` for durable retry identity and tombstone semantics.
3. `src/sync_cycle.rs` and `src/sync_loop.rs` for checkpoint and config-reconciliation policy.
4. `src/metrics.rs`, `src/commands/status.rs`, and tests for reporting and operator behavior.

The main safety boundaries remain:

- incomplete provider enumeration cannot advance a checkpoint;
- provider identity and relation writes must be durable before checkpoint advancement;
- transfer failures may advance only after durable retry representation;
- query absence cannot delete catalog state;
- config reconciliation promotes hashes and candidate tokens atomically.

## Tests

- `cargo test -- --test-threads=1` => passed.
- `cargo fmt --check` => passed.
- `cargo clippy --all-targets --all-features -- -D warnings` => passed.
- `just gate` => passed.
- `just full-test` => passed: 16 phases, 12,426 tests counted, 0 failures.
- `cargo run -- status --help` and an isolated schema-16 `cargo run -- status` smoke => passed.
- Live `sync` suite => 42/42 passed.
- Live `state_auth` suite => 17/17 passed.
- Live `import_existing_live` suite => 17/18 passed; the remaining attempt was stopped after Apple returned an account-lock response.
