### PR TITLE
Refresh and automate Debian runtime image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: debian

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN export TARGET=$(cat /tmp/target) && \
     cp target/$TARGET/release/kei /kei
 
 # ── Runtime stage ────────────────────────────────────────────────────
-FROM debian:bookworm-20250428-slim
+FROM debian:bookworm-20260713-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends bash curl ca-certificates libdbus-1-3 gosu && \

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -165,6 +165,32 @@ fn docker_packaging_defaults_to_service_run() {
 }
 
 #[test]
+fn docker_runtime_is_version_pinned_and_maintained() {
+    let dockerfile = repo_file("Dockerfile");
+    let snapshot = dockerfile
+        .lines()
+        .find_map(|line| line.strip_prefix("FROM debian:bookworm-"))
+        .and_then(|suffix| suffix.strip_suffix("-slim"))
+        .expect("Docker runtime must use a dated Debian Bookworm slim image");
+    assert!(
+        snapshot.len() == 8 && snapshot.bytes().all(|byte| byte.is_ascii_digit()),
+        "Docker runtime snapshot must use a YYYYMMDD date"
+    );
+
+    let dependabot = repo_file(".github/dependabot.yml");
+    for expected in [
+        "package-ecosystem: docker",
+        "interval: weekly",
+        "dependency-name: debian",
+    ] {
+        assert!(
+            dependabot.contains(expected),
+            "Dependabot must keep the pinned Debian runtime current: missing {expected}"
+        );
+    }
+}
+
+#[test]
 fn migration_guide_uses_toml_for_durable_sync_settings() {
     let guide = repo_file("docs/migration-from-icloudpd.md");
     let stale = [


### PR DESCRIPTION
## Summary
- Refresh the pinned Debian runtime image from `bookworm-20250428-slim` to `bookworm-20260713-slim`.
- Add weekly Dependabot updates limited to the Debian image.
- Add a static check covering the dated pin and update automation.

Closes #692

## Tests
- `cargo check`
- `cargo test --test branch_static docker_runtime_is_version_pinned_and_maintained`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate`
- `just docker build`
- `docker run --rm kei:dev --version`
