### PR TITLE
Handle policy-excluded pending assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bounded and fallback full syncs now run targeted pending-asset revalidation after source enumeration, so provider-confirmed deletions clear stale pending rows without requiring an incremental checkpoint. ([#663])
 - Legacy pending rows with a live iCloud master now recover their missing asset identity and retry, so bounded syncs can finish old downloads without a wide photo enumeration. ([#663])
 - Targeted pending retries now adopt verified on-disk files before applying current filters, validate recovered child records against saved version, size, and checksum evidence, and defer policy-excluded live rows without reporting a failed sync. ([#663])
+- Live pending assets excluded by the current filters now remain cataloged as policy-excluded without retrying or making backup status unsafe, and return to pending when a later sync selects them. ([#663])
 
 ## [0.22.12] - 2026-07-13
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -36,6 +36,7 @@ pub(crate) async fn run_status(
     println!("  Total:      {}", summary.total_assets);
     println!("  Downloaded: {}", summary.downloaded);
     println!("  Pending:    {}", summary.pending);
+    println!("  Policy excluded: {}", summary.policy_excluded);
     println!("  Failed:     {}", summary.failed);
     println!("  Source deleted: {}", summary.source_deleted);
     println!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -11998,7 +11998,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bounded_full_sync_defers_filtered_live_pending_without_failure() {
+    async fn bounded_full_sync_excludes_filtered_live_pending_without_failure() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = TestAssetRecord::new("LEGACY_FILTERED_MISSING")
             .filename("legacy-filtered-missing.jpg")
@@ -12042,11 +12042,12 @@ mod tests {
             CancellationToken::new(),
         )
         .await
-        .expect("filtered live pending asset should be deferred");
+        .expect("filtered live pending asset should be policy-excluded");
 
         assert!(matches!(result.outcome, DownloadOutcome::Success));
         let summary = db.get_summary().await.expect("summary");
-        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.policy_excluded, 1);
         assert_eq!(summary.failed, 0);
         assert_eq!(summary.awaiting_provider_verification, 0);
         assert_eq!(

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4163,6 +4163,15 @@ mod tests {
             Ok(())
         }
 
+        async fn mark_policy_excluded(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> Result<bool, StateError> {
+            unimplemented!()
+        }
+
         async fn mark_soft_deleted(
             &self,
             _: &str,

--- a/src/download/planner.rs
+++ b/src/download/planner.rs
@@ -438,6 +438,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn planner_redispatch_reactivates_policy_excluded_asset() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let asset = TestPhotoAsset::new("POLICY_RESELECTED")
+            .filename("reselected.mov")
+            .build();
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let mut task_planner = TaskPlanner::new();
+        let plan = task_planner.plan_asset(&asset, &config).await;
+        let task = plan
+            .tasks
+            .first()
+            .expect("selected asset should plan a task");
+        upsert_seen_for_task(&db, &config, &asset, task)
+            .await
+            .unwrap();
+        assert!(
+            db.mark_policy_excluded(
+                task.library.as_ref(),
+                task.asset_id.as_ref(),
+                task.version_size.as_str(),
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(db.get_summary().await.unwrap().policy_excluded, 1);
+
+        upsert_seen_for_task(&db, &config, &asset, task)
+            .await
+            .unwrap();
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.policy_excluded, 0);
+        assert_eq!(summary.pending, 1);
+    }
+
+    #[tokio::test]
     async fn planner_uses_cross_zone_asset_library_for_state_and_membership() {
         let tmp = TempDir::new().unwrap();
         let base = test_config(tmp.path());

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -242,20 +242,24 @@ impl PendingRetryPlanning<'_> {
             .cloned()
             .collect();
         for target in deferred_targets {
-            self.db
-                .clear_asset_verification(
+            let transitioned = self
+                .db
+                .mark_policy_excluded(
                     &target.library,
                     &target.asset_id,
                     target.version_size.as_str(),
                 )
                 .await?;
-            self.pending_targets.remove(&target);
+            if transitioned {
+                self.pending_targets.remove(&target);
+            }
             tracing::info!(
                 library = %target.library,
                 asset_id = %target.asset_id,
                 version_size = target.version_size.as_str(),
                 filter_reasons = ?filter_reasons,
-                "Pending asset deferred: current sync policy did not produce a retry task"
+                transitioned,
+                "Pending asset excluded: current sync policy did not produce a retry task"
             );
         }
         for target in state_write_failed_targets {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -517,6 +517,11 @@ impl MetricsHandle {
             .get_or_create(&StatusLabels { status: "pending" })
             .set(i64::try_from(summary.pending).unwrap_or(i64::MAX));
         self.db_assets_total
+            .get_or_create(&StatusLabels {
+                status: "policy_excluded",
+            })
+            .set(i64::try_from(summary.policy_excluded).unwrap_or(i64::MAX));
+        self.db_assets_total
             .get_or_create(&StatusLabels { status: "failed" })
             .set(i64::try_from(summary.failed).unwrap_or(i64::MAX));
         self.db_assets_total
@@ -1294,6 +1299,7 @@ mod tests {
             total_assets: downloaded + pending + failed,
             downloaded,
             pending,
+            policy_excluded: 0,
             failed,
             awaiting_provider_verification: 0,
             source_deleted: 0,
@@ -1322,8 +1328,10 @@ mod tests {
     #[tokio::test]
     async fn update_db_stats_sets_asset_count_gauges() {
         let handle = MetricsHandle::new(None);
-        let summary = make_summary(100, 5, 2, 1_000_000);
-        handle.update_db_stats(&summary, 107);
+        let mut summary = make_summary(100, 5, 2, 1_000_000);
+        summary.policy_excluded = 3;
+        summary.total_assets += 3;
+        handle.update_db_stats(&summary, 110);
 
         let output = render_metrics(&handle).await;
         assert!(
@@ -1333,6 +1341,10 @@ mod tests {
         assert!(
             output.contains(r#"kei_db_assets_total{status="pending"} 5"#),
             "pending count missing or wrong:\n{output}"
+        );
+        assert!(
+            output.contains(r#"kei_db_assets_total{status="policy_excluded"} 3"#),
+            "policy-excluded count missing or wrong:\n{output}"
         );
         assert!(
             output.contains(r#"kei_db_assets_total{status="failed"} 2"#),

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -238,6 +238,16 @@ pub trait DownloadStateStore: Send + Sync {
     ) -> Result<(), StateError> {
         Ok(())
     }
+    /// Mark a live asset as intentionally outside the active download policy.
+    ///
+    /// Returns `true` when a pending row was transitioned. A later
+    /// producer-dispatched `upsert_seen` reactivates the row to pending.
+    async fn mark_policy_excluded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+    ) -> Result<bool, StateError>;
     async fn backfill_asset_master_mappings_from_album_memberships(
         &self,
     ) -> Result<u64, StateError> {
@@ -818,6 +828,10 @@ fn upsert_asset_row(
                         ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21,
                         ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33)
                 ON CONFLICT(library, id, version_size) DO UPDATE SET
+                    status = CASE
+                        WHEN assets.status = 'policy_excluded' THEN 'pending'
+                        ELSE assets.status
+                    END,
                     checksum = excluded.checksum,
                     filename = excluded.filename,
                     created_at = excluded.created_at,
@@ -1049,7 +1063,9 @@ impl SqliteStateDb {
                             }
                         }
                     }
-                    AssetStatus::Pending | AssetStatus::Failed => Ok(true),
+                    AssetStatus::Pending | AssetStatus::PolicyExcluded | AssetStatus::Failed => {
+                        Ok(true)
+                    }
                 }
             }
         }
@@ -1401,12 +1417,20 @@ impl SqliteStateDb {
 
     pub(crate) async fn get_summary(&self) -> Result<SyncSummary, StateError> {
         self.with_conn("get_summary", move |conn| {
-            let (total_assets, downloaded, pending, failed, source_deleted, downloaded_bytes) = conn
-                .query_row(
+            let (
+                total_assets,
+                downloaded,
+                pending,
+                policy_excluded,
+                failed,
+                source_deleted,
+                downloaded_bytes,
+            ) = conn.query_row(
                     "SELECT \
                          COUNT(*), \
                          COUNT(CASE WHEN status = 'downloaded' THEN 1 END), \
                          COUNT(CASE WHEN status = 'pending' AND is_deleted = 0 THEN 1 END), \
+                         COUNT(CASE WHEN status = 'policy_excluded' AND is_deleted = 0 THEN 1 END), \
                          COUNT(CASE WHEN status = 'failed' AND is_deleted = 0 THEN 1 END), \
                          COUNT(CASE WHEN is_deleted = 1 THEN 1 END), \
                          COALESCE(SUM(CASE WHEN status = 'downloaded' THEN size_bytes ELSE 0 END), 0) \
@@ -1420,14 +1444,16 @@ impl SqliteStateDb {
                             row.get::<_, i64>(3)?,
                             row.get::<_, i64>(4)?,
                             row.get::<_, i64>(5)?,
+                            row.get::<_, i64>(6)?,
                         ))
                     },
                 )
-                .map(|(t, d, p, f, s, b)| {
+                .map(|(t, d, p, e, f, s, b)| {
                     (
                         u64::try_from(t).unwrap_or(0),
                         u64::try_from(d).unwrap_or(0),
                         u64::try_from(p).unwrap_or(0),
+                        u64::try_from(e).unwrap_or(0),
                         u64::try_from(f).unwrap_or(0),
                         u64::try_from(s).unwrap_or(0),
                         u64::try_from(b).unwrap_or(0),
@@ -1599,6 +1625,7 @@ impl SqliteStateDb {
                 total_assets,
                 downloaded,
                 pending,
+                policy_excluded,
                 failed,
                 awaiting_provider_verification,
                 source_deleted,
@@ -2994,6 +3021,42 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn mark_policy_excluded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+    ) -> Result<bool, StateError> {
+        let library = library.to_owned();
+        let id = id.to_owned();
+        let version_size = version_size.to_owned();
+        self.with_conn_mut("mark_policy_excluded", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("mark_policy_excluded::begin", e))?;
+            let affected = tx
+                .execute(
+                    "UPDATE assets SET status = 'policy_excluded', last_error = NULL \
+                     WHERE library = ?1 AND id = ?2 AND version_size = ?3 \
+                       AND status = 'pending' AND is_deleted = 0",
+                    rusqlite::params![library, id, version_size],
+                )
+                .map_err(|e| StateError::query("mark_policy_excluded::update", e))?;
+            if affected > 0 {
+                tx.execute(
+                    "DELETE FROM asset_verifications \
+                     WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+                    rusqlite::params![library, id, version_size],
+                )
+                .map_err(|e| StateError::query("mark_policy_excluded::verification", e))?;
+            }
+            tx.commit()
+                .map_err(|e| StateError::query("mark_policy_excluded::commit", e))?;
+            Ok(affected > 0)
+        })
+        .await
+    }
+
     pub(crate) async fn backfill_asset_master_mappings_from_album_memberships(
         &self,
     ) -> Result<u64, StateError> {
@@ -3524,6 +3587,15 @@ impl DownloadStateStore for SqliteStateDb {
         version_size: &str,
     ) -> Result<(), StateError> {
         SqliteStateDb::clear_asset_verification(self, library, id, version_size).await
+    }
+
+    async fn mark_policy_excluded(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+    ) -> Result<bool, StateError> {
+        SqliteStateDb::mark_policy_excluded(self, library, id, version_size).await
     }
 
     async fn backfill_asset_master_mappings_from_album_memberships(
@@ -4910,6 +4982,78 @@ mod tests {
         assert_eq!(summary.pending, 3);
         assert_eq!(summary.downloaded, 2);
         assert_eq!(summary.failed, 1);
+        assert_eq!(summary.policy_excluded, 0);
+    }
+
+    #[tokio::test]
+    async fn policy_excluded_asset_is_non_actionable_until_redispatched() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("POLICY_EXCLUDED")
+            .checksum("excluded-checksum")
+            .filename("old.mov")
+            .size(1000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.set_asset_verification(
+            "PrimarySync",
+            "POLICY_EXCLUDED",
+            "original",
+            AssetVerificationState::Unknown,
+            "before policy decision",
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            db.mark_policy_excluded("PrimarySync", "POLICY_EXCLUDED", "original")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !db.mark_policy_excluded("PrimarySync", "POLICY_EXCLUDED", "original")
+                .await
+                .unwrap()
+        );
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.policy_excluded, 1);
+        assert_eq!(summary.awaiting_provider_verification, 0);
+        assert!(db.get_pending().await.unwrap().is_empty());
+
+        db.upsert_seen(&record).await.unwrap();
+        let pending = db.get_pending().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].status, AssetStatus::Pending);
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.policy_excluded, 0);
+    }
+
+    #[tokio::test]
+    async fn source_deletion_supersedes_policy_exclusion() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("EXCLUDED_DELETED")
+            .checksum("excluded-deleted-checksum")
+            .filename("deleted.mov")
+            .size(1000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        assert!(
+            db.mark_policy_excluded("PrimarySync", "EXCLUDED_DELETED", "original")
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            db.resolve_source_deleted("PrimarySync", "EXCLUDED_DELETED", None)
+                .await
+                .unwrap(),
+            1
+        );
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 0);
+        assert_eq!(summary.policy_excluded, 0);
+        assert_eq!(summary.source_deleted, 1);
     }
 
     #[tokio::test]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -92,6 +92,8 @@ impl From<AssetVersionSize> for VersionSizeKey {
 pub enum AssetStatus {
     /// Asset has been seen but not yet downloaded.
     Pending,
+    /// Asset is live at the provider but excluded by the active download policy.
+    PolicyExcluded,
     /// Asset has been successfully downloaded.
     Downloaded,
     /// Asset download failed (will be retried).
@@ -104,6 +106,7 @@ impl AssetStatus {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Pending => "pending",
+            Self::PolicyExcluded => "policy_excluded",
             Self::Downloaded => "downloaded",
             Self::Failed => "failed",
         }
@@ -113,6 +116,7 @@ impl AssetStatus {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "pending" => Some(Self::Pending),
+            "policy_excluded" => Some(Self::PolicyExcluded),
             "downloaded" => Some(Self::Downloaded),
             "failed" => Some(Self::Failed),
             _ => None,
@@ -487,6 +491,8 @@ pub struct SyncSummary {
     pub downloaded: u64,
     /// Number of assets pending download.
     pub pending: u64,
+    /// Number of live assets intentionally excluded by the active download policy.
+    pub policy_excluded: u64,
     /// Number of assets that failed to download.
     pub failed: u64,
     /// Pending or failed rows whose targeted provider lookup was inconclusive.
@@ -604,6 +610,7 @@ mod tests {
     fn test_asset_status_round_trip() {
         for status in [
             AssetStatus::Pending,
+            AssetStatus::PolicyExcluded,
             AssetStatus::Downloaded,
             AssetStatus::Failed,
         ] {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4396,6 +4396,17 @@ mod tests {
             self.inner.touch_last_seen_many(library, asset_ids).await
         }
 
+        async fn mark_policy_excluded(
+            &self,
+            library: &str,
+            id: &str,
+            version_size: &str,
+        ) -> Result<bool, state::error::StateError> {
+            self.inner
+                .mark_policy_excluded(library, id, version_size)
+                .await
+        }
+
         async fn mark_soft_deleted(
             &self,
             library: &str,

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -1552,6 +1552,49 @@ fn status_shows_safe_backup_summary_after_clean_sync() {
 }
 
 #[test]
+fn status_treats_policy_excluded_assets_as_safe_and_visible() {
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+    insert_asset(
+        &conn,
+        "excluded",
+        "policy_excluded",
+        "old.mov",
+        None,
+        None,
+        None,
+    );
+    conn.execute(
+        "INSERT INTO sync_runs (
+            started_at, completed_at, status, assets_seen, assets_downloaded,
+            assets_failed, interrupted, enumeration_errors
+         ) VALUES (?1, ?2, 'complete', 1, 0, 0, 0, 0)",
+        rusqlite::params![1_700_000_000_i64, 1_700_000_010_i64],
+    )
+    .unwrap();
+    drop(conn);
+
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["status"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Pending:    0"), "stdout: {stdout}");
+    assert!(stdout.contains("Policy excluded: 1"), "stdout: {stdout}");
+    assert!(
+        stdout.contains(
+            "Backup status: safe - last sync completed and no pending or failed assets are recorded"
+        ),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn status_shows_unsafe_backup_summary_with_last_run_reasons() {
     let dir = tempfile::tempdir().unwrap();
     let username = "test@example.com";


### PR DESCRIPTION
## Summary
- Persist provider-confirmed live pending assets as policy-excluded when active filters produce no retry task.
- Keep excluded assets visible in status and metrics without making backup status unsafe.
- Return excluded assets to pending when a later sync selects them, while allowing source deletion to supersede the exclusion.

Closes #663

## Tests
- `just gate` => passed
- `cargo run -- status` with an isolated data directory => passed

## Review notes
The asset status column is unconstrained text, so this does not require a schema migration. Reactivation only occurs through the producer-dispatched task path.
