### PR TITLE
Codify contributor safety contracts and validation workflows

### DIFF
--- a/.agents/skills/kei-pr-ready/SKILL.md
+++ b/.agents/skills/kei-pr-ready/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: kei-pr-ready
+description: Validate a kei branch before review without publishing or changing it. Use when asked whether a kei change is PR-ready, to run the repository gate, to check review readiness, to validate a branch or diff, or to identify missing tests, consumers, documentation, safety evidence, or user-flow checks before PR preparation.
+---
+
+# Validate a kei branch
+
+Produce an evidence-backed readiness verdict. Keep the pass read-only unless the
+user separately asks to fix a failure. Do not commit, push, open a pull request,
+or change GitHub state.
+
+## Preflight
+
+1. Read repository-root `AGENTS.md`, then the relevant sections of
+   `CONTRIBUTING.md`, `docs/architecture.md`, and `tests/README.md`.
+2. Run `just agent-status`.
+3. Confirm the current branch, upstream, working-tree state, and comparison
+   base. Prefer the remote default branch; fall back to `origin/main` when the
+   default cannot be resolved.
+4. Inspect committed, staged, and unstaged changes. Return a not-ready verdict
+   if unrelated work prevents an attributable review.
+
+## Classify impact
+
+Map every changed behavior to the owner and direct consumers in
+`docs/architecture.md`. Apply each matching row in its change-impact checklist.
+At minimum, classify:
+
+- provider identity, enumeration, checkpoint, or retry behavior
+- SQLite schema, query, durable key, sentinel, or serialization
+- file, path, publication, import, or metadata behavior
+- CLI, configuration, machine output, service, or documentation
+- tests, scripts, workflows, packaging, or release behavior
+
+Trace shared types and literal consumers with `rg`. Identify the applicable
+safety-contract IDs and focused scenario slices. Do not treat the round-trip
+gate or a passing unit test as proof that all consumers were traced.
+
+## Validate
+
+1. Run the smallest matching focused test or `just test scenario NAME`.
+2. For behavior changes, prefer at least one test through the production call
+   graph and cover the relevant failure, retry, interruption, or boundary case.
+3. For CLI or user-flow changes, run the changed command and inspect help,
+   Docker, service, Homebrew, and documentation consumers where applicable.
+4. For schema, primary-key, sentinel, durable-key, or serialization changes,
+   search every old literal and prove migration and round-trip behavior.
+5. Run `just gate`.
+6. Investigate every failure. Use bounded output and
+   `just agent-failure-summary` when a retained full-test log is relevant.
+
+Do not run live tests unless the changed behavior requires them. Follow
+`tests/README.md`, run live suites single-threaded, and preserve rate-limit and
+shared-session constraints.
+
+## Review and report
+
+Self-review the complete end-state diff for unrelated scope, missed consumers,
+weak evidence, accidental API changes, unnecessary abstractions, and stale
+documentation.
+
+Report:
+
+- base, head, and reviewed diff scope
+- impact classification, owners, safety contracts, and scenario slices
+- exact validation commands and results
+- unresolved failures, skipped checks, risks, and missing evidence
+- final verdict: ready or not ready
+
+Never report ready when a required check failed, was skipped without a
+documented reason, or could not be attributed to the reviewed diff.

--- a/.agents/skills/kei-pr-ready/agents/openai.yaml
+++ b/.agents/skills/kei-pr-ready/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare kei PR"
+  short_description: "Validate a kei branch before review"
+  default_prompt: "Use $kei-pr-ready to validate this kei branch for review readiness."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,17 @@
 
 <!-- What changed and why. Link related issues with "Fixes #123" or "Closes #123". -->
 
+## Contract and risk
+
+<!-- Acceptance criteria or safety contract affected. Note risks, tradeoffs, follow-up work, and independent/adversarial review results. Write "None" when not applicable. -->
+
 ## Test plan
 
 <!-- How you tested this. Commands you ran, scenarios you checked, edge cases you considered. -->
+
+## Regression proof
+
+<!-- For a bug fix or safety-contract change, name the focused test and how you confirmed it fails with the defect present. Write "Not applicable" when it is not a regression. -->
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,11 @@
 
 ## Contract and risk
 
-<!-- Acceptance criteria or safety contract affected. Note risks, tradeoffs, follow-up work, and independent/adversarial review results. Write "None" when not applicable. -->
+<!-- State the acceptance criteria and name any affected safety-contract ID. Note risks, tradeoffs, follow-up work, and independent/adversarial review results. Write "None" when not applicable. -->
 
 ## Test plan
 
-<!-- How you tested this. Commands you ran, scenarios you checked, edge cases you considered. -->
+<!-- List exact commands, focused scenario slices, and edge cases checked. -->
 
 ## Regression proof
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .codex/
 CODEBASE.md
 CODEGRAPH.md
-UNSAFE.md
 
 # Rust
 /target

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Local Repo
-.agents/
 .scratch/
 .codex/
 CODEBASE.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .agents/
 .scratch/
 .codex/
-AGENTS.md
 CODEBASE.md
 CODEGRAPH.md
 UNSAFE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ parsing in the download pipeline.
   delete or forget work.
 - Keep provider quirks and record parsing in `src/icloud/`.
 - Do not remove trust-boundary validation or data-loss guards as cleanup.
+- Never log passwords, session cookies, bearer tokens, Apple IDs, or
+  unredacted provider identifiers. Preserve secret wrappers and redaction.
+- Keep `unsafe` blocks minimal and local. Document each block with a concrete
+  `SAFETY` invariant, and update `UNSAFE.md` when unsafe code changes.
 
 ## Implementation
 
@@ -53,6 +57,8 @@ parsing in the download pipeline.
 - Use `expect` only for a proven same-flow invariant, and state the invariant
   in the message.
 - Do not block the async runtime. Use async I/O or `spawn_blocking`.
+- Profile before performance-only changes. Use bounded concurrency only when
+  it preserves file, state, retry, and checkpoint invariants.
 - Keep internal APIs `pub(crate)` unless public or test-harness precedent
   requires `pub`.
 - Add `#[must_use]` when ignoring a result can lose state, safety, or a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+kei is a Rust CLI that syncs iCloud Photos media to local storage.
+
+Read first:
+
+1. `CONTRIBUTING.md` for the contributor workflow and review contract.
+2. `docs/architecture.md` for owners, flows, and data-safety invariants.
+3. `tests/README.md` before changing or attributing test behavior.
+
+## Discovery
+
+Before editing:
+
+1. Run `cargo check` for code work.
+2. Find the owning area in `docs/architecture.md`.
+3. Use `rg` for the exact symbol, command, flag, SQL name, config key, error,
+   durable key, or serialization shape.
+4. Read the owner module and direct callers.
+5. Trace every consumer before changing a shared type, trait, CLI/API surface,
+   schema, primary key, sentinel, token, path, or serialized value.
+
+Keep policy in its owner. Do not put sync policy in path rendering or CloudKit
+parsing in the download pipeline.
+
+## Safety
+
+- User media and metadata must not be lost, corrupted, truncated, overwritten,
+  or silently discarded.
+- Preserve `.part` writes, SHA-256 verification, no-overwrite publication,
+  parent-directory fsync, and durable state finalization.
+- Local file or metadata rewrites require an explicit user-controlled option.
+- Preserve provider checkpoint gates across interruption, retry, partial work,
+  config drift, and stale planning.
+- Unknown provider identity is durable retry evidence, not permission to
+  delete or forget work.
+- Keep provider quirks and record parsing in `src/icloud/`.
+- Do not remove trust-boundary validation or data-loss guards as cleanup.
+
+## Implementation
+
+- Make the smallest complete change in the fewest owning files.
+- Reuse or delete before adding abstractions.
+- Prefer the standard library, native platform/SQLite support, and existing
+  dependencies, in that order.
+- Avoid speculative knobs, compatibility, helpers, factories, builders, and
+  one-implementation traits.
+- Prefer borrowing to cloning and enums to boolean mode arguments.
+- Use newtypes for IDs, paths, units, tokens, and other easy-to-mix values.
+- Use named constants for sentinels, magic values, timeouts, and retry limits.
+- Use typed errors and `?`.
+- Do not use `unwrap` in production code.
+- Use `expect` only for a proven same-flow invariant, and state the invariant
+  in the message.
+- Do not block the async runtime. Use async I/O or `spawn_blocking`.
+- Keep internal APIs `pub(crate)` unless public or test-harness precedent
+  requires `pub`.
+- Add `#[must_use]` when ignoring a result can lose state, safety, or a
+  user-visible decision.
+- Keep provider, state, filesystem, and policy layers separate.
+
+## Tests and completion
+
+- Every behavior change needs a focused test.
+- Prefer at least one test through the real production call graph.
+- Put unit tests near their owner and integration tests under `tests/`.
+- Assert concrete success, failure, retry, interruption, and boundary behavior.
+- Investigate every failure before changing product code or calling it
+  unrelated.
+- Use check-only formatter and linter commands unless explicitly asked to
+  autofix.
+
+Finish code changes with:
+
+```sh
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Run focused tests while iterating and `just gate` for PR-ready work. Run live
+tests single-threaded only when the change needs them; follow
+`tests/README.md`.
+
+For CLI changes, run the changed command and inspect Docker CMD, systemd
+`ExecStart`, Homebrew formula paths, help, and docs where applicable.
+
+For schema, primary-key, sentinel, durable-key, or serialization changes,
+search every old literal and prove migration and round-trip behavior.
+
+Update `docs/architecture.md` when ownership, a documented flow, or an
+invariant changes.
+
+## Restrictions
+
+Get explicit approval before:
+
+- Deleting production code or tests
+- Changing a public CLI/API contract
+- Adding a dependency
+- Pushing, opening a pull request, or changing `main`
+
+Never use star imports, unexplained `#[allow(...)]`, `git add -A`, `git add .`,
+`git commit --amend`, or `sudo`.
+
+Documentation uses direct language and no em dashes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,108 +2,75 @@
 
 kei is a Rust CLI that syncs iCloud Photos media to local storage.
 
-Read first:
+Read by scope:
 
-1. `CONTRIBUTING.md` for the contributor workflow and review contract.
-2. `docs/architecture.md` for owners, flows, and data-safety invariants.
-3. `tests/README.md` before changing or attributing test behavior.
+- Code work: workflow and Rust style in `CONTRIBUTING.md`.
+- Ownership, sync, state, filesystem, provider, or cross-cutting work: relevant
+  owner, flow, invariant, and impact sections in `docs/architecture.md`.
+- Test changes or failure attribution: relevant sections of `tests/README.md`.
 
 ## Discovery
 
-Before editing:
+Before editing code:
 
-1. Run `cargo check` for code work.
-2. Find the owning area in `docs/architecture.md`.
+1. Run `cargo check`.
+2. Locate the owner in `docs/architecture.md`.
 3. Use `rg` for the exact symbol, command, flag, SQL name, config key, error,
    durable key, or serialization shape.
-4. Read the owner module and direct callers.
-5. Trace every consumer before changing a shared type, trait, CLI/API surface,
-   schema, primary key, sentinel, token, path, or serialized value.
+4. Read the owner and direct callers.
+5. Trace every consumer of shared types, CLI/API surfaces, schema, primary
+   keys, sentinels, tokens, paths, and serialized values before changing them.
 
-Keep policy in its owner. Do not put sync policy in path rendering or CloudKit
-parsing in the download pipeline.
+Keep policy in its owner. Path rendering does not decide sync policy; the
+download pipeline does not parse CloudKit records.
 
 ## Safety
 
-- User media and metadata must not be lost, corrupted, truncated, overwritten,
-  or silently discarded.
+- Never lose, corrupt, truncate, overwrite, or silently discard user media or
+  metadata.
 - Preserve `.part` writes, SHA-256 verification, no-overwrite publication,
   parent-directory fsync, and durable state finalization.
-- Local file or metadata rewrites require an explicit user-controlled option.
+- Local media or metadata rewrites require an explicit user option.
 - Preserve provider checkpoint gates across interruption, retry, partial work,
   config drift, and stale planning.
-- Unknown provider identity is durable retry evidence, not permission to
-  delete or forget work.
+- Unknown provider identity is durable retry evidence, not permission to delete
+  or forget work.
 - Keep provider quirks and record parsing in `src/icloud/`.
-- Do not remove trust-boundary validation or data-loss guards as cleanup.
-- Never log passwords, session cookies, bearer tokens, Apple IDs, or
-  unredacted provider identifiers. Preserve secret wrappers and redaction.
-- Keep `unsafe` blocks minimal and local. Document each block with a concrete
-  `SAFETY` invariant, and update `UNSAFE.md` when unsafe code changes.
+- Keep trust-boundary validation and data-loss guards intact.
+- Never log passwords, cookies, bearer tokens, Apple IDs, or unredacted
+  provider identifiers. Preserve secret wrappers and redaction.
+- Keep `unsafe` local. Document each block with a concrete `SAFETY` invariant
+  and update `UNSAFE.md` when unsafe code changes.
 
 ## Implementation
 
-- Make the smallest complete change in the fewest owning files.
-- Reuse or delete before adding abstractions.
-- Prefer the standard library, native platform/SQLite support, and existing
-  dependencies, in that order.
-- Avoid speculative knobs, compatibility, helpers, factories, builders, and
-  one-implementation traits.
-- Prefer borrowing to cloning and enums to boolean mode arguments.
-- Use newtypes for IDs, paths, units, tokens, and other easy-to-mix values.
-- Use named constants for sentinels, magic values, timeouts, and retry limits.
-- Use typed errors and `?`.
-- Do not use `unwrap` in production code.
-- Use `expect` only for a proven same-flow invariant, and state the invariant
-  in the message.
-- Do not block the async runtime. Use async I/O or `spawn_blocking`.
-- Profile before performance-only changes. Use bounded concurrency only when
-  it preserves file, state, retry, and checkpoint invariants.
-- Keep internal APIs `pub(crate)` unless public or test-harness precedent
-  requires `pub`.
+- Do not block the async runtime; use async I/O or `spawn_blocking`.
+- Profile before performance-only changes. Bounded concurrency must preserve
+  file, state, retry, and checkpoint invariants.
 - Add `#[must_use]` when ignoring a result can lose state, safety, or a
   user-visible decision.
 - Keep provider, state, filesystem, and policy layers separate.
 
 ## Tests and completion
 
-- Every behavior change needs a focused test.
-- Prefer at least one test through the real production call graph.
-- Put unit tests near their owner and integration tests under `tests/`.
-- Assert concrete success, failure, retry, interruption, and boundary behavior.
-- Investigate every failure before changing product code or calling it
-  unrelated.
-- Use check-only formatter and linter commands unless explicitly asked to
-  autofix.
-
-Finish code changes with:
-
-```sh
-cargo fmt --all --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-Run focused tests while iterating and `just gate` for PR-ready work. Run live
-tests single-threaded only when the change needs them; follow
-`tests/README.md`.
-
-For CLI changes, run the changed command and inspect Docker CMD, systemd
-`ExecStart`, Homebrew formula paths, help, and docs where applicable.
-
-For schema, primary-key, sentinel, durable-key, or serialization changes,
-search every old literal and prove migration and round-trip behavior.
-
-Update `docs/architecture.md` when ownership, a documented flow, or an
-invariant changes.
+- Follow the testing contract in `CONTRIBUTING.md`; investigate every failure
+  before changing product code or calling it unrelated.
+- Run focused tests while iterating and `just gate` for PR-ready work.
+- Finish with `cargo fmt --all --check` and
+  `cargo clippy --all-targets --all-features -- -D warnings`.
+- Run live tests single-threaded only when needed; follow `tests/README.md`.
+- CLI changes: run the command and inspect help, docs, Docker CMD, systemd
+  `ExecStart`, and Homebrew paths where applicable.
+- Schema, primary-key, sentinel, durable-key, or serialization changes: search
+  every old literal and prove migration and round-trip behavior.
+- Update `docs/architecture.md` when ownership, a documented flow, or an
+  invariant changes.
 
 ## Restrictions
 
-Get explicit approval before:
-
-- Deleting production code or tests
-- Changing a public CLI/API contract
-- Adding a dependency
-- Pushing, opening a pull request, or changing `main`
+Get explicit approval before deleting production code or tests, changing a
+public CLI/API contract, adding a dependency, pushing, opening a pull request,
+or changing `main`.
 
 Never use star imports, unexplained `#[allow(...)]`, `git add -A`, `git add .`,
 `git commit --amend`, or `sudo`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@ Before editing code:
 5. Trace every consumer of shared types, CLI/API surfaces, schema, primary
    keys, sentinels, tokens, paths, and serialized values before changing them.
 
+Resolve material ambiguity before implementation. State assumptions in the
+plan when they affect behavior, safety, or a public interface.
+
 Keep policy in its owner. Path rendering does not decide sync policy; the
 download pipeline does not parse CloudKit records.
 
@@ -50,6 +53,8 @@ download pipeline does not parse CloudKit records.
 - Add `#[must_use]` when ignoring a result can lose state, safety, or a
   user-visible decision.
 - Keep provider, state, filesystem, and policy layers separate.
+- Every changed line must serve the requested behavior, required tests or docs,
+  or cleanup made necessary by the change. Report unrelated cleanup separately.
 
 ## Tests and completion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,10 @@ Reviews prioritize:
 
 ## Logs and config snippets
 
+Code must not log Apple IDs, passwords, session cookies, bearer tokens, or
+unredacted provider identifiers. Preserve `SecretString`, password redaction,
+and other credential boundaries when changing logging or error paths.
+
 Before posting logs or configuration, redact Apple IDs, passwords, session
 cookies, bearer tokens, webhook URLs, and local paths you do not want public.
 Keep enough surrounding text for the failure to remain readable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,91 @@
 # Contributing
 
-Contributions are welcome. For anything beyond a small fix, open an issue first so we can talk through the approach before you write the code.
+Contributions are welcome. Small, isolated fixes can go straight to a pull
+request. For anything that changes behavior, architecture, state, file writes,
+or a public interface, open an issue first so we can agree on the approach.
+
+## Before you start
+
+Read [the architecture guide](docs/architecture.md) before changing code. It
+maps the major owners and the data-safety boundaries between them.
+
+For a nontrivial change, post a short plan on the issue before implementation:
+
+- What behavior should change, and what are the acceptance criteria?
+- Which module owns the decision, and which direct callers are involved?
+- Can the change affect SQLite state, provider checkpoints, configuration,
+  reports, or local files?
+- What happens after interruption, retry, partial failure, or config drift?
+- Which focused tests will prove the behavior?
+- Which user-facing surfaces need matching changes?
+
+Discuss the approach before deleting production code or tests, changing a
+public CLI/API contract, or adding a dependency or broad configuration option.
+
+## Engineering expectations
+
+### Work in the owning layer
+
+1. Find the relevant area in [the architecture guide](docs/architecture.md).
+2. Search for the exact symbol, command, flag, SQL name, config key, or error.
+3. Read the owner module and its direct callers before editing.
+4. Trace shared types, traits, schema, serialization, tokens, and paths through
+   all consumers.
+5. Update the architecture guide when ownership or a documented flow changes.
+
+Keep policy in its owner. For example, path formatting must not decide sync
+policy, and the download pipeline must not own CloudKit response parsing.
+
+### Protect user data
+
+Media and metadata must never be lost, corrupted, truncated, overwritten, or
+silently discarded.
+
+- Downloads land through `.part` files and are verified before publication.
+- Downloaded bytes require SHA-256 verification.
+- Final publication must not overwrite an existing destination.
+- State transitions and provider checkpoint changes must remain durable.
+- Local media or metadata rewrites require an explicit user-controlled option.
+- Provider-specific behavior belongs in the provider adapter.
+- Trust-boundary validation and data-loss guards are not cleanup candidates.
+
+Changes involving file writes, SQLite state, provider identity, or checkpoints
+must cover interruption, retry, partial completion, and stale configuration.
+
+### Keep the change narrow
+
+- Prefer the smallest complete fix in the fewest owning files.
+- Reuse or delete before adding a helper or abstraction.
+- Prefer the standard library, then native platform/SQLite features, then
+  existing dependencies.
+- Add a dependency only when it is clearly better than the existing choices.
+- Avoid one-implementation traits, factories, builders, speculative
+  compatibility, and configuration without a current requirement.
+- Prefer direct, readable code over clever or generalized code.
 
 ## Workflow
 
-1. Fork the repo and create a branch from `main`.
-2. Make your changes.
-3. Run the pre-push gate:
+1. Fork the repository and create a branch from `main`.
+2. Run `cargo check` before code work.
+3. Make the smallest complete change in the owning module.
+4. Add focused tests for behavior changes.
+5. Run the changed command or user flow when practical.
+6. Review the diff for unrelated changes, unnecessary complexity, missed
+   consumers, and incomplete docs.
+7. Run the pre-push gate:
+
    ```sh
    just gate
    ```
-   This runs the local release-quality gate: formatting, clippy with default
-   and no-default features, default and no-default tests, doc lints, lockfile
-   fetch, `cargo audit`, workflow and script lint, contract markers, typos,
-   and the serializer round-trip detector. Fail-fast.
 
-   Without `just` installed, run the raw commands (see `justfile` for the full list):
+   This runs formatting, clippy with default and no-default features, default
+   and no-default tests, doc lints, lockfile fetch, `cargo audit`, workflow and
+   script lint, contract markers, typos, and the serializer round-trip
+   detector. It stops on the first failure.
+
+   Without `just`, run the raw commands below. See `justfile` for optional
+   local linters and the current full list.
+
    ```sh
    cargo fmt --all --check
    cargo clippy --all-targets --all-features -- -D warnings
@@ -32,36 +102,71 @@ Contributions are welcome. For anything beyond a small fix, open an issue first 
    typos
    bash scripts/check-roundtrip-gate.sh
    ```
-4. Open a pull request against `main`.
 
-All changes go through PRs - no direct commits to `main`.
+8. Open a pull request against `main`.
 
-## Auth tests
+All changes go through pull requests. Do not commit directly to `main`.
+
+## Tests
+
+- Every behavior change needs a focused test.
+- Prefer a test that exercises the real production call graph.
+- Put unit tests near the owning module and cross-module behavior in `tests/`.
+- Assert concrete outcomes and edge cases, not only that a call succeeds.
+- For CLI changes, run the changed command and check Docker, systemd, Homebrew,
+  and documentation surfaces where applicable.
+- Do not dismiss a failing test as unrelated without investigating it.
 
 Some tests (`tests/sync.rs`, `tests/state_auth.rs`, and
-`tests/import_existing_live.rs`) hit the live iCloud API and need real
-credentials. These are `#[ignore]` by default. See
-[tests/README.md](tests/README.md) for setup, then:
+`tests/import_existing_live.rs`) contact the live iCloud API and need real
+credentials. They are `#[ignore]` by default. See
+[tests/README.md](tests/README.md) for setup, then run:
 
 ```sh
 just test live
 ```
 
-You don't need to run auth tests for most changes. CI runs the offline suite on
-every PR.
+Most changes do not need live tests. CI runs the offline suite on every pull
+request.
 
-## Code style
+## Pull requests and review
 
-- Rust 2021 edition, stable toolchain
-- `cargo fmt` and `cargo clippy` must pass clean
-- Warnings are errors in CI (`RUSTFLAGS="-Dwarnings"`)
+Describe the end state, not the sequence of edits. Include:
+
+- The behavior changed and why
+- The related issue, using `Fixes #123` or `Closes #123` when appropriate
+- Exact commands and scenarios tested
+- Data, state, filesystem, compatibility, or migration risks
+- Tradeoffs or follow-up work that remains
+
+Reviews prioritize:
+
+- Correctness and user-data safety
+- Ownership and layer boundaries
+- Interruption, retry, and partial-state behavior
+- Provider checkpoint, state, serialization, and config consistency
+- Focused evidence through tests
+- Unnecessary scope, abstraction, or configuration
+- User-visible behavior and migration effects
+
+## Rust style
+
+- Rust 2024 edition with the minimum Rust version declared in `Cargo.toml`
+- `cargo fmt` and `cargo clippy` must pass cleanly
+- Warnings are errors in CI
+- Use typed errors and `?`; do not use `unwrap` in production code
+- Prefer borrowing to cloning and enums to boolean mode arguments
+- Use newtypes for IDs, paths, units, tokens, and other easy-to-mix values
+- Keep internal APIs `pub(crate)` unless a public surface or test-harness
+  precedent requires `pub`
 
 ## Logs and config snippets
 
-Redact Apple IDs, passwords, session cookies, bearer tokens, webhook URLs, and
-local paths that you don't want public before posting logs or config snippets.
-Keep enough surrounding text for the failure to be readable.
+Before posting logs or configuration, redact Apple IDs, passwords, session
+cookies, bearer tokens, webhook URLs, and local paths you do not want public.
+Keep enough surrounding text for the failure to remain readable.
 
 ## License
 
-By contributing, you agree that your contributions are licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,9 @@ or a public interface, open an issue first so we can agree on the approach.
 
 ## Before you start
 
-Read [the architecture guide](docs/architecture.md) before changing code. It
-maps the major owners and the data-safety boundaries between them.
+Use the owner table in [the architecture guide](docs/architecture.md) before
+changing code, then read the relevant flow, invariant, and change-impact
+sections.
 
 For a nontrivial change, post a short plan on the issue before implementation:
 
@@ -38,16 +39,11 @@ policy, and the download pipeline must not own CloudKit response parsing.
 
 ### Protect user data
 
-Media and metadata must never be lost, corrupted, truncated, overwritten, or
-silently discarded.
-
-- Downloads land through `.part` files and are verified before publication.
-- Downloaded bytes require SHA-256 verification.
-- Final publication must not overwrite an existing destination.
-- State transitions and provider checkpoint changes must remain durable.
-- Local media or metadata rewrites require an explicit user-controlled option.
-- Provider-specific behavior belongs in the provider adapter.
-- Trust-boundary validation and data-loss guards are not cleanup candidates.
+Follow the architecture guide's
+[data-safety invariants](docs/architecture.md#data-safety-invariants). Media and
+metadata must never be lost, corrupted, truncated, overwritten, or silently
+discarded. Local rewrites stay opt-in, provider behavior stays in its adapter,
+and trust-boundary validation and data-loss guards stay intact.
 
 Changes involving file writes, SQLite state, provider identity, or checkpoints
 must cover interruption, retry, partial completion, and stale configuration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ For a nontrivial change, post a short plan on the issue before implementation:
 - Can the change affect SQLite state, provider checkpoints, configuration,
   reports, or local files?
 - What happens after interruption, retry, partial failure, or config drift?
-- Which focused tests will prove the behavior?
+- Which safety contract or focused scenario slice applies, and which tests
+  will prove the behavior?
 - Which user-facing surfaces need matching changes?
 
 Discuss the approach before deleting production code or tests, changing a
@@ -131,6 +132,7 @@ Describe the end state, not the sequence of edits. Include:
 
 - The behavior changed and why
 - The related issue, using `Fixes #123` or `Closes #123` when appropriate
+- Affected safety-contract IDs or focused scenario slices, when applicable
 - Exact commands and scenarios tested
 - Data, state, filesystem, compatibility, or migration risks
 - Tradeoffs or follow-up work that remains

--- a/UNSAFE.md
+++ b/UNSAFE.md
@@ -1,0 +1,41 @@
+# Unsafe usage audit
+
+Audit date: 2026-07-29.
+
+This file lists each `unsafe` block or expression in repo-owned production
+Rust source. Test modules, `tests/`, plain-text mentions of "unsafe", Cargo
+lint settings, and dependency lockfile entries are not counted. There are no
+`unsafe fn`, `unsafe impl`, or raw `extern` declarations in production code.
+
+## Production code
+
+| Location | Usage | Justification | Removal assessment |
+| --- | --- | --- | --- |
+| `src/lib.rs::harden_process` | `libc::prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)` in `harden_process`. | Disables Linux core dumps before secrets can leak into a dump. The call takes integer arguments only, so the local memory-safety risk is limited to correct FFI signature and constants. Failure is logged and ignored. | No safe `std` equivalent. It can be moved out of repo-local `unsafe` by adding a direct `rustix` dependency with the process APIs and calling `rustix::process::set_dumpable_behavior(DumpableBehavior::NotDumpable)`. Dropping the call would weaken credential hardening. |
+| `src/lib.rs::harden_process` | `libc::setrlimit(RLIMIT_CORE, &rlim)` in `harden_process`. | Sets the core-file size limit to zero on Unix. The `rlimit` value is stack-allocated, initialized before the call, and the kernel only reads it during the syscall. Failure is logged and ignored. | No safe `std` equivalent. A direct `rustix` process dependency can replace this with `setrlimit(Resource::Core, Rlimit { current: 0, maximum: 0 })`. Dropping it would weaken the same hardening path. |
+| `src/lib.rs::available_disk_space` (Unix) | `std::mem::zeroed::<libc::statvfs>()` in `available_disk_space`. | Creates an output buffer for `statvfs`. The struct is integer fields on supported Unix targets, and the following syscall overwrites it on success. | Removable. `fs4` is already a direct dependency and exposes safe `fs4::available_space(path)`, which would remove both this initialization and the raw `statvfs` call below. |
+| `src/lib.rs::available_disk_space` (Unix) | `libc::statvfs(c_path.as_ptr(), &raw mut stat)` in `available_disk_space`. | Reads filesystem free-space data through a NUL-terminated path and a valid output pointer that outlives the call. | Removable with the same `fs4::available_space(path).ok()` rewrite as `src/lib.rs::available_disk_space` (Unix). |
+| `src/lib.rs::available_disk_space` (Windows) | `GetDiskFreeSpaceExW(...)` in `available_disk_space`. | Reads filesystem free-space data through a NUL-terminated UTF-16 path and a valid output pointer. The API permits null pointers for the unused totals. | Removable with the same `fs4::available_space(path).ok()` rewrite. |
+| `src/lib.rs::pid_is_alive` | `libc::kill(pid, 0)` in `pid_is_alive`. | Uses POSIX signal `0` as a process-existence probe. It does not deliver a signal; `EPERM` is treated as alive. | No safe `std` equivalent. A direct `rustix` process dependency can replace it with `test_kill_process`, preserving the `PERM` means alive case. The existing unsafe block is small and well-contained. |
+| `src/lib.rs::main_inner` | `std::env::remove_var("ICLOUD_PASSWORD")` in `main_inner`. | Scrubs the password environment variable before the Tokio runtime creates worker threads. This is the narrow window where process environment mutation is safe under Rust's current rules. | Hard to remove while preserving the scrub. Safe `std` has no thread-safe process-env mutation API. Options are to stop scrubbing, move all work into a child process launched with a cleaned environment, or keep a tiny documented unsafe wrapper at startup. |
+| `src/download/file.rs::renameat2_no_replace_blocking` | `libc::syscall(SYS_renameat2, ..., RENAME_NOREPLACE)` in `renameat2_no_replace_blocking`. | Performs atomic no-overwrite promotion of a verified `.part` file on Linux. The paths are owned `CString`s and no Rust references are retained by the kernel. | No safe `std` equivalent for Linux no-overwrite rename. A direct `rustix` fs dependency can replace it with `renameat_with(..., RenameFlags::NOREPLACE)`. Do not rewrite to `exists` then `rename`; that would reintroduce a race. |
+| `src/download/file.rs::rename_no_replace_blocking` (Windows) | Windows `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` in `rename_no_replace_blocking`. | Promotes the `.part` file on Windows with no-overwrite semantics and write-through intent. The UTF-16 paths are NUL-terminated and live for the call. | Not cleanly removable with `std` while preserving write-through behavior. `std::fs::rename` would hide this Windows-specific durability choice. A safe wrapper crate could move the unsafe out of kei, but the platform call is still needed for the current semantics. |
+| `src/download/metadata.rs::exif_datetime_to_iso` | `String::as_bytes_mut()` in `exif_datetime_to_iso`. | Mutates three delimiter bytes in an owned `String`. The length and delimiter checks prove the byte positions exist, and the replacement bytes are ASCII, so UTF-8 stays valid. | Removable. Build a `Vec<u8>` from `s.as_bytes()`, mutate the vector with safe indexing after the same length checks, and convert with `String::from_utf8`. A formatting-based rewrite would also work. |
+| `src/personality/tty_echo.rs::EchoGuard::install` | `std::mem::zeroed::<termios>()` before `tcgetattr` in `EchoGuard::install`. | Prepares a `termios` output buffer. `tcgetattr` fills it before fields are read. | Removable by switching the module to safe termios bindings, for example a direct `rustix` dependency with the `termios` feature. That would also remove the related `tcgetattr` and `tcsetattr` unsafe calls. |
+| `src/personality/tty_echo.rs::EchoGuard::install` | `tcgetattr(STDIN_FILENO, &mut t)` in `EchoGuard::install`. | Reads terminal flags from stdin into a valid `termios` pointer. Failure returns `None`. | Removable with safe termios bindings such as `rustix::termios::tcgetattr(std::io::stdin())`. |
+| `src/personality/tty_echo.rs::EchoGuard::install` | `tcsetattr(STDIN_FILENO, TCSANOW, &t)` in `EchoGuard::install`. | Writes the modified terminal flags back to stdin. The input pointer is valid for the call. | Removable with safe termios bindings such as `rustix::termios::tcsetattr`. |
+| `src/personality/tty_echo.rs::EchoGuard::restore_now` | `std::mem::zeroed::<termios>()` before restore-time `tcgetattr`. | Prepares a `termios` output buffer during terminal restore. | Removable with the same safe termios rewrite as `src/personality/tty_echo.rs::EchoGuard::install`. |
+| `src/personality/tty_echo.rs::EchoGuard::restore_now` | `tcgetattr(STDIN_FILENO, &mut t)` in `restore_now`. | Reads the current terminal flags so only the saved local flags are restored. Failure is ignored because shutdown recovery is best-effort. | Removable with the same safe termios rewrite as `src/personality/tty_echo.rs::EchoGuard::install`. |
+| `src/personality/tty_echo.rs::EchoGuard::restore_now` | `tcsetattr(STDIN_FILENO, TCSANOW, &t)` in `restore_now`. | Restores the saved terminal flags. Failure is ignored because the next shell prompt normally resets tty state. | Removable with the same safe termios rewrite as `src/personality/tty_echo.rs::EchoGuard::install`. |
+| `src/service/env.rs::effective_uid` | `libc::geteuid()` in `effective_uid`. | Centralizes effective-UID lookup for Unix service backends. `geteuid` is stateless and has no pointer or aliasing preconditions. | Removable by adding a direct safe wrapper dependency, for example `rustix::process::geteuid` or `nix::unistd::geteuid`. This is a good cleanup target because tests duplicate this same unsafe call. |
+
+## Best production removal candidates
+
+The easiest local removals are:
+
+1. Replace `available_disk_space` with `fs4::available_space`, removing
+   both Unix expressions and the Windows FFI call.
+2. Rewrite `exif_datetime_to_iso` without `String::as_bytes_mut`, removing
+   its local `unsafe` block.
+3. Add a direct `rustix` dependency for process, fs, and termios wrappers. That
+   would remove most Unix syscall wrappers while preserving their semantics.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,6 +197,19 @@ passwords, session cookies, bearer tokens, or unredacted provider identifiers
 to logs or machine output. Preserve process hardening that limits credential
 exposure through core dumps.
 
+## Safety contract catalog
+
+Stable IDs connect safety rules to production owners and focused tests.
+`scripts/check-contracts` rejects missing links in that chain.
+
+| Contract | Owner | Required behavior |
+|----------|-------|-------------------|
+| `FILE_PUBLISH_NO_OVERWRITE` | `src/download/file.rs` | Publishing a completed `.part` file never replaces an existing final file. |
+| `SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE` | `src/sync_cycle.rs` | The database pre-check token advances only after a successful non-dry-run cycle with a current pass plan. |
+| `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY` | `src/sync_cycle.rs`, `src/download/mod.rs` | A zone checkpoint advances only with complete token evidence and durable recovery for unfinished work. |
+| `UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING` | `src/download/retry.rs` | Inconclusive provider identity retains the pending row and records verification evidence. |
+| `METADATA_WRITES_REQUIRE_OPT_IN` | `src/download/metadata_rewrite.rs` | Media and sidecar metadata writes run only for explicitly enabled metadata flags. |
+
 ## Change-impact checklist
 
 | Change | Check |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,229 @@
+# Architecture
+
+kei is a Rust CLI that transfers iCloud Photos media and metadata to local
+storage. This guide identifies the owner of each major decision and the
+boundaries that protect user data.
+
+Use it as a starting map. Read the owning module and its direct callers before
+changing behavior.
+
+## Design rules
+
+- User media and metadata must not be lost, corrupted, truncated, overwritten,
+  or silently discarded.
+- Local file and metadata rewrites are opt-in.
+- Provider-specific parsing and identity rules stay in the iCloud adapter.
+- Sync policy stays in the sync and download orchestration layers.
+- Path rendering does not decide whether an asset should sync.
+- SQLite transitions and provider checkpoints must survive interruption.
+- Prefer the smallest complete implementation in the owning module.
+
+## Owners
+
+| Area | Owner | Boundary |
+|------|-------|----------|
+| Process startup and dispatch | `src/lib.rs` | Starts the runtime, resolves bootstrap paths, configures logging, dispatches commands, and maps exit codes. |
+| CLI shape | `src/cli.rs` | Defines clap arguments and parsing. It does not execute command behavior. |
+| Runtime configuration | `src/config.rs` | Resolves TOML, environment, and command inputs into runtime policy. |
+| Selection grammar | `src/selection.rs` | Parses album, smart-folder, library, exclusion, and unfiled selectors. |
+| Sync/watch loop | `src/sync_loop.rs` | Owns authentication recovery, watch cadence, library/pass refresh, database pre-checks, and cycle-level reporting. |
+| One sync cycle | `src/sync_cycle.rs` | Chooses source enumeration, reconciles config drift, dispatches each library, and advances or preserves provider checkpoints. |
+| Library and pass planning | `src/commands/service.rs` | Resolves libraries, collection scope, album plans, smart folders, unfiled passes, and cross-zone hydration. |
+| iCloud Photos adapter | `src/icloud/photos/` | Owns CloudKit records, queries, change streams, provider identity, albums, smart folders, and metadata decoding. |
+| Download orchestration | `src/download/mod.rs` | Routes full, incremental, targeted-backfill, and durable-retry work and produces checkpoint evidence. |
+| Asset planning | `src/download/planner.rs` | Applies filters, derives tasks, records dispatched pending work, and persists membership and identity mappings. |
+| Streaming workers | `src/download/pipeline.rs` | Runs bounded producers and consumers, coordinates file transfer, metadata writes, adoption, and outcome aggregation. |
+| File transfer | `src/download/file.rs` | Downloads, resumes, validates, and publishes one media file. |
+| State finalization | `src/download/finalize.rs` | Persists downloaded or failed outcomes and retries deferred state writes. |
+| Durable retry resolution | `src/download/retry.rs` | Revalidates pending provider identity and builds exact retry tasks. |
+| Path rendering | `src/download/paths.rs` | Expands folder templates, normalizes names, and handles collision suffixes. |
+| Metadata writing | `src/download/metadata.rs`, `src/download/heif.rs`, `src/download/metadata_rewrite.rs` | Probes and writes opt-in EXIF/XMP data and drains metadata-only retry markers. |
+| SQLite state | `src/state/` | Owns schema migrations, role traits, asset state, membership snapshots, provider checkpoints, verification state, and sync runs. |
+| Import-existing | `src/commands/import.rs` | Matches existing files to expected iCloud paths and adopts verified files into state. |
+| Service integration | `src/service/` | Owns install, uninstall, status, service execution, and platform renderers. |
+| Operator surfaces | `src/commands/status.rs`, `src/commands/doctor.rs`, `src/commands/manifest.rs` | Read local state for status, redacted diagnostics, and catalog export. |
+| Reports and monitoring | `src/cycle_reporter.rs`, `src/report.rs`, `src/health.rs`, `src/metrics.rs`, `src/notifications.rs` | Converts cycle facts into reports, health, metrics, and notifications. |
+
+## Main flows
+
+### Command dispatch
+
+```text
+src/main.rs
+  -> kei::main_inner
+  -> src/lib.rs::run
+  -> src/cli.rs
+  -> command owner, service owner, or src/sync_loop.rs
+```
+
+The CLI requires a subcommand. `kei sync` enters the sync path. Commands such
+as `status`, `doctor`, and `manifest` read local state without entering the
+normal iCloud sync loop.
+
+### Sync and provider checkpoints
+
+```text
+sync_loop::run_sync
+  -> resolve configuration, credentials, libraries, and pass plans
+  -> optional scoped changes/database pre-check
+  -> sync_cycle::run_cycle
+  -> download::download_photos_with_sync for each active library
+  -> sync_cycle source checkpoint decision
+  -> cycle reporting and watch control
+```
+
+The per-zone provider checkpoint and the scoped database pre-check token have
+different gates:
+
+- A zone checkpoint may advance after a transfer failure when the exact retry
+  work is durable and enumeration/token proof is complete.
+- The broader database pre-check token advances only after a clean aggregate
+  cycle for the exact account, selection, filter, config, and selected-zone
+  scope.
+
+Eligibility-config drift preserves the active checkpoint while a complete
+inventory and delta bridge build a replacement. Path-config drift preserves
+provider checkpoints while local catalog paths are reconciled.
+
+### Full and incremental enumeration
+
+Full enumeration streams records/query results and gathers a provider token
+from every active pass. Natural stream completion and usable, unanimous pass
+tokens are the authoritative proof. Count probes and pagination differences
+are diagnostics. Recoverable pass-token gaps can be retried in the same cycle.
+
+Incremental enumeration consumes changes/zone events. It persists provider
+identity mappings before applying created, soft-deleted, hard-deleted, or
+hidden transitions. Album snapshots and smart folders may require targeted
+refresh work before or alongside the incremental stream.
+
+Recent and date-bounded runs may advance only when the producer proves the
+bound did not truncate the stream.
+
+### Download and publication
+
+```text
+PhotoAsset
+  -> planner::TaskPlanner
+  -> pipeline::run_download_pass
+  -> file::download_file
+  -> optional metadata_rewrite
+  -> verified .part publication
+  -> finalize downloaded or failed state
+```
+
+Only producer-dispatched work becomes pending through `upsert_seen`. Filtered
+or skipped assets must not be left as retryable work unless a dedicated state
+transition owns that result.
+
+### Durable pending retry
+
+Failed and pending rows are not recovered by replaying the entire provider
+inventory. The retry owner:
+
+1. Removes only work already proven source-deleted.
+2. Resolves current provider records in targeted batches.
+3. Uses durable asset/master mappings and checksum/size evidence for legacy
+   identities.
+4. Adopts an existing matching local file when safe.
+5. Marks current filter exclusions as policy-excluded.
+6. Persists unknown or transient verification state.
+7. Queues exact unresolved asset/version/path tasks.
+
+Unknown identity is not permission to delete or forget work.
+
+### Import-existing
+
+`src/commands/import.rs` shares configuration, selection, pass planning, and
+path derivation with normal sync. It optionally compares remote prefix bytes,
+hashes the local candidate, and calls `ImportStateStore::import_adopt`.
+Size/mtime snapshots may skip later rehashing only while path, size, and mtime
+still match.
+
+## Data-safety invariants
+
+### File landing
+
+The media publication sequence is:
+
+```text
+write or resume .part
+  -> validate response and content length
+  -> validate expected size
+  -> validate SHA-256 checksum
+  -> validate content type and sniffed bytes
+  -> apply configured pre-publish metadata
+  -> publish without replacing an existing final path
+  -> fsync the parent directory
+  -> finalize SQLite state
+```
+
+A file may be safe on disk while its state write is still a cycle failure. Do
+not weaken deferred state-write handling or infer that a visible final file
+means the database transition succeeded.
+
+### Checkpoint advancement
+
+Preserve the zone checkpoint on:
+
+- Dry-run
+- Stale pass planning
+- Session expiry or interruption
+- Incomplete enumeration
+- Non-durable state
+- Missing, blank, mismatched, or otherwise blocked token proof
+
+Transfer and metadata failures may use a newer checkpoint only when the
+recovery work needed after that checkpoint is durable.
+
+### Metadata
+
+Provider metadata may be captured in SQLite without changing local media.
+Embedding EXIF/XMP or writing sidecars requires explicit configuration.
+Metadata failure markers must survive so a later run can retry metadata
+without downloading the media again.
+
+### State and serialization
+
+Schema, primary-key, sentinel, durable-key, and serialization changes are
+cross-cutting. Search every reader and writer, migrations, fixtures, reports,
+status output, and round-trip tests before changing them.
+
+## Change-impact checklist
+
+| Change | Check |
+|--------|-------|
+| CLI command or flag | `src/cli.rs`, dispatch in `src/lib.rs`, help output, Docker, services, Homebrew, docs, CLI tests |
+| TOML or runtime config | defaults, setup output, CLI precedence, hashes, persisted examples, docs |
+| Selection or pass scope | list/sync/import parity, shared libraries, unknown names, unfiled scope, membership snapshots |
+| Provider checkpoint | full and incremental proof, interruption, config drift, retry durability, scoped DB pre-check |
+| SQLite schema/query | migration from every supported version, all readers/writers, status/report/manifest output, real SQLite tests |
+| Provider record parsing | missing/malformed fields, shared zones, identity mapping, metadata capture, fixtures |
+| File or path behavior | `.part`, checksum, no-overwrite publish, fsync, import compatibility, collision handling |
+| Metadata writes | opt-in gate, pre-publish mutation, sidecars, retry markers, feature combinations |
+| Service behavior | Linux, macOS, Windows, container defaults, status, install/uninstall renderers |
+| Machine output | JSON/CSV shape, redaction, reports, health, metrics, downstream compatibility |
+
+## Tests
+
+- Unit tests live near their owner module.
+- Cross-module and binary behavior lives under `tests/`.
+- Live iCloud tests are ignored by default and run single-threaded.
+- Shell suites cover crash, concurrency, state-machine, and container behavior.
+- Fuzz targets cover parser and metadata trust boundaries.
+
+See [the test guide](../tests/README.md) for the current suites and commands.
+
+## Maintaining this guide
+
+Update this file in the same pull request when a change:
+
+- Moves an owning decision to another module
+- Adds a command or cross-cutting state transition
+- Changes file publication or metadata mutation
+- Changes provider checkpoint or retry evidence
+- Changes schema, durable keys, or serialization
+- Changes the best test for an invariant
+
+Keep the guide focused on stable ownership and safety. Source code remains the
+final authority.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,14 @@ Schema, primary-key, sentinel, durable-key, and serialization changes are
 cross-cutting. Search every reader and writer, migrations, fixtures, reports,
 status output, and round-trip tests before changing them.
 
+### Secrets and diagnostics
+
+Passwords stay behind `SecretString` and password-source boundaries. Logging
+uses a redacting writer as a backstop, but code must not send Apple IDs,
+passwords, session cookies, bearer tokens, or unredacted provider identifiers
+to logs or machine output. Preserve process hardening that limits credential
+exposure through core dumps.
+
 ## Change-impact checklist
 
 | Change | Check |
@@ -202,6 +210,7 @@ status output, and round-trip tests before changing them.
 | File or path behavior | `.part`, checksum, no-overwrite publish, fsync, import compatibility, collision handling |
 | Metadata writes | opt-in gate, pre-publish mutation, sidecars, retry markers, feature combinations |
 | Service behavior | Linux, macOS, Windows, container defaults, status, install/uninstall renderers |
+| Credentials or logging | secret wrappers, source lifetime, redaction, core-dump hardening, diagnostics, error paths |
 | Machine output | JSON/CSV shape, redaction, reports, health, metrics, downstream compatibility |
 
 ## Tests

--- a/scripts/check-contracts
+++ b/scripts/check-contracts
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Check lightweight data-safety contract markers.
+"""Check lightweight data-safety contract traceability.
 
-Contract markers are intentionally just comments and tests. A production owner
-comment names the invariant with `CONTRACT: SOME_ID`, and at least one
-`contract_` test name must include the same ID in lower snake case.
+Each contract is listed in docs/architecture.md, named by a production owner
+comment with `CONTRACT: SOME_ID`, and covered by at least one `contract_` test
+whose name includes the same ID in lower snake case.
 """
 
 from __future__ import annotations
@@ -13,7 +13,9 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+ARCHITECTURE = REPO / "docs" / "architecture.md"
 CONTRACT_RE = re.compile(r"\bCONTRACT:\s+([A-Z][A-Z0-9_]+)\b")
+CATALOG_RE = re.compile(r"(?m)^\| `([A-Z][A-Z0-9_]*)` \|")
 TEST_RE = re.compile(r"(?m)^\s*(?:async\s+)?fn\s+(contract_[a-zA-Z0-9_]+)\s*\(")
 VALID_ID_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
@@ -32,14 +34,20 @@ def rel(path: Path) -> str:
 
 
 def main() -> int:
-    rust_files = rust_files_under("src", "tests")
+    production_files = rust_files_under("src")
+    test_files = rust_files_under("src", "tests")
     contract_locations: dict[str, list[str]] = {}
     contract_tests: dict[str, list[str]] = {}
     errors: list[str] = []
 
-    file_texts = [(path, path.read_text(encoding="utf-8")) for path in rust_files]
+    architecture = ARCHITECTURE.read_text(encoding="utf-8")
+    catalog_ids = CATALOG_RE.findall(architecture)
+    catalog_set = set(catalog_ids)
+    if len(catalog_ids) != len(catalog_set):
+        errors.append("docs/architecture.md contains duplicate safety contract ids")
 
-    for path, text in file_texts:
+    for path in production_files:
+        text = path.read_text(encoding="utf-8")
         for match in CONTRACT_RE.finditer(text):
             contract_id = match.group(1)
             if not VALID_ID_RE.match(contract_id):
@@ -48,7 +56,8 @@ def main() -> int:
             line = text.count("\n", 0, match.start()) + 1
             contract_locations.setdefault(contract_id, []).append(f"{rel(path)}:{line}")
 
-    for path, text in file_texts:
+    for path in test_files:
+        text = path.read_text(encoding="utf-8")
         for match in TEST_RE.finditer(text):
             test_name = match.group(1)
             for contract_id in contract_locations:
@@ -56,6 +65,13 @@ def main() -> int:
                 if normalized_id in test_name:
                     line = text.count("\n", 0, match.start()) + 1
                     contract_tests.setdefault(contract_id, []).append(f"{rel(path)}:{line}")
+
+    for contract_id in sorted(catalog_set - contract_locations.keys()):
+        errors.append(f"{contract_id}: documented contract has no production owner marker")
+
+    for contract_id in sorted(contract_locations.keys() - catalog_set):
+        locations = ", ".join(contract_locations[contract_id])
+        errors.append(f"{contract_id}: production marker is not documented ({locations})")
 
     for contract_id, locations in sorted(contract_locations.items()):
         normalized_id = contract_id.lower()
@@ -67,8 +83,8 @@ def main() -> int:
                 f"{normalized_id!r} (marker at {joined})"
             )
 
-    if not contract_locations:
-        errors.append("no CONTRACT markers found")
+    if not catalog_ids:
+        errors.append("no safety contracts found in docs/architecture.md")
 
     if errors:
         print("contract check failed:", file=sys.stderr)
@@ -77,7 +93,7 @@ def main() -> int:
         return 1
 
     print(
-        f"contract check passed: {len(contract_locations)} contract id(s), "
+        f"contract check passed: {len(catalog_set)} documented contract(s), "
         f"{sum(len(v) for v in contract_tests.values())} matching test(s)"
     )
     return 0

--- a/scripts/full-test/run_release_regression_smoke.sh
+++ b/scripts/full-test/run_release_regression_smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Offline v0.20 regression smoke.
+# Offline release regression smoke.
 #
 # This is the quick patch-release gate for the May 27, 2026 regression set:
 # token reuse, targeted retry, on-disk pending adoption, pagination-shortfall

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -111,6 +111,7 @@ pub(super) struct MetadataWriteRequest<'a> {
 pub(super) async fn write_download_metadata(
     request: MetadataWriteRequest<'_>,
 ) -> MetadataWriteOutcome {
+    // CONTRACT: METADATA_WRITES_REQUIRE_OPT_IN
     let mut outcome = MetadataWriteOutcome::default();
 
     if request.flags.any_embed()
@@ -618,6 +619,34 @@ mod tests {
         flags.remove(MetadataFlags::XMP_SIDECAR);
         flags.insert(MetadataFlags::EMBED_XMP);
         assert!(flags.any_embed());
+    }
+
+    #[tokio::test]
+    async fn contract_metadata_writes_require_opt_in_leaves_files_untouched() {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let photo_path = dir.path().join("photo.jpg");
+        std::fs::write(&photo_path, b"original-media").expect("seed media");
+
+        write_download_metadata(MetadataWriteRequest {
+            final_path: &photo_path,
+            embed_path: Some(&photo_path),
+            sidecar_path: Some(&photo_path),
+            payload: Arc::new(MetadataPayload::default()),
+            created_local: Local::now(),
+            flags: MetadataFlags::default(),
+            temp_suffix: ".metadata-test",
+        })
+        .await;
+
+        assert_eq!(
+            std::fs::read(&photo_path).expect("read media"),
+            b"original-media",
+            "disabled metadata options must not change media bytes"
+        );
+        let files = std::fs::read_dir(dir.path())
+            .expect("read metadata temp dir")
+            .count();
+        assert_eq!(files, 1, "disabled metadata options created another file");
     }
 
     /// Minimal valid JPEG (SOI + APP0 JFIF + EOI). XMP Toolkit can write

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -12076,7 +12076,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_retry_retains_legacy_siblings_without_durable_match() {
+    async fn contract_unknown_provider_identity_remains_pending_without_durable_match() {
         let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
         let record = TestAssetRecord::new("LEGACY_AMBIGUOUS")
             .checksum("no-sibling-matches")
@@ -15939,6 +15939,63 @@ mod tests {
             };
             assert_eq!(reason, expected_reason);
             assert_eq!(passes, vec![observations[1].pass.clone()]);
+        }
+    }
+
+    #[test]
+    fn contract_source_checkpoint_requires_durable_recovery_token_evidence_exhaustive() {
+        const RESULT_KINDS: usize = 6;
+        for len in 0..=3u32 {
+            for encoded in 0..RESULT_KINDS.pow(len) {
+                let mut value = encoded;
+                let mut observations = Vec::with_capacity(len as usize);
+                for index in 0..len as usize {
+                    let result = match value % RESULT_KINDS {
+                        0 => PassTokenResult::Present("token-a".to_string()),
+                        1 => PassTokenResult::Present("token-b".to_string()),
+                        2 => PassTokenResult::Missing,
+                        3 => PassTokenResult::Blank,
+                        4 => PassTokenResult::ReceiverDropped,
+                        _ => PassTokenResult::EnumerationIncomplete,
+                    };
+                    value /= RESULT_KINDS;
+                    observations.push(PassTokenObservation {
+                        pass: PassKey {
+                            index,
+                            kind: PassKind::Album,
+                            label: format!("pass-{index}"),
+                        },
+                        result,
+                    });
+                }
+
+                let first_token = observations.first().and_then(|observation| {
+                    if let PassTokenResult::Present(token) = &observation.result {
+                        Some(token.as_str())
+                    } else {
+                        None
+                    }
+                });
+                let complete_expected = first_token.is_some()
+                    && observations.iter().all(|observation| {
+                        matches!(
+                            &observation.result,
+                            PassTokenResult::Present(token)
+                                if Some(token.as_str()) == first_token
+                        )
+                    });
+                let evidence = classify_zone_token_evidence(&observations);
+                assert_eq!(
+                    matches!(evidence, ZoneTokenEvidence::Complete { .. }),
+                    complete_expected,
+                    "unexpected complete classification: {observations:?}"
+                );
+                assert_eq!(
+                    matches!(evidence, ZoneTokenEvidence::Incomplete { .. }),
+                    observations.is_empty(),
+                    "only an empty observation set may be incomplete"
+                );
+            }
         }
     }
 

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -500,6 +500,7 @@ pub(super) async fn build_pending_retry_download_tasks(
                 );
             }
             RecordResolution::Unknown => {
+                // CONTRACT: UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING
                 set_verification_for_state_id(
                     db.as_ref(),
                     &pending_targets,

--- a/src/sync_cycle.rs
+++ b/src/sync_cycle.rs
@@ -179,6 +179,7 @@ fn source_checkpoint_decision(
     stale_pass_plan: bool,
     basis: CheckpointBasis,
 ) -> SourceCheckpointDecision {
+    // CONTRACT: SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY
     let preserve = |reason, recovery| SourceCheckpointDecision::Preserve { reason, recovery };
     if dry_run {
         return preserve(CheckpointHoldReason::DryRun, RecoveryAction::Stop);
@@ -636,6 +637,7 @@ pub(crate) async fn run_cycle(
              database pre-check token will not advance this cycle"
         );
     }
+    // CONTRACT: SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE
     let mut db_sync_token_advance_safe = !config.runtime.dry_run && !cycle_has_stale_plan;
     let mut force_full_for_config_hash = false;
     let mut force_full_for_download_config_hash = false;
@@ -1484,6 +1486,58 @@ mod tests {
                 recovery: RecoveryAction::RetryPasses(vec![pass]),
             }
         );
+    }
+
+    #[test]
+    fn contract_source_checkpoint_requires_durable_recovery_exhaustive() {
+        let tokens = [Some("zone-token"), None, Some("   ")];
+        for mask in 0u16..512 {
+            let dry_run = mask & 1 != 0;
+            let stale_pass_plan = mask & 2 != 0;
+            let session_expired = mask & 4 != 0;
+            let interrupted = mask & 8 != 0;
+            let enumeration_error = mask & 16 != 0;
+            let enumeration_incomplete = mask & 32 != 0;
+            let state_not_durable = mask & 64 != 0;
+            let token_proof_blocked = mask & 128 != 0;
+            let durable_transfer_failure = mask & 256 != 0;
+            let has_safety_blocker = mask & 255 != 0;
+            for token in tokens {
+                let result = download::SyncResult {
+                    outcome: if session_expired {
+                        download::DownloadOutcome::SessionExpired {
+                            auth_error_count: 1,
+                        }
+                    } else if durable_transfer_failure {
+                        download::DownloadOutcome::PartialFailure { failed_count: 1 }
+                    } else {
+                        download::DownloadOutcome::Success
+                    },
+                    sync_token: token.map(str::to_string),
+                    stats: download::SyncStats {
+                        interrupted,
+                        enumeration_errors: usize::from(enumeration_error),
+                        enumeration_incomplete,
+                        state_write_failures: usize::from(state_not_durable),
+                        sync_token_blocked: token_proof_blocked,
+                        ..download::SyncStats::default()
+                    },
+                    full_enumeration_ran: false,
+                };
+                let should_advance = !has_safety_blocker && token == Some("zone-token");
+                let decision = source_checkpoint_decision(
+                    &result,
+                    dry_run,
+                    stale_pass_plan,
+                    CheckpointBasis::IncrementalDelta,
+                );
+                assert_eq!(
+                    matches!(decision, SourceCheckpointDecision::Advance { .. }),
+                    should_advance,
+                    "unexpected checkpoint decision for mask {mask:#010b} and token {token:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -5723,7 +5723,6 @@ mod tests {
         assert!(groupings.people.is_empty());
     }
 
-    // CONTRACT: SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE
     // `should_store_sync_token` is the single decision gate protecting the
     // sync-token from being advanced after a partial sync or a dry run. Both
     // situations would lose change events on the next incremental cycle
@@ -5982,7 +5981,6 @@ mod tests {
 
     #[tokio::test]
     async fn run_cycle_published_file_state_write_failure_blocks_token() {
-        // CONTRACT: SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE
         // A published file with a failed state write is unsafe to skip on the
         // next incremental cycle, even though the media bytes are on disk.
         use base64::Engine as _;

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ just test service               # local service-smoke wrapper
 just test PATTERN               # passes through to cargo test PATTERN
 just static-checks              # fmt, clippy, docs, audit, lint, contracts, typos
 just gate                       # static checks + offline behavior tests
-just release-smoke              # fast offline v0.20 hotfix regression smoke
+just release-smoke              # fast offline release regression smoke
 just full-test                  # grouped full battery with logs, live skips, metrics
 ```
 
@@ -229,17 +229,17 @@ happens:
   probes against the extracted binary. `just test packaging` runs the host
   release build plus this smoke.
 - **`scripts/full-test/run_release_regression_smoke.sh`** - fast offline
-  v0.20 hotfix gate. Run `just release-smoke` before any `v0.20.x` hotfix and
-  before release branches that touch sync tokens, retry state, download
-  validation, config paths, or reporting.
+  patch-release gate for sync tokens, retry and pending adoption, pagination
+  diagnostics, media validation, pass templates, and config paths. Run it
+  before releases that touch those areas.
 - **`scripts/full-test/run_docker_puid_smoke.sh`** - offline Docker entrypoint
   checks for PUID/PGID drop, volume chown, `MALLOC_ARENA_MAX=2`, root-default
   behavior, and invalid env rejection. `just test docker-full` runs this with
   Docker build, multiarch, and CLI/default-command smokes.
 - **`scripts/full-test/run_live_import_rehearsal.sh`** - live mini rehearsal
-  for v0.20's TOML-first import path: seed a tiny real tree, import it into a
-  fresh DB, and verify a repeat dry-run stays matched. `just test live-smoke`
-  runs this after the release-binary live CLI smokes.
+  for the TOML-first import path: seed a tiny real tree, import it into a fresh
+  DB, and verify a repeat dry-run stays matched. `just test live-smoke` runs
+  this after the release-binary live CLI smokes.
 - **`scripts/full-test/run_cross_zone_album_hydration.sh`** - opt-in live
   release-binary check for accounts with a prepared cross-zone album fixture.
   It selects the named album with `libraries = ["all"]` and fails unless the

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,24 @@ tests/
 
 Counts are approximate and drift as tests are added.
 
+## Focused scenario slices
+
+Named scenario slices group existing Rust tests by risk so a change can run
+the smallest relevant proof before the broader gate. All slices are offline
+and require no credentials. Run one with `just test scenario NAME`; run the
+full set with `just test scenarios`.
+
+| Slice | Protects | Run for changes to |
+|-------|----------|--------------------|
+| `auth-session` | Persisted-session reuse, validation caching, 2FA push state, and reauthentication routing | Authentication recovery, session validation, or watch-mode reauthentication |
+| `config-docs` | Supported configuration stays aligned with examples, migration guidance, and contributor commands | Config keys, defaults, examples, migration docs, or gate commands |
+| `fulltest-harness` | Full-test phase reachability and rejection of stale or empty scenario filters | `just` dispatch, full-test orchestration, or scenario-runner helpers |
+| `identity-deltas` | Incremental identity mapping, hard and soft deletion, selected relations, and master-family transitions | CloudKit change parsing, identity mapping, membership, or tombstone policy |
+| `path-family` | Collision suffixes and primary, Live Photo, import, and pending-file family matching | Path rendering, collision handling, import matching, or on-disk adoption |
+| `pending-recovery` | Durable pending hydration, deletion proof, ambiguous identity retention, and sibling recovery | Retry resolution, pending state, provider identity, or targeted hydration |
+| `service-health` | Health and metrics facts exposed by unattended operation | Health checks, metrics, cycle reporting, or service monitoring |
+| `url-refresh` | Refresh of expired or aged download URLs without replaying stale deltas | Incremental downloads, URL freshness, album hydration, or retry downloads |
+
 ## Running
 
 ```sh

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -1003,6 +1003,38 @@ fn contributor_docs_match_current_gate() {
 }
 
 #[test]
+fn repo_pr_ready_skill_uses_current_validation_workflow() {
+    let gitignore = repo_file(".gitignore");
+    assert!(
+        !gitignore.lines().any(|line| line.trim() == ".agents/"),
+        "repository skills must remain available for version control"
+    );
+
+    let skill = repo_file(".agents/skills/kei-pr-ready/SKILL.md");
+    for expected in [
+        "name: kei-pr-ready",
+        "without publishing or changing it",
+        "just agent-status",
+        "docs/architecture.md",
+        "tests/README.md",
+        "just test scenario NAME",
+        "just gate",
+        "final verdict: ready or not ready",
+    ] {
+        assert!(
+            skill.contains(expected),
+            "kei-pr-ready skill missing validation contract: {expected}"
+        );
+    }
+
+    let metadata = repo_file(".agents/skills/kei-pr-ready/agents/openai.yaml");
+    assert!(
+        metadata.contains("Use $kei-pr-ready"),
+        "skill metadata must keep its default invocation aligned with SKILL.md"
+    );
+}
+
+#[test]
 fn roundtrip_gate_documents_heuristic_limits_and_bypass_rationale() {
     let gate = repo_file("scripts/check-roundtrip-gate.sh");
 

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -369,6 +369,45 @@ fn full_test_reports_include_newer_phase_metadata() {
     }
 }
 
+#[test]
+fn focused_scenario_catalog_lists_every_runner_slice() {
+    let readme = repo_file("tests/README.md");
+    let section = readme
+        .split_once("## Focused scenario slices")
+        .map(|(_, tail)| tail)
+        .and_then(|tail| tail.split_once("\n## ").map(|(section, _)| section))
+        .expect("tests README must contain a bounded focused scenario section");
+    let documented: BTreeSet<String> = section
+        .lines()
+        .filter_map(|line| {
+            line.strip_prefix("| `")
+                .and_then(|tail| tail.split_once("` |"))
+                .map(|(name, _)| name.to_owned())
+        })
+        .collect();
+
+    let scenario_dir = repo_path("scripts/test-scenarios");
+    let scripts: BTreeSet<String> = std::fs::read_dir(&scenario_dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", scenario_dir.display()))
+        .map(|entry| {
+            entry.unwrap_or_else(|e| panic!("read entry in {}: {e}", scenario_dir.display()))
+        })
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("sh") {
+                return None;
+            }
+            let name = path.file_stem()?.to_str()?;
+            (!matches!(name, "lib" | "list")).then(|| name.to_owned())
+        })
+        .collect();
+
+    assert_eq!(
+        documented, scripts,
+        "tests README focused scenario catalog must match runnable scenario scripts"
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn scenario_runner_rejects_filters_that_match_no_tests() {

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -947,6 +947,16 @@ fn contributor_docs_match_current_gate() {
         pr_template.contains("`just gate` passes"),
         "PR template should ask reviewers for the current local gate"
     );
+    for expected in [
+        "## Contract and risk",
+        "## Regression proof",
+        "independent/adversarial review results",
+    ] {
+        assert!(
+            pr_template.contains(expected),
+            "PR template must capture verification evidence: {expected}"
+        );
+    }
     assert!(
         !pr_template.contains("cargo test --bin kei --test cli --test behavioral"),
         "PR template must not keep stale partial test command"


### PR DESCRIPTION
## Summary
- Publish tracked contributor and coding-agent guidance for source ownership, data-safety boundaries, implementation scope, testing, review, and unsafe-code decisions.
- Add a safety contract catalog and enforce traceability from each documented contract to a production owner marker and focused contract test.
- Add exhaustive checkpoint and token-evidence coverage, metadata opt-in proof, and focused offline scenario guidance for the highest-risk sync paths.
- Add the repository-scoped `kei-pr-ready` skill to classify change impact, select relevant evidence, run the gate, and return a review-readiness verdict.

## Behavior and compatibility
- No user-facing CLI, configuration, state, or sync behavior changes.
- `scripts/check-contracts` now fails when the architecture catalog, production markers, or matching contract tests drift apart.
- `.agents/skills/kei-pr-ready` is version controlled and available to Codex sessions opened in the repository.

## Review notes
- The five initial contract IDs cover no-overwrite publication, database token advancement, source checkpoint durability, unknown provider identity, and opt-in metadata writes.
- Focused scenario slices route contributors to existing offline tests by risk area; live iCloud tests remain opt-in and single-threaded.
- Production-code changes are contract markers plus tests around existing behavior.

## Tests
- `just gate` => passed
- `cargo test --test branch_static repo_pr_ready_skill_uses_current_validation_workflow` => passed
- `target/debug/kei` => exited 2 and displayed required-subcommand help
- `git diff --check` => passed
