### PR TITLE
Link CLI help to documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,11 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check live wiki command documentation
+        run: |
+          git clone --depth=1 https://github.com/rhoopr/kei.wiki.git /tmp/kei-wiki
+          cargo build --bin kei
+          scripts/check-wiki-commands.sh target/debug/kei /tmp/kei-wiki
       - run: cargo doc --no-deps --all-features
 
   # Detects dependencies declared in Cargo.toml but not actually used

--- a/scripts/check-wiki-commands.sh
+++ b/scripts/check-wiki-commands.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <kei-binary> <wiki-directory>" >&2
+    exit 2
+fi
+
+binary="$1"
+home="$2/Home.md"
+
+if [[ ! -x "$binary" ]]; then
+    echo "wiki command check: binary is not executable: $binary" >&2
+    exit 2
+fi
+if [[ ! -f "$home" ]]; then
+    echo "wiki command check: Home.md not found under $2" >&2
+    exit 2
+fi
+
+help_output=$("$binary" --help)
+mapfile -t cli_commands < <(
+    sed -n '/^Commands:$/,/^Options:$/s/^  \([a-z][a-z-]*\)  .*/\1/p' <<<"$help_output" |
+        grep -v '^help$'
+)
+mapfile -t wiki_commands < <(
+    awk '
+        $0 == "## Commands" { in_commands = 1; next }
+        in_commands && /^## / { exit }
+        in_commands && /^\| \[`/ { split($0, parts, "`"); print parts[2] }
+    ' "$home"
+)
+
+if ! diff -u \
+    <(printf '%s\n' "${cli_commands[@]}") \
+    <(printf '%s\n' "${wiki_commands[@]}"); then
+    echo "wiki command check: Home.md command table differs from 'kei --help'" >&2
+    exit 1
+fi
+
+checked=0
+while IFS= read -r example; do
+    # Home's canonical examples intentionally use simple argv with no shell
+    # quoting or pipelines. Add explicit argv fixtures here if that changes.
+    read -r -a args <<<"$example"
+    if ! "$binary" "${args[@]}" --help >/dev/null 2>&1; then
+        echo "wiki command check: invalid Home.md example: kei $example" >&2
+        exit 1
+    fi
+    checked=$((checked + 1))
+done < <(
+    awk '
+        /^```(sh|bash)$/ { in_shell = 1; next }
+        /^```$/ { in_shell = 0; next }
+        in_shell && /^kei / { sub(/^kei /, ""); print }
+    ' "$home"
+)
+
+if [[ $checked -eq 0 ]]; then
+    echo "wiki command check: Home.md has no command examples" >&2
+    exit 1
+fi
+
+echo "wiki command check passed: ${#cli_commands[@]} commands, $checked examples"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -550,6 +550,7 @@ pub enum ServiceAction {
 #[derive(Subcommand, Debug, Clone)]
 pub enum Command {
     /// Download photos from iCloud
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Sync")]
     Sync {
         #[command(flatten)]
         friendly: FriendlyArgs,
@@ -562,6 +563,7 @@ pub enum Command {
     },
 
     /// Authenticate interactively (creates/refreshes session tokens)
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Login")]
     Login {
         #[command(flatten)]
         password: PasswordArgs,
@@ -571,6 +573,7 @@ pub enum Command {
     },
 
     /// List available albums or libraries
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/List")]
     List {
         #[command(flatten)]
         password: PasswordArgs,
@@ -591,6 +594,7 @@ pub enum Command {
     },
 
     /// Manage stored credentials (OS keyring or encrypted file)
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Password")]
     Password {
         #[command(flatten)]
         password: PasswordArgs,
@@ -600,50 +604,61 @@ pub enum Command {
     },
 
     /// Reset state database or sync tokens
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Reset")]
     Reset {
         #[command(subcommand)]
         what: ResetCommand,
     },
 
     /// Config management
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Config")]
     Config {
         #[command(subcommand)]
         action: ConfigAction,
     },
 
     /// Show sync status and database summary
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Status")]
     Status(StatusArgs),
 
     /// Run redacted local diagnostics for support
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Doctor")]
     Doctor(DoctorArgs),
 
     /// Export the local state catalog without contacting iCloud
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Manifest")]
     Manifest(ManifestArgs),
 
     /// Import existing local files into the state database
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Import-Existing")]
     ImportExisting(ImportArgs),
 
     /// Verify downloaded files exist and optionally check checksums
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Verify")]
     Verify(VerifyArgs),
 
     /// Reconcile state database with files on disk: mark assets as
     /// failed when their local file is missing or truncated, so the
     /// next sync re-downloads them.
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Reconcile")]
     Reconcile(ReconcileArgs),
 
     /// Register kei as a system service (launchd on macOS, systemd on
     /// Linux, Service Control Manager on Windows). Inside a Docker
     /// container the command logs that compose-managed deployments are
     /// already supervised and exits without writing anything.
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Install")]
     Install(InstallArgs),
 
     /// Remove the kei service registered by `kei install`. Pass `--purge`
     /// to also delete the state database, configuration, and stored
     /// credentials.
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Service")]
     Uninstall(UninstallArgs),
 
     /// Service-mode operations: run the long-lived worker, or query
     /// service registration status.
+    #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Service")]
     Service {
         #[command(subcommand)]
         action: ServiceAction,
@@ -667,7 +682,9 @@ pub enum Command {
         Advanced:\n  \
         kei install         Register as a background service\n  \
         kei verify          Verify downloaded files\n  \
-        kei import-existing  Adopt an existing local photo tree"
+        kei import-existing  Adopt an existing local photo tree\n\n  \
+        Documentation: https://github.com/rhoopr/kei/wiki\n  \
+        Support and issues: https://github.com/rhoopr/kei/issues"
 )]
 pub struct Cli {
     // ── Global options ──────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,10 @@ impl ExitClassification {
     const fn should_log(self) -> bool {
         !matches!(self, Self::TwoFactorRequired)
     }
+
+    const fn should_suggest_diagnostics(self) -> bool {
+        matches!(self, Self::Other)
+    }
 }
 
 fn classify_exit_error(e: &anyhow::Error) -> ExitClassification {
@@ -654,6 +658,11 @@ pub fn main_inner() -> ExitCode {
                 )]
                 {
                     eprintln!("Error: {e:#}");
+                    if classification.should_suggest_diagnostics() {
+                        eprintln!();
+                        eprintln!("Run `kei doctor --json` for a redacted diagnostic report.");
+                        eprintln!("Report bugs: https://github.com/rhoopr/kei/issues");
+                    }
                 }
             }
             ExitCode::from(classification.exit_code())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -55,7 +55,42 @@ fn help_flag_succeeds() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("kei: photo sync engine"));
+        .stdout(predicate::str::contains("kei: photo sync engine"))
+        .stdout(predicate::str::contains(
+            "https://github.com/rhoopr/kei/wiki",
+        ))
+        .stdout(predicate::str::contains(
+            "https://github.com/rhoopr/kei/issues",
+        ));
+}
+
+#[test]
+fn subcommand_help_links_to_relevant_documentation() {
+    for (command, page) in [
+        ("sync", "Sync"),
+        ("login", "Login"),
+        ("list", "List"),
+        ("password", "Password"),
+        ("reset", "Reset"),
+        ("config", "Config"),
+        ("status", "Status"),
+        ("doctor", "Doctor"),
+        ("manifest", "Manifest"),
+        ("import-existing", "Import-Existing"),
+        ("verify", "Verify"),
+        ("reconcile", "Reconcile"),
+        ("install", "Install"),
+        ("uninstall", "Service"),
+        ("service", "Service"),
+    ] {
+        common::cmd()
+            .args([command, "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "https://github.com/rhoopr/kei/wiki/{page}"
+            )));
+    }
 }
 
 #[test]
@@ -887,6 +922,14 @@ fn config_explicit_nonexistent_path_fails_at_runtime() {
         stderr.contains("config") || stderr.contains("nonexistent"),
         "error should mention the config file, stderr:\n{stderr}"
     );
+    assert!(
+        stderr.contains("kei doctor --json"),
+        "generic runtime errors should suggest diagnostics, stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("https://github.com/rhoopr/kei/issues"),
+        "generic runtime errors should link to issue reporting, stderr:\n{stderr}"
+    );
 }
 
 // ── Auth flags on non-sync subcommands ──────────────────────────────────
@@ -1088,7 +1131,8 @@ fn exit_code_3_on_empty_password_file() {
         .timeout(std::time::Duration::from_secs(30))
         .assert()
         .code(3)
-        .stderr(predicate::str::contains("No password was available"));
+        .stderr(predicate::str::contains("No password was available"))
+        .stderr(predicate::str::contains("kei doctor --json").not());
 }
 
 /// Exit code 3 (auth failure) when password file contains only a newline.


### PR DESCRIPTION
## Summary
- Added documentation and issue links to top-level help, plus command-specific wiki links to every top-level subcommand.
- Added a diagnostic footer for generic runtime failures that points to `kei doctor --json` and the issue tracker.
- Added a CI check that compares the live wiki command table and shell examples with the compiled CLI. The matching wiki Home update is already published.

## Tests
- `just gate` => passed
- `cargo test --test cli -- --test-threads=1` => 119 passed
- `scripts/check-wiki-commands.sh target/debug/kei /tmp/codex/kei/kei.wiki` => passed with 15 commands and 2 examples
- Deliberate stale `kei sync -u ...` wiki example => rejected
