### PR TITLE
Recover legacy pending assets missing CloudKit mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bounded and fallback full syncs now run targeted pending-asset revalidation after source enumeration, so provider-confirmed deletions clear stale pending rows without requiring an incremental checkpoint. ([#663])
+- Legacy pending rows with a live iCloud master now recover their missing asset identity and retry, so bounded syncs can finish old downloads without a wide photo enumeration. ([#663])
 
 ## [0.22.12] - 2026-07-13
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3025,7 +3025,9 @@ pub(crate) async fn reconcile_catalog_paths(
                 }
                 targets.retain(|target| target.asset_id.as_ref() != id);
             }
-            RecordResolution::Unknown | RecordResolution::TransientFailure(_) => {}
+            RecordResolution::MasterPresent
+            | RecordResolution::Unknown
+            | RecordResolution::TransientFailure(_) => {}
         }
     }
 
@@ -8130,6 +8132,49 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug)]
+    struct LegacyPendingHydrationSession {
+        lookup_records: Arc<Vec<Value>>,
+        hydration_records: Arc<Vec<Value>>,
+        hydration_error: Option<Arc<str>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PhotosSession for LegacyPendingHydrationSession {
+        async fn post(
+            &self,
+            url: &str,
+            body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            if url.contains("/records/lookup?") {
+                return Ok(json!({"records": self.lookup_records.as_ref().clone()}));
+            }
+            if url.contains("/changes/zone?") {
+                let request: Value = serde_json::from_str(&body)?;
+                let has_sync_token = request["zones"]
+                    .as_array()
+                    .and_then(|zones| zones.first())
+                    .and_then(|zone| zone.get("syncToken"))
+                    .is_some();
+                let records = if has_sync_token {
+                    Vec::new()
+                } else {
+                    if let Some(error) = &self.hydration_error {
+                        anyhow::bail!(error.to_string());
+                    }
+                    self.hydration_records.as_ref().clone()
+                };
+                return Ok(changes_zone_response(records, "zone-token-next"));
+            }
+            Ok(json!({"records": [], "syncToken": "ignored-query-token"}))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(self.clone())
+        }
+    }
+
     fn changes_zone_response(records: Vec<Value>, sync_token: &str) -> Value {
         json!({
             "zones": [{
@@ -11771,6 +11816,175 @@ mod tests {
         assert_eq!(summary.failed, 0);
         assert_eq!(summary.awaiting_provider_verification, 0);
         assert_eq!(summary.source_deleted, 1);
+    }
+
+    #[tokio::test]
+    async fn bounded_full_sync_hydrates_live_legacy_pending_master() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = crate::start_wiremock_or_skip!();
+        let body = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&body));
+        Mock::given(method("GET"))
+            .and(path("/legacy-pending.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("LEGACY_PENDING_PRESENT")
+            .filename("legacy-pending.jpg")
+            .checksum(&checksum)
+            .size(8)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let download_url = format!("{}/legacy-pending.jpg", server.uri());
+        let mut records = incremental_photo_records_with_url(
+            "LEGACY_PENDING_PRESENT",
+            "legacy-pending.jpg",
+            &download_url,
+            8,
+        );
+        records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] = json!(checksum);
+        let session = LegacyPendingHydrationSession {
+            lookup_records: Arc::new(vec![records[0].clone()]),
+            hydration_records: Arc::new(records),
+            hydration_error: None,
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Full;
+        config.recent = Some(300);
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("live legacy pending master should hydrate and download");
+
+        assert!(result.full_enumeration_ran);
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.downloaded, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.awaiting_provider_verification, 0);
+        assert_eq!(summary.source_deleted, 0);
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-LEGACY_PENDING_PRESENT")
+                .await
+                .expect("mapping lookup")
+                .as_deref(),
+            Some("LEGACY_PENDING_PRESENT")
+        );
+        let downloaded = db
+            .get_downloaded_page(0, 10)
+            .await
+            .expect("downloaded page");
+        let local_path = downloaded[0]
+            .local_path
+            .as_ref()
+            .expect("downloaded row has local path");
+        assert!(tokio::fs::metadata(local_path).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn pending_retry_retains_ambiguous_legacy_siblings() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("LEGACY_AMBIGUOUS")
+            .checksum("no-sibling-matches")
+            .size(999)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+
+        let master = mock_master_record_with_filename("LEGACY_AMBIGUOUS", "ambiguous.jpg");
+        let hydration_records = vec![
+            master.clone(),
+            mock_asset_record_for("asset-ambiguous-a", "LEGACY_AMBIGUOUS"),
+            mock_asset_record_for("asset-ambiguous-b", "LEGACY_AMBIGUOUS"),
+        ];
+        let session = LegacyPendingHydrationSession {
+            lookup_records: Arc::new(vec![master]),
+            hydration_records: Arc::new(hydration_records),
+            hydration_error: None,
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+
+        let plan = build_pending_retry_download_tasks(&passes, &config, CancellationToken::new())
+            .await
+            .expect("ambiguous siblings should remain safely unresolved");
+
+        assert!(plan.tasks.is_empty());
+        assert_eq!(plan.unmatched_targets.len(), 1);
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.awaiting_provider_verification, 1);
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-ambiguous-a")
+                .await
+                .expect("mapping lookup"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_retry_retains_transient_legacy_hydration_failure() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("LEGACY_TRANSIENT").build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        let session = LegacyPendingHydrationSession {
+            lookup_records: Arc::new(vec![mock_master_record_with_filename(
+                "LEGACY_TRANSIENT",
+                "transient.jpg",
+            )]),
+            hydration_records: Arc::new(Vec::new()),
+            hydration_error: Some(Arc::from("temporary changes failure")),
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let mut config = test_config();
+        config.state_db = Some(db.clone());
+
+        let plan = build_pending_retry_download_tasks(&passes, &config, CancellationToken::new())
+            .await
+            .expect("transient hydration failure should retain durable work");
+
+        assert!(plan.tasks.is_empty());
+        assert_eq!(plan.unmatched_targets.len(), 1);
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.awaiting_provider_verification, 1);
     }
 
     #[tokio::test]

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -7,10 +7,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    DownloadConfig, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RetryTaskKey, UrlRetrySource,
-    build_pass_configs_resolving_deferred_excludes, planner,
+    DownloadConfig, DownloadStore, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RetryTaskKey,
+    UrlRetrySource, build_pass_configs_resolving_deferred_excludes, planner,
 };
-use crate::icloud::photos::{ProviderRecordId, RecordLookupRequest, RecordResolution};
+use crate::icloud::photos::{PhotoAsset, ProviderRecordId, RecordLookupRequest, RecordResolution};
 use crate::state::{AssetVerificationState, VersionSizeKey};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -38,6 +38,76 @@ impl PendingRetryTarget {
     }
 }
 
+#[derive(Debug)]
+struct PendingRetryEvidence {
+    checksum: Arc<str>,
+    size_bytes: u64,
+}
+
+impl PendingRetryEvidence {
+    fn from_record(record: &crate::state::AssetRecord) -> Self {
+        Self {
+            checksum: Arc::from(record.checksum.as_ref()),
+            size_bytes: record.size_bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum LegacyCandidateSelection {
+    Selected(PhotoAsset),
+    Missing,
+    Ambiguous { candidates: usize },
+}
+
+fn candidate_matches_durable_evidence(
+    asset: &PhotoAsset,
+    target: &PendingRetryTarget,
+    evidence: &PendingRetryEvidence,
+) -> bool {
+    asset.versions().iter().any(|(version_size, version)| {
+        VersionSizeKey::from(*version_size) == target.version_size
+            && version.size == evidence.size_bytes
+            && version.checksum.as_ref() == evidence.checksum.as_ref()
+    })
+}
+
+fn select_legacy_candidate(
+    candidates: Vec<PhotoAsset>,
+    targets: &[&PendingRetryTarget],
+    evidence: &FxHashMap<PendingRetryTarget, PendingRetryEvidence>,
+) -> LegacyCandidateSelection {
+    if candidates.is_empty() {
+        return LegacyCandidateSelection::Missing;
+    }
+    if candidates.len() == 1 {
+        return candidates.into_iter().next().map_or(
+            LegacyCandidateSelection::Missing,
+            LegacyCandidateSelection::Selected,
+        );
+    }
+
+    let candidate_count = candidates.len();
+    let mut matching = candidates.into_iter().filter(|asset| {
+        targets.iter().any(|target| {
+            evidence
+                .get(*target)
+                .is_some_and(|evidence| candidate_matches_durable_evidence(asset, target, evidence))
+        })
+    });
+    let Some(selected) = matching.next() else {
+        return LegacyCandidateSelection::Ambiguous {
+            candidates: candidate_count,
+        };
+    };
+    if matching.next().is_some() {
+        return LegacyCandidateSelection::Ambiguous {
+            candidates: candidate_count,
+        };
+    }
+    LegacyCandidateSelection::Selected(selected)
+}
+
 pub(super) fn take_matching_pending_retry_tasks<I>(
     tasks: I,
     pending_targets: &mut FxHashSet<PendingRetryTarget>,
@@ -54,6 +124,70 @@ pub(super) fn take_matching_pending_retry_tasks<I>(
             }
         }
     }
+}
+
+async fn plan_resolved_pending_asset(
+    asset: &PhotoAsset,
+    state_id: &str,
+    db: &dyn DownloadStore,
+    pass_configs: &[Arc<DownloadConfig>],
+    pending_targets: &mut FxHashSet<PendingRetryTarget>,
+    task_planner: &mut planner::TaskPlanner,
+    tasks: &mut Vec<DownloadTask>,
+    retry_sources: &mut FxHashMap<RetryTaskKey, UrlRetrySource>,
+) -> Result<()> {
+    for target in pending_targets
+        .iter()
+        .filter(|target| target.asset_id.as_ref() == state_id)
+    {
+        db.clear_asset_verification(
+            &target.library,
+            &target.asset_id,
+            target.version_size.as_str(),
+        )
+        .await?;
+    }
+    for (pass_index, pass_config) in pass_configs.iter().enumerate() {
+        let plan = task_planner.plan_asset(asset, pass_config).await;
+        if plan.filter_reason.is_some() {
+            continue;
+        }
+        let first_new_task = tasks.len();
+        take_matching_pending_retry_tasks(plan.tasks, pending_targets, tasks);
+        for task in tasks.iter().skip(first_new_task) {
+            retry_sources.insert(
+                RetryTaskKey::from(task),
+                UrlRetrySource {
+                    asset_record_name: asset.asset_record_name_arc(),
+                    pass_index,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn set_verification_for_state_id(
+    db: &dyn DownloadStore,
+    pending_targets: &FxHashSet<PendingRetryTarget>,
+    state_id: &str,
+    state: AssetVerificationState,
+    reason: &str,
+) -> Result<()> {
+    for target in pending_targets
+        .iter()
+        .filter(|target| target.asset_id.as_ref() == state_id)
+    {
+        db.set_asset_verification(
+            &target.library,
+            &target.asset_id,
+            target.version_size.as_str(),
+            state,
+            reason,
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Default)]
@@ -82,6 +216,27 @@ pub(super) async fn build_pending_retry_download_tasks(
         .collect();
     if pending_targets.is_empty() {
         return Ok(PendingRetryPlan::default());
+    }
+    let pending_evidence: FxHashMap<PendingRetryTarget, PendingRetryEvidence> = pending
+        .iter()
+        .filter(|record| record.library.as_ref() == config.library.as_ref())
+        .map(|record| {
+            (
+                PendingRetryTarget::from_record(record),
+                PendingRetryEvidence::from_record(record),
+            )
+        })
+        .collect();
+
+    let backfilled = db
+        .backfill_asset_master_mappings_from_album_memberships()
+        .await?;
+    if backfilled > 0 {
+        tracing::info!(
+            inserted = backfilled,
+            library = %config.library,
+            "Backfilled asset/master mappings before pending retry"
+        );
     }
 
     let requested = pending_targets.len();
@@ -166,40 +321,27 @@ pub(super) async fn build_pending_retry_download_tasks(
     } else {
         Vec::new()
     };
+    let mut legacy_present_state_ids = FxHashSet::default();
     for (state_id, resolution) in resolutions {
         if pending_targets.is_empty() || shutdown_token.is_cancelled() {
             break;
         }
         match resolution {
             RecordResolution::Present(asset) => {
-                for target in pending_targets
-                    .iter()
-                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
-                {
-                    db.clear_asset_verification(
-                        &target.library,
-                        &target.asset_id,
-                        target.version_size.as_str(),
-                    )
-                    .await?;
-                }
-                for (pass_index, pass_config) in pass_configs.iter().enumerate() {
-                    let plan = task_planner.plan_asset(&asset, pass_config).await;
-                    if plan.filter_reason.is_some() {
-                        continue;
-                    }
-                    let first_new_task = tasks.len();
-                    take_matching_pending_retry_tasks(plan.tasks, &mut pending_targets, &mut tasks);
-                    for task in tasks.iter().skip(first_new_task) {
-                        retry_sources.insert(
-                            RetryTaskKey::from(task),
-                            UrlRetrySource {
-                                asset_record_name: asset.asset_record_name_arc(),
-                                pass_index,
-                            },
-                        );
-                    }
-                }
+                plan_resolved_pending_asset(
+                    &asset,
+                    state_id.as_str(),
+                    db.as_ref(),
+                    &pass_configs,
+                    &mut pending_targets,
+                    &mut task_planner,
+                    &mut tasks,
+                    &mut retry_sources,
+                )
+                .await?;
+            }
+            RecordResolution::MasterPresent => {
+                legacy_present_state_ids.insert(state_id.as_str().to_string());
             }
             RecordResolution::Deleted {
                 deleted_at,
@@ -230,19 +372,14 @@ pub(super) async fn build_pending_retry_download_tasks(
                 );
             }
             RecordResolution::Unknown => {
-                for target in pending_targets
-                    .iter()
-                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
-                {
-                    db.set_asset_verification(
-                        &target.library,
-                        &target.asset_id,
-                        target.version_size.as_str(),
-                        AssetVerificationState::Unknown,
-                        "provider lookup omitted or could not parse the requested record",
-                    )
-                    .await?;
-                }
+                set_verification_for_state_id(
+                    db.as_ref(),
+                    &pending_targets,
+                    state_id.as_str(),
+                    AssetVerificationState::Unknown,
+                    "provider lookup omitted or could not parse the requested record",
+                )
+                .await?;
                 tracing::warn!(
                     library = %config.library,
                     state_id = state_id.as_str(),
@@ -250,25 +387,146 @@ pub(super) async fn build_pending_retry_download_tasks(
                 );
             }
             RecordResolution::TransientFailure(error) => {
-                for target in pending_targets
-                    .iter()
-                    .filter(|target| target.asset_id.as_ref() == state_id.as_str())
-                {
-                    db.set_asset_verification(
-                        &target.library,
-                        &target.asset_id,
-                        target.version_size.as_str(),
-                        AssetVerificationState::TransientFailure,
-                        &error.to_string(),
-                    )
-                    .await?;
-                }
+                set_verification_for_state_id(
+                    db.as_ref(),
+                    &pending_targets,
+                    state_id.as_str(),
+                    AssetVerificationState::TransientFailure,
+                    &error.to_string(),
+                )
+                .await?;
                 tracing::warn!(
                     library = %config.library,
                     state_id = state_id.as_str(),
                     error = %error,
                     "Pending asset retained: provider lookup failed transiently"
                 );
+            }
+        }
+    }
+
+    if !legacy_present_state_ids.is_empty() && !shutdown_token.is_cancelled() {
+        tracing::info!(
+            library = %config.library,
+            masters = legacy_present_state_ids.len(),
+            "Hydrating missing CPLAsset identities for live legacy pending masters"
+        );
+        let (hydrated, hydration_failed) = match passes.first() {
+            Some(pass) => match pass
+                .album
+                .hydrate_matching_master_assets_from_changes(
+                    &legacy_present_state_ids,
+                    &shutdown_token,
+                    |asset| {
+                        pending_evidence.iter().any(|(target, evidence)| {
+                            target.asset_id.as_ref() == asset.id()
+                                && candidate_matches_durable_evidence(asset, target, evidence)
+                        })
+                    },
+                )
+                .await
+            {
+                Ok(assets) => (assets, false),
+                Err(error) => {
+                    let reason = error.to_string();
+                    for state_id in &legacy_present_state_ids {
+                        set_verification_for_state_id(
+                            db.as_ref(),
+                            &pending_targets,
+                            state_id,
+                            AssetVerificationState::TransientFailure,
+                            &reason,
+                        )
+                        .await?;
+                    }
+                    tracing::warn!(
+                        library = %config.library,
+                        error = %error,
+                        "Pending legacy asset hydration failed transiently"
+                    );
+                    (Vec::new(), true)
+                }
+            },
+            None => (Vec::new(), false),
+        };
+        let mut candidates_by_master: FxHashMap<String, Vec<PhotoAsset>> = FxHashMap::default();
+        for asset in hydrated {
+            candidates_by_master
+                .entry(asset.id().to_string())
+                .or_default()
+                .push(asset);
+        }
+
+        for state_id in legacy_present_state_ids {
+            if shutdown_token.is_cancelled() {
+                break;
+            }
+            if hydration_failed {
+                continue;
+            }
+            let matching_targets: Vec<&PendingRetryTarget> = pending_targets
+                .iter()
+                .filter(|target| target.asset_id.as_ref() == state_id)
+                .collect();
+            let candidates = candidates_by_master.remove(&state_id).unwrap_or_default();
+            match select_legacy_candidate(candidates, &matching_targets, &pending_evidence) {
+                LegacyCandidateSelection::Selected(asset) => {
+                    db.upsert_asset_master_mapping(
+                        &config.library,
+                        asset.asset_record_name(),
+                        asset.id(),
+                    )
+                    .await?;
+                    tracing::info!(
+                        library = %config.library,
+                        state_id,
+                        asset_record_name = %asset.asset_record_name(),
+                        "Recovered legacy pending asset/master mapping"
+                    );
+                    let asset = asset.with_state_record_name(Arc::from(state_id.as_str()));
+                    plan_resolved_pending_asset(
+                        &asset,
+                        &state_id,
+                        db.as_ref(),
+                        &pass_configs,
+                        &mut pending_targets,
+                        &mut task_planner,
+                        &mut tasks,
+                        &mut retry_sources,
+                    )
+                    .await?;
+                }
+                LegacyCandidateSelection::Missing => {
+                    set_verification_for_state_id(
+                        db.as_ref(),
+                        &pending_targets,
+                        &state_id,
+                        AssetVerificationState::Unknown,
+                        "provider confirmed the master exists but no current CPLAsset pair was found",
+                    )
+                    .await?;
+                    tracing::warn!(
+                        library = %config.library,
+                        state_id,
+                        "Pending asset retained: live master had no current CPLAsset pair"
+                    );
+                }
+                LegacyCandidateSelection::Ambiguous { candidates } => {
+                    set_verification_for_state_id(
+                        db.as_ref(),
+                        &pending_targets,
+                        &state_id,
+                        AssetVerificationState::Unknown,
+                        "multiple provider asset records matched the legacy master",
+                    )
+                    .await?;
+                    tracing::warn!(
+                        library = %config.library,
+                        state_id,
+                        candidates,
+                        "Pending asset retained: legacy master resolved to ambiguous CPLAsset siblings"
+                    );
+                }
             }
         }
     }
@@ -302,4 +560,87 @@ pub(super) async fn build_pending_retry_download_tasks(
         unmatched_targets: pending_targets.into_iter().collect(),
         requested,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::test_helpers::TestAssetRecord;
+
+    fn candidate(master: &str, asset: &str, checksum: &str, size: u64) -> PhotoAsset {
+        PhotoAsset::new(
+            json!({
+                "recordName": master,
+                "recordType": "CPLMaster",
+                "fields": {
+                    "filenameEnc": {"value": "legacy.jpg", "type": "STRING"},
+                    "itemType": {"value": "public.jpeg"},
+                    "resOriginalFileType": {"value": "public.jpeg"},
+                    "resOriginalRes": {"value": {
+                        "downloadURL": "https://p01.icloud-content.com/legacy.jpg",
+                        "fileChecksum": checksum,
+                        "size": size,
+                    }},
+                },
+            }),
+            json!({
+                "recordName": asset,
+                "recordType": "CPLAsset",
+                "fields": {
+                    "masterRef": {"value": {"recordName": master}},
+                    "assetDate": {"value": 1700000000000i64},
+                },
+            }),
+        )
+    }
+
+    #[test]
+    fn legacy_candidate_selection_uses_unique_durable_fingerprint() {
+        let record = TestAssetRecord::new("legacy-master")
+            .checksum("checksum-b")
+            .size(200)
+            .build();
+        let target = PendingRetryTarget::from_record(&record);
+        let evidence =
+            FxHashMap::from_iter([(target.clone(), PendingRetryEvidence::from_record(&record))]);
+        let selection = select_legacy_candidate(
+            vec![
+                candidate("legacy-master", "asset-a", "checksum-a", 100),
+                candidate("legacy-master", "asset-b", "checksum-b", 200),
+            ],
+            &[&target],
+            &evidence,
+        );
+
+        let LegacyCandidateSelection::Selected(selected) = selection else {
+            panic!("unique durable fingerprint should select one sibling");
+        };
+        assert_eq!(selected.asset_record_name(), "asset-b");
+    }
+
+    #[test]
+    fn legacy_candidate_selection_retains_ambiguous_siblings() {
+        let record = TestAssetRecord::new("legacy-master")
+            .checksum("missing-checksum")
+            .size(300)
+            .build();
+        let target = PendingRetryTarget::from_record(&record);
+        let evidence =
+            FxHashMap::from_iter([(target.clone(), PendingRetryEvidence::from_record(&record))]);
+        let selection = select_legacy_candidate(
+            vec![
+                candidate("legacy-master", "asset-a", "checksum-a", 100),
+                candidate("legacy-master", "asset-b", "checksum-b", 200),
+            ],
+            &[&target],
+            &evidence,
+        );
+
+        assert!(matches!(
+            selection,
+            LegacyCandidateSelection::Ambiguous { candidates: 2 }
+        ));
+    }
 }

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -10,6 +10,7 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_stream::Stream;
+use tokio_util::sync::CancellationToken;
 
 use super::asset::{ChangeEvent, DeltaRecordBuffer, PhotoAsset};
 use super::cloudkit::ChangesZoneResponse;
@@ -117,6 +118,7 @@ fn classify_provider_lookup_error(error: &anyhow::Error) -> ProviderLookupError 
 #[derive(Debug)]
 pub(crate) enum RecordResolution {
     Present(PhotoAsset),
+    MasterPresent,
     Deleted {
         deleted_at: Option<chrono::DateTime<chrono::Utc>>,
         master_family: bool,
@@ -135,6 +137,7 @@ pub(crate) struct RecordResolutionBatch {
 enum ResolutionEvidence {
     ChildDeleted,
     Inconclusive,
+    MasterPresent,
     MasterDeleted,
     Present,
 }
@@ -142,6 +145,7 @@ enum ResolutionEvidence {
 fn resolution_evidence(resolution: &RecordResolution) -> ResolutionEvidence {
     match resolution {
         RecordResolution::Present(_) => ResolutionEvidence::Present,
+        RecordResolution::MasterPresent => ResolutionEvidence::MasterPresent,
         RecordResolution::Deleted {
             master_family: true,
             ..
@@ -987,12 +991,14 @@ impl PhotoAlbum {
                         deleted_at,
                         master_family: master_deleted,
                     }
-                } else if let (Some(master), Some(asset)) = (master, asset) {
+                } else if let Some(master) = master {
                     match (
                         serde_json::from_value::<super::cloudkit::Record>(master.clone()),
-                        serde_json::from_value::<super::cloudkit::Record>(asset.clone()),
+                        asset.map(|asset| {
+                            serde_json::from_value::<super::cloudkit::Record>(asset.clone())
+                        }),
                     ) {
-                        (Ok(master), Ok(asset))
+                        (Ok(master), Some(Ok(asset)))
                             if master.record_type == "CPLMaster"
                                 && asset.record_type == "CPLAsset" =>
                         {
@@ -1003,6 +1009,12 @@ impl PhotoAlbum {
                             }
                             RecordResolution::Present(photo)
                         }
+                        (Ok(master), None)
+                            if request.asset_record_name.is_none()
+                                && master.record_type == "CPLMaster" =>
+                        {
+                            RecordResolution::MasterPresent
+                        }
                         _ => RecordResolution::Unknown,
                     }
                 } else {
@@ -1010,6 +1022,7 @@ impl PhotoAlbum {
                 };
                 let outcome = match &resolution {
                     RecordResolution::Present(_) => "present",
+                    RecordResolution::MasterPresent => "master_present_unpaired",
                     RecordResolution::Deleted { .. } => "deleted",
                     RecordResolution::Unknown => "unknown",
                     RecordResolution::TransientFailure(_) => "transient_failure",
@@ -1452,6 +1465,89 @@ impl PhotoAlbum {
                 source
                     .matching_assets_from_changes(missing_asset_record_names)
                     .await?,
+            );
+        }
+        Ok(matched)
+    }
+
+    /// Recover current `CPLAsset` records for legacy state keyed only by a
+    /// `CPLMaster` record name.
+    ///
+    /// The caller supplies the proof that a candidate resolves its durable
+    /// target. Scanning stops once every requested master has such a candidate;
+    /// otherwise it continues to EOF so the caller can assess missing or
+    /// ambiguous siblings conservatively.
+    pub(crate) async fn hydrate_matching_master_assets_from_changes<F>(
+        &self,
+        master_record_names: &FxHashSet<String>,
+        shutdown_token: &CancellationToken,
+        mut candidate_resolves_target: F,
+    ) -> anyhow::Result<Vec<PhotoAsset>>
+    where
+        F: FnMut(&PhotoAsset) -> bool,
+    {
+        if master_record_names.is_empty() || shutdown_token.is_cancelled() {
+            return Ok(Vec::new());
+        }
+
+        fn collect_event<F>(
+            event: ChangeEvent,
+            source_zone: &Arc<str>,
+            master_record_names: &FxHashSet<String>,
+            unresolved_master_names: &mut FxHashSet<String>,
+            seen_asset_record_names: &mut FxHashSet<String>,
+            matched: &mut Vec<PhotoAsset>,
+            candidate_resolves_target: &mut F,
+        ) where
+            F: FnMut(&PhotoAsset) -> bool,
+        {
+            if event.reason != crate::types::ChangeReason::Created {
+                return;
+            }
+            let Some(asset) = event.asset else {
+                return;
+            };
+            let asset = asset.with_source_zone(Arc::clone(source_zone));
+            if master_record_names.contains(asset.id())
+                && seen_asset_record_names.insert(asset.asset_record_name().to_string())
+            {
+                if candidate_resolves_target(&asset) {
+                    unresolved_master_names.remove(asset.id());
+                }
+                matched.push(asset);
+            }
+        }
+
+        let mut buffer = DeltaRecordBuffer::new();
+        let source_zone: Arc<str> = Arc::from(self.zone_name());
+        let mut unresolved_master_names = master_record_names.clone();
+        let mut seen_asset_record_names = FxHashSet::default();
+        let mut matched = Vec::new();
+        self.scan_changes_zone(|record| {
+            for event in buffer.process_records(vec![record]) {
+                collect_event(
+                    event,
+                    &source_zone,
+                    master_record_names,
+                    &mut unresolved_master_names,
+                    &mut seen_asset_record_names,
+                    &mut matched,
+                    &mut candidate_resolves_target,
+                );
+            }
+            !shutdown_token.is_cancelled() && !unresolved_master_names.is_empty()
+        })
+        .await?;
+
+        for event in buffer.flush() {
+            collect_event(
+                event,
+                &source_zone,
+                master_record_names,
+                &mut unresolved_master_names,
+                &mut seen_asset_record_names,
+                &mut matched,
+                &mut candidate_resolves_target,
             );
         }
         Ok(matched)
@@ -2808,8 +2904,13 @@ mod tests {
             .next()
             .expect("live account must contain at least one photo");
         let missing_id = "kei-phase0-record-that-does-not-exist";
+        let master_only_state_id = "live-master-only";
         let requests = [
             lookup_request(asset.id(), asset.id(), asset.asset_record_name()),
+            RecordLookupRequest::master_only(
+                ProviderRecordId::new(master_only_state_id),
+                ProviderRecordId::new(asset.id()),
+            ),
             RecordLookupRequest::master_only(
                 ProviderRecordId::new(missing_id),
                 ProviderRecordId::new(missing_id),
@@ -2818,13 +2919,23 @@ mod tests {
 
         let result = album.resolve_records(&requests).await;
 
-        assert!(result.complete, "live lookup batch must be complete");
+        assert!(
+            !result.complete,
+            "a live master-only lookup still needs its CPLAsset pair"
+        );
         assert!(matches!(
             result
                 .results
                 .iter()
                 .find(|(id, _)| id.as_str() == asset.id()),
             Some((_, RecordResolution::Present(_)))
+        ));
+        assert!(matches!(
+            result
+                .results
+                .iter()
+                .find(|(id, _)| id.as_str() == master_only_state_id),
+            Some((_, RecordResolution::MasterPresent))
         ));
         assert!(matches!(
             result
@@ -2912,6 +3023,27 @@ mod tests {
                     ..
                 }
             )]
+        ));
+    }
+
+    #[tokio::test]
+    async fn targeted_master_only_lookup_distinguishes_live_legacy_master() {
+        let response = json!({
+            "records": [test_master_record("legacy-master")]
+        });
+        let album = make_album_with_session(100, Box::new(MockPhotosSession::new().ok(response)));
+
+        let batch = album
+            .resolve_records(&[RecordLookupRequest::master_only(
+                ProviderRecordId::new("legacy-state"),
+                ProviderRecordId::new("legacy-master"),
+            )])
+            .await;
+
+        assert!(!batch.complete);
+        assert!(matches!(
+            batch.results.as_slice(),
+            [(_, RecordResolution::MasterPresent)]
         ));
     }
 
@@ -4649,6 +4781,43 @@ mod tests {
         assert!(missing.is_empty());
         assert_eq!(matched.len(), 1);
         assert_eq!(matched[0].asset_record_name(), "asset-1");
+    }
+
+    #[tokio::test]
+    async fn hydrate_matching_master_assets_collects_every_live_sibling() {
+        let records = vec![
+            changes_master("master-target"),
+            changes_asset("asset-target-a", "master-target"),
+            changes_asset("asset-target-b", "master-target"),
+            changes_master("master-other"),
+            changes_asset("asset-other", "master-other"),
+        ];
+        let mock = MockPhotosSession::new().ok(canned_changes_page(&records, "token-final", false));
+        let album = make_album_with_session(100, Box::new(mock));
+        let masters = FxHashSet::from_iter(["master-target".to_string()]);
+
+        let matched = album
+            .hydrate_matching_master_assets_from_changes(
+                &masters,
+                &CancellationToken::new(),
+                |_| false,
+            )
+            .await
+            .expect("master hydration");
+
+        assert_eq!(matched.len(), 2);
+        assert!(matched.iter().all(|asset| asset.id() == "master-target"));
+        assert!(
+            matched
+                .iter()
+                .all(|asset| asset.source_zone() == Some("PrimarySync"))
+        );
+        let asset_record_names: FxHashSet<&str> =
+            matched.iter().map(PhotoAsset::asset_record_name).collect();
+        assert_eq!(
+            asset_record_names,
+            FxHashSet::from_iter(["asset-target-a", "asset-target-b"])
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Distinguish a live master-only CloudKit lookup from deletion or inconclusive results.
- Recover missing `CPLAsset` identities through `changes/zone`, persist the mapping, and retry through the existing verified download pipeline.
- Use durable version, size, and checksum evidence to select siblings; retain pending rows when results are missing, ambiguous, or transient.
- Add regression coverage for Issue 663's production path.

## Context
Addresses #663.

The remaining legacy row was keyed by its `CPLMaster` without a stored `CPLAsset` mapping. The existing lookup could confirm that the master still existed, but it could not construct a downloadable asset.

A direct `masterRef` query returned HTTP 400 during live validation, so recovery uses the existing `changes/zone` path. It stops after finding exact identity evidence and scans to completion when needed to avoid choosing an ambiguous sibling.

## Tests
- `just gate` - passed
- `just full-test` - 30/30 phases passed, 12,666 tests
- `cargo test bounded_full_sync_hydrates_live_legacy_pending_master -- --test-threads=1` - passed
- `cargo test pending_retry_retains_ -- --test-threads=1` - passed
- `cargo test live_targeted_record_lookup_distinguishes_present_and_missing -- --ignored --test-threads=1` - passed
