### PR TITLE
Fix iCloud location decode to read longitude from `lon`

### DIFF
--- a/src/icloud/photos/enc.rs
+++ b/src/icloud/photos/enc.rs
@@ -97,8 +97,8 @@ pub struct Location {
 
 /// Decode `locationEnc` or `locationV2Enc` fields.
 ///
-/// Both contain a binary plist dict with `lat: f64`, `lng: f64`, `alt: f64`
-/// keys. Returns `None` if decoding fails or lat/lng are absent.
+/// Both contain a binary plist dict with `lat: f64`, `lon: f64`, `alt: f64`
+/// keys. Returns `None` if decoding fails or lat/lon are absent.
 pub fn decode_location(fields: &Value, key: &str) -> Option<Location> {
     let entry = fields.get(key)?;
     if entry.is_null() {
@@ -108,7 +108,7 @@ pub fn decode_location(fields: &Value, key: &str) -> Option<Location> {
     let value = PlistValue::from_reader(Cursor::new(&bytes)).ok()?;
     let dict = value.into_dictionary()?;
     let latitude = dict.get("lat").and_then(plist_to_f64)?;
-    let longitude = dict.get("lng").and_then(plist_to_f64)?;
+    let longitude = dict.get("lon").and_then(plist_to_f64)?;
     let altitude = dict.get("alt").and_then(plist_to_f64);
     Some(Location {
         latitude,
@@ -239,7 +239,7 @@ mod tests {
     fn decode_location_roundtrip_with_altitude() {
         let mut dict = plist::Dictionary::new();
         dict.insert("lat".into(), PlistValue::Real(37.7749));
-        dict.insert("lng".into(), PlistValue::Real(-122.4194));
+        dict.insert("lon".into(), PlistValue::Real(-122.4194));
         dict.insert("alt".into(), PlistValue::Real(17.0));
         let bplist = bplist_from(PlistValue::Dictionary(dict));
         let fields = json!({
@@ -255,7 +255,7 @@ mod tests {
     fn decode_location_without_altitude() {
         let mut dict = plist::Dictionary::new();
         dict.insert("lat".into(), PlistValue::Real(1.0));
-        dict.insert("lng".into(), PlistValue::Real(2.0));
+        dict.insert("lon".into(), PlistValue::Real(2.0));
         let bplist = bplist_from(PlistValue::Dictionary(dict));
         let fields = json!({
             "locationEnc": {"value": b64(&bplist), "type": "ENCRYPTED_BYTES"}
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn decode_location_missing_lat_returns_none() {
         let mut dict = plist::Dictionary::new();
-        dict.insert("lng".into(), PlistValue::Real(2.0));
+        dict.insert("lon".into(), PlistValue::Real(2.0));
         let bplist = bplist_from(PlistValue::Dictionary(dict));
         let fields = json!({
             "locationEnc": {"value": b64(&bplist), "type": "ENCRYPTED_BYTES"}
@@ -285,11 +285,11 @@ mod tests {
         // Build v1 with bad coords, v2 with good coords — fallback must pick v2.
         let mut d1 = plist::Dictionary::new();
         d1.insert("lat".into(), PlistValue::Real(1.0));
-        d1.insert("lng".into(), PlistValue::Real(1.0));
+        d1.insert("lon".into(), PlistValue::Real(1.0));
         let bp1 = bplist_from(PlistValue::Dictionary(d1));
         let mut d2 = plist::Dictionary::new();
         d2.insert("lat".into(), PlistValue::Real(42.0));
-        d2.insert("lng".into(), PlistValue::Real(-7.0));
+        d2.insert("lon".into(), PlistValue::Real(-7.0));
         let bp2 = bplist_from(PlistValue::Dictionary(d2));
         let fields = json!({
             "locationEnc": {"value": b64(&bp1), "type": "ENCRYPTED_BYTES"},

--- a/src/icloud/photos/metadata.rs
+++ b/src/icloud/photos/metadata.rs
@@ -261,7 +261,7 @@ mod tests {
     fn extract_location_from_plist() {
         let mut dict = plist::Dictionary::new();
         dict.insert("lat".into(), PlistValue::Real(10.0));
-        dict.insert("lng".into(), PlistValue::Real(-20.0));
+        dict.insert("lon".into(), PlistValue::Real(-20.0));
         dict.insert("alt".into(), PlistValue::Real(5.0));
         let bp = bplist(PlistValue::Dictionary(dict));
         let m = extract(

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -8556,7 +8556,7 @@ mod tests {
 
         let mut loc_dict = plist::Dictionary::new();
         loc_dict.insert("lat".into(), plist::Value::Real(37.7749));
-        loc_dict.insert("lng".into(), plist::Value::Real(-122.4194));
+        loc_dict.insert("lon".into(), plist::Value::Real(-122.4194));
         loc_dict.insert("alt".into(), plist::Value::Real(17.0));
         let loc_bp = bplist(plist::Value::Dictionary(loc_dict));
 


### PR DESCRIPTION
Closes #672.

## Problem

kei decodes the `locationEnc` and `locationV2Enc` binary plists to read each photo's GPS, but it looked up longitude under the key `lng`.  Apple stores longitude under `lon`, so longitude was never found; since longitude is required for a successful decode, every asset resolved to no location and kei captured no GPS into its catalogue or its XMP sidecars, even though the original file still carried the coordinates in EXIF.  It also left the `set_exif_gps` write path with nothing to write.

An asset's `locationEnc` is a base64 binary plist.  Decoded, with coordinates anonymised, it looks like:

```json
{
  "lat": 37.3349,
  "lon": -122.0090,
  "alt": 25.0,
  "course": 90.0,
  "speed": 0.0,
  "horzAcc": 5.0,
  "vertAcc": 3.0,
  "timestamp": "2020-01-01T00:00:00Z"
}
```

Longitude is under `lon`, so a lookup under `lng` always misses.

## Fix

Read longitude from `lon`, matching Apple's data.  The upstream icloudpd decoder reads the same key: [`src/icloudpd/xmp_sidecar.py`](https://github.com/icloud-photos-downloader/icloud_photos_downloader/blob/879c561240d993d748ddb4546f935090502b16d3/src/icloudpd/xmp_sidecar.py#L130-L136) decodes the same `locationEnc` plist and calls `location.get("lon")`.  The plist test fixtures in `enc`, `metadata`, and `db` used the wrong key as well, so they are corrected to `lon`.

## Verification

Built and deployed to a live backup host.  A fresh sync of two camera originals decoded latitude, longitude, and altitude into the catalogue that matched each file's in-file EXIF exactly, and the XMP sidecar carried the GPS tags.  Before the change the same assets decoded to no GPS.
