### PR TITLE
Fix filtered legacy pending retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bounded and fallback full syncs now run targeted pending-asset revalidation after source enumeration, so provider-confirmed deletions clear stale pending rows without requiring an incremental checkpoint. ([#663])
 - Legacy pending rows with a live iCloud master now recover their missing asset identity and retry, so bounded syncs can finish old downloads without a wide photo enumeration. ([#663])
+- Targeted pending retries now adopt verified on-disk files before applying current filters, validate recovered child records against saved version, size, and checksum evidence, and defer policy-excluded live rows without reporting a failed sync. ([#663])
 
 ## [0.22.12] - 2026-07-13
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -11909,7 +11909,157 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_retry_retains_ambiguous_legacy_siblings() {
+    async fn bounded_full_sync_adopts_filtered_legacy_pending_file() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+
+        let body = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&body));
+        let mut records = incremental_photo_records_with_url(
+            "LEGACY_FILTERED_ON_DISK",
+            "IMG_8905.HEIC",
+            "https://p01.icloud-content.com/IMG_8905.HEIC",
+            16,
+        );
+        records[0]["fields"]["resOriginalVidComplRes"] = json!({"value": {
+            "downloadURL": "https://p01.icloud-content.com/IMG_8905.MOV",
+            "fileChecksum": checksum,
+            "size": 8,
+        }});
+        records[0]["fields"]["resOriginalVidComplFileType"] =
+            json!({"value": "com.apple.quicktime-movie"});
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let session = LegacyPendingHydrationSession {
+            lookup_records: Arc::new(vec![records[0].clone()]),
+            hydration_records: Arc::new(records.clone()),
+            hydration_error: None,
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let dir = TempDir::new().expect("temp dir");
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Full;
+        config.recent = Some(300);
+        config.skip_created_before = Some(Utc.timestamp_opt(1_800_000_000, 0).unwrap());
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let expected_path = filter::expected_paths_for(&asset, &config)
+            .into_iter()
+            .find(|path| path.version_size == VersionSizeKey::LiveOriginal)
+            .expect("legacy live photo should derive its MOV path")
+            .path;
+        let pending_filename = expected_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("expected MOV path should have a filename");
+        let record = TestAssetRecord::new("LEGACY_FILTERED_ON_DISK")
+            .version_size(VersionSizeKey::LiveOriginal)
+            .filename(pending_filename)
+            .checksum(&checksum)
+            .size(8)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        tokio::fs::create_dir_all(expected_path.parent().expect("expected path parent"))
+            .await
+            .expect("create expected path parent");
+        tokio::fs::write(&expected_path, &body)
+            .await
+            .expect("seed existing media");
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("filtered legacy pending file should be adopted");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.downloaded, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.awaiting_provider_verification, 0);
+        let downloaded = db
+            .get_downloaded_page(0, 10)
+            .await
+            .expect("downloaded page");
+        assert_eq!(
+            downloaded[0].local_path.as_deref(),
+            Some(expected_path.as_path())
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_full_sync_defers_filtered_live_pending_without_failure() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let record = TestAssetRecord::new("LEGACY_FILTERED_MISSING")
+            .filename("legacy-filtered-missing.jpg")
+            .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+            .size(1024)
+            .build();
+        db.upsert_seen(&record).await.expect("seed pending row");
+        db.backdate_last_seen(
+            "LEGACY_FILTERED_MISSING",
+            Utc::now().timestamp().saturating_sub(86_400),
+        );
+
+        let records = mock_photo_records_with_filename(
+            "LEGACY_FILTERED_MISSING",
+            "legacy-filtered-missing.jpg",
+        );
+        let session = LegacyPendingHydrationSession {
+            lookup_records: Arc::new(vec![records[0].clone()]),
+            hydration_records: Arc::new(records),
+            hydration_error: None,
+        };
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(session)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+
+        let dir = TempDir::new().expect("temp dir");
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Full;
+        config.recent = Some(300);
+        config.skip_created_before = Some(Utc.timestamp_opt(1_800_000_000, 0).unwrap());
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &passes,
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("filtered live pending asset should be deferred");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        let summary = db.get_summary().await.expect("summary");
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.awaiting_provider_verification, 0);
+        assert_eq!(
+            db.get_master_record_name_for_asset("PrimarySync", "asset-LEGACY_FILTERED_MISSING")
+                .await
+                .expect("mapping lookup")
+                .as_deref(),
+            Some("LEGACY_FILTERED_MISSING")
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_retry_retains_legacy_siblings_without_durable_match() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = TestAssetRecord::new("LEGACY_AMBIGUOUS")
             .checksum("no-sibling-matches")
@@ -11940,7 +12090,7 @@ mod tests {
 
         let plan = build_pending_retry_download_tasks(&passes, &config, CancellationToken::new())
             .await
-            .expect("ambiguous siblings should remain safely unresolved");
+            .expect("non-matching siblings should remain safely unresolved");
 
         assert!(plan.tasks.is_empty());
         assert_eq!(plan.unmatched_targets.len(), 1);

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -346,6 +346,73 @@ enum PendingOnDiskAdoption {
     StateWriteFailed(PathBuf),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PendingRetryAdoption {
+    NotFound,
+    Adopted,
+    StateWriteFailed,
+}
+
+impl From<PendingOnDiskAdoption> for PendingRetryAdoption {
+    fn from(adoption: PendingOnDiskAdoption) -> Self {
+        match adoption {
+            PendingOnDiskAdoption::Adopted(_) => Self::Adopted,
+            PendingOnDiskAdoption::StateWriteFailed(_) => Self::StateWriteFailed,
+        }
+    }
+}
+
+pub(super) struct PendingRetryFileEvidence<'a> {
+    pub(super) version_size: VersionSizeKey,
+    pub(super) filename: &'a str,
+    pub(super) checksum: &'a str,
+    pub(super) size: u64,
+}
+
+pub(super) async fn adopt_pending_on_disk_for_retry(
+    db: &dyn DownloadStore,
+    config: &DownloadConfig,
+    asset: &PhotoAsset,
+    task_planner: &mut TaskPlanner,
+    planned_tasks: &[DownloadTask],
+    evidence: PendingRetryFileEvidence<'_>,
+) -> PendingRetryAdoption {
+    for task in planned_tasks.iter().filter(|task| {
+        task.version_size == evidence.version_size
+            && task.checksum.as_ref() == evidence.checksum
+            && task.size == evidence.size
+    }) {
+        if let Some(adoption) = adopt_pending_task_path(db, config, asset, task_planner, task).await
+        {
+            return adoption.into();
+        }
+    }
+
+    for derived in derive_expected_paths(asset, config)
+        .into_iter()
+        .filter(|derived| {
+            derived.version_size == evidence.version_size
+                && derived.checksum.as_ref() == evidence.checksum
+                && derived.size == evidence.size
+                && pending_filename_matches_derived(evidence.filename, &derived.filename)
+        })
+    {
+        if let Some(adoption) = adopt_pending_derived_path(
+            db,
+            effective_asset_library(asset, config),
+            asset,
+            task_planner,
+            &derived,
+        )
+        .await
+        {
+            return adoption.into();
+        }
+    }
+
+    PendingRetryAdoption::NotFound
+}
+
 async fn adopt_pending_on_disk_task(
     state_db: Option<&dyn DownloadStore>,
     config: &DownloadConfig,

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     DownloadConfig, DownloadStore, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RetryTaskKey,
-    UrlRetrySource, build_pass_configs_resolving_deferred_excludes, planner,
+    UrlRetrySource, build_pass_configs_resolving_deferred_excludes, filter, pipeline, planner,
 };
 use crate::icloud::photos::{PhotoAsset, ProviderRecordId, RecordLookupRequest, RecordResolution};
 use crate::state::{AssetVerificationState, VersionSizeKey};
@@ -41,6 +41,7 @@ impl PendingRetryTarget {
 #[derive(Debug)]
 struct PendingRetryEvidence {
     checksum: Arc<str>,
+    filename: Arc<str>,
     size_bytes: u64,
 }
 
@@ -48,6 +49,7 @@ impl PendingRetryEvidence {
     fn from_record(record: &crate::state::AssetRecord) -> Self {
         Self {
             checksum: Arc::from(record.checksum.as_ref()),
+            filename: Arc::from(record.filename.as_ref()),
             size_bytes: record.size_bytes,
         }
     }
@@ -57,7 +59,8 @@ impl PendingRetryEvidence {
 enum LegacyCandidateSelection {
     Selected(PhotoAsset),
     Missing,
-    Ambiguous { candidates: usize },
+    EvidenceMismatch { candidates: usize },
+    Ambiguous { matches: usize },
 }
 
 fn candidate_matches_durable_evidence(
@@ -80,12 +83,6 @@ fn select_legacy_candidate(
     if candidates.is_empty() {
         return LegacyCandidateSelection::Missing;
     }
-    if candidates.len() == 1 {
-        return candidates.into_iter().next().map_or(
-            LegacyCandidateSelection::Missing,
-            LegacyCandidateSelection::Selected,
-        );
-    }
 
     let candidate_count = candidates.len();
     let mut matching = candidates.into_iter().filter(|asset| {
@@ -96,16 +93,16 @@ fn select_legacy_candidate(
         })
     });
     let Some(selected) = matching.next() else {
-        return LegacyCandidateSelection::Ambiguous {
+        return LegacyCandidateSelection::EvidenceMismatch {
             candidates: candidate_count,
         };
     };
-    if matching.next().is_some() {
-        return LegacyCandidateSelection::Ambiguous {
-            candidates: candidate_count,
-        };
+    if matching.next().is_none() {
+        return LegacyCandidateSelection::Selected(selected);
     }
-    LegacyCandidateSelection::Selected(selected)
+    LegacyCandidateSelection::Ambiguous {
+        matches: 2 + matching.count(),
+    }
 }
 
 pub(super) fn take_matching_pending_retry_tasks<I>(
@@ -126,45 +123,172 @@ pub(super) fn take_matching_pending_retry_tasks<I>(
     }
 }
 
-async fn plan_resolved_pending_asset(
-    asset: &PhotoAsset,
-    state_id: &str,
-    db: &dyn DownloadStore,
-    pass_configs: &[Arc<DownloadConfig>],
-    pending_targets: &mut FxHashSet<PendingRetryTarget>,
-    task_planner: &mut planner::TaskPlanner,
-    tasks: &mut Vec<DownloadTask>,
-    retry_sources: &mut FxHashMap<RetryTaskKey, UrlRetrySource>,
-) -> Result<()> {
-    for target in pending_targets
-        .iter()
-        .filter(|target| target.asset_id.as_ref() == state_id)
-    {
-        db.clear_asset_verification(
-            &target.library,
-            &target.asset_id,
-            target.version_size.as_str(),
-        )
-        .await?;
-    }
-    for (pass_index, pass_config) in pass_configs.iter().enumerate() {
-        let plan = task_planner.plan_asset(asset, pass_config).await;
-        if plan.filter_reason.is_some() {
-            continue;
+struct PendingRetryPlanning<'a> {
+    db: &'a dyn DownloadStore,
+    pass_configs: &'a [Arc<DownloadConfig>],
+    pending_evidence: &'a FxHashMap<PendingRetryTarget, PendingRetryEvidence>,
+    pending_targets: &'a mut FxHashSet<PendingRetryTarget>,
+    task_planner: &'a mut planner::TaskPlanner,
+    tasks: &'a mut Vec<DownloadTask>,
+    retry_sources: &'a mut FxHashMap<RetryTaskKey, UrlRetrySource>,
+}
+
+impl PendingRetryPlanning<'_> {
+    async fn plan_resolved_asset(&mut self, asset: &PhotoAsset, state_id: &str) -> Result<()> {
+        let mut malformed_targets = FxHashSet::default();
+        let mut state_write_failed_targets = FxHashSet::default();
+        let mut filter_reasons = Vec::<filter::FilterReason>::new();
+        for (pass_index, pass_config) in self.pass_configs.iter().enumerate() {
+            let plan = self.task_planner.plan_asset(asset, pass_config).await;
+            let targets: Vec<PendingRetryTarget> = self
+                .pending_targets
+                .iter()
+                .filter(|target| target.asset_id.as_ref() == state_id)
+                .cloned()
+                .collect();
+            for target in targets {
+                let Some(evidence) = self.pending_evidence.get(&target) else {
+                    continue;
+                };
+                match pipeline::adopt_pending_on_disk_for_retry(
+                    self.db,
+                    pass_config,
+                    asset,
+                    self.task_planner,
+                    &plan.tasks,
+                    pipeline::PendingRetryFileEvidence {
+                        version_size: target.version_size,
+                        filename: &evidence.filename,
+                        checksum: &evidence.checksum,
+                        size: evidence.size_bytes,
+                    },
+                )
+                .await
+                {
+                    pipeline::PendingRetryAdoption::Adopted => {
+                        self.pending_targets.remove(&target);
+                        self.db
+                            .clear_asset_verification(
+                                &target.library,
+                                &target.asset_id,
+                                target.version_size.as_str(),
+                            )
+                            .await?;
+                    }
+                    pipeline::PendingRetryAdoption::StateWriteFailed => {
+                        state_write_failed_targets.insert(target);
+                    }
+                    pipeline::PendingRetryAdoption::NotFound => {}
+                }
+            }
+            if let Some(reason) = plan.filter_reason {
+                if !filter_reasons.contains(&reason) {
+                    filter_reasons.push(reason);
+                }
+                continue;
+            }
+            if plan.malformed_resource.is_some() {
+                malformed_targets.extend(
+                    self.pending_targets
+                        .iter()
+                        .filter(|target| target.asset_id.as_ref() == state_id)
+                        .cloned(),
+                );
+            }
+            let retry_tasks: Vec<DownloadTask> = plan
+                .tasks
+                .into_iter()
+                .filter(|task| {
+                    !state_write_failed_targets.contains(&PendingRetryTarget::from_task(task))
+                })
+                .collect();
+            let queued_targets: Vec<PendingRetryTarget> = retry_tasks
+                .iter()
+                .map(PendingRetryTarget::from_task)
+                .filter(|target| self.pending_targets.contains(target))
+                .collect();
+            let first_new_task = self.tasks.len();
+            take_matching_pending_retry_tasks(retry_tasks, self.pending_targets, self.tasks);
+            for target in queued_targets {
+                if !self.pending_targets.contains(&target) {
+                    self.db
+                        .clear_asset_verification(
+                            &target.library,
+                            &target.asset_id,
+                            target.version_size.as_str(),
+                        )
+                        .await?;
+                }
+            }
+            for task in self.tasks.iter().skip(first_new_task) {
+                self.retry_sources.insert(
+                    RetryTaskKey::from(task),
+                    UrlRetrySource {
+                        asset_record_name: asset.asset_record_name_arc(),
+                        pass_index,
+                    },
+                );
+            }
         }
-        let first_new_task = tasks.len();
-        take_matching_pending_retry_tasks(plan.tasks, pending_targets, tasks);
-        for task in tasks.iter().skip(first_new_task) {
-            retry_sources.insert(
-                RetryTaskKey::from(task),
-                UrlRetrySource {
-                    asset_record_name: asset.asset_record_name_arc(),
-                    pass_index,
-                },
+
+        let deferred_targets: Vec<PendingRetryTarget> = self
+            .pending_targets
+            .iter()
+            .filter(|target| target.asset_id.as_ref() == state_id)
+            .filter(|target| {
+                !malformed_targets.contains(*target)
+                    && !state_write_failed_targets.contains(*target)
+            })
+            .cloned()
+            .collect();
+        for target in deferred_targets {
+            self.db
+                .clear_asset_verification(
+                    &target.library,
+                    &target.asset_id,
+                    target.version_size.as_str(),
+                )
+                .await?;
+            self.pending_targets.remove(&target);
+            tracing::info!(
+                library = %target.library,
+                asset_id = %target.asset_id,
+                version_size = target.version_size.as_str(),
+                filter_reasons = ?filter_reasons,
+                "Pending asset deferred: current sync policy did not produce a retry task"
             );
         }
+        for target in state_write_failed_targets {
+            if !self.pending_targets.contains(&target) {
+                continue;
+            }
+            self.db
+                .set_asset_verification(
+                    &target.library,
+                    &target.asset_id,
+                    target.version_size.as_str(),
+                    AssetVerificationState::TransientFailure,
+                    "failed to persist on-disk pending asset adoption",
+                )
+                .await?;
+        }
+        for target in malformed_targets {
+            if !self.pending_targets.contains(&target) {
+                continue;
+            }
+            self.db
+                .set_asset_verification(
+                    &target.library,
+                    &target.asset_id,
+                    target.version_size.as_str(),
+                    AssetVerificationState::Unknown,
+                    "provider record did not contain a usable retry resource",
+                )
+                .await?;
+        }
+
+        Ok(())
     }
-    Ok(())
 }
 
 async fn set_verification_for_state_id(
@@ -328,16 +452,16 @@ pub(super) async fn build_pending_retry_download_tasks(
         }
         match resolution {
             RecordResolution::Present(asset) => {
-                plan_resolved_pending_asset(
-                    &asset,
-                    state_id.as_str(),
-                    db.as_ref(),
-                    &pass_configs,
-                    &mut pending_targets,
-                    &mut task_planner,
-                    &mut tasks,
-                    &mut retry_sources,
-                )
+                PendingRetryPlanning {
+                    db: db.as_ref(),
+                    pass_configs: &pass_configs,
+                    pending_evidence: &pending_evidence,
+                    pending_targets: &mut pending_targets,
+                    task_planner: &mut task_planner,
+                    tasks: &mut tasks,
+                    retry_sources: &mut retry_sources,
+                }
+                .plan_resolved_asset(&asset, state_id.as_str())
                 .await?;
             }
             RecordResolution::MasterPresent => {
@@ -417,12 +541,6 @@ pub(super) async fn build_pending_retry_download_tasks(
                 .hydrate_matching_master_assets_from_changes(
                     &legacy_present_state_ids,
                     &shutdown_token,
-                    |asset| {
-                        pending_evidence.iter().any(|(target, evidence)| {
-                            target.asset_id.as_ref() == asset.id()
-                                && candidate_matches_durable_evidence(asset, target, evidence)
-                        })
-                    },
                 )
                 .await
             {
@@ -484,16 +602,16 @@ pub(super) async fn build_pending_retry_download_tasks(
                         "Recovered legacy pending asset/master mapping"
                     );
                     let asset = asset.with_state_record_name(Arc::from(state_id.as_str()));
-                    plan_resolved_pending_asset(
-                        &asset,
-                        &state_id,
-                        db.as_ref(),
-                        &pass_configs,
-                        &mut pending_targets,
-                        &mut task_planner,
-                        &mut tasks,
-                        &mut retry_sources,
-                    )
+                    PendingRetryPlanning {
+                        db: db.as_ref(),
+                        pass_configs: &pass_configs,
+                        pending_evidence: &pending_evidence,
+                        pending_targets: &mut pending_targets,
+                        task_planner: &mut task_planner,
+                        tasks: &mut tasks,
+                        retry_sources: &mut retry_sources,
+                    }
+                    .plan_resolved_asset(&asset, &state_id)
                     .await?;
                 }
                 LegacyCandidateSelection::Missing => {
@@ -511,7 +629,23 @@ pub(super) async fn build_pending_retry_download_tasks(
                         "Pending asset retained: live master had no current CPLAsset pair"
                     );
                 }
-                LegacyCandidateSelection::Ambiguous { candidates } => {
+                LegacyCandidateSelection::EvidenceMismatch { candidates } => {
+                    set_verification_for_state_id(
+                        db.as_ref(),
+                        &pending_targets,
+                        &state_id,
+                        AssetVerificationState::Unknown,
+                        "no current provider asset matched the pending version, size, and checksum",
+                    )
+                    .await?;
+                    tracing::warn!(
+                        library = %config.library,
+                        state_id,
+                        candidates,
+                        "Pending asset retained: current CPLAsset records did not match durable evidence"
+                    );
+                }
+                LegacyCandidateSelection::Ambiguous { matches } => {
                     set_verification_for_state_id(
                         db.as_ref(),
                         &pending_targets,
@@ -523,7 +657,7 @@ pub(super) async fn build_pending_retry_download_tasks(
                     tracing::warn!(
                         library = %config.library,
                         state_id,
-                        candidates,
+                        matches,
                         "Pending asset retained: legacy master resolved to ambiguous CPLAsset siblings"
                     );
                 }
@@ -621,7 +755,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_candidate_selection_retains_ambiguous_siblings() {
+    fn legacy_candidate_selection_rejects_candidates_without_durable_match() {
         let record = TestAssetRecord::new("legacy-master")
             .checksum("missing-checksum")
             .size(300)
@@ -640,7 +774,59 @@ mod tests {
 
         assert!(matches!(
             selection,
-            LegacyCandidateSelection::Ambiguous { candidates: 2 }
+            LegacyCandidateSelection::EvidenceMismatch { candidates: 2 }
+        ));
+    }
+
+    #[test]
+    fn legacy_candidate_selection_rejects_single_candidate_without_durable_match() {
+        let record = TestAssetRecord::new("legacy-master")
+            .checksum("pending-checksum")
+            .size(300)
+            .build();
+        let target = PendingRetryTarget::from_record(&record);
+        let evidence =
+            FxHashMap::from_iter([(target.clone(), PendingRetryEvidence::from_record(&record))]);
+
+        let selection = select_legacy_candidate(
+            vec![candidate(
+                "legacy-master",
+                "asset-current",
+                "current-checksum",
+                200,
+            )],
+            &[&target],
+            &evidence,
+        );
+
+        assert!(matches!(
+            selection,
+            LegacyCandidateSelection::EvidenceMismatch { candidates: 1 }
+        ));
+    }
+
+    #[test]
+    fn legacy_candidate_selection_retains_multiple_durable_matches() {
+        let record = TestAssetRecord::new("legacy-master")
+            .checksum("shared-checksum")
+            .size(300)
+            .build();
+        let target = PendingRetryTarget::from_record(&record);
+        let evidence =
+            FxHashMap::from_iter([(target.clone(), PendingRetryEvidence::from_record(&record))]);
+
+        let selection = select_legacy_candidate(
+            vec![
+                candidate("legacy-master", "asset-a", "shared-checksum", 300),
+                candidate("legacy-master", "asset-b", "shared-checksum", 300),
+            ],
+            &[&target],
+            &evidence,
+        );
+
+        assert!(matches!(
+            selection,
+            LegacyCandidateSelection::Ambiguous { matches: 2 }
         ));
     }
 }

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -1473,34 +1473,24 @@ impl PhotoAlbum {
     /// Recover current `CPLAsset` records for legacy state keyed only by a
     /// `CPLMaster` record name.
     ///
-    /// The caller supplies the proof that a candidate resolves its durable
-    /// target. Scanning stops once every requested master has such a candidate;
-    /// otherwise it continues to EOF so the caller can assess missing or
-    /// ambiguous siblings conservatively.
-    pub(crate) async fn hydrate_matching_master_assets_from_changes<F>(
+    /// Scans to EOF so the caller sees every current sibling before choosing
+    /// one from durable version, size, and checksum evidence.
+    pub(crate) async fn hydrate_matching_master_assets_from_changes(
         &self,
         master_record_names: &FxHashSet<String>,
         shutdown_token: &CancellationToken,
-        mut candidate_resolves_target: F,
-    ) -> anyhow::Result<Vec<PhotoAsset>>
-    where
-        F: FnMut(&PhotoAsset) -> bool,
-    {
+    ) -> anyhow::Result<Vec<PhotoAsset>> {
         if master_record_names.is_empty() || shutdown_token.is_cancelled() {
             return Ok(Vec::new());
         }
 
-        fn collect_event<F>(
+        fn collect_event(
             event: ChangeEvent,
             source_zone: &Arc<str>,
             master_record_names: &FxHashSet<String>,
-            unresolved_master_names: &mut FxHashSet<String>,
             seen_asset_record_names: &mut FxHashSet<String>,
             matched: &mut Vec<PhotoAsset>,
-            candidate_resolves_target: &mut F,
-        ) where
-            F: FnMut(&PhotoAsset) -> bool,
-        {
+        ) {
             if event.reason != crate::types::ChangeReason::Created {
                 return;
             }
@@ -1511,16 +1501,12 @@ impl PhotoAlbum {
             if master_record_names.contains(asset.id())
                 && seen_asset_record_names.insert(asset.asset_record_name().to_string())
             {
-                if candidate_resolves_target(&asset) {
-                    unresolved_master_names.remove(asset.id());
-                }
                 matched.push(asset);
             }
         }
 
         let mut buffer = DeltaRecordBuffer::new();
         let source_zone: Arc<str> = Arc::from(self.zone_name());
-        let mut unresolved_master_names = master_record_names.clone();
         let mut seen_asset_record_names = FxHashSet::default();
         let mut matched = Vec::new();
         self.scan_changes_zone(|record| {
@@ -1529,13 +1515,11 @@ impl PhotoAlbum {
                     event,
                     &source_zone,
                     master_record_names,
-                    &mut unresolved_master_names,
                     &mut seen_asset_record_names,
                     &mut matched,
-                    &mut candidate_resolves_target,
                 );
             }
-            !shutdown_token.is_cancelled() && !unresolved_master_names.is_empty()
+            !shutdown_token.is_cancelled()
         })
         .await?;
 
@@ -1544,10 +1528,8 @@ impl PhotoAlbum {
                 event,
                 &source_zone,
                 master_record_names,
-                &mut unresolved_master_names,
                 &mut seen_asset_record_names,
                 &mut matched,
-                &mut candidate_resolves_target,
             );
         }
         Ok(matched)
@@ -4797,11 +4779,7 @@ mod tests {
         let masters = FxHashSet::from_iter(["master-target".to_string()]);
 
         let matched = album
-            .hydrate_matching_master_assets_from_changes(
-                &masters,
-                &CancellationToken::new(),
-                |_| false,
-            )
+            .hydrate_matching_master_assets_from_changes(&masters, &CancellationToken::new())
             .await
             .expect("master hydration");
 
@@ -4812,6 +4790,32 @@ mod tests {
                 .iter()
                 .all(|asset| asset.source_zone() == Some("PrimarySync"))
         );
+        let asset_record_names: FxHashSet<&str> =
+            matched.iter().map(PhotoAsset::asset_record_name).collect();
+        assert_eq!(
+            asset_record_names,
+            FxHashSet::from_iter(["asset-target-a", "asset-target-b"])
+        );
+    }
+
+    #[tokio::test]
+    async fn hydrate_matching_master_assets_scans_later_sibling_pages() {
+        let page1 = vec![
+            changes_master("master-target"),
+            changes_asset("asset-target-a", "master-target"),
+        ];
+        let page2 = vec![changes_asset("asset-target-b", "master-target")];
+        let mock = MockPhotosSession::new()
+            .ok(canned_changes_page(&page1, "token-page1", true))
+            .ok(canned_changes_page(&page2, "token-final", false));
+        let album = make_album_with_session(100, Box::new(mock));
+        let masters = FxHashSet::from_iter(["master-target".to_string()]);
+
+        let matched = album
+            .hydrate_matching_master_assets_from_changes(&masters, &CancellationToken::new())
+            .await
+            .expect("master hydration should scan every page");
+
         let asset_record_names: FxHashSet<&str> =
             matched.iter().map(PhotoAsset::asset_record_name).collect();
         assert_eq!(


### PR DESCRIPTION
## Summary

- Adopt verified on-disk pending files before applying current sync filters.
- Require saved version, size, and checksum evidence when recovering legacy child identities.
- Scan all sibling pages to detect ambiguous matches safely.
- Retain policy-excluded live rows without reporting a failed sync.

## Tests

- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused pending-retry and hydration tests
- `just gate`

Closes #663
