### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kei"
 version = "0.22.13-dev"
-edition = "2021"
+edition = "2024"
 # src/download/paths.rs calls str::floor_char_boundary, stabilized in 1.91.
 # Cargo refuses to build on older toolchains with a clean error naming this
 # version; the clippy::incompatible_msrv lint below catches regressions on PR.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kei-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 # Fuzz harnesses depend on the kei lib through the `__fuzz_internals`
 # feature, which exposes a `kei::__fuzz` module of `pub fn` wrappers around

--- a/scripts/full-test/run_release_regression_smoke.sh
+++ b/scripts/full-test/run_release_regression_smoke.sh
@@ -2,8 +2,8 @@
 # Offline v0.20 regression smoke.
 #
 # This is the quick patch-release gate for the May 27, 2026 regression set:
-# token reuse, retry-state fallback, on-disk pending adoption, tolerated
-# pagination shortfalls, permissive valid-media validation, inactive pass
+# token reuse, targeted retry, on-disk pending adoption, pagination-shortfall
+# diagnostics, permissive valid-media validation, inactive pass
 # templates, and dotted config paths.
 
 set -euo pipefail
@@ -14,30 +14,40 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
 }
 cd "$repo_root"
 
-echo "--- stored token decisions stay incremental ---"
-cargo test --lib sync_cycle::tests::determine_sync_mode_two_normal_syncs_reuse_stored_token
+available_tests=$(cargo test --lib -- --list)
+run_lib_test() {
+  local test_name="${1:?test name required}"
+  if ! grep -Fqx "$test_name: test" <<<"$available_tests"; then
+    echo "run_release_regression_smoke: test not found: $test_name" >&2
+    exit 1
+  fi
+  cargo test --lib "$test_name" -- --exact
+}
 
-echo "--- failed rows force full enumeration before normal sync ---"
-cargo test --lib download::tests::incremental_with_failed_rows_falls_back_to_full_enumeration
+echo "--- stored token decisions stay incremental ---"
+run_lib_test sync_cycle::tests::determine_sync_mode_two_normal_syncs_reuse_stored_token
+
+echo "--- failed rows use targeted retry without full enumeration ---"
+run_lib_test download::tests::incremental_with_failed_rows_uses_targeted_retry_not_full_enumeration
 
 echo "--- pending rows with existing files are adopted ---"
-cargo test --lib download::pipeline::tests::producer_adopts_pending_on_disk_skip_as_downloaded
+run_lib_test download::pipeline::tests::producer_adopts_pending_on_disk_skip_as_downloaded
 
-echo "--- tolerated pagination shortfalls remain warnings ---"
-cargo test --lib download::tests::classify_pagination_shortfall_issue_498_fixture_is_tolerated
-cargo test --lib download::tests::classify_pagination_shortfall_billimek_sharedsync_fixture_is_tolerated
+echo "--- pagination shortfall fixtures remain diagnostic warnings ---"
+run_lib_test download::tests::classify_pagination_shortfall_issue_498_fixture_reports_shortfall
+run_lib_test download::tests::classify_pagination_shortfall_billimek_sharedsync_fixture_reports_shortfall
 
 echo "--- valid JPEG bytes under .PNG are saved ---"
-cargo test --lib download::file::tests::attempt_download_promotes_valid_jpeg_with_png_extension_issue_507
+run_lib_test download::file::tests::attempt_download_promotes_valid_jpeg_with_png_extension_issue_507
 
 echo "--- inactive album and smart-folder templates do not force full enumeration ---"
-cargo test --lib download::tests::unfiled_only_incremental_ignores_inactive_album_path_templates
+run_lib_test download::tests::unfiled_only_incremental_ignores_inactive_album_path_templates
 
 echo "--- dotted config path handling ---"
-cargo test --lib config::tests::test_expand_tilde_with_injected_home_uses_path_join
+run_lib_test config::tests::test_expand_tilde_with_injected_home_uses_path_join
 host=$(rustc -vV | awk '/^host:/ { print $2 }')
 if [[ "$host" == *windows* ]]; then
-  cargo test --lib config::tests::test_expand_tilde_windows_home_keeps_separator_before_dot_config
+  run_lib_test config::tests::test_expand_tilde_windows_home_keeps_separator_before_dot_config
 else
   echo "skipping cfg(windows) dotted path smoke on host $host"
 fi

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -44,7 +44,9 @@ pub enum AuthError {
     )]
     TerminalAppleAuth { code: String, message: String },
 
-    #[error("Two-factor authentication is required. Run `kei login get-code`, then `kei login submit-code <CODE>`.")]
+    #[error(
+        "Two-factor authentication is required. Run `kei login get-code`, then `kei login submit-code <CODE>`."
+    )]
     TwoFactorRequired,
 
     /// The Apple ID has FIDO/WebAuthn hardware security keys registered.
@@ -201,16 +203,20 @@ mod tests {
             !AuthError::terminal_apple_auth(APPLE_ACCOUNT_LOCKED_CODE, "locked")
                 .is_two_factor_required()
         );
-        assert!(!AuthError::ApiError {
-            code: 401,
-            message: "test".into()
-        }
-        .is_two_factor_required());
-        assert!(!AuthError::ServiceError {
-            code: "test".into(),
-            message: "test".into()
-        }
-        .is_two_factor_required());
+        assert!(
+            !AuthError::ApiError {
+                code: 401,
+                message: "test".into()
+            }
+            .is_two_factor_required()
+        );
+        assert!(
+            !AuthError::ServiceError {
+                code: "test".into(),
+                message: "test".into()
+            }
+            .is_two_factor_required()
+        );
     }
 
     #[test]
@@ -234,11 +240,13 @@ mod tests {
     fn other_variants_are_not_terminal_apple_auth() {
         assert!(!AuthError::FailedLogin("test".into()).is_terminal_apple_auth());
         assert!(!AuthError::TwoFactorRequired.is_terminal_apple_auth());
-        assert!(!AuthError::ApiError {
-            code: 403,
-            message: "forbidden".into()
-        }
-        .is_terminal_apple_auth());
+        assert!(
+            !AuthError::ApiError {
+                code: 403,
+                message: "forbidden".into()
+            }
+            .is_terminal_apple_auth()
+        );
     }
 
     #[test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -31,9 +31,9 @@ use uuid::Uuid;
 use self::endpoints::Endpoints;
 use self::error::AuthError;
 pub use self::responses::AccountLoginResponse;
-pub(crate) use self::session::strip_session_routing_state;
 use self::session::Session;
 pub use self::session::SharedSession;
+pub(crate) use self::session::strip_session_routing_state;
 
 /// Path to the session data file for a given user, without needing a `Session`.
 pub fn session_file_path(cookie_dir: &Path, apple_id: &str) -> PathBuf {
@@ -193,18 +193,18 @@ async fn authenticate_inner(
     // Fast path: if we validated recently, skip the Apple /validate call entirely.
     // The cookies and session token are still in the session file; if they've
     // actually gone stale, the first CloudKit call will 421 and trigger re-auth.
-    if has_session_token && code.is_none() {
-        if let Some(cached) = session
+    if has_session_token
+        && code.is_none()
+        && let Some(cached) = session
             .load_validation_cache(responses::VALIDATION_CACHE_GRACE_SECS)
             .await
-        {
-            tracing::debug!("Session validated recently, skipping /validate call");
-            return Ok(AuthResult {
-                session,
-                data: cached,
-                requires_2fa: false,
-            });
-        }
+    {
+        tracing::debug!("Session validated recently, skipping /validate call");
+        return Ok(AuthResult {
+            session,
+            data: cached,
+            requires_2fa: false,
+        });
     }
 
     // The 421-recovery flow below is bounded. Each branch takes at most one
@@ -616,15 +616,15 @@ pub async fn validate_session(session: &mut Session, domain: &str) -> Result<boo
                         .and_then(|ws| ws.ckdatabasews.as_ref())
                         .map(|ep| ep.url.as_str());
                     let stored_url = session.session_data.get("ckdatabasews_url");
-                    if let (Some(fresh), Some(stored)) = (fresh_url, stored_url) {
-                        if fresh != stored {
-                            tracing::info!(
-                                old_url = %stored,
-                                new_url = %fresh,
-                                "CloudKit partition changed, forcing full re-auth"
-                            );
-                            return Ok(false);
-                        }
+                    if let (Some(fresh), Some(stored)) = (fresh_url, stored_url)
+                        && fresh != stored
+                    {
+                        tracing::info!(
+                            old_url = %stored,
+                            new_url = %fresh,
+                            "CloudKit partition changed, forcing full re-auth"
+                        );
+                        return Ok(false);
                     }
                     session.save_validation_cache(&d).await;
                     Ok(true)
@@ -663,8 +663,8 @@ mod tests {
     use crate::auth::responses::{AccountLoginResponse, DsInfo};
     use secrecy::SecretString;
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     };
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -59,8 +59,8 @@ pub fn sanitize_username(username: &str) -> String {
             (h ^ u64::from(b)).wrapping_mul(0x0100_0000_01b3)
         });
         let prefix_len = MAX_SANITIZED_USERNAME_LEN - 17; // room for "_" + 16 hex digits
-                                                          // Find the last char boundary at or before prefix_len to avoid
-                                                          // panicking on multi-byte UTF-8 (e.g. CJK usernames).
+        // Find the last char boundary at or before prefix_len to avoid
+        // panicking on multi-byte UTF-8 (e.g. CJK usernames).
         let prefix_end = sanitized[..prefix_len]
             .char_indices()
             .last()
@@ -94,12 +94,12 @@ fn broad_cookie_domain(host: Option<&str>) -> Option<&str> {
 /// Check if a Set-Cookie header string represents an expired cookie.
 /// Parses the `cookie` crate's `Cookie::parse()` to extract `Expires`.
 fn is_cookie_expired(cookie_str: &str, now: &chrono::DateTime<chrono::Utc>) -> bool {
-    if let Ok(parsed) = cookie::Cookie::parse(cookie_str) {
-        if let Some(expires) = parsed.expires_datetime() {
-            let expires_utc =
-                chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(expires));
-            return expires_utc < *now;
-        }
+    if let Ok(parsed) = cookie::Cookie::parse(cookie_str)
+        && let Some(expires) = parsed.expires_datetime()
+    {
+        let expires_utc =
+            chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(expires));
+        return expires_utc < *now;
     }
     false
 }
@@ -608,14 +608,14 @@ impl Session {
         let headers = response.headers();
         let mut session_changed = false;
         for &(header_name, session_key) in HEADER_DATA {
-            if let Some(val) = headers.get(header_name) {
-                if let Ok(val_str) = val.to_str() {
-                    let existing = self.session_data.get(session_key);
-                    if existing.map(std::string::String::as_str) != Some(val_str) {
-                        self.session_data
-                            .insert(session_key.to_string(), val_str.to_string());
-                        session_changed = true;
-                    }
+            if let Some(val) = headers.get(header_name)
+                && let Ok(val_str) = val.to_str()
+            {
+                let existing = self.session_data.get(session_key);
+                if existing.map(std::string::String::as_str) != Some(val_str) {
+                    self.session_data
+                        .insert(session_key.to_string(), val_str.to_string());
+                    session_changed = true;
                 }
             }
         }
@@ -699,14 +699,12 @@ impl Session {
 
         // Check if the cookie file already has the same content to avoid
         // redundant disk writes during high-frequency API calls.
-        if cookiejar_path.exists() {
-            if let Ok(contents) = fs::read_to_string(&cookiejar_path).await {
-                if let Ok(existing) = serde_json::from_str::<Vec<CookieEntry>>(&contents) {
-                    if existing == entries {
-                        return Ok(());
-                    }
-                }
-            }
+        if cookiejar_path.exists()
+            && let Ok(contents) = fs::read_to_string(&cookiejar_path).await
+            && let Ok(existing) = serde_json::from_str::<Vec<CookieEntry>>(&contents)
+            && existing == entries
+        {
+            return Ok(());
         }
 
         atomic_write(
@@ -1067,12 +1065,16 @@ mod tests {
         let contents = std::fs::read_to_string(&cookie_path).unwrap();
         let entries: Vec<CookieEntry> = serde_json::from_str(&contents).unwrap();
         assert!(entries.len() >= 2);
-        assert!(entries
-            .iter()
-            .any(|e| e.cookie.contains("X-APPLE-WEBAUTH-TOKEN")));
-        assert!(entries
-            .iter()
-            .any(|e| e.cookie.contains("X-APPLE-DS-WEB-SESSION-TOKEN")));
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.cookie.contains("X-APPLE-WEBAUTH-TOKEN"))
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.cookie.contains("X-APPLE-DS-WEB-SESSION-TOKEN"))
+        );
 
         // Drop the session and create a new one — cookies should be loaded back
         drop(session);

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use num_bigint::BigUint;
 use rand::RngExt;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -9,12 +9,12 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::Duration;
 
+use super::AUTH_RETRY_CONFIG;
 use super::endpoints::Endpoints;
 use super::responses::AppleServiceError;
 use super::session::Session;
 use super::twofa::{check_rscd_from_headers, rscd_service_error};
-use super::AUTH_RETRY_CONFIG;
-use crate::auth::error::{is_terminal_apple_auth_code, AuthError};
+use crate::auth::error::{AuthError, is_terminal_apple_auth_code};
 use crate::retry::parse_retry_after_header;
 
 /// Buffered HTTP response for SRP authentication steps.
@@ -317,23 +317,23 @@ pub(crate) fn get_auth_headers(
         HeaderValue::from_static(APPLE_WIDGET_KEY),
     );
 
-    if let Some(scnt) = session_data.get("scnt") {
-        if let Ok(v) = HeaderValue::from_str(scnt) {
-            headers.insert("scnt", v);
-        }
+    if let Some(scnt) = session_data.get("scnt")
+        && let Ok(v) = HeaderValue::from_str(scnt)
+    {
+        headers.insert("scnt", v);
     }
-    if let Some(session_id) = session_data.get("session_id") {
-        if let Ok(v) = HeaderValue::from_str(session_id) {
-            headers.insert("X-Apple-ID-Session-Id", v);
-        }
+    if let Some(session_id) = session_data.get("session_id")
+        && let Ok(v) = HeaderValue::from_str(session_id)
+    {
+        headers.insert("X-Apple-ID-Session-Id", v);
     }
 
     if let Some(ovr) = overrides {
         for &(key, val) in ovr {
-            if let Ok(v) = HeaderValue::from_str(val) {
-                if let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
-                    headers.insert(name, v);
-                }
+            if let Ok(v) = HeaderValue::from_str(val)
+                && let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes())
+            {
+                headers.insert(name, v);
             }
         }
     }
@@ -712,10 +712,9 @@ where
     let mut last_transient: Option<SrpResponse> = None;
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 0..total_attempts {
-        let headers = if let Some(h) = prebuilt_headers.take() {
-            h
-        } else {
-            rebuild_headers(transport.session_data())?
+        let headers = match prebuilt_headers.take() {
+            Some(h) => h,
+            None => rebuild_headers(transport.session_data())?,
         };
         match transport.post(url, Some(body), Some(headers)).await {
             Ok(resp) => {
@@ -1093,9 +1092,10 @@ mod tests {
         let err = run_srp(vec![response(200, b"not json".to_vec())])
             .await
             .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Apple login returned an unexpected response during SRP setup"));
+        assert!(
+            err.to_string()
+                .contains("Apple login returned an unexpected response during SRP setup")
+        );
     }
 
     #[tokio::test]

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -2,17 +2,17 @@ use std::io::{self, Write};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use reqwest::header::HeaderMap;
 use reqwest::Response;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 
+use super::AUTH_RETRY_CONFIG;
 use super::endpoints::Endpoints;
 use super::session::Session;
 use super::srp::get_auth_headers;
-use super::AUTH_RETRY_CONFIG;
 use crate::auth::error::AuthError;
 use crate::auth::responses::AccountLoginResponse;
-use crate::retry::{parse_retry_after_header, RetryConfig};
+use crate::retry::{RetryConfig, parse_retry_after_header};
 
 const TWO_FA_CODE_LENGTH: usize = 6;
 
@@ -86,20 +86,20 @@ fn check_apple_service_errors(body: &Value) -> Result<(), AuthError> {
         .or_else(|| body.get("serviceErrors"))
         .and_then(Value::as_array);
 
-    if let Some(errors) = errors {
-        if let Some(first) = errors.first() {
-            let code = first
-                .get("code")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            let raw_message = first
-                .get("message")
-                .and_then(Value::as_str)
-                .filter(|m| !m.is_empty())
-                .or_else(|| first.get("title").and_then(Value::as_str))
-                .unwrap_or("Apple reported an error");
-            return Err(AuthError::service_error(code, raw_message));
-        }
+    if let Some(errors) = errors
+        && let Some(first) = errors.first()
+    {
+        let code = first
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let raw_message = first
+            .get("message")
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+            .or_else(|| first.get("title").and_then(Value::as_str))
+            .unwrap_or("Apple reported an error");
+        return Err(AuthError::service_error(code, raw_message));
     }
 
     if has_error {
@@ -364,11 +364,11 @@ async fn submit_2fa_code_inner(
     }
 
     // Apple can return HTTP 200 with error indicators in the body
-    if let Ok(body) = serde_json::from_str::<Value>(&text) {
-        if let Err(e) = check_apple_service_errors(&body) {
-            tracing::error!(error = %e, "2FA verification returned service error");
-            return Ok(false);
-        }
+    if let Ok(body) = serde_json::from_str::<Value>(&text)
+        && let Err(e) = check_apple_service_errors(&body)
+    {
+        tracing::error!(error = %e, "2FA verification returned service error");
+        return Ok(false);
     }
 
     tracing::debug!("Code verification successful");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -828,10 +828,10 @@ impl Command {
     /// the active command carries.
     pub fn inject_env_password(&mut self, env_password: Option<String>) {
         let Some(pw) = env_password else { return };
-        if let Some(args) = self.password_args_mut() {
-            if args.password.is_none() {
-                args.password = Some(pw);
-            }
+        if let Some(args) = self.password_args_mut()
+            && args.password.is_none()
+        {
+            args.password = Some(pw);
         }
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -13,10 +13,10 @@ use crate::cli;
 use crate::config;
 use crate::download;
 use crate::download::filter::{
-    expected_paths_for, is_asset_filtered, ExpectedAssetPath, PathDerivationConfig,
-    PathDerivationSource,
+    ExpectedAssetPath, PathDerivationConfig, PathDerivationSource, expected_paths_for,
+    is_asset_filtered,
 };
-use crate::download::paths::{normalize_ampm, DirCache};
+use crate::download::paths::{DirCache, normalize_ampm};
 use crate::icloud::photos::PhotoAsset;
 use crate::retry;
 use crate::state;
@@ -412,29 +412,28 @@ fn import_match_candidates(
         fname, asset_id,
     )));
 
-    if candidate.version_size.is_live_photo_motion() {
-        if let Some(primary) = primary_expected_path(all_expected) {
-            if let Some(primary_fname) = primary.path.file_name().and_then(|f| f.to_str()) {
-                let primary_collision_filenames = [
-                    download::paths::add_dedup_suffix(primary_fname, primary.size),
-                    download::paths::insert_asset_identity_suffix(primary_fname, asset_id),
-                ];
-                for primary_filename in primary_collision_filenames {
-                    let mov_filename = match path_config.live_photo_mov_filename_policy() {
-                        LivePhotoMovFilenamePolicy::Suffix => {
-                            download::paths::live_photo_mov_path_suffix(&primary_filename)
-                        }
-                        LivePhotoMovFilenamePolicy::Original => {
-                            download::paths::live_photo_mov_path_original(&primary_filename)
-                        }
-                    };
-                    candidates.push(parent.join(&mov_filename));
-                    candidates.push(parent.join(download::paths::insert_asset_identity_suffix(
-                        &mov_filename,
-                        asset_id,
-                    )));
+    if candidate.version_size.is_live_photo_motion()
+        && let Some(primary) = primary_expected_path(all_expected)
+        && let Some(primary_fname) = primary.path.file_name().and_then(|f| f.to_str())
+    {
+        let primary_collision_filenames = [
+            download::paths::add_dedup_suffix(primary_fname, primary.size),
+            download::paths::insert_asset_identity_suffix(primary_fname, asset_id),
+        ];
+        for primary_filename in primary_collision_filenames {
+            let mov_filename = match path_config.live_photo_mov_filename_policy() {
+                LivePhotoMovFilenamePolicy::Suffix => {
+                    download::paths::live_photo_mov_path_suffix(&primary_filename)
                 }
-            }
+                LivePhotoMovFilenamePolicy::Original => {
+                    download::paths::live_photo_mov_path_original(&primary_filename)
+                }
+            };
+            candidates.push(parent.join(&mov_filename));
+            candidates.push(parent.join(download::paths::insert_asset_identity_suffix(
+                &mov_filename,
+                asset_id,
+            )));
         }
     }
 
@@ -452,10 +451,10 @@ async fn match_exact_or_ampm_variant(
     expected_size: u64,
     dir_cache: &mut DirCache,
 ) -> Option<(PathBuf, std::fs::Metadata)> {
-    if let Ok(m) = tokio::fs::metadata(path).await {
-        if m.len() == expected_size {
-            return Some((path.to_path_buf(), m));
-        }
+    if let Ok(m) = tokio::fs::metadata(path).await
+        && m.len() == expected_size
+    {
+        return Some((path.to_path_buf(), m));
     }
 
     let needs_probe = path
@@ -945,7 +944,7 @@ pub(crate) async fn run_import_existing(
         let empty_zones: Vec<&str> = libraries
             .iter()
             .zip(&counts)
-            .filter(|(_, &count)| count == 0)
+            .filter(|&(_, &count)| count == 0)
             .map(|(library, _)| library.zone_name())
             .collect();
         validate_non_empty_libraries(&empty_zones, prior_db_total)?;
@@ -1043,7 +1042,7 @@ fn build_import_selection(
     toml_filters: Option<&config::TomlFilters>,
     libraries: &crate::selection::LibrarySelector,
 ) -> anyhow::Result<crate::selection::Selection> {
-    use crate::selection::{parse_album_selector, parse_smart_folder_selector, Selection};
+    use crate::selection::{Selection, parse_album_selector, parse_smart_folder_selector};
 
     let raw_albums: Vec<String> = toml_filters
         .and_then(|f| f.albums.as_ref())
@@ -1335,14 +1334,14 @@ mod wiremock_tests {
     use std::sync::Arc;
 
     use rustc_hash::FxHashSet;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use tempfile::TempDir;
     use wiremock::matchers::{header, method as wm_method, path as wm_path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        import_assets, verify_strict_prefix, ImportRunOptions, ImportStats, StrictImportDecision,
-        StrictImportVerifier,
+        ImportRunOptions, ImportStats, StrictImportDecision, StrictImportVerifier, import_assets,
+        verify_strict_prefix,
     };
     use crate::download::filter::expected_paths_for;
     use crate::download::paths::DirCache;
@@ -2077,12 +2076,14 @@ mod wiremock_tests {
 
         assert_eq!(stats.matched, 2);
         let rows = all_downloaded(db.as_ref()).await;
-        assert!(rows
-            .iter()
-            .any(|r| r.filename.as_ref() == "IMG_0600-3000.HEIC"));
-        assert!(rows
-            .iter()
-            .any(|r| r.filename.as_ref() == "IMG_0600-3000_HEVC-LIVE6-2.MOV"));
+        assert!(
+            rows.iter()
+                .any(|r| r.filename.as_ref() == "IMG_0600-3000.HEIC")
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.filename.as_ref() == "IMG_0600-3000_HEVC-LIVE6-2.MOV")
+        );
     }
 
     #[tokio::test]
@@ -2134,12 +2135,14 @@ mod wiremock_tests {
 
         assert_eq!(stats.matched, 2);
         let rows = all_downloaded(db.as_ref()).await;
-        assert!(rows
-            .iter()
-            .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6.HEIC"));
-        assert!(rows
-            .iter()
-            .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6_HEVC-LIVE_SLASH6-22.MOV"));
+        assert!(
+            rows.iter()
+                .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6.HEIC")
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.filename.as_ref() == "IMG_0610-LIVE_SLASH6_HEVC-LIVE_SLASH6-22.MOV")
+        );
     }
 
     #[tokio::test]
@@ -3872,8 +3875,8 @@ mod heartbeat_tests {
     //! end-to-end tests live in `wiremock_tests` because they need the
     //! full wiremock + on-disk staging setup; this module covers the
     //! snapshot + guard behaviour in isolation.
-    use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     /// `HeartbeatState::snapshot` must mirror the live atomics so the
     /// emitted log line reflects whatever the scan loop has counted up

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -22,7 +22,9 @@ pub(crate) async fn run_list(
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
     if username.is_empty() {
-        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username before listing iCloud Photos.");
+        anyhow::bail!(
+            "Set your iCloud username with ICLOUD_USERNAME or [auth].username before listing iCloud Photos."
+        );
     }
 
     let password_provider =

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,10 +21,10 @@ pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
 pub(crate) use reset::{run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
+    AlbumPass, AlbumPlan, CollectionContext, MAX_REAUTH_ATTEMPTS, PassKind, PassScope,
     attempt_reauth, build_collection_context, collection_libraries, init_photos_service,
     pass_scope_for_zone, resolve_cross_zone_libraries_for_album_hydration, resolve_libraries,
-    resolve_passes_for_scope, wait_and_retry_2fa, zone_name_set, AlbumPass, AlbumPlan,
-    CollectionContext, PassKind, PassScope, MAX_REAUTH_ATTEMPTS,
+    resolve_passes_for_scope, wait_and_retry_2fa, zone_name_set,
 };
 pub(crate) use status::run_status;
 pub(crate) use verify::run_verify;

--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -29,7 +29,7 @@ use crate::config;
 use crate::state;
 use crate::state::{ReportStateStore, VersionSizeKey};
 
-use super::{print_truncation_tail, LISTING_CAP};
+use super::{LISTING_CAP, print_truncation_tail};
 
 /// Stable sentinels written to `assets.last_error` so monitoring tools can
 /// key on the reason a row flipped from downloaded back to failed.
@@ -321,7 +321,9 @@ pub(crate) async fn run_reconcile(
     }
 
     if mark_errors > 0 {
-        anyhow::bail!("Reconcile found {mark_errors} drifted files that could not be marked failed in the state database.");
+        anyhow::bail!(
+            "Reconcile found {mark_errors} drifted files that could not be marked failed in the state database."
+        );
     }
 
     Ok(())

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -414,10 +414,10 @@ where
         // Invalidate the validation cache so authenticate() actually checks
         // with Apple instead of returning stale cached data from before 2FA.
         let cache_path = auth::validation_cache_file_path(cookie_dir, username);
-        if cache_path.exists() {
-            if let Err(e) = tokio::fs::remove_file(&cache_path).await {
-                tracing::debug!(error = %e, "Could not remove validation cache");
-            }
+        if cache_path.exists()
+            && let Err(e) = tokio::fs::remove_file(&cache_path).await
+        {
+            tracing::debug!(error = %e, "Could not remove validation cache");
         }
 
         for attempt in 0..3 {
@@ -1372,8 +1372,8 @@ mod tests {
     use crate::test_helpers::MockPhotosSession;
     use std::collections::BTreeSet;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn short_2fa_wait_config(timeout: Duration) -> TwoFaWaitConfig {
         TwoFaWaitConfig {
@@ -2669,14 +2669,18 @@ libraries = ["shared"]
                 .collect();
             assert_eq!(primary_smart_names, vec![smart_name.to_string()]);
             assert_eq!(shared_smart_names, vec![smart_name.to_string()]);
-            assert!(primary_plan
-                .passes
-                .iter()
-                .any(|pass| pass.kind == PassKind::Unfiled));
-            assert!(!shared_plan
-                .passes
-                .iter()
-                .any(|pass| pass.kind == PassKind::Unfiled));
+            assert!(
+                primary_plan
+                    .passes
+                    .iter()
+                    .any(|pass| pass.kind == PassKind::Unfiled)
+            );
+            assert!(
+                !shared_plan
+                    .passes
+                    .iter()
+                    .any(|pass| pass.kind == PassKind::Unfiled)
+            );
         }
     }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -9,7 +9,7 @@ use crate::service::status::{render_oneline, service_state};
 use crate::state;
 use crate::state::AssetRecord;
 
-use super::{print_truncation_tail, LISTING_CAP};
+use super::{LISTING_CAP, print_truncation_tail};
 
 /// Run the status command.
 pub(crate) async fn run_status(
@@ -74,13 +74,13 @@ pub(crate) async fn run_status(
             started.format("%Y-%m-%d %H:%M:%S UTC")
         );
     }
-    if summary.active_sync_started.is_none() {
-        if let Some(completed) = &summary.last_sync_completed {
-            println!(
-                "Last sync completed: {}",
-                completed.format("%Y-%m-%d %H:%M:%S UTC")
-            );
-        }
+    if summary.active_sync_started.is_none()
+        && let Some(completed) = &summary.last_sync_completed
+    {
+        println!(
+            "Last sync completed: {}",
+            completed.format("%Y-%m-%d %H:%M:%S UTC")
+        );
     }
     if !summary.active_enumeration_zones.is_empty() {
         println!(
@@ -158,10 +158,9 @@ fn backup_status_line(summary: &state::types::SyncSummary) -> String {
         .last_sync_status
         .as_deref()
         .is_some_and(|status| status != "complete")
+        && let Some(status) = &summary.last_sync_status
     {
-        if let Some(status) = &summary.last_sync_status {
-            reasons.push(format!("last sync status is {status}"));
-        }
+        reasons.push(format!("last sync status is {status}"));
     }
     if summary.last_sync_completed.is_none() {
         reasons.push("last sync did not record completion".to_string());
@@ -219,11 +218,7 @@ fn count_phrase(count: u64, singular: &str) -> String {
 }
 
 const fn remain_verb(count: u64) -> &'static str {
-    if count == 1 {
-        "remains"
-    } else {
-        "remain"
-    }
+    if count == 1 { "remains" } else { "remain" }
 }
 
 /// Prints the `Service:` line at the top of `kei status`. Errors from

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -10,7 +10,7 @@ use crate::config;
 use crate::download;
 use crate::state;
 
-use super::{print_truncation_tail, LISTING_CAP};
+use super::{LISTING_CAP, print_truncation_tail};
 
 /// Run the verify command.
 pub(crate) async fn run_verify(
@@ -157,12 +157,14 @@ mod tests {
         let file_path = dir.path().join("local_mismatch.bin");
         std::fs::write(&file_path, b"hello world").unwrap();
 
-        assert!(!verify_local_checksum(
-            &file_path,
-            "0000000000000000000000000000000000000000000000000000000000000000"
-        )
-        .await
-        .unwrap());
+        assert!(
+            !verify_local_checksum(
+                &file_path,
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            )
+            .await
+            .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -690,10 +690,10 @@ fn expand_tilde_with_home(path: &str, home: &Path) -> PathBuf {
 }
 
 pub(crate) fn expand_tilde(path: &str) -> PathBuf {
-    if path.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return expand_tilde_with_home(path, &home);
-        }
+    if path.starts_with("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return expand_tilde_with_home(path, &home);
     }
     PathBuf::from(path)
 }
@@ -1389,14 +1389,14 @@ impl Config {
             .map(parse_date_or_interval)
             .transpose()?;
 
-        if let (Some(before), Some(after)) = (&skip_created_before, &skip_created_after) {
-            if before >= after {
-                tracing::warn!(
-                    before = %before.format("%Y-%m-%d"),
-                    after = %after.format("%Y-%m-%d"),
-                    "skip-created-before >= skip-created-after, no assets can match",
-                );
-            }
+        if let (Some(before), Some(after)) = (&skip_created_before, &skip_created_after)
+            && before >= after
+        {
+            tracing::warn!(
+                before = %before.format("%Y-%m-%d"),
+                after = %after.format("%Y-%m-%d"),
+                "skip-created-before >= skip-created-after, no assets can match",
+            );
         }
 
         let watch_with_interval = overrides
@@ -1980,24 +1980,23 @@ pub(crate) fn persist_first_run_config(
 /// - ISO date: `"2025-01-02"` (midnight local time)
 /// - ISO datetime: `"2025-01-02T14:30:00"` (local time)
 pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>> {
-    if let Some(days_str) = s.strip_suffix('d') {
-        if let Ok(days) = days_str.parse::<u64>() {
-            let days = i64::try_from(days)
-                .map_err(|_e| anyhow::anyhow!("Date interval '{s}' is too large"))?;
-            return Ok(Local::now() - chrono::Duration::days(days));
-        }
+    if let Some(days_str) = s.strip_suffix('d')
+        && let Ok(days) = days_str.parse::<u64>()
+    {
+        let days = i64::try_from(days)
+            .map_err(|_e| anyhow::anyhow!("Date interval '{s}' is too large"))?;
+        return Ok(Local::now() - chrono::Duration::days(days));
     }
-    if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        if let Some(naive_dt) = date.and_hms_opt(0, 0, 0) {
-            if let Some(dt) = naive_dt.and_local_timezone(Local).single() {
-                return Ok(dt);
-            }
-        }
+    if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        && let Some(naive_dt) = date.and_hms_opt(0, 0, 0)
+        && let Some(dt) = naive_dt.and_local_timezone(Local).single()
+    {
+        return Ok(dt);
     }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
-        if let Some(local) = dt.and_local_timezone(Local).single() {
-            return Ok(local);
-        }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+        && let Some(local) = dt.and_local_timezone(Local).single()
+    {
+        return Ok(local);
     }
     anyhow::bail!(
         "Could not parse '{s}' as a date. Use a date like 2025-01-02, a datetime like 2025-01-02T14:30:00, or an interval like 20d."
@@ -6205,9 +6204,10 @@ mod tests {
         let mut sync = default_sync();
         sync.config_overrides.filename_exclude = vec!["[invalid".to_string()];
         let err = Config::build(&default_globals(), &default_password(), sync, None).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Invalid --filename-exclude pattern"));
+        assert!(
+            err.to_string()
+                .contains("Invalid --filename-exclude pattern")
+        );
     }
 
     #[test]
@@ -6511,18 +6511,20 @@ mod tests {
         .unwrap();
         let toml = cfg.to_toml();
         // Default value is suppressed on round-trip so config dumps stay clean.
-        assert!(toml
-            .download
-            .as_ref()
-            .unwrap()
-            .folder_structure_albums
-            .is_none());
-        assert!(toml
-            .download
-            .as_ref()
-            .unwrap()
-            .folder_structure_smart_folders
-            .is_none());
+        assert!(
+            toml.download
+                .as_ref()
+                .unwrap()
+                .folder_structure_albums
+                .is_none()
+        );
+        assert!(
+            toml.download
+                .as_ref()
+                .unwrap()
+                .folder_structure_smart_folders
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/download/error.rs
+++ b/src/download/error.rs
@@ -20,7 +20,9 @@ pub(crate) enum DownloadError {
     #[error("Could not write to disk: {0}")]
     Disk(Box<std::io::Error>),
 
-    #[error("Download failed for {path} after {bytes_written} bytes (HTTP {status}, content length {content_length:?}): {source}")]
+    #[error(
+        "Download failed for {path} after {bytes_written} bytes (HTTP {status}, content length {content_length:?}): {source}"
+    )]
     Http {
         source: Box<dyn std::error::Error + Send + Sync>,
         path: Box<str>,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -151,10 +151,10 @@ pub(super) async fn download_file_with_mode<C: DownloadClient>(
     Box::pin(retry::retry_with_backoff_with_mode(
         retry_config,
         |e: &DownloadError| {
-            if e.is_rate_limited() {
-                if let Some(counter) = limits.rate_limit_counter {
-                    counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
+            if e.is_rate_limited()
+                && let Some(counter) = limits.rate_limit_counter
+            {
+                counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
             if e.is_retryable() {
                 RetryAction::Retry
@@ -291,14 +291,14 @@ async fn attempt_download<C: DownloadClient>(
     // writing to disk. Delete any stale .part file so the next successful
     // attempt starts fresh rather than appending to data from a previous
     // (possibly different) response.
-    if let Some(ct) = &response.content_type {
-        if let Some(reason) = rejecting_content_type_reason(ct) {
-            crate::fs_util::log_remove_async(part_path).await;
-            return Err(DownloadError::InvalidContent {
-                path: path_str.into(),
-                reason: format!("server returned {reason} content-type: {ct}").into(),
-            });
-        }
+    if let Some(ct) = &response.content_type
+        && let Some(reason) = rejecting_content_type_reason(ct)
+    {
+        crate::fs_util::log_remove_async(part_path).await;
+        return Err(DownloadError::InvalidContent {
+            path: path_str.into(),
+            reason: format!("server returned {reason} content-type: {ct}").into(),
+        });
     }
 
     let content_length = response.content_length;
@@ -312,25 +312,26 @@ async fn attempt_download<C: DownloadClient>(
     // reconcile with the API-reported size, the resource on the server has
     // likely been rotated since we wrote the .part. Discard and restart
     // cleanly rather than appending new bytes to a stale prefix.
-    if status == 206 && resume_offset > 0 {
-        if let (Some(cl), Some(expected)) = (content_length, expected_size) {
-            let server_total = resume_offset.saturating_add(cl);
-            if server_total != expected {
-                tracing::warn!(
-                    path = %path_str,
-                    resume_offset,
-                    server_remaining = cl,
-                    server_total,
-                    expected,
-                    "Resume bytes inconsistent with API-reported size; discarding .part and restarting"
-                );
-                crate::fs_util::log_remove_async(part_path).await;
-                return Err(DownloadError::ContentLengthMismatch {
-                    path: path_str.into(),
-                    expected,
-                    received: server_total,
-                });
-            }
+    if status == 206
+        && resume_offset > 0
+        && let (Some(cl), Some(expected)) = (content_length, expected_size)
+    {
+        let server_total = resume_offset.saturating_add(cl);
+        if server_total != expected {
+            tracing::warn!(
+                path = %path_str,
+                resume_offset,
+                server_remaining = cl,
+                server_total,
+                expected,
+                "Resume bytes inconsistent with API-reported size; discarding .part and restarting"
+            );
+            crate::fs_util::log_remove_async(part_path).await;
+            return Err(DownloadError::ContentLengthMismatch {
+                path: path_str.into(),
+                expected,
+                received: server_total,
+            });
         }
     }
 
@@ -438,15 +439,15 @@ async fn attempt_download<C: DownloadClient>(
 
     // Verify total bytes written matches the API-reported size (if known).
     // Catches truncation when the CDN omits Content-Length (chunked transfer).
-    if let Some(expected) = expected_size {
-        if bytes_written != expected {
-            crate::fs_util::log_remove_async(part_path).await;
-            return Err(DownloadError::ContentLengthMismatch {
-                path: path_str.into(),
-                expected,
-                received: bytes_written,
-            });
-        }
+    if let Some(expected) = expected_size
+        && bytes_written != expected
+    {
+        crate::fs_util::log_remove_async(part_path).await;
+        return Err(DownloadError::ContentLengthMismatch {
+            path: path_str.into(),
+            expected,
+            received: bytes_written,
+        });
     }
 
     // Defense-in-depth: log when neither size indicator is available.
@@ -693,7 +694,7 @@ async fn publish_part_no_replace(
 #[cfg(windows)]
 fn move_file_no_replace_blocking(part_path: &Path, final_path: &Path) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
+    use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW};
 
     fn nul_terminated(path: &Path) -> std::io::Result<Vec<u16>> {
         let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -9,16 +9,16 @@ use std::sync::Arc;
 use chrono::{DateTime, Local};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::icloud::photos::types::AssetVersion;
 use crate::icloud::photos::VersionsMap;
+use crate::icloud::photos::types::AssetVersion;
 use crate::state::{MediaType, VersionSizeKey};
 use crate::types::{
     AssetItemType, AssetVersionSize, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
     RawPolicy,
 };
 
-use super::paths;
 use super::DownloadConfig;
+use super::paths;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct MalformedTaskResource {
@@ -607,7 +607,9 @@ impl<'a> VersionsView<'a> {
         }
     }
 
-    pub(super) fn iter(&self) -> impl Iterator<Item = (AssetVersionSize, &'a AssetVersion)> + 'a {
+    pub(super) fn iter(
+        &self,
+    ) -> impl Iterator<Item = (AssetVersionSize, &'a AssetVersion)> + 'a + use<'a> {
         let swap = self.swap;
         self.versions.iter().enumerate().map(move |(idx, (k, v))| {
             let key = match swap {
@@ -711,31 +713,29 @@ pub(crate) fn is_asset_filtered(
         return Some(FilterReason::LivePhoto);
     }
     let created_utc = asset.created();
-    if let Some(before) = config.skip_created_before() {
-        if created_utc < before {
-            tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (before date range)");
-            return Some(FilterReason::DateRange);
-        }
+    if let Some(before) = config.skip_created_before()
+        && created_utc < before
+    {
+        tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (before date range)");
+        return Some(FilterReason::DateRange);
     }
-    if let Some(after) = config.skip_created_after() {
-        if created_utc > after {
-            tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (after date range)");
-            return Some(FilterReason::DateRange);
-        }
+    if let Some(after) = config.skip_created_after()
+        && created_utc > after
+    {
+        tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (after date range)");
+        return Some(FilterReason::DateRange);
     }
     // Only check filename exclusion when the asset has a real filename.
     // filter_asset_to_tasks separately handles fallback fingerprint filenames.
-    if !config.filename_exclude().is_empty() {
-        if let Some(filename) = asset.filename() {
-            if config
-                .filename_exclude()
-                .iter()
-                .any(|p| p.matches_with(filename, GLOB_CASE_INSENSITIVE))
-            {
-                tracing::debug!(asset_id = %asset.id(), filename, "Skipping (filename_exclude match)");
-                return Some(FilterReason::Filename);
-            }
-        }
+    if !config.filename_exclude().is_empty()
+        && let Some(filename) = asset.filename()
+        && config
+            .filename_exclude()
+            .iter()
+            .any(|p| p.matches_with(filename, GLOB_CASE_INSENSITIVE))
+    {
+        tracing::debug!(asset_id = %asset.id(), filename, "Skipping (filename_exclude match)");
+        return Some(FilterReason::Filename);
     }
     None
 }
@@ -1075,24 +1075,22 @@ pub(super) fn malformed_no_task_resource(
         return None;
     }
 
-    if !matches!(
+    if (!matches!(
         config.live_photo_mode(),
         LivePhotoMode::Skip | LivePhotoMode::VideoOnly
-    ) || !asset.is_live_photo()
+    ) || !asset.is_live_photo())
+        && let Some(resource) = malformed_for_keys(asset, primary_candidate_keys(config))
     {
-        if let Some(resource) = malformed_for_keys(asset, primary_candidate_keys(config)) {
-            return Some(resource);
-        }
+        return Some(resource);
     }
 
     if matches!(
         config.live_photo_mode(),
         LivePhotoMode::Both | LivePhotoMode::VideoOnly
     ) && asset.item_type() == Some(AssetItemType::Image)
+        && let Some(resource) = malformed_for_keys(asset, live_candidate_keys(config))
     {
-        if let Some(resource) = malformed_for_keys(asset, live_candidate_keys(config)) {
-            return Some(resource);
-        }
+        return Some(resource);
     }
 
     None
@@ -1541,11 +1539,7 @@ fn available_collision_path(
     let unavailable =
         ctx.dir_cache.exists(&path) || ctx.claimed_paths.contains_key(normalized.as_str());
     tried.push(normalized.into_boxed_str());
-    if unavailable {
-        None
-    } else {
-        Some(path)
-    }
+    if unavailable { None } else { Some(path) }
 }
 
 /// Resolve the final download path for a single version, handling on-disk
@@ -1900,9 +1894,9 @@ mod tests {
     use chrono::Utc;
     use rustc_hash::FxHashSet;
 
-    use crate::icloud::photos::PhotoAsset;
     #[cfg(unix)]
     use crate::icloud::photos::PRIMARY_ZONE_NAME;
+    use crate::icloud::photos::PhotoAsset;
     #[cfg(unix)]
     use crate::state::SqliteStateDb;
     #[cfg(unix)]
@@ -3325,11 +3319,13 @@ mod tests {
         assert_eq!(tasks[0].size, 2000);
         assert_eq!(&*tasks[1].url, "https://p01.icloud-content.com/live_mov");
         assert_eq!(tasks[1].size, 3000);
-        assert!(tasks[1]
-            .download_path
-            .to_str()
-            .unwrap()
-            .contains("IMG_0001_HEVC.MOV"));
+        assert!(
+            tasks[1]
+                .download_path
+                .to_str()
+                .unwrap()
+                .contains("IMG_0001_HEVC.MOV")
+        );
     }
 
     #[test]
@@ -3349,11 +3345,13 @@ mod tests {
         config.live_photo_mov_filename_policy = crate::types::LivePhotoMovFilenamePolicy::Original;
         let tasks = filter_asset_fresh(&asset, &config);
         assert_eq!(tasks.len(), 2);
-        assert!(tasks[1]
-            .download_path
-            .to_str()
-            .unwrap()
-            .contains("IMG_0001.MOV"));
+        assert!(
+            tasks[1]
+                .download_path
+                .to_str()
+                .unwrap()
+                .contains("IMG_0001.MOV")
+        );
     }
 
     #[test]

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -520,19 +520,18 @@ pub(crate) fn insert_xmp<W: Write>(
         })
         .collect();
 
-    if let Any::Meta(meta) = &mut atoms[meta_idx] {
-        if let Some(iloc) = meta.get_mut::<Iloc>() {
-            remap_file_offsets(iloc, &file_offset_map);
-            // Now fill in the XMP entry's offset (last iloc entry).
-            if let Some(xmp_loc) = iloc
-                .item_locations
-                .iter_mut()
-                .find(|l| l.item_id == new_item_id)
-            {
-                if let Some(extent) = xmp_loc.extents.first_mut() {
-                    extent.offset = xmp_file_offset;
-                }
-            }
+    if let Any::Meta(meta) = &mut atoms[meta_idx]
+        && let Some(iloc) = meta.get_mut::<Iloc>()
+    {
+        remap_file_offsets(iloc, &file_offset_map);
+        // Now fill in the XMP entry's offset (last iloc entry).
+        if let Some(xmp_loc) = iloc
+            .item_locations
+            .iter_mut()
+            .find(|l| l.item_id == new_item_id)
+            && let Some(extent) = xmp_loc.extents.first_mut()
+        {
+            extent.offset = xmp_file_offset;
         }
     }
 
@@ -937,7 +936,7 @@ mod tests {
         dfla.extend_from_slice(&0x18_u32.to_be_bytes()); // size = 24
         dfla.extend_from_slice(b"dfLa");
         dfla.extend_from_slice(&[0; 4]); // version+flags
-                                         // metadata block header: last_block=1, type=4 (vorbis_comment), length=8
+        // metadata block header: last_block=1, type=4 (vorbis_comment), length=8
         dfla.extend_from_slice(&[0x84, 0x00, 0x00, 0x08]);
         // vorbis comment body: vendor_string_length=0, number_of_fields=0xFFFF_FFFF
         dfla.extend_from_slice(&0_u32.to_le_bytes());

--- a/src/download/limiter.rs
+++ b/src/download/limiter.rs
@@ -10,7 +10,7 @@
 //! [`BandwidthLimiter::consume`] before writing each received chunk. When no
 //! limit is configured, downloads hold `None` and skip the call entirely.
 
-use async_speed_limit::{clock::StandardClock, Limiter};
+use async_speed_limit::{Limiter, clock::StandardClock};
 
 #[derive(Clone)]
 pub(crate) struct BandwidthLimiter {

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -26,7 +26,7 @@ use little_exif::metadata::Metadata;
 #[cfg(not(feature = "xmp"))]
 use little_exif::rational::uR64;
 #[cfg(feature = "xmp")]
-use xmp_toolkit::{xmp_ns, OpenFileOptions, XmpFile, XmpMeta, XmpValue};
+use xmp_toolkit::{OpenFileOptions, XmpFile, XmpMeta, XmpValue, xmp_ns};
 
 #[cfg(feature = "xmp")]
 use super::heif;
@@ -522,7 +522,7 @@ fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) 
         Ok(metadata) => metadata,
         Err(e) if e.to_string().contains("No EXIF data found") => Metadata::new(),
         Err(e) => {
-            return Err(e).with_context(|| format!("Could not read EXIF from {}", path.display()))
+            return Err(e).with_context(|| format!("Could not read EXIF from {}", path.display()));
         }
     };
     if let Some(dt) = &write.datetime {
@@ -1657,17 +1657,17 @@ mod tests {
         use mp4_atom::{Any, DecodeMaybe, FourCC, Iinf};
         let mut cursor: &[u8] = bytes;
         while let Ok(Some(atom)) = Any::decode_maybe(&mut cursor) {
-            if let Any::Meta(meta) = atom {
-                if let Some(iinf) = meta.get::<Iinf>() {
-                    return iinf
-                        .item_infos
-                        .iter()
-                        .filter(|e| {
-                            e.item_type == Some(FourCC::new(b"mime"))
-                                && e.content_type.as_deref() == Some("application/rdf+xml")
-                        })
-                        .count();
-                }
+            if let Any::Meta(meta) = atom
+                && let Some(iinf) = meta.get::<Iinf>()
+            {
+                return iinf
+                    .item_infos
+                    .iter()
+                    .filter(|e| {
+                        e.item_type == Some(FourCC::new(b"mime"))
+                            && e.content_type.as_deref() == Some("application/rdf+xml")
+                    })
+                    .count();
             }
         }
         0

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -107,30 +107,31 @@ pub(super) async fn write_download_metadata(
 ) -> MetadataWriteOutcome {
     let mut outcome = MetadataWriteOutcome::default();
 
-    if request.flags.any_embed() && super::metadata::is_embed_writable_path(request.final_path) {
-        if let Some(embed_path) = request.embed_path {
-            outcome.embed_failed = !write_embed_metadata(
-                embed_path,
-                Arc::clone(&request.payload),
-                request.created_local,
-                request.flags,
-                request.temp_suffix,
-            )
-            .await;
-        }
+    if request.flags.any_embed()
+        && super::metadata::is_embed_writable_path(request.final_path)
+        && let Some(embed_path) = request.embed_path
+    {
+        outcome.embed_failed = !write_embed_metadata(
+            embed_path,
+            Arc::clone(&request.payload),
+            request.created_local,
+            request.flags,
+            request.temp_suffix,
+        )
+        .await;
     }
 
     #[cfg(feature = "xmp")]
-    if request.flags.contains(MetadataFlags::XMP_SIDECAR) {
-        if let Some(sidecar_path) = request.sidecar_path {
-            outcome.sidecar_failed = !write_sidecar_metadata(
-                sidecar_path,
-                Arc::clone(&request.payload),
-                request.created_local,
-                request.temp_suffix,
-            )
-            .await;
-        }
+    if request.flags.contains(MetadataFlags::XMP_SIDECAR)
+        && let Some(sidecar_path) = request.sidecar_path
+    {
+        outcome.sidecar_failed = !write_sidecar_metadata(
+            sidecar_path,
+            Arc::clone(&request.payload),
+            request.created_local,
+            request.temp_suffix,
+        )
+        .await;
     }
 
     outcome
@@ -157,12 +158,12 @@ async fn write_embed_metadata(
         if write.is_empty() {
             return true;
         }
-        if let Err(e) = super::metadata::apply_metadata(&embed_path, &write, &metadata_temp_suffix)
-        {
-            tracing::warn!(path = %embed_path.display(), error = %e, "Failed to write metadata");
-            false
-        } else {
-            true
+        match super::metadata::apply_metadata(&embed_path, &write, &metadata_temp_suffix) {
+            Err(e) => {
+                tracing::warn!(path = %embed_path.display(), error = %e, "Failed to write metadata");
+                false
+            }
+            Ok(()) => true,
         }
     })
     .await
@@ -189,13 +190,12 @@ async fn write_sidecar_metadata(
         if write.is_empty() {
             return true;
         }
-        if let Err(e) =
-            super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix)
-        {
-            tracing::warn!(path = %sidecar_path.display(), error = %e, "Failed to write XMP sidecar");
-            false
-        } else {
-            true
+        match super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix) {
+            Err(e) => {
+                tracing::warn!(path = %sidecar_path.display(), error = %e, "Failed to write XMP sidecar");
+                false
+            }
+            Ok(()) => true,
         }
     })
     .await
@@ -413,8 +413,8 @@ where
         .await;
 
         if !outcome.any_failed() {
-            if let Some(new_hash) = record.metadata.metadata_hash.as_deref() {
-                if let Err(e) = db
+            if let Some(new_hash) = record.metadata.metadata_hash.as_deref()
+                && let Err(e) = db
                     .update_metadata_hash(
                         &record.library,
                         &record.id,
@@ -422,9 +422,8 @@ where
                         new_hash,
                     )
                     .await
-                {
-                    tracing::warn!(asset_id = %record.id, error = %e, "Failed to update metadata_hash");
-                }
+            {
+                tracing::warn!(asset_id = %record.id, error = %e, "Failed to update metadata_hash");
             }
             if let Err(e) = db
                 .clear_metadata_write_failure(&record.library, &record.id, version_size.as_str())
@@ -691,8 +690,8 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn run_pending_skips_missing_file_and_leaves_marker() {
-        use crate::state::types::AssetMetadata;
         use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
 
         let dir = tempfile::tempdir().unwrap();
         let vanished_path = dir.path().join("never_written.jpg");
@@ -738,8 +737,8 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn cancel_returns_partial_and_keeps_retry_marker() {
-        use crate::state::types::AssetMetadata;
         use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
 
         let dir = tempfile::tempdir().unwrap();
         let photo_path = dir.path().join("rewrite_cancel.jpg");

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -21,24 +21,24 @@ mod retry;
 pub(crate) use limiter::BandwidthLimiter;
 
 use pipeline::{
+    AUTH_ERROR_THRESHOLD, MetadataFlags, PassConfig, PassResult, StreamRuntime, StreamingResult,
     build_download_outcome, format_duration, log_sync_summary, run_download_pass,
-    stream_and_download_from_stream, MetadataFlags, PassConfig, PassResult, StreamRuntime,
-    StreamingResult, AUTH_ERROR_THRESHOLD,
+    stream_and_download_from_stream,
 };
 
-pub(crate) use filter::determine_media_type;
 pub(crate) use filter::AssetGroupings;
 use filter::DownloadTask;
+pub(crate) use filter::determine_media_type;
 #[cfg(test)]
 use retry::take_matching_pending_retry_tasks;
-use retry::{build_pending_retry_download_tasks, PendingRetryPlan, PendingRetryTarget};
+use retry::{PendingRetryPlan, PendingRetryTarget, build_pending_retry_download_tasks};
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -46,8 +46,8 @@ use chrono::{DateTime, Utc};
 use reqwest::Client;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use futures_util::stream::{self, StreamExt};
 use futures_util::Stream;
+use futures_util::stream::{self, StreamExt};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -1743,11 +1743,7 @@ impl DownloadContext {
             );
         }
 
-        if trust_state {
-            Some(false)
-        } else {
-            None
-        }
+        if trust_state { Some(false) } else { None }
     }
 
     fn downloaded_local_path(
@@ -4421,10 +4417,10 @@ pub async fn download_photos_with_sync(
 ) -> Result<SyncResult> {
     let sync_started_at = chrono::Utc::now().timestamp();
     cleanup_orphan_part_files(&config).await;
-    if matches!(config.sync_mode, SyncMode::Incremental { .. }) {
-        if let Some(db) = &config.state_db {
-            backfill_asset_master_mappings_from_album_history(db.as_ref()).await;
-        }
+    if matches!(config.sync_mode, SyncMode::Incremental { .. })
+        && let Some(db) = &config.state_db
+    {
+        backfill_asset_master_mappings_from_album_history(db.as_ref()).await;
     }
 
     // Give every non-downloaded asset a fresh start this sync:
@@ -4598,20 +4594,20 @@ pub async fn download_photos_with_sync(
 
     // Pending is transient — anything still pending after a complete sync either
     // wasn't enumerated or failed silently. Skip on interrupt where pending is expected.
-    if let Some(db) = &config.state_db {
-        if !shutdown_token.is_cancelled() {
-            match db.promote_pending_to_failed(sync_started_at).await {
-                Ok(promoted) if promoted > 0 => {
-                    tracing::warn!(
-                        count = promoted,
-                        "Promoted unresolved pending assets to failed"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to promote pending assets");
-                }
-                _ => {}
+    if let Some(db) = &config.state_db
+        && !shutdown_token.is_cancelled()
+    {
+        match db.promote_pending_to_failed(sync_started_at).await {
+            Ok(promoted) if promoted > 0 => {
+                tracing::warn!(
+                    count = promoted,
+                    "Promoted unresolved pending assets to failed"
+                );
             }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to promote pending assets");
+            }
+            _ => {}
         }
     }
 
@@ -4933,33 +4929,33 @@ async fn download_photos_full_with_token_policy(
                         Arc::clone(&bounds_truncated),
                     );
 
-                    if pass.kind == crate::commands::PassKind::Album {
-                        if let Some(deferred_ids) = deferred_ids {
-                            let stream = stream.map(move |item| {
-                                if let Ok(asset) = &item {
-                                    if let Ok(mut ids) = deferred_ids.lock() {
-                                        ids.insert(asset.asset_record_name().to_string());
-                                    }
-                                }
-                                item
-                            });
-                            return run_full_pass_stream(
-                                download_client,
-                                stream,
-                                token_rx,
-                                pass_config,
-                                FullPassStreamOptions {
-                                    pass_index,
-                                    controls,
-                                    count,
-                                    kind: pass.kind,
-                                    shutdown_token,
-                                    download_ctx: download_ctx.clone(),
-                                    album_snapshot,
-                                },
-                            )
-                            .await;
-                        }
+                    if pass.kind == crate::commands::PassKind::Album
+                        && let Some(deferred_ids) = deferred_ids
+                    {
+                        let stream = stream.map(move |item| {
+                            if let Ok(asset) = &item
+                                && let Ok(mut ids) = deferred_ids.lock()
+                            {
+                                ids.insert(asset.asset_record_name().to_string());
+                            }
+                            item
+                        });
+                        return run_full_pass_stream(
+                            download_client,
+                            stream,
+                            token_rx,
+                            pass_config,
+                            FullPassStreamOptions {
+                                pass_index,
+                                controls,
+                                count,
+                                kind: pass.kind,
+                                shutdown_token,
+                                download_ctx: download_ctx.clone(),
+                                album_snapshot,
+                            },
+                        )
+                        .await;
                     }
 
                     run_full_pass_stream(
@@ -5216,39 +5212,35 @@ async fn download_photos_full_with_token_policy(
     if !count_lookup_failed
         && !controls.run_mode.only_print_filenames()
         && !controls.run_mode.is_dry_run()
+        && let Some(total) = exact_total.filter(|total| *total > 0)
     {
-        if let Some(total) = exact_total.filter(|total| *total > 0) {
-            let duplicate_asset_ids =
-                u64::try_from(streaming_result.skip_summary.duplicates).unwrap_or(u64::MAX);
-            let decision = classify_pagination_shortfall(
-                total,
-                streaming_result.assets_seen,
-                duplicate_asset_ids,
-            );
-            match decision {
-                PaginationShortfall::Match => {}
-                PaginationShortfall::DuplicateCompensated { shortfall } => {
-                    tracing::warn!(
-                        expected = total,
-                        seen = streaming_result.assets_seen,
-                        shortfall,
-                        duplicate_asset_ids,
-                        "Enumeration count shortfall was explained by duplicate asset IDs; \
+        let duplicate_asset_ids =
+            u64::try_from(streaming_result.skip_summary.duplicates).unwrap_or(u64::MAX);
+        let decision =
+            classify_pagination_shortfall(total, streaming_result.assets_seen, duplicate_asset_ids);
+        match decision {
+            PaginationShortfall::Match => {}
+            PaginationShortfall::DuplicateCompensated { shortfall } => {
+                tracing::warn!(
+                    expected = total,
+                    seen = streaming_result.assets_seen,
+                    shortfall,
+                    duplicate_asset_ids,
+                    "Enumeration count shortfall was explained by duplicate asset IDs; \
                          continuing sync token capture"
-                    );
-                }
-                PaginationShortfall::Shortfall { shortfall } => {
-                    pagination_shortfall_assets = shortfall;
-                    pagination_shortfall_warnings = 1;
-                    tracing::warn!(
-                        expected = total,
-                        seen = streaming_result.assets_seen,
-                        duplicate_asset_ids,
-                        shortfall,
-                        "Enumeration saw fewer assets than the count side-channel reported; \
+                );
+            }
+            PaginationShortfall::Shortfall { shortfall } => {
+                pagination_shortfall_assets = shortfall;
+                pagination_shortfall_warnings = 1;
+                tracing::warn!(
+                    expected = total,
+                    seen = streaming_result.assets_seen,
+                    duplicate_asset_ids,
+                    shortfall,
+                    "Enumeration saw fewer assets than the count side-channel reported; \
                          recording diagnostic and continuing sync token capture"
-                    );
-                }
+                );
             }
         }
     }
@@ -5684,12 +5676,10 @@ async fn download_photos_full_with_token_policy(
     // doesn't leave the marker set forever. Shutdown still suppresses the
     // clear because the producer's cancellation path leaves
     // `enumeration_complete = false`.
-    if enumeration_complete {
-        if let Some(db) = &config.state_db {
-            for zone in &enum_zones {
-                if let Err(e) = db.end_enum_progress(zone).await {
-                    tracing::debug!(error = %e, zone, "Failed to clear enumeration marker");
-                }
+    if enumeration_complete && let Some(db) = &config.state_db {
+        for zone in &enum_zones {
+            if let Err(e) = db.end_enum_progress(zone).await {
+                tracing::debug!(error = %e, zone, "Failed to clear enumeration marker");
             }
         }
     }
@@ -6233,10 +6223,10 @@ fn stream_incremental_assets_for_single_unfiled_pass(
             match event.reason {
                 ChangeReason::Created => {
                     summary.record_created();
-                    if let Some(asset) = event.asset {
-                        if asset_tx.send(Ok(asset)).await.is_err() {
-                            return Ok(summary);
-                        }
+                    if let Some(asset) = event.asset
+                        && asset_tx.send(Ok(asset)).await.is_err()
+                    {
+                        return Ok(summary);
                     }
                 }
                 ChangeReason::SoftDeleted | ChangeReason::HardDeleted | ChangeReason::Hidden => {
@@ -6705,16 +6695,15 @@ async fn download_photos_incremental_collecting_inner(
             if let Err(e) =
                 planner::record_album_membership_if_named(db.as_ref(), effective_config, asset)
                     .await
+                && let Some(album_name) = effective_config.album_name.as_deref()
             {
-                if let Some(album_name) = effective_config.album_name.as_deref() {
-                    tracing::warn!(
-                        asset_id = %asset.id(),
-                        album = %album_name,
-                        library = %effective_config.library,
-                        error = %e,
-                        "Failed to record album membership after retries"
-                    );
-                }
+                tracing::warn!(
+                    asset_id = %asset.id(),
+                    album = %album_name,
+                    library = %effective_config.library,
+                    error = %e,
+                    "Failed to record album membership after retries"
+                );
             }
         }
 
@@ -7003,12 +6992,12 @@ mod tests {
     use crate::icloud::photos::{PhotoAlbum, PhotoAlbumConfig, PhotosSession};
     use crate::state::SqliteStateDb;
     use crate::test_helpers::{
+        DynamicRecentPhotosSession, MockPhotosFlow, TestAssetRecord, TracingCapture,
         mock_photo_query_page, mock_photo_records_for_zone_with_filename,
-        mock_photo_records_for_zone_with_filename_and_asset_date, DynamicRecentPhotosSession,
-        MockPhotosFlow, TestAssetRecord, TracingCapture,
+        mock_photo_records_for_zone_with_filename_and_asset_date,
     };
     use chrono::TimeZone;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tempfile::TempDir;
@@ -14843,7 +14832,8 @@ mod tests {
 
         assert!(matches!(result.outcome, DownloadOutcome::Success));
         assert_eq!(
-            result.stats.assets_seen, 10,
+            result.stats.assets_seen,
+            10,
             "each album should plan only assets inside the library-wide recent frontier; offsets={:?}",
             session.album_offsets()
         );

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -22,27 +22,27 @@ use crate::state::{AssetRecord, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
 use super::filter::{
-    derive_expected_paths, determine_media_type, extract_skip_candidates, is_asset_filtered,
-    DerivedPath, DownloadTask,
+    DerivedPath, DownloadTask, derive_expected_paths, determine_media_type,
+    extract_skip_candidates, is_asset_filtered,
 };
 #[cfg(test)]
 use super::finalize::update_metadata_marker_for_test as update_metadata_marker;
 use super::finalize::{
-    check_state_write_circuit_breaker, finalize_downloaded, finalize_failed,
-    flush_pending_state_writes, flush_pending_state_writes_retaining_failures,
-    state_db_unwritable_error, state_write_circuit_breaker_tripped, DownloadedFinalization,
-    PendingStateWrite, StateWriteFlush,
+    DownloadedFinalization, PendingStateWrite, StateWriteFlush, check_state_write_circuit_breaker,
+    finalize_downloaded, finalize_failed, flush_pending_state_writes,
+    flush_pending_state_writes_retaining_failures, state_db_unwritable_error,
+    state_write_circuit_breaker_tripped,
 };
 #[cfg(test)]
 use super::finalize::{STATE_DB_UNWRITABLE_THRESHOLD, STATE_WRITE_MAX_RETRIES};
 #[cfg(test)]
-use super::planner::add_asset_album_with_retry;
-#[cfg(test)]
 use super::planner::ADD_ASSET_ALBUM_MAX_RETRIES;
+#[cfg(test)]
+use super::planner::add_asset_album_with_retry;
 use super::planner::{self, ExistingPathMatch, TaskPlanner};
 use super::{
-    metadata_rewrite, preload_download_context, DownloadConfig, DownloadContext, DownloadControls,
-    DownloadOutcome, DownloadReporting, DownloadStore,
+    DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome, DownloadReporting,
+    DownloadStore, metadata_rewrite, preload_download_context,
 };
 
 pub(super) use metadata_rewrite::MetadataFlags;
@@ -550,18 +550,18 @@ fn collision_family_base_filenames(
         super::paths::insert_asset_identity_suffix(&derived.filename, asset_id),
     ];
 
-    if derived.version_size.is_live_photo_motion() {
-        if let Some(primary) = primary_derived_path(derived_paths) {
-            let primary_collision_filenames = [
-                super::paths::add_dedup_suffix(&primary.filename, primary.size),
-                super::paths::insert_asset_identity_suffix(&primary.filename, asset_id),
-            ];
-            for primary_filename in primary_collision_filenames {
-                bases.push(live_photo_motion_filename_for_primary(
-                    &primary_filename,
-                    config,
-                ));
-            }
+    if derived.version_size.is_live_photo_motion()
+        && let Some(primary) = primary_derived_path(derived_paths)
+    {
+        let primary_collision_filenames = [
+            super::paths::add_dedup_suffix(&primary.filename, primary.size),
+            super::paths::insert_asset_identity_suffix(&primary.filename, asset_id),
+        ];
+        for primary_filename in primary_collision_filenames {
+            bases.push(live_photo_motion_filename_for_primary(
+                &primary_filename,
+                config,
+            ));
         }
     }
 
@@ -1132,14 +1132,14 @@ where
     // Refuse to start if free disk space is critically low (< 100 MiB).
     // The per-asset batch_forecast_decision catches the rest mid-stream.
     const MIN_FREE_BYTES_HARD: u64 = 100 * 1024 * 1024; // 100 MiB
-    if let Some(free) = initial_free_at_start {
-        if free < MIN_FREE_BYTES_HARD {
-            return Err(anyhow::anyhow!(
-                "Not enough free disk space: only {} bytes are available on {}, but kei needs at least {MIN_FREE_BYTES_HARD} bytes. Free up space or choose a different [download].directory.",
-                free,
-                config.directory.display(),
-            ));
-        }
+    if let Some(free) = initial_free_at_start
+        && free < MIN_FREE_BYTES_HARD
+    {
+        return Err(anyhow::anyhow!(
+            "Not enough free disk space: only {} bytes are available on {}, but kei needs at least {MIN_FREE_BYTES_HARD} bytes. Free up space or choose a different [download].directory.",
+            free,
+            config.directory.display(),
+        ));
     }
 
     let pipeline_shutdown = shutdown_token.child_token();
@@ -1233,23 +1233,22 @@ where
                 total_so_far + size,
                 last_resnapshot_total.load(std::sync::atomic::Ordering::Relaxed),
                 FREE_SPACE_RESNAPSHOT_INTERVAL_BYTES,
-            ) {
-                if let Some(refreshed) = crate::available_disk_space(&directory_for_resnapshot) {
-                    let prior = initial_free_atomic.load(std::sync::atomic::Ordering::Relaxed);
-                    initial_free_atomic.store(refreshed, std::sync::atomic::Ordering::Relaxed);
-                    last_resnapshot_total
-                        .store(total_so_far + size, std::sync::atomic::Ordering::Relaxed);
-                    tracing::debug!(
-                        prior_free_bytes = if prior == FREE_PROBE_NONE_SENTINEL {
-                            0
-                        } else {
-                            prior
-                        },
-                        refreshed_free_bytes = refreshed,
-                        queued_bytes = total_so_far + size,
-                        "Refreshed free-disk snapshot"
-                    );
-                }
+            ) && let Some(refreshed) = crate::available_disk_space(&directory_for_resnapshot)
+            {
+                let prior = initial_free_atomic.load(std::sync::atomic::Ordering::Relaxed);
+                initial_free_atomic.store(refreshed, std::sync::atomic::Ordering::Relaxed);
+                last_resnapshot_total
+                    .store(total_so_far + size, std::sync::atomic::Ordering::Relaxed);
+                tracing::debug!(
+                    prior_free_bytes = if prior == FREE_PROBE_NONE_SENTINEL {
+                        0
+                    } else {
+                        prior
+                    },
+                    refreshed_free_bytes = refreshed,
+                    queued_bytes = total_so_far + size,
+                    "Refreshed free-disk snapshot"
+                );
             }
             let raw = initial_free_atomic.load(std::sync::atomic::Ordering::Relaxed);
             let initial_free = if raw == FREE_PROBE_NONE_SENTINEL {
@@ -1396,39 +1395,33 @@ where
                             // Mark assets that have exceeded the retry limit as failed.
                             if let Some(attempts) =
                                 download_ctx.attempt_count(&task.library, &task.asset_id)
+                                && config.max_download_attempts > 0
+                                && attempts >= config.max_download_attempts
                             {
-                                if config.max_download_attempts > 0
-                                    && attempts >= config.max_download_attempts
-                                {
-                                    tracing::warn!(
-                                        asset_id = %task.asset_id,
-                                        attempts,
-                                        max = config.max_download_attempts,
-                                        "Asset exceeded max download attempts, marking as failed"
+                                tracing::warn!(
+                                    asset_id = %task.asset_id,
+                                    attempts,
+                                    max = config.max_download_attempts,
+                                    "Asset exceeded max download attempts, marking as failed"
+                                );
+                                if let Some(db) = &producer_state_db {
+                                    let error = format!(
+                                        "Exceeded max download attempts ({attempts}/{})",
+                                        config.max_download_attempts
                                     );
-                                    if let Some(db) = &producer_state_db {
-                                        let error = format!(
-                                            "Exceeded max download attempts ({attempts}/{})",
-                                            config.max_download_attempts
+                                    if let Err(e) =
+                                        finalize_failed(db.as_ref(), &task.library, &task, &error)
+                                            .await
+                                    {
+                                        tracing::warn!(
+                                            asset_id = %task.asset_id,
+                                            error = %e,
+                                            "Failed to mark asset as failed"
                                         );
-                                        if let Err(e) = finalize_failed(
-                                            db.as_ref(),
-                                            &task.library,
-                                            &task,
-                                            &error,
-                                        )
-                                        .await
-                                        {
-                                            tracing::warn!(
-                                                asset_id = %task.asset_id,
-                                                error = %e,
-                                                "Failed to mark asset as failed"
-                                            );
-                                        }
                                     }
-                                    disposition = disposition.max(AssetDisposition::RetryExhausted);
-                                    continue;
                                 }
+                                disposition = disposition.max(AssetDisposition::RetryExhausted);
+                                continue;
                             }
 
                             if config.retry_only
@@ -1453,15 +1446,14 @@ where
                                     &asset,
                                 )
                                 .await
+                                    && let Some(album) = config.album_name.as_deref()
                                 {
-                                    if let Some(album) = config.album_name.as_deref() {
-                                        tracing::warn!(
-                                            asset_id = %asset.id(),
-                                            album = %album,
-                                            error = %e,
-                                            "Failed to record album membership after retries"
-                                        );
-                                    }
+                                    tracing::warn!(
+                                        asset_id = %asset.id(),
+                                        album = %album,
+                                        error = %e,
+                                        "Failed to record album membership after retries"
+                                    );
                                 }
 
                                 if let Some(adoption) = adopt_pending_on_disk_task(
@@ -1716,26 +1708,25 @@ where
         // loop exiting and touch_last_seen_many returning), stuck-pipeline
         // promotion is delayed by exactly one sync. The same row hits the
         // same path next run and gets adopted or promoted then. No data loss.
-        if let Some(db) = &producer_state_db {
-            if !touched_assets.is_empty() {
-                let mut touched_by_library: FxHashMap<Arc<str>, Vec<Arc<str>>> =
-                    FxHashMap::default();
-                for (library, id) in touched_assets {
-                    touched_by_library.entry(library).or_default().push(id);
-                }
-                for (library, ids) in touched_by_library {
-                    let touched_count = ids.len();
-                    let id_refs: Vec<&str> = ids.iter().map(AsRef::as_ref).collect();
-                    if let Err(e) = db.touch_last_seen_many(&library, &id_refs).await {
-                        producer_pb.suspend(|| {
-                            tracing::warn!(
-                                error = %e,
-                                count = touched_count,
-                                library = %library,
-                                "Failed to batch-update last_seen_at for skipped assets"
-                            );
-                        });
-                    }
+        if let Some(db) = &producer_state_db
+            && !touched_assets.is_empty()
+        {
+            let mut touched_by_library: FxHashMap<Arc<str>, Vec<Arc<str>>> = FxHashMap::default();
+            for (library, id) in touched_assets {
+                touched_by_library.entry(library).or_default().push(id);
+            }
+            for (library, ids) in touched_by_library {
+                let touched_count = ids.len();
+                let id_refs: Vec<&str> = ids.iter().map(AsRef::as_ref).collect();
+                if let Err(e) = db.touch_last_seen_many(&library, &id_refs).await {
+                    producer_pb.suspend(|| {
+                        tracing::warn!(
+                            error = %e,
+                            count = touched_count,
+                            library = %library,
+                            "Failed to batch-update last_seen_at for skipped assets"
+                        );
+                    });
                 }
             }
         }
@@ -1879,22 +1870,21 @@ async fn consume_stream_download_tasks(
                                 );
                             });
                             pending_state_writes.push(write);
-                            if state_write_circuit_error.is_none() {
-                                if let Some(err) = check_state_write_circuit_breaker(
+                            if state_write_circuit_error.is_none()
+                                && let Some(err) = check_state_write_circuit_breaker(
                                     db.as_ref(),
                                     &mut pending_state_writes,
                                 )
                                 .await
-                                {
-                                    pb.suspend(|| {
-                                        tracing::error!(
-                                            error = %err,
-                                            "State write circuit breaker opened; halting downloads"
-                                        );
-                                    });
-                                    state_write_circuit_error = Some(err);
-                                    pipeline_shutdown.cancel();
-                                }
+                            {
+                                pb.suspend(|| {
+                                    tracing::error!(
+                                        error = %err,
+                                        "State write circuit breaker opened; halting downloads"
+                                    );
+                                });
+                                state_write_circuit_error = Some(err);
+                                pipeline_shutdown.cancel();
                             }
                         }
                     }
@@ -1945,16 +1935,15 @@ async fn consume_stream_download_tasks(
                         });
                     }
                 }
-                if let Some(db) = &state_db {
-                    if let Err(e) =
+                if let Some(db) = &state_db
+                    && let Err(e) =
                         finalize_failed(db.as_ref(), &task.library, &task, &e.to_string()).await
-                    {
-                        tracing::warn!(
-                            asset_id = %task.asset_id,
-                            error = %e,
-                            "Failed to mark failure"
-                        );
-                    }
+                {
+                    tracing::warn!(
+                        asset_id = %task.asset_id,
+                        error = %e,
+                        "Failed to mark failure"
+                    );
                 }
                 failed.push(task);
             }
@@ -2031,17 +2020,20 @@ async fn finalize_streaming_download(
                 || consumer.url_expired_abort,
             ..Default::default()
         };
-        if let Err(e) = db.complete_sync_run(run_id, &stats).await {
-            tracing::warn!(error = %e, "Failed to complete sync run tracking");
-            complete_sync_failed = true;
-        } else {
-            tracing::debug!(
-                run_id,
-                assets_seen = assets_seen_count,
-                downloaded = consumer.downloaded,
-                failed = consumer.failed.len(),
-                "Completed sync run"
-            );
+        match db.complete_sync_run(run_id, &stats).await {
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to complete sync run tracking");
+                complete_sync_failed = true;
+            }
+            Ok(()) => {
+                tracing::debug!(
+                    run_id,
+                    assets_seen = assets_seen_count,
+                    downloaded = consumer.downloaded,
+                    failed = consumer.failed.len(),
+                    "Completed sync run"
+                );
+            }
         }
     }
 
@@ -2083,18 +2075,18 @@ async fn finalize_streaming_download(
     // from a previous one). This re-applies EXIF/XMP on the existing files
     // without re-downloading bytes; the alternative was to leave markers
     // accumulating in the DB forever.
-    if consumer.state_write_circuit_error.is_none() {
-        if let Some(db) = &state_db {
-            let metadata_flags = MetadataFlags::from(config.as_ref());
-            if metadata_flags.has_any_write() {
-                consumer.exif_failures += metadata_rewrite::run_pending(
-                    db.as_ref(),
-                    metadata_flags,
-                    Arc::clone(&config.temp_suffix),
-                    &pipeline_shutdown,
-                )
-                .await;
-            }
+    if consumer.state_write_circuit_error.is_none()
+        && let Some(db) = &state_db
+    {
+        let metadata_flags = MetadataFlags::from(config.as_ref());
+        if metadata_flags.has_any_write() {
+            consumer.exif_failures += metadata_rewrite::run_pending(
+                db.as_ref(),
+                metadata_flags,
+                Arc::clone(&config.temp_suffix),
+                &pipeline_shutdown,
+            )
+            .await;
         }
     }
 
@@ -2634,22 +2626,21 @@ pub(super) async fn run_download_pass(
                                 );
                             });
                             pending_state_writes.push(write);
-                            if !state_write_circuit_open {
-                                if let Some(err) = check_state_write_circuit_breaker(
+                            if !state_write_circuit_open
+                                && let Some(err) = check_state_write_circuit_breaker(
                                     db.as_ref(),
                                     &mut pending_state_writes,
                                 )
                                 .await
-                                {
-                                    pb.suspend(|| {
+                            {
+                                pb.suspend(|| {
                                         tracing::error!(
                                             error = %err,
                                             "State write circuit breaker opened; halting cleanup downloads"
                                         );
                                     });
-                                    state_write_circuit_open = true;
-                                    pass_shutdown.cancel();
-                                }
+                                state_write_circuit_open = true;
+                                pass_shutdown.cancel();
                             }
                         }
                     }
@@ -2686,16 +2677,15 @@ pub(super) async fn run_download_pass(
                         });
                     }
                 }
-                if let Some(db) = &state_db {
-                    if let Err(e) =
+                if let Some(db) = &state_db
+                    && let Err(e) =
                         finalize_failed(db.as_ref(), &task.library, &task, &e.to_string()).await
-                    {
-                        tracing::warn!(
-                            asset_id = %task.asset_id,
-                            error = %e,
-                            "Failed to mark failure"
-                        );
-                    }
+                {
+                    tracing::warn!(
+                        asset_id = %task.asset_id,
+                        error = %e,
+                        "Failed to mark failure"
+                    );
                 }
                 failed.push(task);
             }
@@ -3287,7 +3277,7 @@ mod tests {
     fn batch_forecast_decision_crossing_100pct_bails() {
         let queued = AtomicU64::new(800);
         let warn = AtomicBool::new(true); // already warned at 800
-                                          // 800 + 250 = 1050 ≥ 1000 → bail
+        // 800 + 250 = 1050 ≥ 1000 → bail
         let (decision, total) = batch_forecast_decision(250, Some(1000), &queued, &warn);
         assert_eq!(decision, BatchForecast::Bail);
         assert_eq!(total, 1050);

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -11,12 +11,12 @@ use rustc_hash::FxHashMap;
 use crate::icloud::photos::PhotoAsset;
 use crate::state::{AssetRecord, DownloadStateStore, MembershipStore};
 
+use super::DownloadConfig;
 use super::filter::{
-    determine_media_type, filter_asset_to_tasks, is_asset_filtered, pre_ensure_asset_dir,
-    DownloadTask, FilterReason, MalformedTaskResource, NormalizedPath,
+    DownloadTask, FilterReason, MalformedTaskResource, NormalizedPath, determine_media_type,
+    filter_asset_to_tasks, is_asset_filtered, pre_ensure_asset_dir,
 };
 use super::paths;
-use super::DownloadConfig;
 
 /// Mutable path-planning state carried across assets in one pass.
 #[derive(Debug)]

--- a/src/download/recap.rs
+++ b/src/download/recap.rs
@@ -13,8 +13,8 @@
 //! the off path allocates only a handful of bytes per cycle
 //! (`Default::default()`).
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 
 use chrono::{DateTime, Local};
 
@@ -83,19 +83,18 @@ impl RunRecap {
     /// result for one cycle). `other` wins ties on biggest because the
     /// later pass observed it last; deterministic enough for display.
     pub fn merge(&mut self, other: RunRecap) {
-        if let Some(b) = other.biggest {
-            if self.biggest.as_ref().is_none_or(|cur| b.bytes >= cur.bytes) {
-                self.biggest = Some(b);
-            }
+        if let Some(b) = other.biggest
+            && self.biggest.as_ref().is_none_or(|cur| b.bytes >= cur.bytes)
+        {
+            self.biggest = Some(b);
         }
-        if let Some(o) = other.oldest {
-            if self
+        if let Some(o) = other.oldest
+            && self
                 .oldest
                 .as_ref()
                 .is_none_or(|cur| o.created_local <= cur.created_local)
-            {
-                self.oldest = Some(o);
-            }
+        {
+            self.oldest = Some(o);
         }
         for (label, asset) in other.albums {
             self.albums

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -7,8 +7,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    build_pass_configs_resolving_deferred_excludes, planner, DownloadConfig, DownloadTask,
-    RetryTaskKey, UrlRetrySource, PENDING_RETRY_UNMATCHED_REASON,
+    DownloadConfig, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RetryTaskKey, UrlRetrySource,
+    build_pass_configs_resolving_deferred_excludes, planner,
 };
 use crate::icloud::photos::{ProviderRecordId, RecordLookupRequest, RecordResolution};
 use crate::state::{AssetVerificationState, VersionSizeKey};

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -12,28 +12,28 @@ use std::path::Path;
 /// The async sibling `log_remove_async` is available for callers already on a
 /// tokio task.
 pub(crate) fn log_remove(path: &Path) {
-    if let Err(e) = std::fs::remove_file(path) {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(
-                path = %path.display(),
-                error = %e,
-                "Failed to remove file during cleanup"
-            );
-        }
+    if let Err(e) = std::fs::remove_file(path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "Failed to remove file during cleanup"
+        );
     }
 }
 
 /// Async sibling of [`log_remove`] for callers already on a tokio task;
 /// uses `tokio::fs::remove_file` so it doesn't block a runtime worker.
 pub(crate) async fn log_remove_async(path: &Path) {
-    if let Err(e) = tokio::fs::remove_file(path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(
-                path = %path.display(),
-                error = %e,
-                "Failed to remove file during cleanup"
-            );
-        }
+    if let Err(e) = tokio::fs::remove_file(path).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "Failed to remove file during cleanup"
+        );
     }
 }
 

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -163,10 +163,12 @@ mod tests {
     #[test]
     fn is_session_error_false_for_other_variants() {
         assert!(!ICloudError::Connection("x".into()).is_session_error());
-        assert!(!ICloudError::ServiceNotActivated {
-            code: "ADP".into(),
-            reason: "y".into()
-        }
-        .is_session_error());
+        assert!(
+            !ICloudError::ServiceNotActivated {
+                code: "ADP".into(),
+                reason: "y".into()
+            }
+            .is_session_error()
+        );
     }
 }

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use anyhow::Context;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_stream::Stream;
 
 use super::asset::{ChangeEvent, DeltaRecordBuffer, PhotoAsset};
 use super::cloudkit::ChangesZoneResponse;
-use super::queries::{build_changes_zone_request, encode_params, DESIRED_KEYS_VALUES};
-use super::session::{check_changes_zone_error, PhotosSession};
+use super::queries::{DESIRED_KEYS_VALUES, build_changes_zone_request, encode_params};
+use super::session::{PhotosSession, check_changes_zone_error};
 use crate::retry::RetryConfig;
 
 /// How many consecutive empty /records/query pages trigger true EOF.
@@ -193,11 +193,11 @@ fn download_stream_page_size(default_page_size: usize, download_concurrency: usi
 async fn await_fetcher_handles(handles: Vec<JoinHandle<()>>) -> bool {
     let mut panicked = false;
     for handle in handles {
-        if let Err(e) = handle.await {
-            if e.is_panic() {
-                tracing::error!(error = ?e, "Photo fetcher task panicked");
-                panicked = true;
-            }
+        if let Err(e) = handle.await
+            && e.is_panic()
+        {
+            tracing::error!(error = ?e, "Photo fetcher task panicked");
+            panicked = true;
         }
     }
     panicked
@@ -2011,11 +2011,11 @@ impl PhotoAlbum {
                             ) {
                                 continue;
                             }
-                            if let Some(n) = limit {
-                                if total_sent >= u64::from(n) {
-                                    limit_reached = true;
-                                    break;
-                                }
+                            if let Some(n) = limit
+                                && total_sent >= u64::from(n)
+                            {
+                                limit_reached = true;
+                                break;
                             }
                             let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
                             if sibling_count > 1 && index > 0 {
@@ -2063,11 +2063,11 @@ impl PhotoAlbum {
                             ) {
                                 continue;
                             }
-                            if let Some(n) = limit {
-                                if total_sent >= u64::from(n) {
-                                    limit_reached = true;
-                                    break;
-                                }
+                            if let Some(n) = limit
+                                && total_sent >= u64::from(n)
+                            {
+                                limit_reached = true;
+                                break;
                             }
                             let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
                             if sibling_count > 1 && index > 0 {
@@ -2094,11 +2094,11 @@ impl PhotoAlbum {
                             ) {
                                 continue;
                             }
-                            if let Some(n) = limit {
-                                if total_sent >= u64::from(n) {
-                                    limit_reached = true;
-                                    break;
-                                }
+                            if let Some(n) = limit
+                                && total_sent >= u64::from(n)
+                            {
+                                limit_reached = true;
+                                break;
                             }
                             let asset = PhotoAsset::from_records(master.clone(), &asset_rec)
                                 .with_state_record_name(Arc::from(asset_rec.record_name.as_str()));
@@ -2229,10 +2229,10 @@ impl PhotoAlbum {
             }),
         ];
 
-        if let Some(qf) = query_filter {
-            if let Some(arr) = qf.as_array() {
-                filter_by.extend(arr.iter().cloned());
-            }
+        if let Some(qf) = query_filter
+            && let Some(arr) = qf.as_array()
+        {
+            filter_by.extend(arr.iter().cloned());
         }
 
         let query_part = json!({
@@ -2319,11 +2319,11 @@ impl PhotoAlbum {
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        mock_photo_query_page, DynamicRecentPhotosSession, MockPhotosFlow, MockPhotosSession,
+        DynamicRecentPhotosSession, MockPhotosFlow, MockPhotosSession, mock_photo_query_page,
     };
     use serde_json::json;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Clone)]
     struct BatchCountSession {
@@ -3275,12 +3275,14 @@ mod tests {
         let (mut stream, token_rx) =
             album.photo_stream_with_token_for_download_policy(None, Some(1), 1, true);
 
-        assert!(stream
-            .next()
-            .await
-            .transpose()
-            .expect("first asset")
-            .is_some());
+        assert!(
+            stream
+                .next()
+                .await
+                .transpose()
+                .expect("first asset")
+                .is_some()
+        );
         drop(stream);
 
         assert_eq!(token_rx.await.expect("sync token sender"), None);

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use super::cloudkit::Record;
 use super::enc;
 use super::metadata;
-use super::queries::{item_type_from_str, PHOTO_VERSION_LOOKUP, VIDEO_VERSION_LOOKUP};
+use super::queries::{PHOTO_VERSION_LOOKUP, VIDEO_VERSION_LOOKUP, item_type_from_str};
 use super::types::{AssetItemType, AssetVersion, AssetVersionSize, ChangeReason};
 use crate::state::AssetMetadata;
 
@@ -160,20 +160,18 @@ fn resolve_item_type(fields: &Value, filename: Option<&str>) -> AssetItemType {
         .get("itemType")
         .and_then(|f| f.get("value"))
         .and_then(Value::as_str)
+        && let Some(t) = item_type_from_str(s)
     {
-        if let Some(t) = item_type_from_str(s) {
-            return t;
-        }
+        return t;
     }
-    if let Some(ext) = filename.and_then(|n| std::path::Path::new(n).extension()) {
-        if ext.eq_ignore_ascii_case("heic")
+    if let Some(ext) = filename.and_then(|n| std::path::Path::new(n).extension())
+        && (ext.eq_ignore_ascii_case("heic")
             || ext.eq_ignore_ascii_case("png")
             || ext.eq_ignore_ascii_case("jpg")
             || ext.eq_ignore_ascii_case("jpeg")
-            || ext.eq_ignore_ascii_case("webp")
-        {
-            return AssetItemType::Image;
-        }
+            || ext.eq_ignore_ascii_case("webp"))
+    {
+        return AssetItemType::Image;
     }
     AssetItemType::Movie
 }
@@ -613,21 +611,19 @@ pub(crate) fn classify_change_reason(record: &Record) -> ChangeReason {
     }
 
     // Soft delete: fields.isDeleted.value == 1
-    if let Some(is_deleted) = record.fields.get("isDeleted") {
-        if let Some(val) = is_deleted.get("value") {
-            if val.as_i64() == Some(1) {
-                return ChangeReason::SoftDeleted;
-            }
-        }
+    if let Some(is_deleted) = record.fields.get("isDeleted")
+        && let Some(val) = is_deleted.get("value")
+        && val.as_i64() == Some(1)
+    {
+        return ChangeReason::SoftDeleted;
     }
 
     // Hidden: fields.isHidden.value == 1
-    if let Some(is_hidden) = record.fields.get("isHidden") {
-        if let Some(val) = is_hidden.get("value") {
-            if val.as_i64() == Some(1) {
-                return ChangeReason::Hidden;
-            }
-        }
+    if let Some(is_hidden) = record.fields.get("isHidden")
+        && let Some(val) = is_hidden.get("value")
+        && val.as_i64() == Some(1)
+    {
+        return ChangeReason::Hidden;
     }
 
     // Default: Created (new or modified record)
@@ -889,11 +885,7 @@ impl DeltaRecordBuffer {
                 ChangeReason::Created => 0,
             }
         }
-        if severity(a) >= severity(b) {
-            a
-        } else {
-            b
-        }
+        if severity(a) >= severity(b) { a } else { b }
     }
 
     fn emit_paired(

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use base64::Engine;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::album::{
-    PhotoAlbum, PhotoAlbumConfig, DEFAULT_PAGE_SIZE, QUERY_ALL_LIST, QUERY_ALL_OBJ,
+    DEFAULT_PAGE_SIZE, PhotoAlbum, PhotoAlbumConfig, QUERY_ALL_LIST, QUERY_ALL_OBJ,
     QUERY_FOLDER_LIST,
 };
 use super::queries::encode_params;
@@ -39,13 +39,13 @@ const PROJECT_ROOT_FOLDER: &str = "----Project-Root-Folder----";
 /// Map typed CloudKit initialization failures to the library-level iCloud
 /// contract consumed by sync orchestration.
 fn map_library_init_error(error: &anyhow::Error) -> ICloudError {
-    if let Some(ck) = error.downcast_ref::<crate::icloud::photos::session::CloudKitServerError>() {
-        if ck.service_not_activated {
-            return ICloudError::ServiceNotActivated {
-                code: ck.code.to_string(),
-                reason: ck.reason.to_string(),
-            };
-        }
+    if let Some(ck) = error.downcast_ref::<crate::icloud::photos::session::CloudKitServerError>()
+        && ck.service_not_activated
+    {
+        return ICloudError::ServiceNotActivated {
+            code: ck.code.to_string(),
+            reason: ck.reason.to_string(),
+        };
     }
     if let Some(http_err) = error.downcast_ref::<crate::icloud::photos::session::HttpStatusError>()
     {

--- a/src/icloud/photos/metadata.rs
+++ b/src/icloud/photos/metadata.rs
@@ -5,7 +5,7 @@
 //! fields that don't fit the canonical schema are preserved verbatim in
 //! `provider_data` so that invariant 4 (capture everything available) holds.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 use crate::state::AssetMetadata;
@@ -90,10 +90,10 @@ pub fn extract(master_fields: &Value, asset_fields: &Value) -> AssetMetadata {
     meta.title = enc::decode_string(asset_fields, "captionEnc");
     meta.description = enc::decode_string(asset_fields, "extendedDescEnc");
 
-    if let Some(keywords) = enc::decode_keywords(asset_fields) {
-        if !keywords.is_empty() {
-            meta.keywords = serde_json::to_string(&keywords).ok();
-        }
+    if let Some(keywords) = enc::decode_keywords(asset_fields)
+        && !keywords.is_empty()
+    {
+        meta.keywords = serde_json::to_string(&keywords).ok();
     }
 
     meta.media_subtype = map_media_subtype(asset_fields);

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -13,22 +13,22 @@ pub mod session;
 pub(crate) mod smart_folders;
 pub mod types;
 
+#[cfg(test)]
+pub(crate) use album::MAX_EMPTY_PAGE_PROBES;
 pub use album::PhotoAlbum;
 #[cfg(test)]
 pub use album::PhotoAlbumConfig;
-#[cfg(test)]
-pub(crate) use album::MAX_EMPTY_PAGE_PROBES;
 pub(crate) use album::{ProviderRecordId, RecordLookupRequest, RecordResolution};
 pub use asset::{PhotoAsset, VersionsMap};
 pub use library::PhotoLibrary;
-pub(crate) use library::{is_shared_zone, PRIMARY_ZONE_NAME};
+pub(crate) use library::{PRIMARY_ZONE_NAME, is_shared_zone};
 pub use session::{PhotosSession, SyncTokenError};
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::icloud::error::ICloudError;
 use crate::icloud::photos::cloudkit::ChangesDatabaseResponse;

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::types::{AssetItemType, AssetVersionSize};
 
@@ -263,10 +263,10 @@ pub(crate) fn build_changes_zone_request(
         "zoneID": zone_id,
         "resultsLimit": results_limit,
     });
-    if let Some(token) = sync_token {
-        if let Some(obj) = zone_entry.as_object_mut() {
-            obj.insert("syncToken".into(), json!(token));
-        }
+    if let Some(token) = sync_token
+        && let Some(obj) = zone_entry.as_object_mut()
+    {
+        obj.insert("syncToken".into(), json!(token));
     }
     json!({"zones": [zone_entry]})
 }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 
-use crate::retry::{self, parse_retry_after_header, RetryAction, RetryConfig};
+use crate::retry::{self, RetryAction, RetryConfig, parse_retry_after_header};
 
 /// Upper bound on any `Retry-After` hint from CloudKit, chosen so a
 /// pathological server value can't stall the retry loop.

--- a/src/icloud/photos/smart_folders.rs
+++ b/src/icloud/photos/smart_folders.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 #[derive(Debug)]
 pub(crate) struct FolderDef {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -16,11 +16,11 @@ use std::sync::{Arc, LazyLock};
 
 use chrono::Utc;
 
+use axum::Router;
 use axum::extract::State;
-use axum::http::{header, HeaderValue, StatusCode};
+use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::Router;
 use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;

--- a/src/password.rs
+++ b/src/password.rs
@@ -759,8 +759,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invoke_password_provider_yields_runtime_for_blocking_closure() {
-        use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicBool, Ordering};
         use std::time::Duration;
 
         let interleaved = StdArc::new(AtomicBool::new(false));

--- a/src/personality/album_divider.rs
+++ b/src/personality/album_divider.rs
@@ -20,8 +20,8 @@
 
 use std::time::Duration;
 
-use crate::personality::active_bar;
 use crate::personality::Mode;
+use crate::personality::active_bar;
 
 /// Renders a short human-readable elapsed duration for the per-album done
 /// line. Fixed-width columns (`NNs` or `Nm NNs` or `Nh NNm`).

--- a/src/personality/progress.rs
+++ b/src/personality/progress.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
-use crate::personality::{active_bar, progress_card, Mode};
+use crate::personality::{Mode, active_bar, progress_card};
 
 /// Progress bar plus shared byte counter for multi-pass download loops.
 #[derive(Debug)]

--- a/src/personality/summary.rs
+++ b/src/personality/summary.rs
@@ -139,11 +139,7 @@ fn format_duration(d: Duration) -> String {
 }
 
 fn plural<'a>(n: u64, singular: &'a str, plural: &'a str) -> &'a str {
-    if n == 1 {
-        singular
-    } else {
-        plural
-    }
+    if n == 1 { singular } else { plural }
 }
 
 #[cfg(test)]

--- a/src/personality/tracing.rs
+++ b/src/personality/tracing.rs
@@ -9,9 +9,9 @@
 use std::fmt;
 
 use tracing::{Event, Level, Subscriber};
-use tracing_subscriber::fmt::{format::Writer, FmtContext, FormatEvent, FormatFields};
-use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, format::Writer};
+use tracing_subscriber::registry::LookupSpan;
 
 use crate::personality::Mode;
 

--- a/src/personality/tty_echo.rs
+++ b/src/personality/tty_echo.rs
@@ -21,7 +21,7 @@
 mod platform {
     use std::sync::Mutex;
 
-    use libc::{tcgetattr, tcsetattr, termios, ECHOCTL, STDIN_FILENO, TCSANOW};
+    use libc::{ECHOCTL, STDIN_FILENO, TCSANOW, tcgetattr, tcsetattr, termios};
 
     /// Saved `c_lflag` from the call to `install`. Held in a `Mutex<Option<...>>`
     /// so a manual `restore_now()` from the shutdown path and the `Drop` of
@@ -105,7 +105,7 @@ mod platform {
     pub fn restore_now() {}
 }
 
-pub use platform::{restore_now, EchoGuard};
+pub use platform::{EchoGuard, restore_now};
 
 #[cfg(test)]
 mod tests {

--- a/src/report.rs
+++ b/src/report.rs
@@ -252,9 +252,11 @@ mod tests {
         assert_eq!(parsed["stats"]["inventory_drop_library"], "PrimarySync");
         assert_eq!(parsed["stats"]["skipped"]["by_state"], 300);
         assert_eq!(parsed["options"]["username"], "user@example.com");
-        assert!(parsed["options"]["set_exif_datetime"]
-            .as_bool()
-            .unwrap_or(false));
+        assert!(
+            parsed["options"]["set_exif_datetime"]
+                .as_bool()
+                .unwrap_or(false)
+        );
     }
 
     #[test]

--- a/src/service/env.rs
+++ b/src/service/env.rs
@@ -115,12 +115,15 @@ pub(crate) fn read_config_username(kei_dir: &Path) -> Option<String> {
 pub(crate) fn purge_kei_state(kei_dir: &Path, extra_dirs: &[PathBuf]) -> Result<()> {
     if let Some(username) = read_config_username(kei_dir) {
         let store = crate::credential::CredentialStore::new(&username, kei_dir);
-        if let Err(e) = store.delete() {
-            // delete() bails when neither backend has anything to remove,
-            // which is fine for purge — we're cleaning up regardless.
-            tracing::debug!(error = %e, "credential delete during purge: nothing to remove");
-        } else {
-            tracing::info!(username, "cleared stored credential");
+        match store.delete() {
+            Err(e) => {
+                // delete() bails when neither backend has anything to remove,
+                // which is fine for purge - we're cleaning up regardless.
+                tracing::debug!(error = %e, "credential delete during purge: nothing to remove");
+            }
+            Ok(()) => {
+                tracing::info!(username, "cleared stored credential");
+            }
         }
     }
 

--- a/src/service/install.rs
+++ b/src/service/install.rs
@@ -58,7 +58,7 @@ async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 async fn dispatch(plan: InstallPlan, config_path: &Path) -> Result<()> {
-    use crate::service::env::{current_executable, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER};
+    use crate::service::env::{SERVICE_DESCRIPTION, SERVICE_IDENTIFIER, current_executable};
     let exe = current_executable()?;
     tracing::info!(
         service = SERVICE_IDENTIFIER,

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -27,13 +27,13 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use tokio::process::Command;
 
 use crate::cli::UninstallArgs;
 use crate::service::env::{
-    current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
+    SERVICE_DESCRIPTION, SERVICE_IDENTIFIER, current_executable, effective_uid, purge_kei_state,
 };
 use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -30,13 +30,13 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use plist::{Dictionary, Value as PlistValue};
 use tokio::process::Command;
 
 use crate::cli::UninstallArgs;
 use crate::service::env::{
-    current_executable, effective_uid, purge_kei_state, SERVICE_DESCRIPTION, SERVICE_IDENTIFIER,
+    SERVICE_DESCRIPTION, SERVICE_IDENTIFIER, current_executable, effective_uid, purge_kei_state,
 };
 use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;

--- a/src/service/plan.rs
+++ b/src/service/plan.rs
@@ -5,7 +5,7 @@
 //! whether it is preview-only, and which system-scope requests are safe to
 //! proceed with.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::cli::InstallArgs;
 
@@ -189,14 +189,18 @@ mod tests {
 
     #[test]
     fn unsupported_platform_system_errors_live_in_policy() {
-        assert!(reject_macos_system_install()
-            .expect_err("macOS system install must fail")
-            .to_string()
-            .contains("per-user only"));
-        assert!(reject_windows_system_install()
-            .expect_err("Windows system install must fail")
-            .to_string()
-            .contains("not supported on Windows"));
+        assert!(
+            reject_macos_system_install()
+                .expect_err("macOS system install must fail")
+                .to_string()
+                .contains("per-user only")
+        );
+        assert!(
+            reject_windows_system_install()
+                .expect_err("Windows system install must fail")
+                .to_string()
+                .contains("not supported on Windows")
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/service/run.rs
+++ b/src/service/run.rs
@@ -19,7 +19,7 @@
 use anyhow::Result;
 
 use crate::config;
-use crate::service::env::{current_executable, SERVICE_IDENTIFIER};
+use crate::service::env::{SERVICE_IDENTIFIER, current_executable};
 use crate::sync_loop;
 
 pub(crate) async fn run(globals: &config::GlobalArgs, args: sync_loop::SyncArgs) -> Result<()> {

--- a/src/service/status.rs
+++ b/src/service/status.rs
@@ -136,10 +136,10 @@ pub(crate) fn render_oneline(state: &ServiceState) -> String {
             if let Some(pid) = pid {
                 detail.push_str(&format!(", pid {pid}"));
             }
-            if *state_label == RUNNING_LABEL {
-                if let Some(since) = since {
-                    detail.push_str(&format!(", since {}", since.format("%Y-%m-%d %H:%M UTC")));
-                }
+            if *state_label == RUNNING_LABEL
+                && let Some(since) = since
+            {
+                detail.push_str(&format!(", since {}", since.format("%Y-%m-%d %H:%M UTC")));
             }
             detail.push(')');
             detail

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -28,12 +28,12 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 use crate::cli::UninstallArgs;
 use crate::service::env::{
-    current_executable, kei_state_dir_dotted, purge_kei_state, SERVICE_DESCRIPTION,
-    SERVICE_IDENTIFIER,
+    SERVICE_DESCRIPTION, SERVICE_IDENTIFIER, current_executable, kei_state_dir_dotted,
+    purge_kei_state,
 };
 use crate::service::plan::{self, InstallPlan};
 use crate::service::status::ServiceState;
@@ -288,10 +288,10 @@ fn render_status(inputs: StatusInputs) -> String {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 fn current_user_name() -> Option<String> {
-    if let Ok(u) = std::env::var("USERNAME") {
-        if !u.is_empty() {
-            return Some(u);
-        }
+    if let Ok(u) = std::env::var("USERNAME")
+        && !u.is_empty()
+    {
+        return Some(u);
     }
     // USERPROFILE is `C:\Users\Alice`; the basename is the account name.
     let profile = std::env::var("USERPROFILE").ok()?;
@@ -363,8 +363,8 @@ mod scm_impl {
             .map_err(|_| anyhow!("internal: SCM payload mutex poisoned"))
     }
 
-    fn lock_scm_shutdown_tx(
-    ) -> Result<MutexGuard<'static, Option<tokio::sync::oneshot::Sender<()>>>> {
+    fn lock_scm_shutdown_tx()
+    -> Result<MutexGuard<'static, Option<tokio::sync::oneshot::Sender<()>>>> {
         SCM_SHUTDOWN_TX
             .lock()
             .map_err(|_| anyhow!("internal: SCM shutdown mutex poisoned"))

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,7 +7,7 @@ use std::fmt::Write as FmtWrite;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use console::Style;
 use dialoguer::{Confirm, Input, Password, Select};
 use indicatif::ProgressBar;
@@ -1134,7 +1134,9 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
                 // any are added or renamed.
                 let known: Vec<&'static str> =
                     crate::icloud::photos::smart_folders::smart_folder_names().collect();
-                println!("  Enter one smart-folder name per line. Press Enter on a blank line to finish.");
+                println!(
+                    "  Enter one smart-folder name per line. Press Enter on a blank line to finish."
+                );
                 println!("  Names are case-sensitive. Available smart folders:");
                 println!("  {}.", known.join(", "));
                 loop {

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -4,8 +4,8 @@
 //! [`tokio_util::sync::CancellationToken`] so the download pipeline can
 //! drain in-flight work before exiting. A second signal force-exits.
 
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 #[cfg(unix)]
@@ -54,7 +54,7 @@ pub(crate) fn install_signal_handler(
 
     #[cfg(unix)]
     let (mut sigterm, mut sighup) = {
-        use tokio::signal::unix::{signal, SignalKind};
+        use tokio::signal::unix::{SignalKind, signal};
         (
             signal(SignalKind::terminate()).context("failed to register SIGTERM handler")?,
             signal(SignalKind::hangup()).context("failed to register SIGHUP handler")?,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -160,7 +160,7 @@ pub trait DownloadStateStore: Send + Sync {
     async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError>;
     async fn reset_failed(&self) -> Result<u64, StateError>;
     async fn prepare_for_retry(&self, library: Option<&str>)
-        -> Result<(u64, u64, u64), StateError>;
+    -> Result<(u64, u64, u64), StateError>;
     async fn prune_source_deleted_retries(
         &self,
         _library: Option<&str>,
@@ -8094,10 +8094,11 @@ mod tests {
         db.complete_album_membership_snapshot("PrimarySync", "container-a", generation)
             .await
             .unwrap();
-        assert!(db
-            .selected_album_containers_have_complete_snapshots("PrimarySync", &["container-a"])
-            .await
-            .unwrap());
+        assert!(
+            db.selected_album_containers_have_complete_snapshots("PrimarySync", &["container-a"])
+                .await
+                .unwrap()
+        );
 
         db.mark_album_container_deleted("PrimarySync", "container-a")
             .await

--- a/src/state/error.rs
+++ b/src/state/error.rs
@@ -48,12 +48,16 @@ pub enum StateError {
     Spawn(#[from] tokio::task::JoinError),
 
     /// The database schema version is newer than supported.
-    #[error("This state database is from a newer kei version (schema {found}); this kei supports schema {expected}")]
+    #[error(
+        "This state database is from a newer kei version (schema {found}); this kei supports schema {expected}"
+    )]
     UnsupportedSchemaVersion { found: i32, expected: i32 },
 
     /// The database schema must be migrated before a read-only command can
     /// inspect it.
-    #[error("This state database uses schema {found}; schema {expected} is required for this read-only command. Run a normal kei command that updates state first.")]
+    #[error(
+        "This state database uses schema {found}; schema {expected} is required for this read-only command. Run a normal kei command that updates state first."
+    )]
     ReadOnlySchemaTooOld { found: i32, expected: i32 },
 
     /// A producer-dispatch invariant was violated — typically a write
@@ -69,7 +73,9 @@ pub enum StateError {
     /// `mark_downloaded` matched zero rows. The asset row should have
     /// been upserted before this call; its absence indicates a missed
     /// upsert step or out-of-band row deletion.
-    #[error("Could not mark asset {asset_id} ({version_size}) downloaded because it was not in the state database")]
+    #[error(
+        "Could not mark asset {asset_id} ({version_size}) downloaded because it was not in the state database"
+    )]
     AssetRowMissing {
         asset_id: String,
         version_size: String,

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -827,21 +827,24 @@ mod tests {
         assert_eq!(get_schema_version(&conn).unwrap(), 3);
 
         // Verify local_checksum exists but download_checksum does not
-        assert!(conn
-            .prepare("SELECT local_checksum FROM assets LIMIT 0")
-            .is_ok());
-        assert!(conn
-            .prepare("SELECT download_checksum FROM assets LIMIT 0")
-            .is_err());
+        assert!(
+            conn.prepare("SELECT local_checksum FROM assets LIMIT 0")
+                .is_ok()
+        );
+        assert!(
+            conn.prepare("SELECT download_checksum FROM assets LIMIT 0")
+                .is_err()
+        );
 
         // Migrate should bring it to v4
         migrate(&conn).unwrap();
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
 
         // download_checksum should now exist
-        assert!(conn
-            .prepare("SELECT download_checksum FROM assets LIMIT 0")
-            .is_ok());
+        assert!(
+            conn.prepare("SELECT download_checksum FROM assets LIMIT 0")
+                .is_ok()
+        );
 
         // Verify data survives migration: insert a row using all columns
         conn.execute(
@@ -881,9 +884,10 @@ mod tests {
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
 
         // Column should be usable
-        assert!(conn
-            .prepare("SELECT download_checksum FROM assets LIMIT 0")
-            .is_ok());
+        assert!(
+            conn.prepare("SELECT download_checksum FROM assets LIMIT 0")
+                .is_ok()
+        );
     }
 
     /// T-9: Simulate crash after V3+V4 columns added but version left at V2.
@@ -907,9 +911,10 @@ mod tests {
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
 
         // Both columns should exist and be queryable
-        assert!(conn
-            .prepare("SELECT local_checksum, download_checksum FROM assets LIMIT 0")
-            .is_ok());
+        assert!(
+            conn.prepare("SELECT local_checksum, download_checksum FROM assets LIMIT 0")
+                .is_ok()
+        );
 
         // Database should be fully usable (insert + query round-trip)
         conn.execute(

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -651,29 +651,28 @@ pub(crate) async fn run_cycle(
     // pipeline's `config_hash` (which tracks path-affecting fields only).
     // Using a single key for both would cause the two hashes to overwrite
     // each other every cycle, permanently preventing incremental sync.
-    if !config.runtime.dry_run {
-        if let Some(db) = state_db {
-            enum_config_hash_outcome =
-                check_and_persist_enum_config_hash(db, &enum_config_hash).await;
-            force_full_for_config_hash = enum_config_hash_outcome.must_force_full_sync();
-            if matches!(enum_config_hash_outcome, EnumConfigHashOutcome::Changed) {
-                let recovery = RecoveryAction::ReconcileInventory(
-                    download::FullEnumerationReason::EnumConfigHashDrift,
-                );
-                if let Err(e) = db
-                    .set_metadata(LAST_RECOVERY_ACTION_KEY, recovery.as_str())
-                    .await
-                {
-                    tracing::debug!(error = %e, "Failed to persist inventory reconciliation action");
-                }
+    if !config.runtime.dry_run
+        && let Some(db) = state_db
+    {
+        enum_config_hash_outcome = check_and_persist_enum_config_hash(db, &enum_config_hash).await;
+        force_full_for_config_hash = enum_config_hash_outcome.must_force_full_sync();
+        if matches!(enum_config_hash_outcome, EnumConfigHashOutcome::Changed) {
+            let recovery = RecoveryAction::ReconcileInventory(
+                download::FullEnumerationReason::EnumConfigHashDrift,
+            );
+            if let Err(e) = db
+                .set_metadata(LAST_RECOVERY_ACTION_KEY, recovery.as_str())
+                .await
+            {
+                tracing::debug!(error = %e, "Failed to persist inventory reconciliation action");
             }
-            if matches!(
-                enum_config_hash_outcome,
-                EnumConfigHashOutcome::ChangedTokenPurgeFailed | EnumConfigHashOutcome::ReadFailed
-            ) {
-                checkpoint_transition_state_safe = false;
-                db_sync_token_advance_safe = false;
-            }
+        }
+        if matches!(
+            enum_config_hash_outcome,
+            EnumConfigHashOutcome::ChangedTokenPurgeFailed | EnumConfigHashOutcome::ReadFailed
+        ) {
+            checkpoint_transition_state_safe = false;
+            db_sync_token_advance_safe = false;
         }
     }
 
@@ -683,24 +682,24 @@ pub(crate) async fn run_cycle(
     // into the new directory/template. Detect that before choosing
     // incremental mode. Path-only drift keeps source tracking incremental;
     // the pending marker drives separate catalog/targeted rehydration work.
-    if !config.runtime.dry_run {
-        if let (Some(db), Some(first_library)) = (state_db, library_states.first()) {
-            let probe_config = build_download_config(
-                download::SyncMode::Full,
-                Arc::new(rustc_hash::FxHashSet::default()),
-                Arc::new(download::AssetGroupings::default()),
-                Arc::from(first_library.zone_name.as_str()),
-            );
-            let download_config_hash = download::hash_download_config(&probe_config);
-            let outcome = check_download_config_hash_for_cycle(db, &download_config_hash).await;
-            force_full_for_download_config_hash = outcome.must_force_full_sync();
-            if matches!(outcome, DownloadConfigHashOutcome::Changed) {
-                pending_download_config_hash = Some(download_config_hash);
-            }
-            if outcome.token_purge_failed() {
-                checkpoint_transition_state_safe = false;
-                db_sync_token_advance_safe = false;
-            }
+    if !config.runtime.dry_run
+        && let (Some(db), Some(first_library)) = (state_db, library_states.first())
+    {
+        let probe_config = build_download_config(
+            download::SyncMode::Full,
+            Arc::new(rustc_hash::FxHashSet::default()),
+            Arc::new(download::AssetGroupings::default()),
+            Arc::from(first_library.zone_name.as_str()),
+        );
+        let download_config_hash = download::hash_download_config(&probe_config);
+        let outcome = check_download_config_hash_for_cycle(db, &download_config_hash).await;
+        force_full_for_download_config_hash = outcome.must_force_full_sync();
+        if matches!(outcome, DownloadConfigHashOutcome::Changed) {
+            pending_download_config_hash = Some(download_config_hash);
+        }
+        if outcome.token_purge_failed() {
+            checkpoint_transition_state_safe = false;
+            db_sync_token_advance_safe = false;
         }
     }
 
@@ -779,13 +778,12 @@ pub(crate) async fn run_cycle(
             download::SyncMode::Incremental { .. } => "incremental",
         };
         if let Some(reason) = sync_mode_decision.full_enumeration_reason {
-            if let Some(db) = state_db {
-                if let Err(e) = db
+            if let Some(db) = state_db
+                && let Err(e) = db
                     .set_metadata(LAST_FULL_ENUMERATION_REASON_KEY, reason.as_str())
                     .await
-                {
-                    tracing::debug!(error = %e, "Failed to persist full-enumeration reason");
-                }
+            {
+                tracing::debug!(error = %e, "Failed to persist full-enumeration reason");
             }
             tracing::info!(
                 sync_mode = sync_mode_label,
@@ -952,16 +950,15 @@ pub(crate) async fn run_cycle(
         if library_completed_without_errors
             && !cycle_has_stale_plan
             && download_controls.run_mode.downloads_files()
+            && let Some(db) = state_db
         {
-            if let Some(db) = state_db {
-                update_inventory_anchor_for_cycle(
-                    db,
-                    &enum_config_hash,
-                    &lib_state.zone_name,
-                    &mut sync_result.stats,
-                )
-                .await;
-            }
+            update_inventory_anchor_for_cycle(
+                db,
+                &enum_config_hash,
+                &lib_state.zone_name,
+                &mut sync_result.stats,
+            )
+            .await;
         }
 
         // Provider cursor safety is independent from transfer completion.
@@ -1075,8 +1072,8 @@ pub(crate) async fn run_cycle(
                 checkpoint_hold_action = Some(recovery.as_str());
                 crate::metrics::record_checkpoint_decision("preserved", reason.as_str());
                 db_sync_token_advance_safe = false;
-                if let Some(db) = state_db {
-                    if let Err(e) = db
+                if let Some(db) = state_db
+                    && let Err(e) = db
                         .commit_checkpoint_transition(state::CheckpointTransition {
                             metadata_updates: vec![
                                 (
@@ -1091,9 +1088,8 @@ pub(crate) async fn run_cycle(
                             metadata_deletes: Vec::new(),
                         })
                         .await
-                    {
-                        tracing::debug!(error = %e, "Failed to persist checkpoint hold status");
-                    }
+                {
+                    tracing::debug!(error = %e, "Failed to persist checkpoint hold status");
                 }
                 let diagnostic = sync_result
                     .stats
@@ -1145,71 +1141,68 @@ pub(crate) async fn run_cycle(
         && db_sync_token_advance_safe
         && !cycle_session_expired
         && !shutdown_token.is_cancelled()
+        && let Some(db) = state_db
     {
-        if let Some(db) = state_db {
-            let mut metadata_updates = Vec::new();
-            let mut metadata_deletes = Vec::new();
-            if force_full_for_config_hash {
-                for lib_state in library_states
-                    .iter()
-                    .copied()
-                    .filter(|state| has_active_passes(state))
-                {
-                    let candidate_key =
-                        pending_zone_token_key(&enum_config_hash, &lib_state.zone_name);
-                    let Some(token) = db
-                        .get_metadata(&candidate_key)
-                        .await?
-                        .filter(|token| !token.trim().is_empty())
-                    else {
-                        db_sync_token_advance_safe = false;
-                        tracing::warn!(
-                            zone = %lib_state.zone_name,
-                            "Config reconciliation has no completed checkpoint for selected zone"
-                        );
-                        break;
-                    };
-                    metadata_updates.push((lib_state.sync_token_key.clone(), token));
-                    metadata_deletes.push(candidate_key);
-                }
-                if db_sync_token_advance_safe {
-                    metadata_updates.push((ENUM_CONFIG_HASH_KEY.to_owned(), enum_config_hash));
-                    metadata_deletes.push(PENDING_ENUM_CONFIG_HASH_KEY.to_owned());
-                }
+        let mut metadata_updates = Vec::new();
+        let mut metadata_deletes = Vec::new();
+        if force_full_for_config_hash {
+            for lib_state in library_states
+                .iter()
+                .copied()
+                .filter(|state| has_active_passes(state))
+            {
+                let candidate_key = pending_zone_token_key(&enum_config_hash, &lib_state.zone_name);
+                let Some(token) = db
+                    .get_metadata(&candidate_key)
+                    .await?
+                    .filter(|token| !token.trim().is_empty())
+                else {
+                    db_sync_token_advance_safe = false;
+                    tracing::warn!(
+                        zone = %lib_state.zone_name,
+                        "Config reconciliation has no completed checkpoint for selected zone"
+                    );
+                    break;
+                };
+                metadata_updates.push((lib_state.sync_token_key.clone(), token));
+                metadata_deletes.push(candidate_key);
             }
             if db_sync_token_advance_safe {
-                metadata_updates
-                    .push((LAST_CHECKPOINT_STATUS_KEY.to_owned(), "current".to_owned()));
-                metadata_updates.push((LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()));
-                if let Err(e) = db
-                    .commit_checkpoint_transition(state::CheckpointTransition {
-                        metadata_updates,
-                        metadata_deletes,
-                    })
-                    .await
-                {
-                    db_sync_token_advance_safe = false;
-                    tracing::warn!(error = %e, "Failed to atomically promote checkpoint reconciliation");
-                }
+                metadata_updates.push((ENUM_CONFIG_HASH_KEY.to_owned(), enum_config_hash));
+                metadata_deletes.push(PENDING_ENUM_CONFIG_HASH_KEY.to_owned());
+            }
+        }
+        if db_sync_token_advance_safe {
+            metadata_updates.push((LAST_CHECKPOINT_STATUS_KEY.to_owned(), "current".to_owned()));
+            metadata_updates.push((LAST_RECOVERY_ACTION_KEY.to_owned(), "none".to_owned()));
+            if let Err(e) = db
+                .commit_checkpoint_transition(state::CheckpointTransition {
+                    metadata_updates,
+                    metadata_deletes,
+                })
+                .await
+            {
+                db_sync_token_advance_safe = false;
+                tracing::warn!(error = %e, "Failed to atomically promote checkpoint reconciliation");
             }
         }
     }
 
-    if path_reconciliation_complete && !cycle_session_expired && !shutdown_token.is_cancelled() {
-        if let (Some(db), Some(download_config_hash)) = (state_db, pending_download_config_hash) {
-            if let Err(e) = db
-                .commit_checkpoint_transition(state::CheckpointTransition {
-                    metadata_updates: vec![(
-                        download::DOWNLOAD_CONFIG_HASH_KEY.to_owned(),
-                        download_config_hash,
-                    )],
-                    metadata_deletes: vec![PENDING_DOWNLOAD_CONFIG_HASH_KEY.to_owned()],
-                })
-                .await
-            {
-                tracing::warn!(error = %e, "Failed to promote completed local path reconciliation");
-            }
-        }
+    if path_reconciliation_complete
+        && !cycle_session_expired
+        && !shutdown_token.is_cancelled()
+        && let (Some(db), Some(download_config_hash)) = (state_db, pending_download_config_hash)
+        && let Err(e) = db
+            .commit_checkpoint_transition(state::CheckpointTransition {
+                metadata_updates: vec![(
+                    download::DOWNLOAD_CONFIG_HASH_KEY.to_owned(),
+                    download_config_hash,
+                )],
+                metadata_deletes: vec![PENDING_DOWNLOAD_CONFIG_HASH_KEY.to_owned()],
+            })
+            .await
+    {
+        tracing::warn!(error = %e, "Failed to promote completed local path reconciliation");
     }
 
     Ok(CycleResult {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -13,10 +13,10 @@ use crate::cli;
 #[cfg(test)]
 use crate::commands::PassScope;
 use crate::commands::{
-    attempt_reauth, build_collection_context, collection_libraries, init_photos_service,
-    pass_scope_for_zone, resolve_cross_zone_libraries_for_album_hydration, resolve_libraries,
-    resolve_passes_for_scope, wait_and_retry_2fa, zone_name_set, CollectionContext,
-    MAX_REAUTH_ATTEMPTS,
+    CollectionContext, MAX_REAUTH_ATTEMPTS, attempt_reauth, build_collection_context,
+    collection_libraries, init_photos_service, pass_scope_for_zone,
+    resolve_cross_zone_libraries_for_album_hydration, resolve_libraries, resolve_passes_for_scope,
+    wait_and_retry_2fa, zone_name_set,
 };
 use crate::config;
 use crate::credential;
@@ -27,14 +27,14 @@ use crate::password::{self, ExposeSecret, SecretString};
 use crate::retry;
 use crate::shutdown;
 use crate::state;
-use crate::sync_cycle::{run_cycle, sync_token_key as make_sync_token_key, LibraryState};
+use crate::sync_cycle::{LibraryState, run_cycle, sync_token_key as make_sync_token_key};
 
 #[cfg(test)]
 use crate::sync_cycle::{
+    CycleResult, DownloadConfigHashOutcome, ENUM_CONFIG_HASH_KEY, EnumConfigHashOutcome,
+    PENDING_DOWNLOAD_CONFIG_HASH_KEY, PENDING_ENUM_CONFIG_HASH_KEY, SYNC_TOKEN_PREFIX,
     check_and_persist_enum_config_hash, check_download_config_hash_for_cycle, determine_sync_mode,
     pending_zone_token_key, should_store_sync_token, should_store_sync_token_for_cycle,
-    CycleResult, DownloadConfigHashOutcome, EnumConfigHashOutcome, ENUM_CONFIG_HASH_KEY,
-    PENDING_DOWNLOAD_CONFIG_HASH_KEY, PENDING_ENUM_CONFIG_HASH_KEY, SYNC_TOKEN_PREFIX,
 };
 
 #[cfg(all(test, feature = "xmp"))]
@@ -42,8 +42,8 @@ use crate::sync_cycle::preload_asset_groupings;
 
 use crate::systemd::SystemdNotifier;
 use crate::{
-    available_disk_space, check_min_disk_space, make_password_provider, PartialSyncError,
-    PidFileGuard,
+    PartialSyncError, PidFileGuard, available_disk_space, check_min_disk_space,
+    make_password_provider,
 };
 #[cfg(test)]
 use tokio_util::sync::CancellationToken;
@@ -362,19 +362,18 @@ async fn maybe_notify_shared_libraries(
     };
 
     let Some(msg) = should_notify_shared_libraries(selector, shared_count, already_notified) else {
-        if shared_count == 0 {
-            if let Err(e) = db
+        if shared_count == 0
+            && let Err(e) = db
                 .set_metadata(
                     SHARED_LIBRARY_NOTICE_CHECKED_KEY,
                     &chrono::Utc::now().timestamp().to_string(),
                 )
                 .await
-            {
-                tracing::debug!(
-                    error = %e,
-                    "shared-library notice: failed to persist no-shared check marker"
-                );
-            }
+        {
+            tracing::debug!(
+                error = %e,
+                "shared-library notice: failed to persist no-shared check marker"
+            );
         }
         return;
     };
@@ -465,12 +464,12 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // runs don't need the same env again. Only when the user explicitly chose
     // a config path (--config), to avoid surprise writes at the default
     // location during tests or one-off runs.
-    if !toml_existed && config_explicitly_set {
-        if let Err(e) =
+    if !toml_existed
+        && config_explicitly_set
+        && let Err(e) =
             config::persist_first_run_config(&config_path, &config, cli_data_dir.as_deref())
-        {
-            tracing::warn!(error = %e, "Failed to save first-run config");
-        }
+    {
+        tracing::warn!(error = %e, "Failed to save first-run config");
     }
 
     // One-shot operations — never inherit watch mode from TOML config,
@@ -493,10 +492,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
 
     // Install password redaction now that we know the password
-    if let Some(pw) = &config.auth.password {
-        if let Ok(mut guard) = redact_password.lock() {
-            *guard = Some(SecretString::from(pw.expose_secret().to_owned()));
-        }
+    if let Some(pw) = &config.auth.password
+        && let Ok(mut guard) = redact_password.lock()
+    {
+        *guard = Some(SecretString::from(pw.expose_secret().to_owned()));
     }
 
     // Prevent core dumps from leaking in-memory credentials
@@ -1095,16 +1094,17 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             WatchPrecheck::proceed_all()
         };
 
-        if !config.runtime.dry_run && !config.runtime.only_print_filenames {
-            if let Some(db) = state_db.as_deref() {
-                let drift = run_bounded_local_drift_probe(db, cycle_index).await;
-                if drift.marked_failed > 0 {
-                    tracing::warn!(
-                        marked_failed = drift.marked_failed,
-                        "Local drift probe found missing or damaged files; forcing this cycle to retry them"
-                    );
-                    watch_precheck = WatchPrecheck::proceed_all();
-                }
+        if !config.runtime.dry_run
+            && !config.runtime.only_print_filenames
+            && let Some(db) = state_db.as_deref()
+        {
+            let drift = run_bounded_local_drift_probe(db, cycle_index).await;
+            if drift.marked_failed > 0 {
+                tracing::warn!(
+                    marked_failed = drift.marked_failed,
+                    "Local drift probe found missing or damaged files; forcing this cycle to retry them"
+                );
+                watch_precheck = WatchPrecheck::proceed_all();
             }
         }
 
@@ -1318,11 +1318,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         // for operators who want to sweep the whole state DB immediately.
         if is_watch_mode
             && should_reconcile_this_cycle(cycle_index, config.watch.reconcile_every_n_cycles)
+            && let Some(db) = state_db.as_ref()
         {
-            if let Some(db) = state_db.as_ref() {
-                run_periodic_reconcile(db.as_ref() as &dyn state::ReportStateStore, cycle_index)
-                    .await;
-            }
+            run_periodic_reconcile(db.as_ref() as &dyn state::ReportStateStore, cycle_index).await;
         }
 
         if let Some(interval) = config.watch.interval {
@@ -1602,7 +1600,7 @@ async fn notify_and_wait_for_2fa(
 /// the periodic walk is a diagnostic, not a load-bearing correctness gate,
 /// and a transient SQLite hiccup must not crash the watch daemon.
 async fn run_periodic_reconcile(db: &dyn state::ReportStateStore, cycle_index: u64) {
-    use crate::commands::reconcile::{scan_local_drift, LocalDriftAsset, LocalDriftKind};
+    use crate::commands::reconcile::{LocalDriftAsset, LocalDriftKind, scan_local_drift};
     tracing::info!(
         cycle_index,
         "Periodic reconciliation: scanning state DB for missing or damaged local files"
@@ -2981,21 +2979,15 @@ mod tests {
         // template content or active-pass selection.
         let sel = selection_all_passes_active();
         let states0 = commingle_test_states(0, &sel);
-        assert!(find_multi_library_commingle_flags(
-            &states0,
-            "%Y/%m/%d",
-            "{album}",
-            "{smart-folder}"
-        )
-        .is_empty());
+        assert!(
+            find_multi_library_commingle_flags(&states0, "%Y/%m/%d", "{album}", "{smart-folder}")
+                .is_empty()
+        );
         let states1 = commingle_test_states(1, &sel);
-        assert!(find_multi_library_commingle_flags(
-            &states1,
-            "%Y/%m/%d",
-            "{album}",
-            "{smart-folder}"
-        )
-        .is_empty());
+        assert!(
+            find_multi_library_commingle_flags(&states1, "%Y/%m/%d", "{album}", "{smart-folder}")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -3121,8 +3113,8 @@ mod tests {
     }
 
     #[test]
-    fn find_multi_library_commingle_flags_reports_all_missing_when_every_active_template_lacks_token(
-    ) {
+    fn find_multi_library_commingle_flags_reports_all_missing_when_every_active_template_lacks_token()
+     {
         let sel = selection_all_passes_active();
         let states = commingle_test_states(2, &sel);
         let missing =
@@ -3654,7 +3646,7 @@ mod tests {
         Arc<download::AssetGroupings>,
         Arc<str>,
     ) -> Arc<download::DownloadConfig>
-           + '_ {
+    + '_ {
         make_run_cycle_download_config_builder_with_options(
             download_dir,
             db,
@@ -3672,7 +3664,7 @@ mod tests {
         Arc<download::AssetGroupings>,
         Arc<str>,
     ) -> Arc<download::DownloadConfig>
-           + '_ {
+    + '_ {
         move |sync_mode, exclude_asset_ids, asset_groupings, library| {
             let mut config = download::DownloadConfig::test_default();
             config.directory = Arc::from(download_dir);
@@ -3706,7 +3698,7 @@ mod tests {
         Arc<download::AssetGroupings>,
         Arc<str>,
     ) -> Arc<download::DownloadConfig>
-           + '_ {
+    + '_ {
         let build_download_config = make_run_cycle_download_config_builder(download_dir, db);
         move |sync_mode, exclude_asset_ids, asset_groupings, library| {
             observed_modes
@@ -6398,11 +6390,12 @@ mod tests {
                 .as_deref(),
             Some("old-enum-hash")
         );
-        assert!(db
-            .get_metadata(PENDING_ENUM_CONFIG_HASH_KEY)
-            .await
-            .unwrap()
-            .is_some());
+        assert!(
+            db.get_metadata(PENDING_ENUM_CONFIG_HASH_KEY)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -6451,11 +6444,13 @@ mod tests {
         .expect("legacy cleanup cycle");
 
         assert!(result.db_sync_token_advance_safe);
-        assert!(observed_modes
-            .lock()
-            .expect("observed modes lock")
-            .iter()
-            .any(|mode| matches!(mode, download::SyncMode::Incremental { .. })));
+        assert!(
+            observed_modes
+                .lock()
+                .expect("observed modes lock")
+                .iter()
+                .any(|mode| matches!(mode, download::SyncMode::Incremental { .. }))
+        );
         assert!(result.stats.full_enumeration_reason.is_none());
         assert_eq!(
             db.get_metadata("sync_token:PrimarySync")

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -184,8 +184,8 @@ async fn watchdog_heartbeat_loop<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn disabled_notifier_is_noop() {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -7,10 +7,10 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use crate::icloud::photos::session::PhotosSession;
 use crate::icloud::photos::PhotoAsset;
+use crate::icloud::photos::session::PhotosSession;
 use crate::state::types::{AssetMetadata, AssetRecord, MediaType, VersionSizeKey};
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,11 +17,10 @@ const CLOUDKIT_STALE_SESSION_MARKER: &str = "HTTP 401 for https://";
 static AUTH_CREDS: OnceLock<(String, String, PathBuf)> = OnceLock::new();
 
 thread_local! {
-    /// Keep each live test's isolated state directory alive for the lifetime
-    /// of its test thread. Auth material is copied in, while the SQLite state
-    /// DB starts empty so one test's download/config choices cannot leave
-    /// durable pending work that changes another test's result.
-    static ISOLATED_DATA_DIR: RefCell<Option<tempfile::TempDir>> = const { RefCell::new(None) };
+    /// Keep every live test state directory alive for the lifetime of its test
+    /// thread. A test may call `require_preauth` more than once; retaining all
+    /// directories prevents a later call from deleting an earlier auth source.
+    static ISOLATED_DATA_DIRS: RefCell<Vec<tempfile::TempDir>> = const { RefCell::new(Vec::new()) };
 }
 
 fn copy_auth_material(username: &str, source: &Path, destination: &Path) {
@@ -47,24 +46,44 @@ fn copy_auth_material(username: &str, source: &Path, destination: &Path) {
 }
 
 fn isolated_data_dir(username: &str, shared_cookie_dir: &Path) -> PathBuf {
-    ISOLATED_DATA_DIR.with(|slot| {
+    ISOLATED_DATA_DIRS.with(|dirs| {
         let dir = tempfile::Builder::new()
             .prefix("kei-live-state-")
             .tempdir()
             .expect("create isolated live-test data dir");
         copy_auth_material(username, shared_cookie_dir, dir.path());
         let path = dir.path().to_path_buf();
-        *slot.borrow_mut() = Some(dir);
+        dirs.borrow_mut().push(dir);
         path
     })
 }
 
 fn refresh_isolated_auth_material(username: &str, shared_cookie_dir: &Path) {
-    ISOLATED_DATA_DIR.with(|slot| {
-        if let Some(dir) = slot.borrow().as_ref() {
+    ISOLATED_DATA_DIRS.with(|dirs| {
+        for dir in dirs.borrow().iter() {
             copy_auth_material(username, shared_cookie_dir, dir.path());
         }
     });
+}
+
+#[test]
+fn repeated_isolated_data_dirs_remain_available() {
+    let source = tempfile::tempdir().expect("create auth source");
+    std::fs::write(source.path().join("userexamplecom.session"), b"session")
+        .expect("write auth source");
+
+    let first = isolated_data_dir("user@example.com", source.path());
+    let second = isolated_data_dir("user@example.com", source.path());
+
+    assert_ne!(first, second);
+    assert_eq!(
+        std::fs::read(first.join("userexamplecom.session")).expect("read first auth copy"),
+        b"session"
+    );
+    assert_eq!(
+        std::fs::read(second.join("userexamplecom.session")).expect("read second auth copy"),
+        b"session"
+    );
 }
 
 /// Load `.env` exactly once across all test functions.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,8 +3,8 @@
 
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Set when any test detects an Apple 503 rate-limit response.
 static RATE_LIMITED: AtomicBool = AtomicBool::new(false);
@@ -306,7 +306,7 @@ fn refresh_auth() {
 /// Does **not** retry on 503 rate limits or other errors.
 #[allow(dead_code)]
 pub fn with_auth_retry(f: impl Fn()) {
-    use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+    use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 
     match catch_unwind(AssertUnwindSafe(&f)) {
         Ok(()) => {}

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -1015,8 +1015,7 @@ fn roundtrip_skip_videos_sync_skips_imported_photos() {
         // import-existing doesn't expose media selection as a flag. Use TOML
         // to force it.
         let test_data = tempdir().unwrap();
-        let media_filter_toml =
-            "[filters]\nalbums = [\"none\"]\nunfiled = true\nmedia = [\"photos\", \"live-photos\"]\n";
+        let media_filter_toml = "[filters]\nalbums = [\"none\"]\nunfiled = true\nmedia = [\"photos\", \"live-photos\"]\n";
         let toml_path = write_kei_toml(test_data.path(), download_dir, media_filter_toml);
 
         let recent = ROUNDTRIP_RECENT.to_string();

--- a/tests/import_existing_live.rs
+++ b/tests/import_existing_live.rs
@@ -1191,10 +1191,14 @@ fn default_used_when_no_toml_no_cli_flag() {
             .success()
             .get_output()
             .clone();
-        let summary = parse_summary(&String::from_utf8_lossy(&out.stdout));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let summary = parse_summary(&stdout);
         assert!(
             summary.matched > 0,
-            "no-toml/no-flag default did not match the fixture: {summary:?}"
+            "no-toml/no-flag default did not match the fixture: {summary:?}\n\
+             stdout:\n{stdout}\n\
+             stderr:\n{stderr}"
         );
     });
 }

--- a/tests/shell/concurrency.sh
+++ b/tests/shell/concurrency.sh
@@ -41,6 +41,14 @@ kei_sync() {
         --log-level info "$@" 2>&1
 }
 
+# Each scenario uses a different download root. Clear provider checkpoints and
+# path/config hashes with the asset rows so the next scenario starts with a
+# full inventory instead of treating the new root as deferred reconciliation.
+reset_sync_state() {
+    kei_db_exec "DELETE FROM metadata WHERE key LIKE '%token%' OR key IN ('config_hash', 'enum_config_hash', 'pending_download_config_hash', 'pending_enum_config_hash')"
+    kei_db_exec "DELETE FROM assets"
+}
+
 kei_suite_banner "CONCURRENCY / RESUME / PARTIAL-FAILURE"
 
 echo ""
@@ -53,7 +61,7 @@ kei_preflight_session
 echo ""
 echo "=== 1. Concurrent downloads (threads=5) ==="
 DIR1=$(kei_scratch_dir concurrent)
-kei_db_exec "DELETE FROM assets"
+reset_sync_state
 
 OUT=$(KEI_SYNC_DOWNLOAD_TOML=$'threads = 5\n' kei_sync "$DIR1")
 echo "$OUT" | grep -E "concurrency|downloaded|failed|completed"
@@ -88,7 +96,7 @@ rm -rf "$DIR1"
 echo ""
 echo "=== 2. Interrupted download + resume ==="
 DIR2=$(kei_scratch_dir resume)
-kei_db_exec "DELETE FROM assets"
+reset_sync_state
 
 # Session reuse puts auth at ~3s; kill at 4s so we interrupt mid- or
 # just-post-download. Even if all files complete before the kill the
@@ -120,7 +128,7 @@ rm -rf "$DIR2"
 echo ""
 echo "=== 3. Exit code 2 (partial failure) ==="
 DIR3=$(kei_scratch_dir partial-fail)
-kei_db_exec "DELETE FROM assets"
+reset_sync_state
 
 # Force one of the test album's files to land in a read-only directory.
 # Album passes default to `{album}/` since the per-category template

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1100,10 +1100,9 @@ fn first_jpeg(dir: &&std::path::Path) -> std::path::PathBuf {
 #[test]
 #[ignore]
 fn sync_raw_policy_controls_raw_naming() {
-    let (username, password, cookie_dir) = common::require_preauth();
-
     common::with_auth_retry(|| {
         for variant in ["as-is", "prefer-raw", "prefer-jpeg"] {
+            let (username, password, cookie_dir) = common::require_preauth();
             let dir = tempdir().expect("tempdir");
             album_cmd_with_toml(
                 &username,
@@ -1137,10 +1136,9 @@ fn sync_raw_policy_controls_raw_naming() {
 #[test]
 #[ignore]
 fn sync_live_photo_mov_policy_controls_naming() {
-    let (username, password, cookie_dir) = common::require_preauth();
-
     common::with_auth_retry(|| {
         for policy in ["suffix", "original"] {
+            let (username, password, cookie_dir) = common::require_preauth();
             let dir = tempdir().expect("tempdir");
             album_cmd_with_toml(
                 &username,

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -793,7 +793,7 @@ fn sync_set_exif_datetime_embeds_date() {
         assert!(!jpeg_files.is_empty(), "should have at least one JPEG file");
 
         // Read XMP from the first JPEG and verify DateTimeOriginal is present
-        use xmp_toolkit::{xmp_ns, OpenFileOptions, XmpFile};
+        use xmp_toolkit::{OpenFileOptions, XmpFile, xmp_ns};
         let mut file = XmpFile::new().expect("xmp file handle");
         file.open_file(jpeg_files[0], OpenFileOptions::default().for_read())
             .expect("open JPEG for XMP read");


### PR DESCRIPTION
## Summary
- Moved the main crate and fuzz harnesses to Rust 2024.
- Applied the required edition migration and formatting changes with no intended runtime behavior change.
- Fixed test isolation and stale smoke-test references found during comprehensive offline and authenticated iCloud validation.

## Tests
- `just full-test` => 30/30 phases passed, 12,638 tests
- `just cov check` => passed, 91.70% line coverage
- `just cov live` => passed, 92.74% merged line coverage
- `just fuzz all 10` => all 10 fuzz targets passed
- `KEI_FULL_TEST_REAL_SERVICE=1 scripts/full-test/run_real_service_lifecycle.sh` => passed
- `just release-smoke` => passed
- `cargo fmt --check` => passed
- `cargo clippy --all-targets --all-features -- -D warnings` => passed
- `just gate` => passed

## Review notes
- The broad source diff is primarily the Rust 2024 migration and formatter output.
- The second commit contains the test-harness fixes separately.
- The existing Rust 1.91 minimum version already supports Rust 2024.
