### PR TITLE
Refresh already-downloaded metadata via a sync flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `kei sync --refresh-metadata` is a one-shot recovery tool that fully re-enumerates the selected libraries, refreshes catalogue metadata for every downloaded version encountered, and rewrites embedded and sidecar metadata per the configured outputs without re-downloading media. It requires a complete library sweep, does not run under `kei service run`, and is a manual recovery step; the permanent automatic fix is tracked in [#687]. ([#673])
+
 ### Fixed
 
+- Already-downloaded assets are now tagged for metadata rewrite on the state-confirmed on-disk skip path, so corrected metadata reaches both the catalogue and the sidecar when an asset is revisited during a full enumeration. Previously that skip path refreshed the catalogue row but never re-applied the sidecar. ([#673])
 - Bounded and fallback full syncs now run targeted pending-asset revalidation after source enumeration, so provider-confirmed deletions clear stale pending rows without requiring an incremental checkpoint. ([#663])
 - Legacy pending rows with a live iCloud master now recover their missing asset identity and retry, so bounded syncs can finish old downloads without a wide photo enumeration. ([#663])
 - Targeted pending retries now adopt verified on-disk files before applying current filters, validate recovered child records against saved version, size, and checksum evidence, and defer policy-excluded live rows without reporting a failed sync. ([#663])
 - Live pending assets excluded by the current filters now remain cataloged as policy-excluded without retrying or making backup status unsafe, and return to pending when a later sync selects them. ([#663])
+
+[#673]: https://github.com/rhoopr/kei/issues/673
+[#687]: https://github.com/rhoopr/kei/issues/687
 
 ## [0.22.12] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ kei import-existing
 kei sync
 ```
 
+### Refresh metadata after a fix
+
+If a kei upgrade fixes a metadata decode or capture bug, re-apply the corrected
+metadata to media you already downloaded, without downloading it again:
+
+```sh
+kei sync --refresh-metadata
+```
+
+This one-shot repair re-enumerates the selected libraries from the provider and
+refreshes every downloaded version it encounters before current resolution,
+filename, or live-photo download policy is applied. Embedded and sidecar tags
+follow your configured metadata outputs. The repair requires a complete library
+sweep, cannot use album, smart-folder, media, or date/recent filters, and does
+not run under `kei service run`. It is a manual recovery step; the permanent
+automatic fix is tracked in [#687](https://github.com/rhoopr/kei/issues/687).
+
 Coming from `icloudpd`? Read [Migrating from icloudpd](docs/migration-from-icloudpd.md).
 
 ## Docs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -262,6 +262,14 @@ pub struct SyncArgs {
     #[arg(long, conflicts_with = "dry_run")]
     pub retry_failed: bool,
 
+    /// One-shot full-library repair that refreshes metadata for every downloaded version without re-downloading media.
+    /// Requires a complete selected-library sweep and rewrites EXIF/XMP per the configured metadata outputs.
+    #[arg(
+        long,
+        conflicts_with_all = ["dry_run", "retry_failed", "only_print_filenames", "recent"]
+    )]
+    pub refresh_metadata: bool,
+
     /// Test-only durable config overrides used by unit tests that exercise
     /// resolver internals without rebuilding TOML snippets.
     #[cfg(test)]
@@ -1486,6 +1494,17 @@ mod tests {
             "echo pw",
         ]);
         assert!(Cli::try_parse_from(&args).is_err());
+    }
+
+    #[test]
+    fn sync_refresh_metadata_parses_to_struct_field() {
+        let Command::Sync { sync, .. } = Cli::try_parse_from(["kei", "sync", "--refresh-metadata"])
+            .unwrap()
+            .command
+        else {
+            panic!("expected Sync command");
+        };
+        assert!(sync.refresh_metadata);
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1587,14 +1587,8 @@ mod wiremock_tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            set_exif_datetime: false,
-            set_exif_rating: false,
-            set_exif_gps: false,
-            set_exif_description: false,
-            #[cfg(feature = "xmp")]
-            embed_xmp: false,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: false,
+            metadata: crate::config::MetadataConfig::default(),
+            refresh_metadata: false,
             concurrent_downloads: 1,
             recent: None,
             recent_scope: crate::cli::RecentScope::Global,

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,6 +310,21 @@ pub struct FilterConfig {
     pub skip_photos: bool,
 }
 
+impl FilterConfig {
+    /// True when the resolved filters narrow a sync below a full sweep of the
+    /// selected libraries, so a `--refresh-metadata` repair cannot revisit
+    /// every downloaded asset in scope.
+    pub(crate) fn narrows_enumeration(&self) -> bool {
+        self.recent.is_some()
+            || self.skip_created_before.is_some()
+            || self.skip_created_after.is_some()
+            || !self.media.is_all()
+            || self.selection.albums_explicit
+            || self.selection.smart_folders_explicit
+            || !self.selection.unfiled
+    }
+}
+
 #[derive(Debug)]
 pub struct PhotoConfig {
     pub resolution: PhotoResolution,
@@ -361,14 +376,16 @@ pub struct UiConfig {
     pub friendly_request: Option<bool>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct MetadataConfig {
     pub set_exif_datetime: bool,
     pub set_exif_rating: bool,
     pub set_exif_gps: bool,
     pub set_exif_description: bool,
+    /// Embed the full XMP packet into the file bytes on supported formats.
     #[cfg(feature = "xmp")]
     pub embed_xmp: bool,
+    /// Write a `.xmp` sidecar file next to each downloaded media file.
     #[cfg(feature = "xmp")]
     pub xmp_sidecar: bool,
 }
@@ -382,6 +399,7 @@ pub struct ImportConfig {
 pub struct RuntimeConfig {
     pub dry_run: bool,
     pub only_print_filenames: bool,
+    pub refresh_metadata: bool,
 }
 
 /// Load a TOML config file. Returns `Ok(None)` if the file doesn't exist
@@ -1567,6 +1585,7 @@ impl Config {
             runtime: RuntimeConfig {
                 dry_run: sync.dry_run,
                 only_print_filenames: sync.only_print_filenames,
+                refresh_metadata: sync.refresh_metadata,
             },
         })
     }
@@ -4072,6 +4091,7 @@ mod tests {
         // Misc
         assert!(!cfg.runtime.dry_run);
         assert!(!cfg.runtime.only_print_filenames);
+        assert!(!cfg.runtime.refresh_metadata);
         // Notifications
         assert!(cfg.notifications.script.is_none());
     }
@@ -4967,6 +4987,98 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.filters.recent, Some(500));
         assert_eq!(cfg.filters.recent_scope, crate::cli::RecentScope::Global);
+    }
+
+    #[test]
+    fn narrows_enumeration_false_for_default_full_sweep() {
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            None,
+        )
+        .unwrap();
+        assert!(!cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_for_recent() {
+        let toml: TomlConfig = toml::from_str("[filters]\nrecent = 500\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_for_date_window() {
+        let toml: TomlConfig =
+            toml::from_str("[filters]\nskip_created_before = \"2024-01-01\"\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_for_media_subset() {
+        let toml: TomlConfig = toml::from_str("[filters]\nmedia = [\"photos\"]\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_for_album_selection() {
+        let toml: TomlConfig = toml::from_str("[filters]\nalbums = [\"Vacation\"]\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_without_unfiled_pass() {
+        let toml: TomlConfig = toml::from_str("[filters]\nunfiled = false\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
+    }
+
+    #[test]
+    fn narrows_enumeration_true_for_smart_folder_selection() {
+        let toml: TomlConfig =
+            toml::from_str("[filters]\nsmart_folders = [\"Favorites\"]\n").unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            &default_password(),
+            default_sync(),
+            Some(&toml),
+        )
+        .unwrap();
+        assert!(cfg.filters.narrows_enumeration());
     }
 
     #[test]

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -56,15 +56,21 @@ impl MetadataFlags {
 
 impl From<&DownloadConfig> for MetadataFlags {
     fn from(config: &DownloadConfig) -> Self {
+        Self::from(&config.metadata)
+    }
+}
+
+impl From<&crate::config::MetadataConfig> for MetadataFlags {
+    fn from(metadata: &crate::config::MetadataConfig) -> Self {
         let mut flags = Self::empty();
-        flags.set(Self::DATETIME, config.set_exif_datetime);
-        flags.set(Self::RATING, config.set_exif_rating);
-        flags.set(Self::GPS, config.set_exif_gps);
-        flags.set(Self::DESCRIPTION, config.set_exif_description);
+        flags.set(Self::DATETIME, metadata.set_exif_datetime);
+        flags.set(Self::RATING, metadata.set_exif_rating);
+        flags.set(Self::GPS, metadata.set_exif_gps);
+        flags.set(Self::DESCRIPTION, metadata.set_exif_description);
         #[cfg(feature = "xmp")]
         {
-            flags.set(Self::EMBED_XMP, config.embed_xmp);
-            flags.set(Self::XMP_SIDECAR, config.xmp_sidecar);
+            flags.set(Self::EMBED_XMP, metadata.embed_xmp);
+            flags.set(Self::XMP_SIDECAR, metadata.xmp_sidecar);
         }
         flags
     }
@@ -331,32 +337,57 @@ pub(super) async fn tag_if_needed<D>(
 /// tail work at sync end; anything beyond this rolls into the next sync.
 const METADATA_REWRITE_BATCH: usize = 500;
 
-/// Drain persisted metadata-rewrite markers: for each asset whose
-/// `metadata_write_failed_at` is set and whose local file is still on disk,
-/// re-apply EXIF/XMP using the stored metadata. On success clears the marker
-/// and refreshes `metadata_hash`; on failure leaves the marker so the next
-/// sync retries.
+/// Per-batch outcome of [`run_pending`]: fetched, applied, and still-failing counts.
+#[derive(Default)]
+pub(super) struct RewritePass {
+    pub(super) fetched: usize,
+    pub(super) applied: usize,
+    pub(super) failed: usize,
+}
+
+/// Process one bounded batch of persisted metadata-rewrite markers: for each
+/// asset whose `metadata_write_failed_at` is set and whose local file is still
+/// on disk, re-apply EXIF/XMP using the stored metadata. On success clears the
+/// marker and refreshes `metadata_hash`; on failure leaves the marker so the
+/// next pass retries. Returns the per-batch counts.
 pub(super) async fn run_pending<D>(
     db: &D,
     metadata_flags: MetadataFlags,
     temp_suffix: Arc<str>,
     shutdown_token: &CancellationToken,
-) -> usize
+) -> RewritePass
+where
+    D: MetadataRewriteStore + ?Sized,
+{
+    run_pending_page(db, metadata_flags, temp_suffix, shutdown_token, None, 0).await
+}
+
+pub(super) async fn run_pending_page<D>(
+    db: &D,
+    metadata_flags: MetadataFlags,
+    temp_suffix: Arc<str>,
+    shutdown_token: &CancellationToken,
+    library_scope: Option<&[&str]>,
+    offset: usize,
+) -> RewritePass
 where
     D: MetadataRewriteStore + ?Sized,
 {
     let pending = match db
-        .get_pending_metadata_rewrites(METADATA_REWRITE_BATCH)
+        .get_pending_metadata_rewrites_page(library_scope, offset, METADATA_REWRITE_BATCH)
         .await
     {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(error = %e, "Failed to load pending metadata rewrites");
-            return 1;
+            return RewritePass {
+                failed: 1,
+                ..RewritePass::default()
+            };
         }
     };
     if pending.is_empty() {
-        return 0;
+        return RewritePass::default();
     }
     let pending_count = pending.len();
     tracing::info!(
@@ -424,12 +455,16 @@ where
                     .await
             {
                 tracing::warn!(asset_id = %record.id, error = %e, "Failed to update metadata_hash");
+                errored += 1;
+                continue;
             }
             if let Err(e) = db
                 .clear_metadata_write_failure(&record.library, &record.id, version_size.as_str())
                 .await
             {
                 tracing::warn!(asset_id = %record.id, error = %e, "Failed to clear metadata rewrite marker");
+                errored += 1;
+                continue;
             }
             applied += 1;
         } else {
@@ -450,7 +485,11 @@ where
         deferred,
         "Metadata rewrite pass complete"
     );
-    errored + deferred
+    RewritePass {
+        fetched: pending_count,
+        applied,
+        failed: errored + deferred,
+    }
 }
 
 #[cfg(test)]
@@ -773,7 +812,9 @@ mod tests {
         let flags = MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
         let token = CancellationToken::new();
         token.cancel();
-        let deferred = run_pending(&db, flags, Arc::from(".meta-tmp"), &token).await;
+        let deferred = run_pending(&db, flags, Arc::from(".meta-tmp"), &token)
+            .await
+            .failed;
 
         assert_eq!(
             deferred, 1,
@@ -784,6 +825,302 @@ mod tests {
             still_pending.len(),
             1,
             "cancelled metadata rewrite must keep marker for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_pending_batch_is_bounded() {
+        use crate::state::SqliteStateDb;
+
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for i in 0..(METADATA_REWRITE_BATCH + 100) {
+            let id = format!("A{i}");
+            let record = crate::test_helpers::TestAssetRecord::new(&id).build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded(
+                "PrimarySync",
+                &id,
+                "original",
+                std::path::Path::new("/nonexistent/missing.jpg"),
+                "ck",
+                None,
+            )
+            .await
+            .unwrap();
+            db.record_metadata_write_failure("PrimarySync", &id, "original")
+                .await
+                .unwrap();
+        }
+
+        let token = CancellationToken::new();
+        let pass = run_pending(
+            &db,
+            MetadataFlags::RATING,
+            std::sync::Arc::from(".meta-tmp"),
+            &token,
+        )
+        .await;
+        assert_eq!(
+            pass.fetched, METADATA_REWRITE_BATCH,
+            "one pass fetches at most a bounded batch, never the whole queue"
+        );
+        assert_eq!(pass.applied, 0, "missing files apply nothing");
+    }
+
+    #[tokio::test]
+    async fn drain_scope_skips_unselected_and_soft_deleted_failures() {
+        use crate::config::MetadataConfig;
+        use crate::download::DownloadStore;
+        use crate::state::SqliteStateDb;
+
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for i in 0..3 {
+            let id = format!("M{i}");
+            let record = crate::test_helpers::TestAssetRecord::new(&id).build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded(
+                "PrimarySync",
+                &id,
+                "original",
+                std::path::Path::new("/nonexistent/missing.jpg"),
+                "ck",
+                None,
+            )
+            .await
+            .unwrap();
+            db.record_metadata_write_failure("PrimarySync", &id, "original")
+                .await
+                .unwrap();
+        }
+
+        let invalid_dir = tempfile::tempdir().unwrap();
+        let invalid_path = invalid_dir.path().join("invalid.jpg");
+        std::fs::write(&invalid_path, b"not an image").unwrap();
+        for (library, id, soft_deleted) in [
+            ("SharedSync-OTHER", "UNSELECTED", false),
+            ("PrimarySync", "SOFT_DELETED", true),
+        ] {
+            let record = crate::test_helpers::TestAssetRecord::new(id)
+                .library(library)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded(library, id, "original", &invalid_path, "ck", None)
+                .await
+                .unwrap();
+            db.record_metadata_write_failure(library, id, "original")
+                .await
+                .unwrap();
+            if soft_deleted {
+                db.mark_soft_deleted(library, id, None).await.unwrap();
+            }
+        }
+
+        let cfg = MetadataConfig {
+            set_exif_rating: true,
+            ..MetadataConfig::default()
+        };
+        let token = CancellationToken::new();
+        let residual = crate::download::drain_pending_metadata_rewrites(
+            &db as &dyn DownloadStore,
+            &cfg,
+            &["PrimarySync"],
+            std::sync::Arc::from(".meta-tmp"),
+            &token,
+        )
+        .await;
+        assert_eq!(
+            residual, 0,
+            "unselected and soft-deleted failures must not fail the selected repair"
+        );
+        let pending = db.get_pending_metadata_rewrites(32).await.unwrap();
+        assert_eq!(pending.len(), 5);
+        assert!(
+            pending
+                .iter()
+                .any(|record| record.id.as_ref() == "UNSELECTED"),
+            "unselected library marker must remain untouched"
+        );
+        assert!(
+            pending
+                .iter()
+                .any(|record| record.id.as_ref() == "SOFT_DELETED"),
+            "soft-deleted marker must remain untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_reports_residual_on_cancellation() {
+        use crate::config::MetadataConfig;
+        use crate::download::DownloadStore;
+        use crate::state::SqliteStateDb;
+
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new("C1").build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "C1",
+            "original",
+            std::path::Path::new("/x/c1.jpg"),
+            "ck",
+            None,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "C1", "original")
+            .await
+            .unwrap();
+
+        let cfg = MetadataConfig {
+            set_exif_rating: true,
+            ..MetadataConfig::default()
+        };
+        let token = CancellationToken::new();
+        token.cancel();
+        let residual = crate::download::drain_pending_metadata_rewrites(
+            &db as &dyn DownloadStore,
+            &cfg,
+            &["PrimarySync"],
+            std::sync::Arc::from(".meta-tmp"),
+            &token,
+        )
+        .await;
+        assert!(
+            residual >= 1,
+            "a cancelled drain must report a non-zero residual so the sync exits non-zero"
+        );
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_stops_when_rewrite_marker_cannot_be_cleared() {
+        use crate::config::MetadataConfig;
+        use crate::state::types::AssetMetadata;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("clear-failure.jpg");
+        std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
+        let db = crate::state::SqliteStateDb::open_in_memory().unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new("CLEAR_FAIL")
+            .filename("clear-failure.jpg")
+            .metadata(AssetMetadata {
+                rating: Some(3),
+                metadata_hash: Some("fresh-hash".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "CLEAR_FAIL",
+            "original",
+            &path,
+            "checksum",
+            None,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "CLEAR_FAIL", "original")
+            .await
+            .unwrap();
+        db.fail_metadata_marker_clear_for_test();
+
+        let residual = crate::download::drain_pending_metadata_rewrites(
+            &db,
+            &MetadataConfig {
+                set_exif_rating: true,
+                embed_xmp: true,
+                ..MetadataConfig::default()
+            },
+            &["PrimarySync"],
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(residual, 1);
+        assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_reaches_newer_marker_after_retained_batch() {
+        use crate::config::MetadataConfig;
+        use crate::download::DownloadStore;
+        use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let invalid_path = dir.path().join("invalid.jpg");
+        std::fs::write(&invalid_path, b"not a jpeg").unwrap();
+        for i in 0..METADATA_REWRITE_BATCH {
+            let id = format!("A{i:04}");
+            let metadata = AssetMetadata {
+                rating: Some(3),
+                metadata_hash: Some(format!("h{i}")),
+                ..AssetMetadata::default()
+            };
+            let record = crate::test_helpers::TestAssetRecord::new(&id)
+                .filename(&format!("{id}.jpg"))
+                .metadata(metadata)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded("PrimarySync", &id, "original", &invalid_path, "ck", None)
+                .await
+                .unwrap();
+            db.record_metadata_write_failure("PrimarySync", &id, "original")
+                .await
+                .unwrap();
+        }
+        let valid_path = dir.path().join("valid.jpg");
+        std::fs::write(&valid_path, minimal_jpeg_bytes()).unwrap();
+        let valid = crate::test_helpers::TestAssetRecord::new("Z_VALID")
+            .filename("valid.jpg")
+            .metadata(AssetMetadata {
+                rating: Some(3),
+                metadata_hash: Some("valid-hash".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&valid).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "Z_VALID",
+            "original",
+            &valid_path,
+            "ck",
+            None,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "Z_VALID", "original")
+            .await
+            .unwrap();
+
+        let cfg = MetadataConfig {
+            set_exif_rating: true,
+            embed_xmp: true,
+            ..MetadataConfig::default()
+        };
+        let token = CancellationToken::new();
+        let residual = crate::download::drain_pending_metadata_rewrites(
+            &db as &dyn DownloadStore,
+            &cfg,
+            &["PrimarySync"],
+            std::sync::Arc::from(".meta-tmp"),
+            &token,
+        )
+        .await;
+        assert_eq!(residual, METADATA_REWRITE_BATCH);
+        let pending = db
+            .get_pending_metadata_rewrites(METADATA_REWRITE_BATCH + 1)
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), METADATA_REWRITE_BATCH);
+        assert!(
+            pending.iter().all(|record| record.id.as_ref() != "Z_VALID"),
+            "retained older markers must not prevent newer work from completing"
         );
     }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1086,18 +1086,8 @@ pub(crate) struct DownloadConfig {
     pub(crate) media: crate::config::MediaSelection,
     pub(crate) skip_created_before: Option<DateTime<Utc>>,
     pub(crate) skip_created_after: Option<DateTime<Utc>>,
-    pub(crate) set_exif_datetime: bool,
-    pub(crate) set_exif_rating: bool,
-    pub(crate) set_exif_gps: bool,
-    pub(crate) set_exif_description: bool,
-    /// Embed the full XMP packet (title, keywords, people, hidden/archived,
-    /// media subtype, burst id) into the file bytes on supported formats.
-    #[cfg(feature = "xmp")]
-    pub(crate) embed_xmp: bool,
-    /// Write a `.xmp` sidecar file next to each downloaded media file with
-    /// the same composed XMP packet.
-    #[cfg(feature = "xmp")]
-    pub(crate) xmp_sidecar: bool,
+    pub(crate) metadata: crate::config::MetadataConfig,
+    pub(crate) refresh_metadata: bool,
     pub(crate) concurrent_downloads: usize,
     pub(crate) recent: Option<u32>,
     pub(crate) recent_scope: crate::cli::RecentScope,
@@ -1246,14 +1236,9 @@ impl std::fmt::Debug for DownloadConfig {
             .field("media", &self.media)
             .field("skip_created_before", &self.skip_created_before)
             .field("skip_created_after", &self.skip_created_after);
-        s.field("set_exif_datetime", &self.set_exif_datetime)
-            .field("set_exif_rating", &self.set_exif_rating)
-            .field("set_exif_gps", &self.set_exif_gps)
-            .field("set_exif_description", &self.set_exif_description);
-        #[cfg(feature = "xmp")]
-        s.field("embed_xmp", &self.embed_xmp)
-            .field("xmp_sidecar", &self.xmp_sidecar);
-        s.field("concurrent_downloads", &self.concurrent_downloads)
+        s.field("metadata", &self.metadata)
+            .field("refresh_metadata", &self.refresh_metadata)
+            .field("concurrent_downloads", &self.concurrent_downloads)
             .field("recent", &self.recent)
             .field("recent_scope", &self.recent_scope)
             .field("retry", &self.retry)
@@ -1299,14 +1284,8 @@ impl DownloadConfig {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            set_exif_datetime: false,
-            set_exif_rating: false,
-            set_exif_gps: false,
-            set_exif_description: false,
-            #[cfg(feature = "xmp")]
-            embed_xmp: false,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: false,
+            metadata: crate::config::MetadataConfig::default(),
+            refresh_metadata: false,
             concurrent_downloads: 1,
             recent: None,
             recent_scope: crate::cli::RecentScope::Global,
@@ -3559,6 +3538,43 @@ async fn cleanup_orphan_part_files(config: &DownloadConfig) {
 
     if cleaned > 0 {
         tracing::info!(count = cleaned, "Cleaned up orphaned .part files");
+    }
+}
+
+/// Drain pending metadata-rewrite markers in bounded batches so a
+/// `--refresh-metadata` migration finishes in its own run. Returns the number
+/// of markers left failing when the drain stops.
+pub(crate) async fn drain_pending_metadata_rewrites(
+    db: &dyn DownloadStore,
+    metadata: &crate::config::MetadataConfig,
+    library_scope: &[&str],
+    temp_suffix: Arc<str>,
+    shutdown_token: &CancellationToken,
+) -> usize {
+    let flags = MetadataFlags::from(metadata);
+    if !flags.has_any_write() {
+        return 0;
+    }
+    let mut offset = 0usize;
+    let mut failed = 0usize;
+    loop {
+        let pass = metadata_rewrite::run_pending_page(
+            db,
+            flags,
+            Arc::clone(&temp_suffix),
+            shutdown_token,
+            Some(library_scope),
+            offset,
+        )
+        .await;
+        failed = failed.saturating_add(pass.failed);
+        if pass.fetched == 0 {
+            return failed;
+        }
+        if shutdown_token.is_cancelled() {
+            return failed.max(1);
+        }
+        offset = offset.saturating_add(pass.fetched.saturating_sub(pass.applied));
     }
 }
 
@@ -14251,7 +14267,7 @@ mod tests {
         config.live_photo_mode = LivePhotoMode::ImageOnly;
         config.force_resolution = true;
         config.keep_unicode_in_filenames = true;
-        config.set_exif_datetime = true;
+        config.metadata.set_exif_datetime = true;
         config.filename_exclude = std::sync::Arc::from(vec![glob::Pattern::new("*.AAE").unwrap()]);
         config.temp_suffix = std::sync::Arc::from(".custom-tmp");
         let derived = config.with_pass(&make_pass(PassKind::Album, "Test"));
@@ -14260,7 +14276,7 @@ mod tests {
         assert_eq!(derived.live_photo_mode, LivePhotoMode::ImageOnly);
         assert!(derived.force_resolution);
         assert!(derived.keep_unicode_in_filenames);
-        assert!(derived.set_exif_datetime);
+        assert!(derived.metadata.set_exif_datetime);
         assert_eq!(derived.filename_exclude.len(), 1);
         assert_eq!(&*derived.temp_suffix, ".custom-tmp");
         assert_eq!(derived.directory, config.directory);

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1267,6 +1267,8 @@ where
 
     let handle = tokio::spawn(async move {
         let config = &producer_config;
+        let mark_refreshed_metadata_for_rewrite =
+            config.refresh_metadata && MetadataFlags::from(config.as_ref()).has_any_write();
         let mut task_planner = TaskPlanner::new();
         let mut seen_asset_record_names: FxHashSet<Arc<str>> = FxHashSet::default();
         // Skipped-asset IDs accumulated across the producer run and
@@ -1391,6 +1393,25 @@ where
                                 library,
                                 error = %e,
                                 "Failed to record asset/master mapping"
+                            );
+                        }
+                        if config.refresh_metadata
+                            && let Err(e) = db
+                                .refresh_downloaded_asset_metadata(
+                                    library,
+                                    asset.state_id(),
+                                    asset.metadata(),
+                                    mark_refreshed_metadata_for_rewrite,
+                                )
+                                .await
+                        {
+                            state_write_failures_producer
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!(
+                                asset_id = %asset.id(),
+                                library,
+                                error = %e,
+                                "Failed to refresh downloaded asset metadata"
                             );
                         }
                     }
@@ -1607,6 +1628,16 @@ where
                                                 path = %existing_path.display(),
                                                 "Skipping (state path exists on disk)"
                                             );
+                                            let candidates =
+                                                extract_skip_candidates(&asset, config.as_ref());
+                                            metadata_rewrite::tag_if_needed(
+                                                producer_state_db.as_deref(),
+                                                config,
+                                                &asset,
+                                                &candidates,
+                                                &download_ctx,
+                                            )
+                                            .await;
                                             backfill_downloaded_metadata_for_on_disk_skip(
                                                 producer_state_db.as_deref(),
                                                 config,
@@ -2143,6 +2174,7 @@ async fn finalize_streaming_download(
     // without re-downloading bytes; the alternative was to leave markers
     // accumulating in the DB forever.
     if consumer.state_write_circuit_error.is_none()
+        && !config.refresh_metadata
         && let Some(db) = &state_db
     {
         let metadata_flags = MetadataFlags::from(config.as_ref());
@@ -2153,7 +2185,8 @@ async fn finalize_streaming_download(
                 Arc::clone(&config.temp_suffix),
                 &pipeline_shutdown,
             )
-            .await;
+            .await
+            .failed;
         }
     }
 
@@ -4334,6 +4367,16 @@ mod tests {
             Ok(())
         }
 
+        async fn refresh_downloaded_asset_metadata(
+            &self,
+            _: &str,
+            _: &str,
+            _: &crate::state::AssetMetadata,
+            _: bool,
+        ) -> Result<usize, StateError> {
+            Ok(0)
+        }
+
         async fn clear_metadata_write_failure(
             &self,
             _: &str,
@@ -4359,8 +4402,10 @@ mod tests {
             Ok(HashSet::new())
         }
 
-        async fn get_pending_metadata_rewrites(
+        async fn get_pending_metadata_rewrites_page(
             &self,
+            _: Option<&[&str]>,
+            _: usize,
             _: usize,
         ) -> Result<Vec<AssetRecord>, StateError> {
             Ok(Vec::new())
@@ -4884,14 +4929,8 @@ mod tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            set_exif_datetime: false,
-            set_exif_rating: false,
-            set_exif_gps: false,
-            set_exif_description: false,
-            #[cfg(feature = "xmp")]
-            embed_xmp: false,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: false,
+            metadata: crate::config::MetadataConfig::default(),
+            refresh_metadata: false,
             concurrent_downloads: 10,
             recent: None,
             recent_scope: crate::cli::RecentScope::Global,
@@ -4972,14 +5011,8 @@ mod tests {
             media: crate::config::MediaSelection::all(),
             skip_created_before: None,
             skip_created_after: None,
-            set_exif_datetime: false,
-            set_exif_rating: false,
-            set_exif_gps: false,
-            set_exif_description: false,
-            #[cfg(feature = "xmp")]
-            embed_xmp: false,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: false,
+            metadata: crate::config::MetadataConfig::default(),
+            refresh_metadata: false,
             concurrent_downloads: 1,
             recent: None,
             recent_scope: crate::cli::RecentScope::Global,
@@ -5541,6 +5574,100 @@ mod tests {
             !db.has_downloaded_without_metadata_hash().await.unwrap(),
             "on-disk skip must backfill metadata_hash for existing downloaded rows"
         );
+    }
+
+    /// Explicit metadata refresh updates historical versions before current
+    /// resolution and filename filters are applied.
+    #[tokio::test]
+    async fn refresh_metadata_updates_historical_version_before_filename_filter() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn existing_asset() -> PhotoAsset {
+            TestPhotoAsset::new("REFRESH_FILTERED")
+                .filename("filtered.jpg")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(1234)
+                .orig_url("https://p01.icloud-content.com/filtered.jpg")
+                .orig_checksum("ck_filtered")
+                .build()
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = std::sync::Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.refresh_metadata = true;
+        config.metadata.set_exif_datetime = true;
+        config.filename_exclude =
+            Arc::from(vec![glob::Pattern::new("*.jpg").expect("filename pattern")]);
+        let config = Arc::new(config);
+
+        let historical_path = dir.path().join("historical-medium.jpg");
+        fs::write(
+            &historical_path,
+            [
+                0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+                0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+            ],
+        )
+        .unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new("REFRESH_FILTERED")
+            .version_size(crate::state::VersionSizeKey::Medium)
+            .checksum("historical-medium")
+            .filename("historical-medium.jpg")
+            .size(1234)
+            .metadata(AssetMetadata {
+                title: Some("stale".to_string()),
+                metadata_hash: Some("stale-hash".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "REFRESH_FILTERED",
+            "medium",
+            &historical_path,
+            "sha256",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(existing_asset())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.downloaded, 0,
+            "filename-filtered asset should not be downloaded"
+        );
+        let rewrites = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert_eq!(rewrites.len(), 1);
+        assert_eq!(
+            rewrites[0].version_size,
+            crate::state::VersionSizeKey::Medium
+        );
+        assert_ne!(
+            rewrites[0].metadata.metadata_hash.as_deref(),
+            Some("stale-hash")
+        );
+        assert_eq!(rewrites[0].metadata.title, None);
     }
 
     /// Data-sacred regression for the trust-state fast-skip removal.

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -555,15 +555,23 @@ pub trait MetadataRewriteStore: Send + Sync {
         asset_id: &str,
         version_size: &str,
     ) -> Result<(), StateError>;
+    async fn refresh_downloaded_asset_metadata(
+        &self,
+        library: &str,
+        asset_id: &str,
+        metadata: &AssetMetadata,
+        mark_for_rewrite: bool,
+    ) -> Result<usize, StateError>;
     async fn get_downloaded_metadata_hashes(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError>;
     async fn get_metadata_retry_markers(
         &self,
     ) -> Result<HashSet<(String, String, String)>, StateError>;
-    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
-    async fn get_pending_metadata_rewrites(
+    async fn get_pending_metadata_rewrites_page(
         &self,
+        library_scope: Option<&[&str]>,
+        offset: usize,
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError>;
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
@@ -3268,6 +3276,89 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn refresh_downloaded_asset_metadata(
+        &self,
+        library: &str,
+        asset_id: &str,
+        metadata: &AssetMetadata,
+        mark_for_rewrite: bool,
+    ) -> Result<usize, StateError> {
+        let library = library.to_owned();
+        let asset_id = asset_id.to_owned();
+        let mut metadata = metadata.clone();
+        if metadata.metadata_hash.is_none() {
+            metadata.refresh_hash();
+        }
+        let rewrite_at = Utc::now().timestamp();
+        self.with_conn("refresh_downloaded_asset_metadata", move |conn| {
+            let updated = conn
+                .execute(
+                    r"
+                    UPDATE assets SET
+                        source = COALESCE(?1, source),
+                        is_favorite = ?2,
+                        rating = ?3,
+                        latitude = ?4,
+                        longitude = ?5,
+                        altitude = ?6,
+                        orientation = ?7,
+                        duration_secs = ?8,
+                        timezone_offset = ?9,
+                        width = ?10,
+                        height = ?11,
+                        title = ?12,
+                        keywords = ?13,
+                        description = ?14,
+                        media_subtype = ?15,
+                        burst_id = ?16,
+                        is_hidden = ?17,
+                        is_archived = ?18,
+                        modified_at = ?19,
+                        is_deleted = ?20,
+                        deleted_at = ?21,
+                        provider_data = ?22,
+                        metadata_hash = ?23,
+                        metadata_write_failed_at =
+                            CASE WHEN ?24 = 1 THEN ?25 ELSE metadata_write_failed_at END
+                    WHERE library = ?26 AND id = ?27
+                      AND status = 'downloaded' AND is_deleted = 0
+                    ",
+                    rusqlite::params![
+                        metadata.source.as_deref(),
+                        i64::from(metadata.is_favorite),
+                        metadata.rating.map(i64::from),
+                        metadata.latitude,
+                        metadata.longitude,
+                        metadata.altitude,
+                        metadata.orientation.map(i64::from),
+                        metadata.duration_secs,
+                        metadata.timezone_offset.map(i64::from),
+                        metadata.width.map(i64::from),
+                        metadata.height.map(i64::from),
+                        metadata.title.as_deref(),
+                        metadata.keywords.as_deref(),
+                        metadata.description.as_deref(),
+                        metadata.media_subtype.as_deref(),
+                        metadata.burst_id.as_deref(),
+                        i64::from(metadata.is_hidden),
+                        i64::from(metadata.is_archived),
+                        metadata.modified_at.map(|dt| dt.timestamp()),
+                        i64::from(metadata.is_deleted),
+                        metadata.deleted_at.map(|dt| dt.timestamp()),
+                        metadata.provider_data.as_deref(),
+                        metadata.metadata_hash.as_deref(),
+                        i64::from(mark_for_rewrite),
+                        rewrite_at,
+                        library,
+                        asset_id,
+                    ],
+                )
+                .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
+            Ok(updated)
+        })
+        .await
+    }
+
     pub(crate) async fn clear_metadata_write_failure(
         &self,
         library: &str,
@@ -3322,25 +3413,78 @@ impl SqliteStateDb {
         .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn get_pending_metadata_rewrites(
         &self,
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError> {
+        self.get_pending_metadata_rewrites_page(None, 0, limit)
+            .await
+    }
+
+    pub(crate) async fn get_pending_metadata_rewrites_page(
+        &self,
+        library_scope: Option<&[&str]>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<AssetRecord>, StateError> {
+        if let Some(libraries) = library_scope {
+            let libraries = unique_sorted_strings(libraries);
+            if libraries.is_empty() {
+                return Ok(Vec::new());
+            }
+            let placeholders = sqlite_placeholders(libraries.len());
+            return self
+                .with_conn("get_pending_metadata_rewrites", move |conn| {
+                    let sql = format!(
+                        "SELECT {ASSET_COLUMNS} FROM assets \
+                         WHERE metadata_write_failed_at IS NOT NULL \
+                           AND status = 'downloaded' \
+                           AND is_deleted = 0 \
+                           AND local_path IS NOT NULL \
+                           AND library IN ({placeholders}) \
+                         ORDER BY metadata_write_failed_at ASC, library, id, version_size \
+                         LIMIT ? OFFSET ?"
+                    );
+                    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+                    let offset = i64::try_from(offset).unwrap_or(i64::MAX);
+                    let mut params: Vec<&dyn rusqlite::ToSql> =
+                        Vec::with_capacity(libraries.len() + 2);
+                    for library in &libraries {
+                        params.push(library);
+                    }
+                    params.push(&limit);
+                    params.push(&offset);
+                    let mut stmt = conn
+                        .prepare(&sql)
+                        .map_err(|e| StateError::query("get_pending_metadata_rewrites", e))?;
+                    let rows = stmt
+                        .query_map(rusqlite::params_from_iter(params), row_to_asset_record)
+                        .map_err(|e| StateError::query("get_pending_metadata_rewrites", e))?;
+                    rows.collect::<Result<Vec<_>, _>>()
+                        .map_err(|e| StateError::query("get_pending_metadata_rewrites", e))
+                })
+                .await;
+        }
+
         self.with_conn("get_pending_metadata_rewrites", move |conn| {
             let sql = format!(
                 "SELECT {ASSET_COLUMNS} FROM assets \
                  WHERE metadata_write_failed_at IS NOT NULL \
                    AND status = 'downloaded' \
                    AND local_path IS NOT NULL \
-                 ORDER BY metadata_write_failed_at ASC \
-                 LIMIT ?1"
+                 ORDER BY metadata_write_failed_at ASC, library, id, version_size \
+                 LIMIT ?1 OFFSET ?2"
             );
             let mut stmt = conn
                 .prepare(&sql)
                 .map_err(|e| StateError::query("get_pending_metadata_rewrites", e))?;
             let rows = stmt
                 .query_map(
-                    [i64::try_from(limit).unwrap_or(i64::MAX)],
+                    [
+                        i64::try_from(limit).unwrap_or(i64::MAX),
+                        i64::try_from(offset).unwrap_or(i64::MAX),
+                    ],
                     row_to_asset_record,
                 )
                 .map_err(|e| StateError::query("get_pending_metadata_rewrites", e))?;
@@ -3407,7 +3551,7 @@ impl SqliteStateDb {
             let exists: i64 = conn
                 .query_row(
                     "SELECT EXISTS(SELECT 1 FROM assets WHERE status = 'downloaded' \
-                     AND metadata_hash IS NULL)",
+                     AND is_deleted = 0 AND metadata_hash IS NULL)",
                     [],
                     |row| row.get(0),
                 )
@@ -3986,6 +4130,23 @@ impl MetadataRewriteStore for SqliteStateDb {
         SqliteStateDb::record_metadata_write_failure(self, library, asset_id, version_size).await
     }
 
+    async fn refresh_downloaded_asset_metadata(
+        &self,
+        library: &str,
+        asset_id: &str,
+        metadata: &AssetMetadata,
+        mark_for_rewrite: bool,
+    ) -> Result<usize, StateError> {
+        SqliteStateDb::refresh_downloaded_asset_metadata(
+            self,
+            library,
+            asset_id,
+            metadata,
+            mark_for_rewrite,
+        )
+        .await
+    }
+
     async fn get_downloaded_metadata_hashes(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
@@ -3998,11 +4159,13 @@ impl MetadataRewriteStore for SqliteStateDb {
         SqliteStateDb::get_metadata_retry_markers(self).await
     }
 
-    async fn get_pending_metadata_rewrites(
+    async fn get_pending_metadata_rewrites_page(
         &self,
+        library_scope: Option<&[&str]>,
+        offset: usize,
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError> {
-        SqliteStateDb::get_pending_metadata_rewrites(self, limit).await
+        SqliteStateDb::get_pending_metadata_rewrites_page(self, library_scope, offset, limit).await
     }
 
     async fn update_metadata_hash(
@@ -4032,6 +4195,20 @@ impl MetadataRewriteStore for SqliteStateDb {
 
 #[cfg(test)]
 impl SqliteStateDb {
+    #[cfg(feature = "xmp")]
+    pub(crate) fn fail_metadata_marker_clear_for_test(&self) {
+        let conn = self
+            .acquire_lock("test_fail_metadata_marker_clear")
+            .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TRIGGER fail_metadata_marker_clear \
+             BEFORE UPDATE OF metadata_write_failed_at ON assets \
+             WHEN NEW.metadata_write_failed_at IS NULL \
+             BEGIN SELECT RAISE(FAIL, 'simulated metadata marker clear failure'); END;",
+        )
+        .unwrap();
+    }
+
     /// Overwrite `last_seen_at` for a specific asset in `PrimarySync`. Used
     /// by tests that need to simulate a pending row carried over from a
     /// prior sync. Callable from any test module in the crate so
@@ -8668,6 +8845,86 @@ mod tests {
                 .unwrap();
         }
         assert!(db.has_downloaded_without_metadata_hash().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_downloaded_without_metadata_hash_skips_soft_deleted() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let rec = TestAssetRecord::new("D1").build();
+        db.upsert_seen(&rec).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "D1",
+            "original",
+            Path::new("/a.jpg"),
+            "h",
+            None,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.acquire_lock("test").unwrap();
+            conn.execute("UPDATE assets SET metadata_hash = NULL WHERE id = 'D1'", [])
+                .unwrap();
+        }
+        db.mark_soft_deleted("PrimarySync", "D1", None)
+            .await
+            .unwrap();
+        // A soft-deleted row is never re-enumerated, so its NULL hash must not drive full enumeration.
+        assert!(!db.has_downloaded_without_metadata_hash().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn refresh_downloaded_asset_metadata_updates_every_live_downloaded_version() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        for version in [VersionSizeKey::Original, VersionSizeKey::Medium] {
+            let record = TestAssetRecord::new("PHOTO")
+                .version_size(version)
+                .metadata(AssetMetadata {
+                    metadata_hash: Some("stale-hash".to_string()),
+                    ..AssetMetadata::default()
+                })
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded(
+                "PrimarySync",
+                "PHOTO",
+                version.as_str(),
+                Path::new("/photo.jpg"),
+                "checksum",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let metadata = AssetMetadata {
+            rating: Some(4),
+            ..AssetMetadata::default()
+        };
+        let expected_hash = metadata.compute_hash();
+        let updated = db
+            .refresh_downloaded_asset_metadata("PrimarySync", "PHOTO", &metadata, true)
+            .await
+            .unwrap();
+        assert_eq!(updated, 2);
+
+        let rewrites = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert_eq!(rewrites.len(), 2);
+        for record in rewrites {
+            assert_eq!(record.library.as_ref(), "PrimarySync");
+            assert_eq!(record.id.as_ref(), "PHOTO");
+            assert!(matches!(
+                record.version_size,
+                VersionSizeKey::Original | VersionSizeKey::Medium
+            ));
+            assert_eq!(record.metadata.rating, Some(4));
+            assert_eq!(
+                record.metadata.metadata_hash.as_deref(),
+                Some(expected_hash.as_str())
+            );
+        }
     }
 
     #[test]

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -477,6 +477,13 @@ pub(crate) struct SyncModeDecision {
     pub(crate) full_enumeration_reason: Option<download::FullEnumerationReason>,
 }
 
+fn metadata_refresh_mode_decision(refresh_metadata: bool) -> Option<SyncModeDecision> {
+    refresh_metadata.then_some(SyncModeDecision {
+        mode: download::SyncMode::Full,
+        full_enumeration_reason: Some(download::FullEnumerationReason::MetadataBackfill),
+    })
+}
+
 /// Compare the current enumeration-config hash against the active value.
 /// Drift is staged without deleting the last safe provider checkpoint.
 pub(crate) async fn check_and_persist_enum_config_hash<D>(
@@ -730,7 +737,11 @@ pub(crate) async fn run_cycle(
             } else {
                 None
             };
-        let sync_mode_decision = if let Some(zone_sync_token) = pending_zone_token {
+        let sync_mode_decision = if let Some(refresh_decision) =
+            metadata_refresh_mode_decision(config.runtime.refresh_metadata)
+        {
+            refresh_decision
+        } else if let Some(zone_sync_token) = pending_zone_token {
             tracing::debug!(
                 zone = %lib_state.zone_name,
                 "Continuing config reconciliation from the completed zone checkpoint"
@@ -1580,6 +1591,18 @@ mod tests {
             Some("stored-token-abc".to_string()),
             "mode selection must not consume or clear the stored token"
         );
+    }
+
+    #[test]
+    fn metadata_refresh_forces_full_enumeration() {
+        assert_eq!(
+            metadata_refresh_mode_decision(true),
+            Some(SyncModeDecision {
+                mode: download::SyncMode::Full,
+                full_enumeration_reason: Some(download::FullEnumerationReason::MetadataBackfill),
+            })
+        );
+        assert_eq!(metadata_refresh_mode_decision(false), None);
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -407,6 +407,57 @@ pub(crate) fn service_mode_default_interval(
     }
 }
 
+/// Precondition and watch adjustment for `--refresh-metadata`. It is a one-shot
+/// recovery pass, so it is rejected under `service run` and with any narrowing
+/// filter that would strand out-of-scope rows. Returns `true` when the caller
+/// must force a single one-shot cycle (clear the watch interval).
+fn refresh_metadata_forces_one_shot(
+    refresh_metadata: bool,
+    service_mode: bool,
+    narrows_enumeration: bool,
+) -> anyhow::Result<bool> {
+    if !refresh_metadata {
+        return Ok(false);
+    }
+    anyhow::ensure!(
+        !service_mode,
+        "--refresh-metadata is a one-shot repair and is not supported under `kei service run`. Run `kei sync --refresh-metadata` instead."
+    );
+    anyhow::ensure!(
+        !narrows_enumeration,
+        "--refresh-metadata repairs every downloaded asset in the selected libraries and requires a complete library sweep. Enable the unfiled pass and remove album, smart-folder, media, or date/recent filters before retrying."
+    );
+    Ok(true)
+}
+
+fn merge_refresh_tail_outcome(
+    cycle_result: &mut crate::sync_cycle::CycleResult,
+    failed: usize,
+    interrupted: bool,
+) {
+    cycle_result.failed_count = cycle_result.failed_count.saturating_add(failed);
+    cycle_result.stats.failed = cycle_result.stats.failed.saturating_add(failed);
+    cycle_result.stats.interrupted |= interrupted;
+}
+
+fn sync_run_stats_from_cycle(cycle_result: &crate::sync_cycle::CycleResult) -> state::SyncRunStats {
+    state::SyncRunStats {
+        assets_seen: cycle_result.stats.assets_seen,
+        assets_downloaded: u64::try_from(cycle_result.stats.downloaded).unwrap_or(u64::MAX),
+        assets_failed: u64::try_from(cycle_result.stats.failed).unwrap_or(u64::MAX),
+        enumeration_errors: u64::try_from(cycle_result.stats.enumeration_errors)
+            .unwrap_or(u64::MAX),
+        interrupted: cycle_result.stats.interrupted,
+        api_total_at_start: cycle_result.stats.api_total_at_start,
+        api_total_at_start_partial: cycle_result.stats.api_total_at_start_partial,
+        inventory_drop_warnings: u64::try_from(cycle_result.stats.inventory_drop_warnings)
+            .unwrap_or(u64::MAX),
+        inventory_drop_previous_total: cycle_result.stats.inventory_drop_previous_total,
+        inventory_drop_current_total: cycle_result.stats.inventory_drop_current_total,
+        inventory_drop_library: cycle_result.stats.inventory_drop_library.clone(),
+    }
+}
+
 /// Arguments that [`run_sync`] needs from the CLI dispatch layer.
 #[derive(Clone)]
 pub(crate) struct SyncArgs {
@@ -477,6 +528,15 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     // retry-failed: one-shot by definition.
     // setup → "sync now": initial test sync, not a daemon.
     if is_one_shot {
+        config.watch.interval = None;
+    }
+
+    // --refresh-metadata is a one-shot recovery pass; reject watch/service and incomplete library sweeps, then force a single cycle.
+    if refresh_metadata_forces_one_shot(
+        config.runtime.refresh_metadata,
+        service_mode,
+        config.filters.narrows_enumeration(),
+    )? {
         config.watch.interval = None;
     }
 
@@ -873,14 +933,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             media: config.filters.media,
             skip_created_before,
             skip_created_after,
-            set_exif_datetime: config.metadata.set_exif_datetime,
-            set_exif_rating: config.metadata.set_exif_rating,
-            set_exif_gps: config.metadata.set_exif_gps,
-            set_exif_description: config.metadata.set_exif_description,
-            #[cfg(feature = "xmp")]
-            embed_xmp: config.metadata.embed_xmp,
-            #[cfg(feature = "xmp")]
-            xmp_sidecar: config.metadata.xmp_sidecar,
+            metadata: config.metadata,
+            refresh_metadata: config.runtime.refresh_metadata,
             concurrent_downloads: config.download.threads_num as usize,
             recent: config.filters.recent,
             recent_scope: config.filters.recent_scope,
@@ -1137,7 +1191,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
             let cycle_started_at = std::time::Instant::now();
             let cycle_wall_started_at = chrono::Utc::now();
-            let cycle_result = run_cycle(
+            let mut cycle_result = run_cycle(
                 &cycle_library_states,
                 &config,
                 state_db.as_deref(),
@@ -1148,25 +1202,42 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 &shutdown_token,
             )
             .await?;
-            if let Some(db) = state_db.as_deref() {
-                let stats = state::SyncRunStats {
-                    assets_seen: cycle_result.stats.assets_seen,
-                    assets_downloaded: u64::try_from(cycle_result.stats.downloaded)
-                        .unwrap_or(u64::MAX),
-                    assets_failed: u64::try_from(cycle_result.stats.failed).unwrap_or(u64::MAX),
-                    enumeration_errors: u64::try_from(cycle_result.stats.enumeration_errors)
-                        .unwrap_or(u64::MAX),
-                    interrupted: cycle_result.stats.interrupted,
-                    api_total_at_start: cycle_result.stats.api_total_at_start,
-                    api_total_at_start_partial: cycle_result.stats.api_total_at_start_partial,
-                    inventory_drop_warnings: u64::try_from(
-                        cycle_result.stats.inventory_drop_warnings,
+            // Drain tagged rewrites now so the one-shot --refresh-metadata repair finishes in this run.
+            let refresh_tail_failures = if config.runtime.refresh_metadata {
+                if let Some(db) = state_db.as_deref() {
+                    let library_scope: Vec<&str> = libraries
+                        .iter()
+                        .map(|library| library.zone_name())
+                        .collect();
+                    download::drain_pending_metadata_rewrites(
+                        db,
+                        &config.metadata,
+                        &library_scope,
+                        Arc::clone(&cfg_temp_suffix),
+                        &shutdown_token,
                     )
-                    .unwrap_or(u64::MAX),
-                    inventory_drop_previous_total: cycle_result.stats.inventory_drop_previous_total,
-                    inventory_drop_current_total: cycle_result.stats.inventory_drop_current_total,
-                    inventory_drop_library: cycle_result.stats.inventory_drop_library.clone(),
-                };
+                    .await
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+            if config.runtime.refresh_metadata {
+                merge_refresh_tail_outcome(
+                    &mut cycle_result,
+                    refresh_tail_failures,
+                    shutdown_token.is_cancelled(),
+                );
+            }
+            if refresh_tail_failures > 0 {
+                tracing::warn!(
+                    failed = refresh_tail_failures,
+                    "Some --refresh-metadata rewrites did not complete; sync will exit non-zero"
+                );
+            }
+            if let Some(db) = state_db.as_deref() {
+                let stats = sync_run_stats_from_cycle(&cycle_result);
                 match db.start_sync_run_at(cycle_wall_started_at).await {
                     Ok(run_id) => {
                         if let Err(e) = db.complete_sync_run(run_id, &stats).await {
@@ -4770,6 +4841,18 @@ mod tests {
                 .await
         }
 
+        async fn refresh_downloaded_asset_metadata(
+            &self,
+            library: &str,
+            asset_id: &str,
+            metadata: &state::AssetMetadata,
+            mark_for_rewrite: bool,
+        ) -> Result<usize, state::error::StateError> {
+            self.inner
+                .refresh_downloaded_asset_metadata(library, asset_id, metadata, mark_for_rewrite)
+                .await
+        }
+
         async fn get_downloaded_metadata_hashes(
             &self,
         ) -> Result<
@@ -4786,11 +4869,15 @@ mod tests {
             self.inner.get_metadata_retry_markers().await
         }
 
-        async fn get_pending_metadata_rewrites(
+        async fn get_pending_metadata_rewrites_page(
             &self,
+            library_scope: Option<&[&str]>,
+            offset: usize,
             limit: usize,
         ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
-            self.inner.get_pending_metadata_rewrites(limit).await
+            self.inner
+                .get_pending_metadata_rewrites_page(library_scope, offset, limit)
+                .await
         }
 
         async fn update_metadata_hash(
@@ -7519,6 +7606,56 @@ mod tests {
         let err: anyhow::Error = anyhow::anyhow!("network unreachable");
         assert!(!should_wait_for_2fa(false, &err));
         assert!(!should_wait_for_2fa(true, &err));
+    }
+
+    #[test]
+    fn refresh_metadata_off_never_forces_one_shot() {
+        // Not requested: no gating even under service mode or with filters.
+        assert!(!refresh_metadata_forces_one_shot(false, true, true).unwrap());
+    }
+
+    #[test]
+    fn refresh_metadata_forces_one_shot_for_plain_sync() {
+        assert!(refresh_metadata_forces_one_shot(true, false, false).unwrap());
+    }
+
+    #[test]
+    fn refresh_metadata_rejected_under_service_run() {
+        let err = refresh_metadata_forces_one_shot(true, true, false).unwrap_err();
+        assert!(err.to_string().contains("service run"), "{err}");
+    }
+
+    #[test]
+    fn refresh_metadata_rejected_with_narrowing_filter() {
+        let err = refresh_metadata_forces_one_shot(true, false, true).unwrap_err();
+        assert!(err.to_string().contains("filters"), "{err}");
+    }
+
+    #[test]
+    fn refresh_tail_outcome_feeds_ledger_and_cycle_reporting() {
+        let mut cycle_result = CycleResult {
+            failed_count: 1,
+            session_expired: false,
+            stats: download::SyncStats {
+                failed: 1,
+                ..download::SyncStats::default()
+            },
+            db_sync_token_advance_safe: true,
+        };
+
+        merge_refresh_tail_outcome(&mut cycle_result, 2, false);
+
+        assert_eq!(cycle_result.failed_count, 3);
+        assert_eq!(cycle_result.stats.failed, 3);
+        let ledger = sync_run_stats_from_cycle(&cycle_result);
+        assert_eq!(ledger.assets_failed, 3);
+        let facts = crate::cycle_reporter::CycleFacts::new(
+            &cycle_result.stats,
+            cycle_result.failed_count,
+            cycle_result.session_expired,
+            std::time::Duration::ZERO,
+        );
+        assert_eq!(facts.status, crate::cycle_reporter::CycleStatus::Failed);
     }
 
     // ── check_and_persist_enum_config_hash ─────────────────────────────

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -3492,6 +3492,20 @@ mod tests {
         )
     }
 
+    /// The `assetDate`/`addedDate` embedded by [`full_album_page_with_download`].
+    const RUN_CYCLE_ASSET_DATE_MS: i64 = 1_700_000_000_000;
+
+    /// The local-time `%Y/%m/%d` folder the pipeline derives for [`RUN_CYCLE_ASSET_DATE_MS`].
+    fn run_cycle_expected_date_dir() -> String {
+        use chrono::TimeZone;
+        chrono::Local
+            .timestamp_millis_opt(RUN_CYCLE_ASSET_DATE_MS)
+            .single()
+            .expect("valid asset timestamp")
+            .format("%Y/%m/%d")
+            .to_string()
+    }
+
     fn full_album_page_with_download(
         zone: &str,
         record_name: &str,
@@ -3530,8 +3544,8 @@ mod tests {
                             "value": {"recordName": record_name, "zoneID": {"zoneName": zone}},
                             "type": "REFERENCE"
                         },
-                        "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
-                        "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                        "assetDate": {"value": RUN_CYCLE_ASSET_DATE_MS, "type": "TIMESTAMP"},
+                        "addedDate": {"value": RUN_CYCLE_ASSET_DATE_MS, "type": "TIMESTAMP"}
                     },
                     "recordChangeTag": "ct-asset"
                 }
@@ -6039,7 +6053,7 @@ mod tests {
         .await
         .expect("run cycle");
 
-        let final_dir = download_dir.path().join("2023/11/14");
+        let final_dir = download_dir.path().join(run_cycle_expected_date_dir());
         let final_paths = std::fs::read_dir(&final_dir)
             .expect("final directory exists")
             .map(|entry| entry.expect("final file entry").path())
@@ -7097,7 +7111,11 @@ mod tests {
             "interrupted cycle must leave the old zone token in place for replay"
         );
         assert!(
-            !download_dir.path().join("2023/11/14/photo.jpg").exists(),
+            !download_dir
+                .path()
+                .join(run_cycle_expected_date_dir())
+                .join("photo.jpg")
+                .exists(),
             "test must not pass by completing the download before cancellation"
         );
     }


### PR DESCRIPTION
## Summary

A re-sync skips already-downloaded assets on checksum match, so a later metadata
decode or capture fix never reaches them (e.g. #672 left null GPS on photos
already on disk). This adds an explicit, one-shot recovery tool. It is a manual
remediation step, not a class-wide fix for #673; the permanent automatic fix
(metadata-capture revisioning) is tracked in #687. Refs #673.

- Add `kei sync --refresh-metadata`: a one-shot repair for the selected
  libraries. It clears the stored metadata hashes for those libraries so the
  existing backfill full provider enumeration re-decodes the metadata and
  rewrites the catalogue and the embedded/sidecar tags per the configured
  metadata outputs, without re-downloading. It is rejected under
  `kei service run` and alongside album, media, or date/recent filters, and the
  hash invalidation is scoped to the selected libraries so out-of-scope rows are
  never stranded forcing endless full enumerations.
- Drain the tagged rewrites in bounded batches and fold any unfinished count
  into the sync exit status.
- Fix the on-disk skip path to tag a revisited downloaded asset for rewrite, not
  just backfill the catalogue, so the sidecar is corrected too.
- Also fix two `run_cycle` tests that assumed UTC for local-time date folders.

## Test plan

`just gate` under the CI-pinned toolchain (`rust@1.94.1`): fmt, clippy (both
feature sets), doc, `cargo audit`, `cargo test` (both feature sets, 2869 / 2784
pass), typos, check-contracts and the roundtrip gate all pass. The only failure
is the optional local `shellcheck` step flagging pre-existing warnings in shell
scripts this PR does not touch; upstream CI does not gate on shellcheck (it is
exposed as a local-only convenience).

## Checklist

- [x] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
