### PR TITLE
Refresh provider metadata on full and single-pass skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A metadata-only iCloud edit (favourite, rating, keywords, caption, GPS) on an unchanged file now refreshes the catalogue during full enumeration and single-pass incremental sync. Changed provider metadata is applied before filtering and path planning, so the refresh reaches every downloaded version of the asset even when its media task is skipped as already on disk or excluded by a filter. The catalogue row and the rewrite marker commit together, so a queued sidecar or EXIF rewrite reads the corrected values instead of replaying stale ones, and no media is re-downloaded. ([#707], refs [#674])
+- A failed catalogue refresh now preserves the previous zone checkpoint instead of advancing past a provider edit that was never stored. ([#707])
+- Metadata rewrite failures are now reported when a sync downloads nothing. A metadata-only edit cycle transfers no media, so a failed sidecar or EXIF write was previously invisible in the sync result. ([#707])
+
 ## [0.23.1] - 2026-08-16
 
 ### Fixed
@@ -48,11 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#673]: https://github.com/rhoopr/kei/issues/673
 [#671]: https://github.com/rhoopr/kei/pull/671
+[#674]: https://github.com/rhoopr/kei/issues/674
 [#683]: https://github.com/rhoopr/kei/pull/683
 [#686]: https://github.com/rhoopr/kei/pull/686
 [#687]: https://github.com/rhoopr/kei/issues/687
 [#705]: https://github.com/rhoopr/kei/pull/705
 [#706]: https://github.com/rhoopr/kei/pull/706
+[#707]: https://github.com/rhoopr/kei/issues/707
 [@te&#104;-hippo]: https://github.com/teh-hippo
 
 ## [0.22.12] - 2026-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A metadata-only iCloud edit (favourite, rating, keywords, caption, GPS) on an unchanged file now refreshes the catalogue during full enumeration and single-pass incremental sync. Changed provider metadata is applied before filtering and path planning, so the refresh reaches every downloaded version of the asset even when its media task is skipped as already on disk or excluded by a filter. The catalogue row and the rewrite marker commit together, so a queued sidecar or EXIF rewrite reads the corrected values instead of replaying stale ones, and no media is re-downloaded. ([#707], refs [#674])
 - A failed catalogue refresh now preserves the previous zone checkpoint instead of advancing past a provider edit that was never stored. ([#707])
 - Metadata rewrite failures are now reported when a sync downloads nothing. A metadata-only edit cycle transfers no media, so a failed sidecar or EXIF write was previously invisible in the sync result. ([#707])
+- An embedded metadata rewrite now records the hash of the file it leaves on disk, keeping the pre-rewrite hash as the provider download checksum, so `kei verify --checksums` and `kei reconcile` read an intentional edit as intact rather than corrupted or truncated. A file that no longer matches its recorded checksum keeps its marker and is left untouched for those commands to report. ([#707])
 
 ## [0.23.1] - 2026-08-16
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,21 @@ drain. Only that drain retires a marker on success, because it writes the file
 from the same row it then clears. A completed download writes the snapshot it
 was planned from, so it records a marker on failure but never retires one.
 
+A drain only rewrites a file whose bytes still match the checksum on its row,
+because the alternative is embedding into damage and then vouching for it. A
+file that no longer matches keeps its marker and its recorded checksum, so
+`kei verify --checksums` and `kei reconcile` continue to report it. When a
+rewrite does change the media, the new hash is stored before the marker
+retires, and the pre-rewrite hash is kept as the provider download checksum so
+reconcile can still tell an intentional rewrite from a truncated file. A
+retired marker therefore implies the row describes the bytes on disk.
+
+A rewrite whose result could not be measured records the checksum as unknown
+rather than leaving the superseded value in place, because a known-stale hash
+would make the next pass read kei's own rewrite as damage and refuse it. A row
+that never recorded a checksum is rewritten but claims no provider download
+hash, so reconcile keeps reporting a file that is short of its provider size.
+
 ### State and serialization
 
 Schema, primary-key, sentinel, durable-key, and serialization changes are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,10 +188,15 @@ recovery work needed after that checkpoint is durable.
 Provider metadata may be captured in SQLite without changing local media.
 Embedding EXIF/XMP or writing sidecars requires explicit configuration.
 Metadata failure markers must survive so a later run can retry metadata
-without downloading the media again. Collecting incremental sync commits
-changed catalogue metadata and its configured rewrite marker before album
-routing or deciding whether unchanged media needs downloading. A failed commit
-preserves the provider checkpoint.
+without downloading the media again. Full enumeration, single-pass incremental,
+and collecting incremental sync all commit changed catalogue metadata and its
+configured rewrite marker together, before filtering, album routing, or
+deciding whether unchanged media needs downloading. A failed commit preserves
+the provider checkpoint. Queued rewrites drain once per cycle, after every
+producer has finished, so a single writer owns each file. Read-only runs never
+drain. Only that drain retires a marker on success, because it writes the file
+from the same row it then clears. A completed download writes the snapshot it
+was planned from, so it records a marker on failure but never retires one.
 
 ### State and serialization
 

--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -51,8 +51,9 @@ pub(super) enum DownloadedFinalization {
 }
 
 /// Persist success state for a task that has already landed safely on disk.
-/// On success, metadata retry markers are updated immediately. On failure,
-/// the caller receives a deferred write record for bounded retry.
+/// A failed metadata write records a retry marker; retiring markers is left to
+/// the rewrite drain. On failure, the caller receives a deferred write record
+/// for bounded retry.
 pub(super) async fn finalize_downloaded<D>(
     db: &D,
     library: &Arc<str>,
@@ -114,8 +115,14 @@ where
         .await
 }
 
-/// Set or clear the metadata-rewrite marker for an asset-version pair based
-/// on whether the EXIF/XMP writer succeeded.
+/// Record a metadata-rewrite marker when the EXIF/XMP writer failed.
+///
+/// A successful write does not retire an existing marker. This writes the file
+/// from the snapshot the task was planned with, while the marker describes the
+/// row, and a concurrent pass may have moved the row on since. Retiring it here
+/// would leave the row and the file on different snapshots with nothing left to
+/// repair them. The rewrite drain owns that decision, because it writes the
+/// file from the same row it then clears.
 async fn update_metadata_marker<D>(
     db: &D,
     library: &str,
@@ -126,19 +133,6 @@ async fn update_metadata_marker<D>(
     D: MetadataRewriteStore + ?Sized,
 {
     if exif_ok {
-        if let Err(e) = db
-            .clear_metadata_write_failure(library, asset_id, version_size)
-            .await
-        {
-            tracing::warn!(
-                library,
-                asset_id,
-                version_size,
-                error = %e,
-                "Could not clear metadata-write-failed marker; asset will be \
-                 re-rewritten on next sync"
-            );
-        }
         return;
     }
     if let Err(e) = db
@@ -316,19 +310,6 @@ where
 }
 
 #[cfg(test)]
-pub(super) async fn update_metadata_marker_for_test<D>(
-    db: &D,
-    library: &str,
-    asset_id: &str,
-    version_size: &str,
-    exif_ok: bool,
-) where
-    D: MetadataRewriteStore + ?Sized,
-{
-    update_metadata_marker(db, library, asset_id, version_size, exif_ok).await;
-}
-
-#[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
@@ -372,7 +353,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalize_downloaded_marks_persisted_and_clears_metadata_marker() {
+    async fn finalize_downloaded_marks_persisted_and_keeps_metadata_marker() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("persisted.jpg");
         write_file(&path).await;
@@ -399,12 +380,10 @@ mod tests {
                 .unwrap(),
             "downloaded row with existing file should not be queued again"
         );
-        assert!(
-            db.get_pending_metadata_rewrites(32)
-                .await
-                .unwrap()
-                .is_empty(),
-            "successful metadata write must clear the retry marker"
+        assert_eq!(
+            db.get_pending_metadata_rewrites(32).await.unwrap().len(),
+            1,
+            "the marker describes the row, so only the drain may retire it"
         );
     }
 

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -363,6 +363,32 @@ where
     run_pending_page(db, metadata_flags, temp_suffix, shutdown_token, None, 0).await
 }
 
+/// Drops a recorded hash that a rewrite may already have invalidated. Keeping a
+/// known-stale hash would make the next pass read kei's own rewrite as damage
+/// and refuse it forever, so recording "unknown" is both truthful and the only
+/// state a later pass can recover from.
+async fn forget_stale_checksum<D>(
+    db: &D,
+    record: &crate::state::types::AssetRecord,
+    version_size: &str,
+) where
+    D: MetadataRewriteStore + ?Sized,
+{
+    if record.local_checksum.is_none() {
+        return;
+    }
+    if let Err(e) = db
+        .set_metadata_rewrite_checksums(&record.library, &record.id, version_size, None, None)
+        .await
+    {
+        tracing::warn!(
+            asset_id = %record.id,
+            error = %e,
+            "Could not clear the stale media checksum; `kei reconcile` can still repair the file"
+        );
+    }
+}
+
 pub(super) async fn run_pending_page<D>(
     db: &D,
     metadata_flags: MetadataFlags,
@@ -397,6 +423,7 @@ where
     );
     let mut applied = 0usize;
     let mut skipped_missing = 0usize;
+    let mut skipped_drifted = 0usize;
     let mut errored = 0usize;
     let mut deferred = 0usize;
     for (idx, record) in pending.into_iter().enumerate() {
@@ -433,9 +460,49 @@ where
         let payload = Arc::new(MetadataPayload::from_metadata(&record.metadata));
         let created_local: DateTime<Local> = DateTime::from(record.created_at);
         let version_size = record.version_size;
+
+        // Only an embedded write touches media bytes, so the drain needs the
+        // pre-write hash to tell its own rewrite apart from damage that
+        // arrived some other way.
+        let pre_rewrite_checksum = if metadata_flags.any_embed() {
+            match super::file::compute_sha256(&path).await {
+                Ok(checksum) => Some(checksum),
+                Err(e) => {
+                    tracing::warn!(
+                        asset_id = %record.id,
+                        path = %path.display(),
+                        error = %e,
+                        "Could not hash file before metadata rewrite; leaving marker for future retry"
+                    );
+                    errored += 1;
+                    continue;
+                }
+            }
+        } else {
+            None
+        };
+
+        // A file that no longer matches the recorded hash is not kei's to
+        // rewrite: embedding would overwrite the evidence that `verify` and
+        // `reconcile` rely on, and re-hashing would bless the damage. The
+        // sidecar is a separate file, so it still runs.
+        let drifted = matches!(
+            (&pre_rewrite_checksum, &record.local_checksum),
+            (Some(actual), Some(recorded)) if actual != recorded
+        );
+        if drifted {
+            tracing::warn!(
+                asset_id = %record.id,
+                path = %path.display(),
+                "On-disk file does not match its recorded checksum; leaving the media and the \
+                 marker alone. Run `kei verify --checksums` or `kei reconcile`"
+            );
+            skipped_drifted += 1;
+        }
+
         let outcome = write_download_metadata(MetadataWriteRequest {
             final_path: &path,
-            embed_path: Some(&path),
+            embed_path: if drifted { None } else { Some(&path) },
             sidecar_path: Some(&path),
             payload,
             created_local,
@@ -443,6 +510,61 @@ where
             temp_suffix: &temp_suffix,
         })
         .await;
+
+        if drifted {
+            // The media still owes its metadata, so the marker cannot retire
+            // no matter how the sidecar fared.
+            continue;
+        }
+
+        // Hash whenever an embed could have run. A reported failure can still
+        // leave replaced bytes, because the durable install renames before it
+        // syncs the parent directory.
+        //
+        // `download_checksum` asserts the provider's pre-metadata bytes. Only a
+        // row that already agreed with its file can make that claim, so a row
+        // without a recorded checksum establishes `local_checksum` alone and
+        // stays visible to reconcile's size check.
+        let verified_before = record.local_checksum.is_some();
+        if let Some(before) = &pre_rewrite_checksum {
+            match super::file::compute_sha256(&path).await {
+                // Stored before the marker retires below, so a later failure
+                // cannot leave a rewritten file behind a stale hash. An
+                // unchanged file is left alone: kei only vouches for bytes it
+                // wrote.
+                Ok(after) if after != *before => {
+                    if let Err(e) = db
+                        .set_metadata_rewrite_checksums(
+                            &record.library,
+                            &record.id,
+                            version_size.as_str(),
+                            Some(after.as_str()),
+                            verified_before.then_some(before.as_str()),
+                        )
+                        .await
+                    {
+                        tracing::warn!(asset_id = %record.id, error = %e, "Failed to record rewritten media checksum");
+                        forget_stale_checksum(db, &record, version_size.as_str()).await;
+                        errored += 1;
+                        continue;
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        asset_id = %record.id,
+                        path = %path.display(),
+                        error = %e,
+                        "Could not hash file after metadata rewrite; leaving marker for future retry"
+                    );
+                    // The rewrite may already have replaced the bytes, so the
+                    // recorded hash can no longer be trusted either way.
+                    forget_stale_checksum(db, &record, version_size.as_str()).await;
+                    errored += 1;
+                    continue;
+                }
+            }
+        }
 
         if !outcome.any_failed() {
             if let Err(e) = db
@@ -469,13 +591,14 @@ where
         applied,
         errored,
         skipped_missing,
+        skipped_drifted,
         deferred,
         "Metadata rewrite pass complete"
     );
     RewritePass {
         fetched: pending_count,
         applied,
-        failed: errored + deferred,
+        failed: errored + deferred + skipped_drifted,
     }
 }
 
@@ -662,6 +785,9 @@ mod tests {
         std::fs::write(&photo_path, minimal_jpeg_bytes()).unwrap();
 
         let db = SqliteStateDb::open_in_memory().unwrap();
+        let seeded_checksum = crate::download::file::compute_sha256(&photo_path)
+            .await
+            .unwrap();
 
         let seeded_hash = "seed_hash_before_rewrite".to_string();
         let metadata = AssetMetadata {
@@ -681,7 +807,7 @@ mod tests {
             "REWRITE_1",
             "original",
             &photo_path,
-            "rewrite_ck",
+            &seeded_checksum,
             None,
         )
         .await
@@ -1016,6 +1142,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("clear-failure.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
+        let seeded_checksum = crate::download::file::compute_sha256(&path).await.unwrap();
         let db = crate::state::SqliteStateDb::open_in_memory().unwrap();
         let record = crate::test_helpers::TestAssetRecord::new("CLEAR_FAIL")
             .filename("clear-failure.jpg")
@@ -1031,7 +1158,7 @@ mod tests {
             "CLEAR_FAIL",
             "original",
             &path,
-            "checksum",
+            &seeded_checksum,
             None,
         )
         .await
@@ -1058,6 +1185,416 @@ mod tests {
         assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
     }
 
+    /// Seeds a downloaded JPEG carrying a rewrite marker. Returns the
+    /// database, the media path, and the checksum recorded for the file.
+    /// `rating` drives whether the embedded writer has anything to write.
+    #[cfg(feature = "xmp")]
+    async fn seed_marked_jpeg(
+        dir: &std::path::Path,
+        asset_id: &'static str,
+        rating: Option<u8>,
+    ) -> (crate::state::SqliteStateDb, PathBuf, String) {
+        use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
+
+        let path = dir.join(format!("{asset_id}.jpg"));
+        std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
+        let recorded = crate::download::file::compute_sha256(&path).await.unwrap();
+
+        // File backed so a test can reopen it and drop connection-scoped
+        // failure triggers between passes.
+        let db = SqliteStateDb::open(&dir.join("state.db")).await.unwrap();
+        let record = crate::test_helpers::TestAssetRecord::new(asset_id)
+            .filename(&format!("{asset_id}.jpg"))
+            .metadata(AssetMetadata {
+                rating,
+                metadata_hash: Some("fresh-hash".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded("PrimarySync", asset_id, "original", &path, &recorded, None)
+            .await
+            .unwrap();
+        db.record_metadata_write_failure("PrimarySync", asset_id, "original")
+            .await
+            .unwrap();
+
+        (db, path, recorded)
+    }
+
+    #[cfg(feature = "xmp")]
+    fn embedded_rating_flags() -> MetadataFlags {
+        MetadataFlags::RATING | MetadataFlags::EMBED_XMP
+    }
+
+    #[cfg(feature = "xmp")]
+    async fn stored_checksums(
+        db: &crate::state::SqliteStateDb,
+    ) -> (Option<String>, Option<String>) {
+        let row = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        (row.local_checksum, row.download_checksum)
+    }
+
+    /// #707 review: the drain must not re-hash a file it did not write. A file
+    /// that already drifted from its recorded checksum is damage `verify` and
+    /// `reconcile` must keep reporting, so the rewrite is refused outright.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_refuses_to_rewrite_a_file_that_drifted_from_its_checksum() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "DRIFTED", Some(3)).await;
+        // Trailing bytes after EOI keep the container readable, so the writer
+        // would still accept the file if the drain offered it.
+        let mut drifted_bytes = minimal_jpeg_bytes();
+        drifted_bytes.push(0x00);
+        std::fs::write(&path, &drifted_bytes).unwrap();
+
+        let pass = run_pending_page(
+            &db,
+            embedded_rating_flags() | MetadataFlags::XMP_SIDECAR,
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+            None,
+            0,
+        )
+        .await;
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            drifted_bytes,
+            "a file that does not match its checksum must not be rewritten"
+        );
+        let mut sidecar = path.clone().into_os_string();
+        sidecar.push(".xmp");
+        assert!(
+            PathBuf::from(sidecar).exists(),
+            "the sidecar is a separate file, so the export still runs"
+        );
+        assert_eq!(
+            pass.failed, 1,
+            "a refused rewrite is unfinished work, not a clean pass"
+        );
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(
+            local.as_deref(),
+            Some(recorded.as_str()),
+            "the recorded checksum is the evidence of damage and must survive"
+        );
+        assert_eq!(download, None, "a refused rewrite records no download hash");
+        assert_eq!(
+            db.get_pending_metadata_rewrites(10).await.unwrap().len(),
+            1,
+            "the marker stays because the metadata never reached the file"
+        );
+    }
+
+    /// #707 review: an embedded rewrite changes the media, so the row must
+    /// carry the new hash and keep the pre-rewrite hash as the provider
+    /// download checksum.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_records_the_rewritten_media_checksum() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "REWRITTEN", Some(3)).await;
+
+        run_pending(
+            &db,
+            embedded_rating_flags(),
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let on_disk = crate::download::file::compute_sha256(&path).await.unwrap();
+        assert_ne!(
+            on_disk, recorded,
+            "precondition: the rewrite must change the media bytes"
+        );
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(local.as_deref(), Some(on_disk.as_str()));
+        assert_eq!(download.as_deref(), Some(recorded.as_str()));
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a complete rewrite retires its marker"
+        );
+    }
+
+    /// #707 review: the checksum is stored before the marker retires, so a
+    /// failure in between leaves a rewritten file the next pass can still
+    /// recognise as its own.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_keeps_the_marker_when_the_rewritten_checksum_cannot_be_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "CKFAIL", Some(3)).await;
+        db.fail_metadata_checksum_write_for_test();
+
+        run_pending(
+            &db,
+            embedded_rating_flags(),
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let on_disk = crate::download::file::compute_sha256(&path).await.unwrap();
+        assert_ne!(on_disk, recorded, "precondition: the media was rewritten");
+        assert_eq!(
+            db.get_pending_metadata_rewrites(10).await.unwrap().len(),
+            1,
+            "the marker must survive so the rewrite is retried"
+        );
+        let (local, _) = stored_checksums(&db).await;
+        assert_eq!(
+            local, None,
+            "a hash kei could not confirm must read as unknown, not as the              pre-rewrite value the next pass would treat as damage"
+        );
+
+        // A later pass, once the state write works again, must be able to
+        // finish the job rather than refuse its own rewrite forever.
+        let db = crate::state::SqliteStateDb::open(db.path()).await.unwrap();
+        run_pending(
+            &db,
+            embedded_rating_flags(),
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let healed = crate::download::file::compute_sha256(&path).await.unwrap();
+        let (local, _) = stored_checksums(&db).await;
+        assert_eq!(
+            local.as_deref(),
+            Some(healed.as_str()),
+            "the retry must record the bytes on disk"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the retry must retire the marker"
+        );
+    }
+
+    /// #707 review: a sidecar-only rewrite leaves the media untouched, so it
+    /// must not restate either checksum.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_leaves_checksums_untouched_for_a_sidecar_only_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "SIDECAR", Some(3)).await;
+        let before = std::fs::read(&path).unwrap();
+
+        run_pending(
+            &db,
+            MetadataFlags::XMP_SIDECAR,
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a sidecar write must not touch the media"
+        );
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(local.as_deref(), Some(recorded.as_str()));
+        assert_eq!(
+            download, None,
+            "no media rewrite happened, so no pre-rewrite hash is established"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the sidecar rewrite completed, so its marker retires"
+        );
+    }
+
+    /// #707 review: a legacy row carries no checksum, so there is nothing to
+    /// verify against and nothing to protect. The rewrite proceeds and
+    /// establishes the baseline.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_establishes_a_checksum_baseline_when_none_was_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, _recorded) = seed_marked_jpeg(dir.path(), "LEGACY", Some(3)).await;
+        db.clear_local_checksum_for_test("PrimarySync", "LEGACY", "original");
+
+        run_pending(
+            &db,
+            embedded_rating_flags(),
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let on_disk = crate::download::file::compute_sha256(&path).await.unwrap();
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(
+            local.as_deref(),
+            Some(on_disk.as_str()),
+            "the rewrite establishes the checksum a legacy row never had"
+        );
+        assert_eq!(
+            download, None,
+            "the pre-rewrite bytes were never verified, so kei cannot claim              them as the provider download"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a legacy row must not be stranded behind a missing checksum"
+        );
+        let (counts, _) = crate::commands::reconcile::scan_local_drift(
+            &db,
+            |_: &crate::commands::reconcile::LocalDriftAsset| {},
+            |_: &str| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            counts.damaged, 1,
+            "a legacy file short of its provider size must still read as damaged"
+        );
+    }
+
+    /// #707 review: the rewritten hash is stored before the marker retires, so
+    /// a failure later in the same attempt still leaves the row describing the
+    /// bytes on disk. Without that, the next pass would read its own rewrite as
+    /// damage and refuse to touch it again.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_records_the_rewritten_checksum_even_when_the_sidecar_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "SIDEFAIL", Some(3)).await;
+
+        // A directory where the sidecar belongs fails the sidecar write while
+        // leaving the embedded write free to change the media.
+        let mut sidecar = path.clone().into_os_string();
+        sidecar.push(".xmp");
+        std::fs::create_dir(PathBuf::from(sidecar)).unwrap();
+
+        run_pending(
+            &db,
+            embedded_rating_flags() | MetadataFlags::XMP_SIDECAR,
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let on_disk = crate::download::file::compute_sha256(&path).await.unwrap();
+        assert_ne!(
+            on_disk, recorded,
+            "precondition: the embedded write must land before the sidecar fails"
+        );
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(
+            local.as_deref(),
+            Some(on_disk.as_str()),
+            "the row must describe the rewritten bytes even though the attempt failed"
+        );
+        assert_eq!(download.as_deref(), Some(recorded.as_str()));
+        assert_eq!(
+            db.get_pending_metadata_rewrites(10).await.unwrap().len(),
+            1,
+            "the sidecar still owes a write, so the marker stays"
+        );
+    }
+
+    /// #707 review: a rewrite with nothing to write leaves the media alone, so
+    /// the row must not gain a checksum for bytes kei never wrote. Vouching for
+    /// an untouched file would hide damage that arrived some other way.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drain_writing_nothing_does_not_vouch_for_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // No rating to write, and only the rating writer is enabled, so the
+        // embedded plan comes out empty.
+        let (db, path, recorded) = seed_marked_jpeg(dir.path(), "UNTOUCHED", None).await;
+        let before = std::fs::read(&path).unwrap();
+
+        run_pending(
+            &db,
+            MetadataFlags::RATING,
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "precondition: an empty plan must leave the media alone"
+        );
+        let (local, download) = stored_checksums(&db).await;
+        assert_eq!(local.as_deref(), Some(recorded.as_str()));
+        assert_eq!(
+            download, None,
+            "kei must not claim a pre-rewrite hash for a file it did not rewrite"
+        );
+    }
+
+    /// #718 taught reconcile that a metadata-rewritten file is legitimately
+    /// smaller than the provider size, proving it by hashing against
+    /// `local_checksum`. That proof needs both checksums, so a drained file
+    /// must not be reported as truncated damage.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn drained_file_is_not_reported_as_truncated_damage() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, _path, _recorded) = seed_marked_jpeg(dir.path(), "SHRUNK", Some(3)).await;
+
+        let (before, _) = stored_checksums(&db).await;
+        let (counts, drift) = crate::commands::reconcile::scan_local_drift(
+            &db,
+            |_: &crate::commands::reconcile::LocalDriftAsset| {},
+            |_: &str| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            counts.damaged, 1,
+            "precondition: the provider size is larger than the file, so an \
+             unexplained difference reads as damage"
+        );
+        assert_eq!(drift.len(), 1);
+
+        run_pending(
+            &db,
+            embedded_rating_flags(),
+            Arc::from(".meta-tmp"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        let (after, download) = stored_checksums(&db).await;
+        assert_ne!(after, before, "precondition: the drain rewrote the media");
+        assert!(
+            download.is_some(),
+            "reconcile needs the pre-rewrite hash to run its proof"
+        );
+
+        let (counts, drift) = crate::commands::reconcile::scan_local_drift(
+            &db,
+            |_: &crate::commands::reconcile::LocalDriftAsset| {},
+            |_: &str| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(counts.present, 1);
+        assert_eq!(counts.damaged, 0, "a drained file is intact, not truncated");
+        assert!(drift.is_empty());
+    }
+
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn drain_reaches_newer_marker_after_retained_batch() {
@@ -1070,6 +1607,9 @@ mod tests {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let invalid_path = dir.path().join("invalid.jpg");
         std::fs::write(&invalid_path, b"not a jpeg").unwrap();
+        let invalid_checksum = crate::download::file::compute_sha256(&invalid_path)
+            .await
+            .unwrap();
         for i in 0..METADATA_REWRITE_BATCH {
             let id = format!("A{i:04}");
             let metadata = AssetMetadata {
@@ -1082,15 +1622,25 @@ mod tests {
                 .metadata(metadata)
                 .build();
             db.upsert_seen(&record).await.unwrap();
-            db.mark_downloaded("PrimarySync", &id, "original", &invalid_path, "ck", None)
-                .await
-                .unwrap();
+            db.mark_downloaded(
+                "PrimarySync",
+                &id,
+                "original",
+                &invalid_path,
+                &invalid_checksum,
+                None,
+            )
+            .await
+            .unwrap();
             db.record_metadata_write_failure("PrimarySync", &id, "original")
                 .await
                 .unwrap();
         }
         let valid_path = dir.path().join("valid.jpg");
         std::fs::write(&valid_path, minimal_jpeg_bytes()).unwrap();
+        let valid_checksum = crate::download::file::compute_sha256(&valid_path)
+            .await
+            .unwrap();
         let valid = crate::test_helpers::TestAssetRecord::new("Z_VALID")
             .filename("valid.jpg")
             .metadata(AssetMetadata {
@@ -1105,7 +1655,7 @@ mod tests {
             "Z_VALID",
             "original",
             &valid_path,
-            "ck",
+            &valid_checksum,
             None,
         )
         .await

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -349,8 +349,8 @@ pub(super) struct RewritePass {
 /// Process one bounded batch of persisted metadata-rewrite markers: for each
 /// asset whose `metadata_write_failed_at` is set and whose local file is still
 /// on disk, re-apply EXIF/XMP using the stored metadata. On success clears the
-/// marker and refreshes `metadata_hash`; on failure leaves the marker so the
-/// next pass retries. Returns the per-batch counts.
+/// marker; on failure leaves it so the next pass retries. Returns the
+/// per-batch counts.
 pub(super) async fn run_pending<D>(
     db: &D,
     metadata_flags: MetadataFlags,
@@ -445,20 +445,6 @@ where
         .await;
 
         if !outcome.any_failed() {
-            if let Some(new_hash) = record.metadata.metadata_hash.as_deref()
-                && let Err(e) = db
-                    .update_metadata_hash(
-                        &record.library,
-                        &record.id,
-                        version_size.as_str(),
-                        new_hash,
-                    )
-                    .await
-            {
-                tracing::warn!(asset_id = %record.id, error = %e, "Failed to update metadata_hash");
-                errored += 1;
-                continue;
-            }
             if let Err(e) = db
                 .clear_metadata_write_failure(&record.library, &record.id, version_size.as_str())
                 .await
@@ -664,7 +650,7 @@ mod tests {
     /// calls `run_pending` and asserts:
     /// 1. the on-disk JPEG now carries the rating in its XMP packet,
     /// 2. the DB marker is cleared (rewrite won't re-fire next cycle),
-    /// 3. `metadata_hash` is refreshed to match the asset state.
+    /// 3. the recorded `metadata_hash` is left in place.
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn run_pending_applies_embed_and_clears_marker() {
@@ -735,7 +721,7 @@ mod tests {
             .expect("row must remain in the downloaded set");
         assert_eq!(
             new_hash, &seeded_hash,
-            "update_metadata_hash uses the asset's recorded metadata_hash"
+            "a successful rewrite leaves the recorded metadata_hash in place"
         );
 
         // The file on disk now contains an XMP packet with the rating.
@@ -962,7 +948,7 @@ mod tests {
             "unselected and soft-deleted failures must not fail the selected repair"
         );
         let pending = db.get_pending_metadata_rewrites(32).await.unwrap();
-        assert_eq!(pending.len(), 5);
+        assert_eq!(pending.len(), 4);
         assert!(
             pending
                 .iter()
@@ -970,10 +956,11 @@ mod tests {
             "unselected library marker must remain untouched"
         );
         assert!(
-            pending
+            !pending
                 .iter()
                 .any(|record| record.id.as_ref() == "SOFT_DELETED"),
-            "soft-deleted marker must remain untouched"
+            "a soft-deleted row must not be offered for rewrite, since its \
+             metadata is frozen at the values held before the deletion"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1399,6 +1399,10 @@ struct DownloadContext {
     /// changed.
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     metadata_retry_markers: LibraryAssetVersionSet,
+    /// Assets the provider reported deleted whose downloaded rows remain.
+    /// Staleness checks skip these so they cannot report a change that
+    /// `refresh_downloaded_asset_metadata` is unable to apply.
+    soft_deleted_ids: LibraryAssetSet,
     /// Nested map: `library` -> `asset_id` -> set of `version_sizes` that
     /// are pending at sync start. Used to resolve failed/pending rows when
     /// the expected file is already on disk instead of promoting them back to
@@ -1424,7 +1428,7 @@ impl DownloadContext {
     /// Load the download context from the state database. All state queries
     /// are independent and run concurrently so sync start doesn't serialize
     /// on round-trip latency across them.
-    async fn load<D>(db: &D, retry_only: bool, metadata_writes_enabled: bool) -> Self
+    async fn load<D>(db: &D, retry_only: bool) -> Self
     where
         D: DownloadStateStore + MetadataRewriteStore + ?Sized,
     {
@@ -1438,10 +1442,26 @@ impl DownloadContext {
                 Default::default()
             }
         };
-        let (ids, checksums, paths, hashes, markers, pending, attempts, known_id_rows) = tokio::join!(
+        let (
+            ids,
+            soft_deleted,
+            checksums,
+            paths,
+            hashes,
+            markers,
+            pending,
+            attempts,
+            known_id_rows,
+        ) = tokio::join!(
             async {
                 db.get_downloaded_ids().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load downloaded IDs from state DB");
+                    Default::default()
+                })
+            },
+            async {
+                db.get_soft_deleted_downloaded_ids().await.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to load soft-deleted assets from state DB");
                     Default::default()
                 })
             },
@@ -1466,14 +1486,10 @@ impl DownloadContext {
                     })
             },
             async {
-                if metadata_writes_enabled {
-                    db.get_metadata_retry_markers().await.unwrap_or_else(|e| {
-                        tracing::warn!(error = %e, "Failed to load metadata retry markers from state DB");
-                        Default::default()
-                    })
-                } else {
+                db.get_metadata_retry_markers().await.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to load metadata retry markers from state DB");
                     Default::default()
-                }
+                })
             },
             async {
                 db.get_pending().await.unwrap_or_else(|e| {
@@ -1511,6 +1527,13 @@ impl DownloadContext {
                 .entry(id)
                 .or_default()
                 .insert(version_size.into_boxed_str());
+        }
+
+        let mut soft_deleted_ids: LibraryAssetSet = FxHashMap::default();
+        for (library, asset_id) in soft_deleted {
+            let lib = intern_id(&mut interner, library);
+            let id = intern_id(&mut interner, asset_id);
+            soft_deleted_ids.entry(lib).or_default().insert(id);
         }
 
         let mut downloaded_checksums: LibraryAssetVersionValueMap = FxHashMap::default();
@@ -1606,6 +1629,7 @@ impl DownloadContext {
             downloaded_local_paths,
             downloaded_metadata_hashes,
             metadata_retry_markers,
+            soft_deleted_ids,
             pending_ids,
             pending_filenames,
             known_ids,
@@ -1640,6 +1664,9 @@ impl DownloadContext {
         version_size: VersionSizeKey,
         new_metadata_hash: Option<&str>,
     ) -> bool {
+        if self.is_soft_deleted(library, asset_id) {
+            return false;
+        }
         let vs_str = version_size.as_str();
         let has_retry_marker = self
             .metadata_retry_markers
@@ -1663,6 +1690,16 @@ impl DownloadContext {
         }
     }
 
+    /// Whether the provider reported this asset deleted while its downloaded
+    /// rows remain. `refresh_downloaded_asset_metadata` cannot match those
+    /// rows, so treating them as stale would report a change that can never
+    /// be applied.
+    fn is_soft_deleted(&self, library: &str, asset_id: &str) -> bool {
+        self.soft_deleted_ids
+            .get(library)
+            .is_some_and(|assets| assets.contains(asset_id))
+    }
+
     /// Whether at least one downloaded version has provider metadata that
     /// differs from the complete asset returned by iCloud.
     fn has_provider_metadata_drift(
@@ -1674,6 +1711,9 @@ impl DownloadContext {
         let Some(new_hash) = new_metadata_hash else {
             return false;
         };
+        if self.is_soft_deleted(library, asset_id) {
+            return false;
+        }
         let Some(downloaded_versions) = self
             .downloaded_ids
             .get(library)
@@ -1690,6 +1730,30 @@ impl DownloadContext {
                 .and_then(|hashes| hashes.get(version_size.as_ref()))
                 .is_none_or(|stored| stored.as_ref() != new_hash)
         })
+    }
+
+    /// Whether any live downloaded version of this asset carries a metadata
+    /// rewrite retry marker. Asset-level counterpart to the per-version
+    /// `needs_metadata_rewrite`, for callers that decide once per asset.
+    fn has_downloaded_metadata_retry_marker(&self, library: &str, asset_id: &str) -> bool {
+        if self.is_soft_deleted(library, asset_id) {
+            return false;
+        }
+        let Some(markers) = self
+            .metadata_retry_markers
+            .get(library)
+            .and_then(|assets| assets.get(asset_id))
+        else {
+            return false;
+        };
+        self.downloaded_ids
+            .get(library)
+            .and_then(|assets| assets.get(asset_id))
+            .is_some_and(|downloaded| {
+                markers
+                    .iter()
+                    .any(|version_size| downloaded.contains(version_size.as_ref()))
+            })
     }
 
     fn has_state_version(&self, library: &str, asset_id: &str) -> bool {
@@ -1839,8 +1903,7 @@ fn count_value_map_entries(map: &LibraryAssetVersionValueMap) -> usize {
 async fn preload_download_context(config: &DownloadConfig) -> Arc<DownloadContext> {
     let download_ctx = if let Some(db) = &config.state_db {
         tracing::debug!("Pre-loading download state from database");
-        let metadata_writes_enabled = MetadataFlags::from(config).has_any_write();
-        DownloadContext::load(db.as_ref(), config.retry_only, metadata_writes_enabled).await
+        DownloadContext::load(db.as_ref(), config.retry_only).await
     } else {
         DownloadContext::default()
     };
@@ -2779,7 +2842,8 @@ where
             Some(pass_pb.clone()),
             Some(std::sync::Arc::clone(&pass_bytes)),
             options.download_ctx,
-        ),
+        )
+        .deferring_metadata_drain(),
     )
     .await?;
     if let Some(snapshot) = &options.album_snapshot {
@@ -5261,7 +5325,7 @@ async fn download_photos_full_with_token_policy(
             controls,
             display_total,
             shutdown_token.clone(),
-            StreamRuntime::new(None, None),
+            StreamRuntime::new(None, None).deferring_metadata_drain(),
         )
         .await?;
 
@@ -5681,6 +5745,26 @@ async fn download_photos_full_with_token_policy(
     let count_undercount_assets = exact_total
         .map(|count| streaming_result.assets_seen.saturating_sub(count))
         .unwrap_or(0);
+
+    // Both enumeration branches defer their rewrite queue to here, so a full
+    // enumeration drains exactly once. Per-pass pipelines run concurrently and
+    // separate drains can otherwise write the same file, where the later write
+    // wins whether or not it holds the newer metadata.
+    let metadata_flags = MetadataFlags::from(config.as_ref());
+    if controls.run_mode.downloads_files()
+        && !config.refresh_metadata
+        && metadata_flags.has_any_write()
+        && let Some(db) = &config.state_db
+    {
+        streaming_result.exif_failures += metadata_rewrite::run_pending(
+            db.as_ref(),
+            metadata_flags,
+            Arc::clone(&config.temp_suffix),
+            &shutdown_token,
+        )
+        .await
+        .failed;
+    }
 
     // Build the outcome using the same logic as download_photos
     let (outcome, mut stats) = build_download_outcome(
@@ -10439,6 +10523,48 @@ mod tests {
 
         assert!(!ctx.has_provider_metadata_drift("PrimarySync", "asset1", Some("metadata-a")));
         assert!(ctx.has_provider_metadata_drift("PrimarySync", "asset1", Some("metadata-b")));
+    }
+
+    /// A tombstoned row cannot be refreshed, so no staleness check may
+    /// report it as needing one.
+    #[test]
+    fn staleness_checks_ignore_soft_deleted_assets() {
+        let mut ctx = DownloadContext::default();
+        ctx.downloaded_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .entry("asset1".into())
+            .or_default()
+            .insert("original".into());
+        ctx.metadata_retry_markers
+            .entry("PrimarySync".into())
+            .or_default()
+            .entry("asset1".into())
+            .or_default()
+            .insert("original".into());
+
+        assert!(ctx.has_provider_metadata_drift("PrimarySync", "asset1", Some("metadata-b")));
+        assert!(ctx.has_downloaded_metadata_retry_marker("PrimarySync", "asset1"));
+        assert!(ctx.needs_metadata_rewrite(
+            "PrimarySync",
+            "asset1",
+            VersionSizeKey::Original,
+            Some("metadata-b")
+        ));
+
+        ctx.soft_deleted_ids
+            .entry("PrimarySync".into())
+            .or_default()
+            .insert("asset1".into());
+
+        assert!(!ctx.has_provider_metadata_drift("PrimarySync", "asset1", Some("metadata-b")));
+        assert!(!ctx.has_downloaded_metadata_retry_marker("PrimarySync", "asset1"));
+        assert!(!ctx.needs_metadata_rewrite(
+            "PrimarySync",
+            "asset1",
+            VersionSizeKey::Original,
+            Some("metadata-b")
+        ));
     }
 
     #[test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -25,8 +25,6 @@ use super::filter::{
     DerivedPath, DownloadTask, derive_expected_paths, determine_media_type,
     extract_skip_candidates, is_asset_filtered,
 };
-#[cfg(test)]
-use super::finalize::update_metadata_marker_for_test as update_metadata_marker;
 use super::finalize::{
     DownloadedFinalization, PendingStateWrite, StateWriteFlush, check_state_write_circuit_breaker,
     finalize_downloaded, finalize_failed, flush_pending_state_writes,
@@ -824,52 +822,6 @@ async fn record_seen_for_forwarded_task(
     result
 }
 
-async fn backfill_downloaded_metadata_for_on_disk_skip(
-    state_db: Option<&dyn DownloadStore>,
-    config: &DownloadConfig,
-    asset: &PhotoAsset,
-    ctx: &DownloadContext,
-) {
-    if !ctx.has_downloaded_without_metadata_hash() {
-        return;
-    }
-    let Some(db) = state_db else {
-        return;
-    };
-    let library = effective_asset_library(asset, config);
-    let downloaded_versions = ctx
-        .downloaded_ids
-        .get(library)
-        .and_then(|assets| assets.get(asset.state_id()));
-    let Some(downloaded_versions) = downloaded_versions else {
-        return;
-    };
-    let version_hashes = ctx
-        .downloaded_metadata_hashes
-        .get(library)
-        .and_then(|assets| assets.get(asset.state_id()));
-
-    for derived in derive_expected_paths(asset, config) {
-        let version_size = derived.version_size.as_str();
-        let has_metadata_hash =
-            version_hashes.is_some_and(|hashes| hashes.contains_key(version_size));
-        if !downloaded_versions.contains(version_size) || has_metadata_hash {
-            continue;
-        }
-
-        let record = asset_record_for_derived_path(Arc::from(library), asset, &derived);
-
-        if let Err(e) = db.upsert_seen(&record).await {
-            tracing::warn!(
-                asset_id = %asset.id(),
-                version_size,
-                error = %e,
-                "Failed to backfill metadata for skipped downloaded asset"
-            );
-        }
-    }
-}
-
 /// Configuration for a download pass.
 pub(super) struct PassConfig<'a> {
     pub(super) client: &'a Client,
@@ -960,6 +912,11 @@ pub(super) struct StreamRuntime {
     shared_pb: Option<ProgressBar>,
     shared_bytes: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
     preloaded_download_ctx: Option<Arc<DownloadContext>>,
+    /// Set when the caller runs several of these pipelines concurrently and
+    /// drains the shared rewrite queue itself once they have all finished.
+    /// Concurrent drains can otherwise write the same file, and the later
+    /// write wins regardless of which holds the newer metadata.
+    defer_metadata_drain: bool,
 }
 
 impl StreamRuntime {
@@ -971,6 +928,7 @@ impl StreamRuntime {
             shared_pb,
             shared_bytes,
             preloaded_download_ctx: None,
+            defer_metadata_drain: false,
         }
     }
 
@@ -983,7 +941,15 @@ impl StreamRuntime {
             shared_pb,
             shared_bytes,
             preloaded_download_ctx,
+            defer_metadata_drain: false,
         }
+    }
+
+    /// Leaves the rewrite queue for the caller to drain once every concurrent
+    /// pipeline has finished.
+    pub(super) fn deferring_metadata_drain(mut self) -> Self {
+        self.defer_metadata_drain = true;
+        self
     }
 }
 
@@ -1223,6 +1189,7 @@ where
     let mode = reporting.personality_mode;
 
     // Pre-load download context for O(1) skip decisions
+    let defer_metadata_drain = runtime.defer_metadata_drain;
     let download_ctx = match runtime.preloaded_download_ctx {
         Some(ctx) => ctx,
         None => preload_download_context(config).await,
@@ -1309,7 +1276,15 @@ where
     )
     .await;
 
-    finalize_streaming_download(producer, consumer_result, sync_run_id, owns_pb, shared).await
+    finalize_streaming_download(
+        producer,
+        consumer_result,
+        sync_run_id,
+        owns_pb,
+        shared,
+        defer_metadata_drain,
+    )
+    .await
 }
 
 fn spawn_stream_download_producer<S>(
@@ -1338,8 +1313,7 @@ where
 
     let handle = tokio::spawn(async move {
         let config = &producer_config;
-        let mark_refreshed_metadata_for_rewrite =
-            config.refresh_metadata && MetadataFlags::from(config.as_ref()).has_any_write();
+        let metadata_writers_enabled = MetadataFlags::from(config.as_ref()).has_any_write();
         let mut task_planner = TaskPlanner::new();
         let mut seen_asset_record_names: FxHashSet<Arc<str>> = FxHashSet::default();
         // Skipped-asset IDs accumulated across the producer run and
@@ -1451,6 +1425,10 @@ where
                     }
 
                     assets_seen_producer.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    // The pre-plan refresh has already committed the marker,
+                    // so the skip sites must not re-stamp it from the stale
+                    // context.
+                    let mut metadata_refresh_attempted = false;
                     if let Some(db) = &producer_state_db {
                         let library = effective_asset_library(&asset, config);
                         if let Err(e) =
@@ -1466,24 +1444,61 @@ where
                                 "Failed to record asset/master mapping"
                             );
                         }
-                        if config.refresh_metadata
-                            && let Err(e) = db
+                        // Apply changed provider metadata before filtering and
+                        // path planning, so a metadata-only edit reaches the
+                        // catalogue even when the media task is filtered or
+                        // skipped as already on disk.
+                        let drift = download_ctx.has_provider_metadata_drift(
+                            library,
+                            asset.state_id(),
+                            asset.metadata().metadata_hash.as_deref(),
+                        );
+                        // A marker outlives a stale row whose stored hash still
+                        // matches the provider, which drift alone cannot see.
+                        let retry_marker = !drift
+                            && download_ctx
+                                .has_downloaded_metadata_retry_marker(library, asset.state_id());
+                        if config.refresh_metadata || drift || retry_marker {
+                            metadata_refresh_attempted = true;
+                            // A marker-only refresh must not queue more work:
+                            // the marker is already visible for retry.
+                            let mark_for_rewrite =
+                                metadata_writers_enabled && (config.refresh_metadata || drift);
+                            match db
                                 .refresh_downloaded_asset_metadata(
                                     library,
                                     asset.state_id(),
                                     asset.metadata(),
-                                    mark_refreshed_metadata_for_rewrite,
+                                    mark_for_rewrite,
                                 )
                                 .await
-                        {
-                            state_write_failures_producer
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            tracing::warn!(
-                                asset_id = %asset.id(),
-                                library,
-                                error = %e,
-                                "Failed to refresh downloaded asset metadata"
-                            );
+                            {
+                                Ok(updated) if updated > 0 => {}
+                                Ok(_) => {
+                                    // A forced sweep legitimately visits assets
+                                    // with no live downloaded row; drift and
+                                    // markers imply one exists.
+                                    if drift || retry_marker {
+                                        state_write_failures_producer
+                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                        tracing::warn!(
+                                            asset_id = %asset.id(),
+                                            library,
+                                            "Changed provider metadata matched no downloaded state row"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    state_write_failures_producer
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    tracing::warn!(
+                                        asset_id = %asset.id(),
+                                        library,
+                                        error = %e,
+                                        "Failed to refresh downloaded asset metadata"
+                                    );
+                                }
+                            }
                         }
                     }
 
@@ -1512,14 +1527,16 @@ where
                         // is already on disk; if adoption fails, the touched
                         // flush still lets stuck-pipeline recovery promote it.
                         let candidates = extract_skip_candidates(&asset, config.as_ref());
-                        metadata_rewrite::tag_if_needed(
-                            producer_state_db.as_deref(),
-                            config,
-                            &asset,
-                            &candidates,
-                            &download_ctx,
-                        )
-                        .await;
+                        if !metadata_refresh_attempted {
+                            metadata_rewrite::tag_if_needed(
+                                producer_state_db.as_deref(),
+                                config,
+                                &asset,
+                                &candidates,
+                                &download_ctx,
+                            )
+                            .await;
+                        }
                         let adoption = adopt_pending_on_disk_skip(
                             producer_state_db.as_deref(),
                             config,
@@ -1534,13 +1551,6 @@ where
                                 std::sync::atomic::Ordering::Relaxed,
                             );
                         }
-                        backfill_downloaded_metadata_for_on_disk_skip(
-                            producer_state_db.as_deref(),
-                            config,
-                            &asset,
-                            &download_ctx,
-                        )
-                        .await;
                         if producer_state_db.is_some() {
                             let library = effective_asset_library_arc(&asset, config);
                             touched_assets.push((library, asset.state_id_arc()));
@@ -1701,21 +1711,16 @@ where
                                             );
                                             let candidates =
                                                 extract_skip_candidates(&asset, config.as_ref());
-                                            metadata_rewrite::tag_if_needed(
-                                                producer_state_db.as_deref(),
-                                                config,
-                                                &asset,
-                                                &candidates,
-                                                &download_ctx,
-                                            )
-                                            .await;
-                                            backfill_downloaded_metadata_for_on_disk_skip(
-                                                producer_state_db.as_deref(),
-                                                config,
-                                                &asset,
-                                                &download_ctx,
-                                            )
-                                            .await;
+                                            if !metadata_refresh_attempted {
+                                                metadata_rewrite::tag_if_needed(
+                                                    producer_state_db.as_deref(),
+                                                    config,
+                                                    &asset,
+                                                    &candidates,
+                                                    &download_ctx,
+                                                )
+                                                .await;
+                                            }
                                             continue;
                                         }
 
@@ -2142,6 +2147,7 @@ async fn finalize_streaming_download(
     sync_run_id: Option<i64>,
     owns_pb: bool,
     shared: StreamPipelineShared,
+    defer_metadata_drain: bool,
 ) -> Result<StreamingResult> {
     let StreamProducer { handle, metrics } = producer;
     let config = shared.config;
@@ -2245,6 +2251,7 @@ async fn finalize_streaming_download(
     // without re-downloading bytes; the alternative was to leave markers
     // accumulating in the DB forever.
     if consumer.state_write_circuit_error.is_none()
+        && !defer_metadata_drain
         && !config.refresh_metadata
         && let Some(db) = &state_db
     {
@@ -2395,6 +2402,7 @@ pub(super) async fn build_download_outcome(
         let mut stats = super::SyncStats {
             assets_seen: streaming_result.assets_seen,
             skipped: skip_breakdown,
+            exif_failures,
             state_write_failures,
             enumeration_errors,
             elapsed_secs: started.elapsed().as_secs_f64(),
@@ -2411,7 +2419,11 @@ pub(super) async fn build_download_outcome(
         } else {
             tracing::info!("No new photos to download");
         }
+        // A metadata-only edit cycle downloads nothing, so rewrite failures
+        // must still surface here. They stay out of `state_write_failures`:
+        // the catalogue and marker are durable, so the checkpoint may advance.
         let failed_count = state_write_failures
+            + exif_failures
             + retry_exhausted
             + enumeration_errors
             + usize::from(streaming_result.url_expired_abort)
@@ -4122,7 +4134,6 @@ mod tests {
         failed_calls: AtomicUsize,
         downloaded_id_loads: AtomicUsize,
         track_failed_calls: bool,
-        fail_metadata_clear: bool,
         fail_complete_sync_run: bool,
     }
 
@@ -4135,7 +4146,6 @@ mod tests {
                 failed_calls: AtomicUsize::new(0),
                 downloaded_id_loads: AtomicUsize::new(0),
                 track_failed_calls: false,
-                fail_metadata_clear: false,
                 fail_complete_sync_run: false,
             }
         }
@@ -4143,12 +4153,6 @@ mod tests {
         fn with_mark_failed_tracking() -> Self {
             let mut s = Self::new(0);
             s.track_failed_calls = true;
-            s
-        }
-
-        fn with_failing_metadata_clear() -> Self {
-            let mut s = Self::new(0);
-            s.fail_metadata_clear = true;
             s
         }
 
@@ -4246,6 +4250,12 @@ mod tests {
             &self,
         ) -> Result<HashSet<(String, String, String)>, StateError> {
             self.downloaded_id_loads.fetch_add(1, Ordering::Relaxed);
+            Ok(HashSet::new())
+        }
+
+        async fn get_soft_deleted_downloaded_ids(
+            &self,
+        ) -> Result<HashSet<(String, String)>, StateError> {
             Ok(HashSet::new())
         }
 
@@ -4454,11 +4464,7 @@ mod tests {
             _: &str,
             _: &str,
         ) -> Result<(), StateError> {
-            if self.fail_metadata_clear {
-                Err(StateError::LockPoisoned("simulated clear failure".into()))
-            } else {
-                Ok(())
-            }
+            Ok(())
         }
 
         async fn get_downloaded_metadata_hashes(
@@ -4482,16 +4488,6 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn update_metadata_hash(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &str,
-        ) -> Result<(), StateError> {
-            Ok(())
-        }
-
         async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
             Ok(false)
         }
@@ -4503,26 +4499,6 @@ mod tests {
         let result = flush_pending_state_writes(&db, &[]).await;
         assert_eq!(result, 0);
         assert_eq!(db.success_count(), 0);
-    }
-
-    /// CG-13: when `clear_metadata_write_failure` returns Err, the
-    /// previous `let _ = ...` swallow let the metadata-rewrite marker
-    /// stay set forever. The asset would be re-rewritten on every
-    /// subsequent sync. Surface the failure as a structured warn so it
-    /// shows up in logs/metrics.
-    #[tracing_test::traced_test]
-    #[tokio::test]
-    async fn update_metadata_marker_warns_when_clear_fails() {
-        let db = FailingDownloadStore::with_failing_metadata_clear();
-        update_metadata_marker(&db, "PrimarySync", "ASSET_X", "original", true).await;
-        assert!(
-            logs_contain("Could not clear metadata-write-failed marker"),
-            "warn must fire when clear returns Err"
-        );
-        assert!(
-            logs_contain("asset_id=\"ASSET_X\""),
-            "structured asset_id field expected"
-        );
     }
 
     /// CG-2 (broadened from adversarial pass, 2026-05-03): `log_sync_summary`
@@ -5739,6 +5715,804 @@ mod tests {
             Some("stale-hash")
         );
         assert_eq!(rewrites[0].metadata.title, None);
+    }
+
+    /// #674 regression: a metadata-only edit drifts the source hash from the
+    /// stored hash. On the on-disk skip the catalogue must be refreshed to the
+    /// edited source metadata (not left stale) without re-downloading, so a
+    /// queued rewrite applies corrected values instead of replaying old ones.
+    #[tokio::test]
+    async fn on_disk_skip_refreshes_catalogue_on_metadata_drift() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        // Downloaded while a favourite; the source has since dropped it.
+        let stored: PhotoAsset = TestPhotoAsset::new("DRIFT")
+            .filename("drift.jpg")
+            .orig_size(1000)
+            .orig_checksum("ck_drift")
+            .favorite(true)
+            .build();
+        let edited: PhotoAsset = TestPhotoAsset::new("DRIFT")
+            .filename("drift.jpg")
+            .orig_size(1000)
+            .orig_checksum("ck_drift")
+            .favorite(false)
+            .build();
+
+        let derived = derive_expected_paths(&stored, config.as_ref())
+            .into_iter()
+            .next()
+            .unwrap();
+        fs::create_dir_all(derived.path.parent().unwrap()).unwrap();
+        fs::write(&derived.path, vec![0u8; 1000]).unwrap();
+        let record = asset_record_for_derived_path(Arc::from("PrimarySync"), &stored, &derived);
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+            &derived.path,
+            "local-checksum",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0, "unchanged bytes must not re-download");
+        let refreshed = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        assert!(
+            !refreshed.metadata.is_favorite,
+            "the on-disk skip must refresh the stale catalogue to the edited source metadata"
+        );
+        let queued = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert!(
+            queued.is_empty(),
+            "the queued rewrite must run from the fresh catalogue and clear its marker"
+        );
+        assert_eq!(result.exif_failures, 0);
+        assert_eq!(
+            fs::read_dir(derived.path.parent().unwrap())
+                .unwrap()
+                .count(),
+            1,
+            "the refresh must not create a suffixed duplicate"
+        );
+    }
+
+    /// Minimal valid JPEG (SOI + APP0 JFIF + EOI). The XMP toolkit accepts it,
+    /// so a metadata write against it exercises the real writer.
+    #[cfg(feature = "xmp")]
+    const MINIMAL_JPEG: [u8; 22] = [
+        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+    ];
+
+    /// A `PhotoAsset` backed by `MINIMAL_JPEG`, so a metadata write against its
+    /// file exercises the real writer rather than failing to decode.
+    #[cfg(feature = "xmp")]
+    fn jpeg_asset(id: &str, filename: &str, favorite: bool) -> crate::icloud::photos::PhotoAsset {
+        TestPhotoAsset::new(id)
+            .filename(filename)
+            .orig_size(MINIMAL_JPEG.len() as u64)
+            .orig_checksum(&format!("ck_{id}"))
+            .favorite(favorite)
+            .build()
+    }
+
+    /// Seeds a downloaded asset whose on-disk file is a real JPEG.
+    #[cfg(feature = "xmp")]
+    async fn seed_downloaded_jpeg_asset(
+        db: &Arc<crate::state::SqliteStateDb>,
+        config: &DownloadConfig,
+        stored: &crate::icloud::photos::PhotoAsset,
+    ) -> super::DerivedPath {
+        let derived = derive_expected_paths(stored, config)
+            .into_iter()
+            .next()
+            .unwrap();
+        fs::create_dir_all(derived.path.parent().unwrap()).unwrap();
+        fs::write(&derived.path, MINIMAL_JPEG).unwrap();
+        let record = asset_record_for_derived_path(Arc::from("PrimarySync"), stored, &derived);
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+            &derived.path,
+            "local-checksum",
+            None,
+        )
+        .await
+        .unwrap();
+        derived
+    }
+
+    /// The `.xmp` sidecar kei writes beside a media file.
+    #[cfg(feature = "xmp")]
+    fn sidecar_path_for(media_path: &std::path::Path) -> std::path::PathBuf {
+        let mut name = media_path.file_name().unwrap().to_os_string();
+        name.push(".xmp");
+        media_path.with_file_name(name)
+    }
+
+    /// A stored/edited `PhotoAsset` pair sharing identical bytes but differing
+    /// provider metadata, which is the shape of a metadata-only iCloud edit.
+    fn drifted_asset_pair(
+        id: &str,
+        filename: &str,
+    ) -> (
+        crate::icloud::photos::PhotoAsset,
+        crate::icloud::photos::PhotoAsset,
+    ) {
+        let checksum = format!("ck_{id}");
+        let stored = TestPhotoAsset::new(id)
+            .filename(filename)
+            .orig_size(1000)
+            .orig_checksum(&checksum)
+            .favorite(true)
+            .build();
+        let edited = TestPhotoAsset::new(id)
+            .filename(filename)
+            .orig_size(1000)
+            .orig_checksum(&checksum)
+            .favorite(false)
+            .build();
+        (stored, edited)
+    }
+
+    /// Seed a downloaded asset with its file on disk, as a prior sync would
+    /// have left it, and return the derived path it was recorded against.
+    async fn seed_downloaded_drift_asset(
+        db: &Arc<crate::state::SqliteStateDb>,
+        config: &DownloadConfig,
+        stored: &crate::icloud::photos::PhotoAsset,
+    ) -> super::DerivedPath {
+        let derived = derive_expected_paths(stored, config)
+            .into_iter()
+            .next()
+            .unwrap();
+        fs::create_dir_all(derived.path.parent().unwrap()).unwrap();
+        fs::write(&derived.path, vec![0u8; 1000]).unwrap();
+        let record = asset_record_for_derived_path(Arc::from("PrimarySync"), stored, &derived);
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+            &derived.path,
+            "local-checksum",
+            None,
+        )
+        .await
+        .unwrap();
+        derived
+    }
+
+    /// #707: with local metadata outputs disabled the catalogue must still be
+    /// refreshed, and no rewrite may be queued. Backup fidelity of the
+    /// manifest does not depend on the user opting into sidecars or EXIF.
+    #[tokio::test]
+    async fn metadata_drift_without_writers_refreshes_catalogue_and_queues_nothing() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        // No metadata writers enabled.
+        let config = Arc::new(config);
+
+        let (stored, edited) = drifted_asset_pair("NOWRITERS", "nowriters.jpg");
+        let derived = seed_downloaded_drift_asset(&db, &config, &stored).await;
+        let before = fs::metadata(&derived.path).unwrap().len();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.state_write_failures, 0);
+        let refreshed = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        assert!(
+            !refreshed.metadata.is_favorite,
+            "the catalogue must refresh even with local metadata outputs disabled"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no rewrite may be queued when no metadata writer is enabled"
+        );
+        assert_eq!(
+            fs::metadata(&derived.path).unwrap().len(),
+            before,
+            "local files must be untouched"
+        );
+    }
+
+    /// #707: a downloaded asset whose media task is filtered out must still
+    /// have its provider metadata applied. The refresh runs before filtering
+    /// and path planning, so an excluded asset cannot strand a stale
+    /// catalogue row.
+    #[tokio::test]
+    async fn metadata_drift_refreshes_when_media_task_is_filtered() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+
+        let (stored, edited) = drifted_asset_pair("FILTERED", "filtered.jpg");
+        // Filter the asset out of media planning entirely.
+        config.exclude_asset_ids = Arc::new(std::iter::once(stored.id().to_string()).collect());
+        let config = Arc::new(config);
+
+        seed_downloaded_drift_asset(&db, &config, &stored).await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.state_write_failures, 0);
+        let refreshed = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        assert!(
+            !refreshed.metadata.is_favorite,
+            "a filtered media task must not prevent the provider metadata refresh"
+        );
+    }
+
+    /// #707: a photo the provider deleted and the user then restored must
+    /// still be recognised as already held. The exclusion for deleted rows
+    /// belongs in the staleness checks, not in the shared downloaded list:
+    /// filtering that list sends the asset down the fast path, which skips the
+    /// on-disk check, so the default naming policy files a copy beside the
+    /// original.
+    #[tokio::test]
+    async fn restored_soft_deleted_asset_is_skipped_without_downloading() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (stored, _) = drifted_asset_pair("RESTORED", "restored.jpg");
+        let derived = seed_downloaded_drift_asset(&db, &config, &stored).await;
+        db.mark_soft_deleted("PrimarySync", stored.state_id(), None)
+            .await
+            .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(stored.clone())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert!(
+            result.failed.is_empty(),
+            "a restored photo must not be queued for download"
+        );
+        assert_eq!(result.skip_summary.on_disk, 1);
+        assert_eq!(
+            fs::read_dir(derived.path.parent().unwrap())
+                .unwrap()
+                .count(),
+            1,
+            "no duplicate may be written beside the original"
+        );
+    }
+
+    /// #707: a restored photo that was also edited must not report unsafe
+    /// provider state. Its rows cannot be refreshed while the deletion stands,
+    /// and reporting that every cycle would hold the checkpoint forever.
+    #[tokio::test]
+    async fn restored_and_edited_asset_does_not_report_unsafe_state() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (stored, edited) = drifted_asset_pair("RESTORED_EDIT", "restored_edit.jpg");
+        seed_downloaded_drift_asset(&db, &config, &stored).await;
+        db.mark_soft_deleted("PrimarySync", stored.state_id(), None)
+            .await
+            .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.state_write_failures, 0,
+            "a deleted row that cannot be refreshed is not a durability failure"
+        );
+        assert_eq!(result.downloaded, 0);
+    }
+
+    /// #707 acceptance criterion 1, sidecar half: the rewrite must run from
+    /// the refreshed catalogue and land the new value on disk. The direction
+    /// matters. Un-favouriting clears the rating and writes nothing, so only
+    /// favouriting proves the fresh value reached the file.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn metadata_drift_writes_fresh_value_into_the_sidecar() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let stored = jpeg_asset("SIDECAR", "sidecar.jpg", false);
+        let edited = jpeg_asset("SIDECAR", "sidecar.jpg", true);
+        let derived = seed_downloaded_jpeg_asset(&db, &config, &stored).await;
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0, "a metadata edit must not fetch media");
+        assert_eq!(result.exif_failures, 0);
+
+        let sidecar = fs::read_to_string(sidecar_path_for(&derived.path))
+            .expect("sidecar written next to the media file");
+        assert!(
+            sidecar.contains("<xmp:Rating>5</xmp:Rating>"),
+            "the sidecar must carry the favourite from the refreshed catalogue: {sidecar}"
+        );
+    }
+
+    /// #707: a rewrite marker that predates a provider deletion must not
+    /// drain against the tombstoned row. Its metadata is frozen at the values
+    /// held before the deletion, so writing it would publish stale data.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn marker_predating_a_deletion_is_not_drained() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let stored = jpeg_asset("OLDMARKER", "oldmarker.jpg", false);
+        let derived = seed_downloaded_jpeg_asset(&db, &config, &stored).await;
+        db.record_metadata_write_failure(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+        )
+        .await
+        .unwrap();
+        db.mark_soft_deleted("PrimarySync", stored.state_id(), None)
+            .await
+            .unwrap();
+
+        stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(jpeg_asset(
+                "OLDMARKER",
+                "oldmarker.jpg",
+                true,
+            ))]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !sidecar_path_for(&derived.path).exists(),
+            "a marker on a deleted row must not write metadata"
+        );
+    }
+
+    /// #707: a tombstoned row cannot be refreshed, so it must not be queued
+    /// for rewrite either. Doing so would publish the stale values the issue
+    /// exists to stop.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn restored_asset_is_not_rewritten_from_the_stale_catalogue() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let stored = jpeg_asset("TOMBSTONE", "tombstone.jpg", false);
+        let derived = seed_downloaded_jpeg_asset(&db, &config, &stored).await;
+        db.mark_soft_deleted("PrimarySync", stored.state_id(), None)
+            .await
+            .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(jpeg_asset(
+                "TOMBSTONE",
+                "tombstone.jpg",
+                true,
+            ))]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert!(
+            !sidecar_path_for(&derived.path).exists(),
+            "a tombstoned asset must not have metadata written from its stale row"
+        );
+        assert!(
+            db.get_metadata_retry_markers().await.unwrap().is_empty(),
+            "a tombstoned asset must not be queued for a later rewrite either"
+        );
+    }
+
+    /// #707: when the catalogue write fails, the prior metadata must survive
+    /// intact and the failure must reach `state_write_failures`, which is the
+    /// signal `sync_cycle` uses to hold the zone checkpoint.
+    #[tokio::test]
+    async fn metadata_drift_refresh_failure_preserves_state_and_reports_not_durable() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (stored, edited) = drifted_asset_pair("DBFAIL", "dbfail.jpg");
+        seed_downloaded_drift_asset(&db, &config, &stored).await;
+
+        db.fail_provider_metadata_refresh_for_test();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.state_write_failures > 0,
+            "a failed catalogue refresh must be reported as non-durable provider state"
+        );
+        let unchanged = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        assert!(
+            unchanged.metadata.is_favorite,
+            "a failed refresh must leave the prior catalogue metadata intact"
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a failed refresh must not queue a rewrite, which would publish the stale row"
+        );
+    }
+
+    /// #707: unchanged provider metadata is a no-op. The failure trigger
+    /// would turn any attempted catalogue write into an error, so a clean
+    /// result proves no write was attempted and no rewrite was queued.
+    #[tokio::test]
+    async fn unchanged_metadata_performs_no_catalogue_write() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (stored, _) = drifted_asset_pair("SAME", "same.jpg");
+        seed_downloaded_drift_asset(&db, &config, &stored).await;
+
+        db.fail_provider_metadata_refresh_for_test();
+
+        // Re-enumerate the identical asset: same bytes, same metadata.
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(stored.clone())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.state_write_failures, 0,
+            "unchanged metadata must not attempt a catalogue write"
+        );
+        assert_eq!(result.downloaded, 0);
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "unchanged metadata must not queue a rewrite"
+        );
+    }
+
+    /// #707: a retry marker must trigger a refresh even when the stored hash
+    /// matches the provider. `mark_hidden_at_source` sets `is_hidden` without
+    /// recomputing `metadata_hash`, so after an unhide the hashes agree while
+    /// the row still reads hidden. Drift alone cannot see that.
+    #[tokio::test]
+    async fn retry_marker_refreshes_row_whose_hash_matches_but_columns_are_stale() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.set_exif_rating = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (visible, _) = drifted_asset_pair("UNHIDE", "unhide.jpg");
+        let derived = seed_downloaded_drift_asset(&db, &config, &visible).await;
+
+        // Hidden at source: the column flips, the stored hash does not.
+        db.mark_hidden_at_source("PrimarySync", visible.state_id())
+            .await
+            .unwrap();
+        db.record_metadata_write_failure(
+            "PrimarySync",
+            visible.state_id(),
+            derived.version_size.as_str(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            db.get_downloaded_page(0, 1).await.unwrap()[0]
+                .metadata
+                .is_hidden,
+            "precondition: the stored row reads hidden"
+        );
+
+        // The provider now reports it visible again, matching the stored hash.
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(visible.clone())]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.state_write_failures, 0);
+        assert!(
+            !db.get_downloaded_page(0, 1).await.unwrap()[0]
+                .metadata
+                .is_hidden,
+            "the retry marker must drive a refresh that clears the stale hidden flag"
+        );
+    }
+
+    /// #707: when the queued rewrite cannot complete, its marker must survive
+    /// for retry and the surviving row must hold the fresh provider metadata,
+    /// so the retry cannot replay stale values.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn rewrite_failure_retains_marker_holding_fresh_metadata() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let (stored, edited) = drifted_asset_pair("REWRITEFAIL", "rewritefail.jpg");
+        seed_downloaded_drift_asset(&db, &config, &stored).await;
+        db.fail_metadata_marker_clear_for_test();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.state_write_failures, 0,
+            "a local rewrite failure is not a provider-state failure"
+        );
+        let surviving = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert_eq!(
+            surviving.len(),
+            1,
+            "a failed rewrite must remain visible for retry"
+        );
+        assert!(
+            !surviving[0].metadata.is_favorite,
+            "the retained marker must point at the fresh catalogue metadata"
+        );
+
+        // A metadata-only edit downloads nothing, so the zero-download branch
+        // is the one that has to report the failure.
+        assert_eq!(result.downloaded, 0);
+        assert!(result.exif_failures > 0);
+        let (outcome, stats) = build_download_outcome(
+            &reqwest::Client::new(),
+            &[],
+            &config,
+            DownloadControls::download_hidden(),
+            result,
+            Instant::now(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(outcome, DownloadOutcome::PartialFailure { .. }),
+            "a failed rewrite must not report a clean sync, got {outcome:?}"
+        );
+        assert!(stats.exif_failures > 0);
+        assert_eq!(
+            stats.state_write_failures, 0,
+            "the checkpoint may still advance once the marker is durable"
+        );
     }
 
     /// Data-sacred regression for the trust-state fast-skip removal.

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4467,6 +4467,17 @@ mod tests {
             Ok(())
         }
 
+        async fn set_metadata_rewrite_checksums(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> Result<(), StateError> {
+            Ok(())
+        }
+
         async fn get_downloaded_metadata_hashes(
             &self,
         ) -> Result<HashMap<(String, String, String), String>, StateError> {
@@ -5717,6 +5728,109 @@ mod tests {
         assert_eq!(rewrites[0].metadata.title, None);
     }
 
+    /// #707 review: the pre-plan refresh makes embedded rewrites reachable for
+    /// a filtered downloaded asset. The drain rewrites the media, so the row
+    /// must end holding a checksum of the bytes that are now on disk, and the
+    /// pre-rewrite hash must survive as the provider download checksum.
+    #[tokio::test]
+    async fn filtered_embed_rewrite_keeps_stored_checksums_current() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.metadata.set_exif_rating = true;
+        config.filename_exclude =
+            Arc::from(vec![glob::Pattern::new("*.jpg").expect("filename pattern")]);
+        let config = Arc::new(config);
+
+        let media_path = dir.path().join("filtered-embed.jpg");
+        fs::write(
+            &media_path,
+            [
+                0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+                0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+            ],
+        )
+        .unwrap();
+        let seeded_checksum = crate::download::file::compute_sha256(&media_path)
+            .await
+            .expect("hash the seeded media");
+
+        // Stored without the favourite, so the provider edit below raises the
+        // rating and gives the embedded writer real work to do.
+        let record = crate::test_helpers::TestAssetRecord::new("FILTERED_EMBED")
+            .checksum("ck_filtered_embed")
+            .filename("filtered-embed.jpg")
+            .size(1234)
+            .metadata(AssetMetadata {
+                metadata_hash: Some("stale-hash".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "FILTERED_EMBED",
+            "original",
+            &media_path,
+            &seeded_checksum,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let edited: PhotoAsset = TestPhotoAsset::new("FILTERED_EMBED")
+            .filename("filtered-embed.jpg")
+            .item_type("public.jpeg")
+            .orig_file_type("public.jpeg")
+            .orig_size(1234)
+            .orig_url("https://p01.icloud-content.com/filtered-embed.jpg")
+            .orig_checksum("ck_filtered_embed")
+            .favorite(true)
+            .build();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(edited)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(result.downloaded, 0, "the filter must skip the media task");
+        let on_disk = crate::download::file::compute_sha256(&media_path)
+            .await
+            .expect("hash the rewritten media");
+        assert_ne!(
+            on_disk, seeded_checksum,
+            "precondition: the embedded rewrite must change the media bytes"
+        );
+
+        let row = db.get_downloaded_page(0, 1).await.unwrap().remove(0);
+        assert_eq!(
+            row.local_checksum.as_deref(),
+            Some(on_disk.as_str()),
+            "the row must record the bytes the rewrite left on disk"
+        );
+        assert_eq!(
+            row.download_checksum.as_deref(),
+            Some(seeded_checksum.as_str()),
+            "the pre-rewrite hash must survive as the provider download checksum"
+        );
+    }
+
     /// #674 regression: a metadata-only edit drifts the source hash from the
     /// stored hash. On the on-disk skip the catalogue must be refreshed to the
     /// edited source metadata (not left stale) without re-downloading, so a
@@ -5757,6 +5871,9 @@ mod tests {
             .unwrap();
         fs::create_dir_all(derived.path.parent().unwrap()).unwrap();
         fs::write(&derived.path, vec![0u8; 1000]).unwrap();
+        let seeded_checksum = crate::download::file::compute_sha256(&derived.path)
+            .await
+            .unwrap();
         let record = asset_record_for_derived_path(Arc::from("PrimarySync"), &stored, &derived);
         db.upsert_seen(&record).await.unwrap();
         db.mark_downloaded(
@@ -5764,7 +5881,7 @@ mod tests {
             stored.state_id(),
             derived.version_size.as_str(),
             &derived.path,
-            "local-checksum",
+            &seeded_checksum,
             None,
         )
         .await

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -587,6 +587,15 @@ pub trait MetadataRewriteStore: Send + Sync {
         asset_id: &str,
         version_size: &str,
     ) -> Result<(), StateError>;
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
+    async fn set_metadata_rewrite_checksums(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        local_checksum: Option<&str>,
+        pre_rewrite_checksum: Option<&str>,
+    ) -> Result<(), StateError>;
     async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError>;
 }
 
@@ -3432,6 +3441,48 @@ impl SqliteStateDb {
         .await
     }
 
+    /// Records the media hash a metadata rewrite left on disk, keeping the
+    /// rewrite marker so the caller decides when the write is complete.
+    /// `pre_rewrite_checksum` seeds `download_checksum` only when the column is
+    /// empty, so the provider's pre-metadata hash is established once and later
+    /// rewrites never overwrite it. Pass `None` for `pre_rewrite_checksum` when
+    /// those bytes were never verified against the row, because an unproven
+    /// hash would tell reconcile the file is an intentional rewrite rather than
+    /// damage. A `None` `local_checksum` records that the file changed and its
+    /// hash is unknown, which is the truth after a rewrite whose result could
+    /// not be measured, and which lets a later pass rewrite it again.
+    pub(crate) async fn set_metadata_rewrite_checksums(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        local_checksum: Option<&str>,
+        pre_rewrite_checksum: Option<&str>,
+    ) -> Result<(), StateError> {
+        let library = library.to_owned();
+        let asset_id = asset_id.to_owned();
+        let version_size = version_size.to_owned();
+        let local_checksum = local_checksum.map(str::to_owned);
+        let pre_rewrite_checksum = pre_rewrite_checksum.map(str::to_owned);
+        self.with_conn("set_metadata_rewrite_checksums", move |conn| {
+            conn.execute(
+                "UPDATE assets SET local_checksum = ?4, \
+                 download_checksum = COALESCE(download_checksum, ?5) \
+                 WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+                rusqlite::params![
+                    library,
+                    asset_id,
+                    version_size,
+                    local_checksum,
+                    pre_rewrite_checksum
+                ],
+            )
+            .map_err(|e| StateError::query("set_metadata_rewrite_checksums", e))?;
+            Ok(())
+        })
+        .await
+    }
+
     pub(crate) async fn get_downloaded_metadata_hashes(
         &self,
     ) -> Result<HashMap<(String, String, String), String>, StateError> {
@@ -4213,6 +4264,25 @@ impl MetadataRewriteStore for SqliteStateDb {
         SqliteStateDb::clear_metadata_write_failure(self, library, asset_id, version_size).await
     }
 
+    async fn set_metadata_rewrite_checksums(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+        local_checksum: Option<&str>,
+        pre_rewrite_checksum: Option<&str>,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::set_metadata_rewrite_checksums(
+            self,
+            library,
+            asset_id,
+            version_size,
+            local_checksum,
+            pre_rewrite_checksum,
+        )
+        .await
+    }
+
     async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
         SqliteStateDb::has_downloaded_without_metadata_hash(self).await
     }
@@ -4242,6 +4312,36 @@ impl SqliteStateDb {
              BEFORE UPDATE OF metadata_write_failed_at ON assets \
              WHEN NEW.metadata_write_failed_at IS NULL \
              BEGIN SELECT RAISE(FAIL, 'simulated metadata marker clear failure'); END;",
+        )
+        .unwrap();
+    }
+
+    #[cfg(feature = "xmp")]
+    pub(crate) fn fail_metadata_checksum_write_for_test(&self) {
+        let conn = self
+            .acquire_lock("test_fail_metadata_checksum_write")
+            .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TRIGGER fail_metadata_checksum_write \
+             BEFORE UPDATE OF local_checksum ON assets \
+             WHEN NEW.local_checksum IS NOT NULL \
+             BEGIN SELECT RAISE(FAIL, 'simulated rewritten checksum write failure'); END;",
+        )
+        .unwrap();
+    }
+
+    #[cfg(feature = "xmp")]
+    pub(crate) fn clear_local_checksum_for_test(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: &str,
+    ) {
+        let conn = self.acquire_lock("test_clear_local_checksum").unwrap();
+        conn.execute(
+            "UPDATE assets SET local_checksum = NULL \
+             WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+            rusqlite::params![library, asset_id, version_size],
         )
         .unwrap();
     }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -183,6 +183,12 @@ pub trait DownloadStateStore: Send + Sync {
         Ok(0)
     }
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError>;
+    /// Assets whose downloaded rows survive a provider deletion. Staleness
+    /// checks skip these, so an implementor must answer deliberately rather
+    /// than inherit an empty default.
+    async fn get_soft_deleted_downloaded_ids(
+        &self,
+    ) -> Result<HashSet<(String, String)>, StateError>;
     async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError>;
     async fn get_downloaded_checksums(
         &self,
@@ -575,13 +581,6 @@ pub trait MetadataRewriteStore: Send + Sync {
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError>;
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
-    async fn update_metadata_hash(
-        &self,
-        library: &str,
-        asset_id: &str,
-        version_size: &str,
-        metadata_hash: &str,
-    ) -> Result<(), StateError>;
     async fn clear_metadata_write_failure(
         &self,
         library: &str,
@@ -2118,6 +2117,37 @@ impl SqliteStateDb {
         .await
     }
 
+    /// Assets that still hold `status = 'downloaded'` rows after the provider
+    /// reported them deleted. Soft deletion flips every version of an asset
+    /// together, so this is keyed by asset rather than by version.
+    pub(crate) async fn get_soft_deleted_downloaded_ids(
+        &self,
+    ) -> Result<HashSet<(String, String)>, StateError> {
+        self.with_conn("get_soft_deleted_downloaded_ids", move |conn| {
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT DISTINCT library, id FROM assets \
+                     WHERE status = 'downloaded' AND is_deleted = 1",
+                )
+                .map_err(|e| StateError::query("get_soft_deleted_downloaded_ids", e))?;
+
+            let mut ids = HashSet::new();
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| StateError::query("get_soft_deleted_downloaded_ids", e))?;
+            for row in rows {
+                ids.insert(
+                    row.map_err(|e| StateError::query("get_soft_deleted_downloaded_ids", e))?,
+                );
+            }
+
+            Ok(ids)
+        })
+        .await
+    }
+
     pub(crate) async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
         self.with_conn("get_all_known_ids", move |conn| {
             let mut stmt = conn
@@ -3477,6 +3507,7 @@ impl SqliteStateDb {
                 "SELECT {ASSET_COLUMNS} FROM assets \
                  WHERE metadata_write_failed_at IS NOT NULL \
                    AND status = 'downloaded' \
+                   AND is_deleted = 0 \
                    AND local_path IS NOT NULL \
                  ORDER BY metadata_write_failed_at ASC, library, id, version_size \
                  LIMIT ?1 OFFSET ?2"
@@ -3524,29 +3555,6 @@ impl SqliteStateDb {
                 markers.insert(key);
             }
             Ok(markers)
-        })
-        .await
-    }
-
-    pub(crate) async fn update_metadata_hash(
-        &self,
-        library: &str,
-        asset_id: &str,
-        version_size: &str,
-        metadata_hash: &str,
-    ) -> Result<(), StateError> {
-        let library = library.to_owned();
-        let asset_id = asset_id.to_owned();
-        let version_size = version_size.to_owned();
-        let metadata_hash = metadata_hash.to_owned();
-        self.with_conn("update_metadata_hash", move |conn| {
-            conn.execute(
-                "UPDATE assets SET metadata_hash = ?1 \
-                 WHERE library = ?2 AND id = ?3 AND version_size = ?4",
-                rusqlite::params![metadata_hash, library, asset_id, version_size],
-            )
-            .map_err(|e| StateError::query("update_metadata_hash", e))?;
-            Ok(())
         })
         .await
     }
@@ -3657,6 +3665,12 @@ impl DownloadStateStore for SqliteStateDb {
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String, String)>, StateError> {
         SqliteStateDb::get_downloaded_ids(self).await
+    }
+
+    async fn get_soft_deleted_downloaded_ids(
+        &self,
+    ) -> Result<HashSet<(String, String)>, StateError> {
+        SqliteStateDb::get_soft_deleted_downloaded_ids(self).await
     }
 
     async fn get_all_known_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
@@ -4171,17 +4185,6 @@ impl MetadataRewriteStore for SqliteStateDb {
         limit: usize,
     ) -> Result<Vec<AssetRecord>, StateError> {
         SqliteStateDb::get_pending_metadata_rewrites_page(self, library_scope, offset, limit).await
-    }
-
-    async fn update_metadata_hash(
-        &self,
-        library: &str,
-        asset_id: &str,
-        version_size: &str,
-        metadata_hash: &str,
-    ) -> Result<(), StateError> {
-        SqliteStateDb::update_metadata_hash(self, library, asset_id, version_size, metadata_hash)
-            .await
     }
 
     async fn clear_metadata_write_failure(
@@ -8943,6 +8946,18 @@ mod tests {
                 record.metadata.metadata_hash.as_deref(),
                 Some(expected_hash.as_str())
             );
+        }
+
+        // The refresh must not disturb download state: #707 requires every
+        // live downloaded version to keep its status, local path, checksums
+        // and download timestamp while its metadata is replaced.
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 2, "both versions must remain downloaded");
+        for record in &downloaded {
+            assert_eq!(record.local_path.as_deref(), Some(Path::new("/photo.jpg")));
+            assert_eq!(record.local_checksum.as_deref(), Some("checksum"));
+            assert_eq!(record.checksum.as_ref(), "checksum123");
+            assert_eq!(record.metadata.rating, Some(4));
         }
     }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -3389,7 +3389,24 @@ impl SqliteStateDb {
                     ],
                 )
                 .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
-            Ok(updated)
+            if updated > 0 {
+                return Ok(updated);
+            }
+            // A row can leave `downloaded` mid-cycle when the provider
+            // publishes new media for the same asset, which stores the
+            // incoming metadata as it resets the row for re-download. The
+            // metadata is durable, so report the match rather than a lost
+            // write. A missing or still-stale row stays a failure.
+            let durable: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM assets \
+                     WHERE library = ?1 AND id = ?2 AND is_deleted = 0 \
+                       AND metadata_hash IS NOT NULL AND metadata_hash = ?3",
+                    rusqlite::params![library, asset_id, metadata.metadata_hash.as_deref()],
+                    |row| row.get(0),
+                )
+                .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
+            Ok(usize::try_from(durable).unwrap_or(0))
         })
         .await
     }
@@ -8774,6 +8791,57 @@ mod tests {
 
         assert_eq!(deleted, 0);
         assert_eq!(hidden, 0);
+    }
+
+    /// #707 review: new provider media returns a downloaded row to pending and
+    /// stores the incoming metadata in the same statement. A refresh that then
+    /// matches no downloaded row has still found its metadata durable, so it
+    /// must not be reported as a lost write and hold the provider checkpoint.
+    #[tokio::test]
+    async fn refresh_reports_metadata_already_durable_on_a_row_that_left_downloaded() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let mut edited = AssetMetadata {
+            is_favorite: true,
+            rating: Some(5),
+            ..AssetMetadata::default()
+        };
+        edited.refresh_hash();
+
+        let seeded = TestAssetRecord::new("MOVED_ON").checksum("ck_v1").build();
+        db.upsert_seen(&seeded).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "MOVED_ON",
+            "original",
+            std::path::Path::new("/tmp/moved-on.jpg"),
+            "local_v1",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // New media for the same asset: the row returns to pending and carries
+        // the edited metadata forward.
+        let republished = TestAssetRecord::new("MOVED_ON")
+            .checksum("ck_v2")
+            .metadata(edited.clone())
+            .build();
+        db.upsert_seen(&republished).await.unwrap();
+
+        let matched = db
+            .refresh_downloaded_asset_metadata("PrimarySync", "MOVED_ON", &edited, true)
+            .await
+            .unwrap();
+        assert!(
+            matched > 0,
+            "metadata already stored by the reset must count as durable"
+        );
+
+        let stale = db
+            .refresh_downloaded_asset_metadata("PrimarySync", "ABSENT", &edited, true)
+            .await
+            .unwrap();
+        assert_eq!(stale, 0, "a missing row is still a lost write");
     }
 
     #[tokio::test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -3712,6 +3712,11 @@ mod tests {
         per_pass_paths: bool,
         recent: Option<u32>,
         file_match_policy: Option<crate::types::FileMatchPolicy>,
+        #[cfg(feature = "xmp")]
+        xmp_sidecar: bool,
+        /// Passes run through `buffer_unordered(pass_parallelism)`, which is
+        /// capped by this, so it must exceed one for passes to overlap.
+        concurrent_downloads: Option<usize>,
     }
 
     fn media_without_photo_downloads() -> config::MediaSelection {
@@ -3763,7 +3768,14 @@ mod tests {
                 config.file_match_policy = file_match_policy;
             }
             config.media = options.media;
+            #[cfg(feature = "xmp")]
+            {
+                config.metadata.xmp_sidecar = options.xmp_sidecar;
+            }
             config.recent = options.recent;
+            if let Some(concurrent_downloads) = options.concurrent_downloads {
+                config.concurrent_downloads = concurrent_downloads;
+            }
             config.state_db = Some(Arc::clone(&db));
             config.sync_mode = sync_mode;
             config.exclude_asset_ids = exclude_asset_ids;
@@ -4270,6 +4282,13 @@ mod tests {
         fail_upsert_seen: bool,
         fail_mark_downloaded: bool,
         fail_refresh_downloaded_metadata: bool,
+        /// Stands in for a concurrent pass: refreshes the row to this snapshot
+        /// and marks it for rewrite in the window between the downloader
+        /// writing the file and the finaliser deciding the marker's fate.
+        refresh_on_mark_downloaded: Option<state::AssetMetadata>,
+        /// Counts drains: `run_pending` starts each one with an offset-zero
+        /// page fetch.
+        drains: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl std::fmt::Debug for FailingMetadataSetDb {
@@ -4300,7 +4319,14 @@ mod tests {
                 fail_upsert_seen: false,
                 fail_mark_downloaded: false,
                 fail_refresh_downloaded_metadata: false,
+                refresh_on_mark_downloaded: None,
+                drains: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
+        }
+
+        #[cfg(feature = "xmp")]
+        fn drain_counter(&self) -> Arc<std::sync::atomic::AtomicUsize> {
+            Arc::clone(&self.drains)
         }
 
         fn without_set_failure(
@@ -4336,6 +4362,12 @@ mod tests {
 
         fn with_mark_downloaded_failure(mut self) -> Self {
             self.fail_mark_downloaded = true;
+            self
+        }
+
+        #[cfg(feature = "xmp")]
+        fn with_refresh_on_mark_downloaded(mut self, metadata: state::AssetMetadata) -> Self {
+            self.refresh_on_mark_downloaded = Some(metadata);
             self
         }
 
@@ -4394,6 +4426,11 @@ mod tests {
             if self.fail_mark_downloaded {
                 return Err(state::error::StateError::LockPoisoned(self.message.into()));
             }
+            if let Some(newer) = &self.refresh_on_mark_downloaded {
+                self.inner
+                    .refresh_downloaded_asset_metadata(library, id, newer, true)
+                    .await?;
+            }
             self.inner
                 .mark_downloaded(
                     library,
@@ -4447,6 +4484,12 @@ mod tests {
         ) -> Result<std::collections::HashSet<(String, String, String)>, state::error::StateError>
         {
             self.inner.get_downloaded_ids().await
+        }
+
+        async fn get_soft_deleted_downloaded_ids(
+            &self,
+        ) -> Result<std::collections::HashSet<(String, String)>, state::error::StateError> {
+            self.inner.get_soft_deleted_downloaded_ids().await
         }
 
         async fn get_all_known_ids(
@@ -4901,20 +4944,12 @@ mod tests {
             offset: usize,
             limit: usize,
         ) -> Result<Vec<state::types::AssetRecord>, state::error::StateError> {
+            if offset == 0 {
+                self.drains
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
             self.inner
                 .get_pending_metadata_rewrites_page(library_scope, offset, limit)
-                .await
-        }
-
-        async fn update_metadata_hash(
-            &self,
-            library: &str,
-            asset_id: &str,
-            version_size: &str,
-            metadata_hash: &str,
-        ) -> Result<(), state::error::StateError> {
-            self.inner
-                .update_metadata_hash(library, asset_id, version_size, metadata_hash)
                 .await
         }
 
@@ -5942,8 +5977,6 @@ mod tests {
 
     #[tokio::test]
     async fn run_cycle_provider_metadata_write_failure_preserves_zone_checkpoint() {
-        use chrono::TimeZone as _;
-
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(10);
         let inner = make_state_db();
@@ -5952,39 +5985,7 @@ mod tests {
             .await
             .expect("seed zone token");
         let download_dir = tempfile::tempdir().expect("download tempdir");
-        let media_dir = download_dir.path().join(run_cycle_expected_date_dir());
-        std::fs::create_dir_all(&media_dir).expect("create media directory");
-        let media_path = media_dir.join("photo.jpg");
-        std::fs::write(&media_path, vec![0u8; 1024]).expect("seed media file");
-        let mut stored_metadata = state::AssetMetadata {
-            is_favorite: false,
-            ..state::AssetMetadata::default()
-        };
-        stored_metadata.refresh_hash();
-        let record = crate::test_helpers::TestAssetRecord::new("master-PrimarySync")
-            .filename("photo.jpg")
-            .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-            .created_at(
-                chrono::Utc
-                    .timestamp_millis_opt(RUN_CYCLE_ASSET_DATE_MS)
-                    .single()
-                    .expect("valid asset date"),
-            )
-            .size(1024)
-            .metadata(stored_metadata)
-            .build();
-        inner.upsert_seen(&record).await.expect("seed state row");
-        inner
-            .mark_downloaded(
-                "PrimarySync",
-                "master-PrimarySync",
-                "original",
-                &media_path,
-                "local-checksum",
-                None,
-            )
-            .await
-            .expect("mark downloaded");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
 
         let db: Arc<dyn download::DownloadStore> = Arc::new(
             FailingMetadataSetDb::without_set_failure(
@@ -5993,16 +5994,7 @@ mod tests {
             )
             .with_refresh_downloaded_metadata_failure(),
         );
-        let mut page = full_album_page_with_download(
-            "PrimarySync",
-            "master-PrimarySync",
-            "zone-tok-new",
-            "https://p01.icloud-content.com/photo.jpg",
-            1024,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        );
-        page["records"][1]["fields"]["isFavorite"] =
-            serde_json::json!({"value": 1, "type": "INT64"});
+        let page = run_cycle_favourited_asset_page();
         let album = make_full_album_with_session(
             "PrimarySync",
             crate::test_helpers::MockPhotosSession::new().ok(serde_json::json!({
@@ -6057,6 +6049,659 @@ mod tests {
                 .as_deref(),
             Some("zone-tok-prev"),
             "failed provider metadata write must preserve the replay checkpoint"
+        );
+    }
+
+    /// Seeds a downloaded asset whose stored metadata is not a favourite,
+    /// with its media file on disk, ready for the provider to report a
+    /// metadata-only edit against it.
+    async fn seed_run_cycle_metadata_drift_asset(
+        inner: &Arc<dyn download::DownloadStore>,
+        download_dir: &std::path::Path,
+    ) {
+        use chrono::TimeZone as _;
+
+        let media_dir = download_dir.join(run_cycle_expected_date_dir());
+        std::fs::create_dir_all(&media_dir).expect("create media directory");
+        let media_path = media_dir.join("photo.jpg");
+        std::fs::write(&media_path, vec![0u8; 1024]).expect("seed media file");
+
+        let mut stored_metadata = state::AssetMetadata {
+            is_favorite: false,
+            ..state::AssetMetadata::default()
+        };
+        stored_metadata.refresh_hash();
+        let record = crate::test_helpers::TestAssetRecord::new("master-PrimarySync")
+            .filename("photo.jpg")
+            .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+            .created_at(
+                chrono::Utc
+                    .timestamp_millis_opt(RUN_CYCLE_ASSET_DATE_MS)
+                    .single()
+                    .expect("valid asset date"),
+            )
+            .size(1024)
+            .metadata(stored_metadata)
+            .build();
+        inner.upsert_seen(&record).await.expect("seed state row");
+        inner
+            .mark_downloaded(
+                "PrimarySync",
+                "master-PrimarySync",
+                "original",
+                &media_path,
+                "local-checksum",
+                None,
+            )
+            .await
+            .expect("mark downloaded");
+    }
+
+    /// The same asset as `seed_run_cycle_metadata_drift_asset`, but reported
+    /// by the provider as a favourite, so its metadata drifts from the row.
+    fn run_cycle_favourited_asset_page() -> serde_json::Value {
+        let mut page = full_album_page_with_download(
+            "PrimarySync",
+            "master-PrimarySync",
+            "zone-tok-new",
+            "https://p01.icloud-content.com/photo.jpg",
+            1024,
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
+        page["records"][1]["fields"]["isFavorite"] =
+            serde_json::json!({"value": 1, "type": "INT64"});
+        page
+    }
+
+    /// The same asset carrying a caption edit instead of a favourite, so two
+    /// passes can deliver different provider snapshots of one asset and both
+    /// drift from the stored row.
+    #[cfg(feature = "xmp")]
+    fn run_cycle_captioned_asset_page() -> serde_json::Value {
+        let mut page = run_cycle_favourited_asset_page();
+        page["records"][1]["fields"]["isFavorite"] =
+            serde_json::json!({"value": 0, "type": "INT64"});
+        page["records"][1]["fields"]["captionEnc"] =
+            serde_json::json!({"value": "edited in another pass", "type": "STRING"});
+        page
+    }
+
+    /// #707: the paired single-pass streaming path must gate the zone
+    /// checkpoint on provider-metadata durability exactly as the collecting
+    /// path does. Identical to the collecting regression above but without
+    /// `recent`, which is what routes the cycle through the streaming
+    /// producer rather than collecting incremental planning.
+    #[tokio::test]
+    async fn run_cycle_single_pass_metadata_refresh_failure_preserves_zone_checkpoint() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+
+        let db: Arc<dyn download::DownloadStore> = Arc::new(
+            FailingMetadataSetDb::without_set_failure(
+                Arc::clone(&inner),
+                "simulated provider metadata write failure",
+            )
+            .with_refresh_downloaded_metadata_failure(),
+        );
+        let mut page = full_album_page_with_download(
+            "PrimarySync",
+            "master-PrimarySync",
+            "zone-tok-new",
+            "https://p01.icloud-content.com/photo.jpg",
+            1024,
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
+        // A metadata-only edit: the provider now reports the asset as a
+        // favourite while the stored row does not.
+        page["records"][1]["fields"]["isFavorite"] =
+            serde_json::json!({"value": 1, "type": "INT64"});
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new().ok(serde_json::json!({
+                "zones": [{
+                    "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                    "syncToken": "zone-tok-new",
+                    "moreComing": false,
+                    "records": page["records"].clone()
+                }]
+            })),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.stats.downloaded, 0);
+        assert!(
+            result.stats.state_write_failures > 0,
+            "the streaming producer must report the failed refresh as non-durable state"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "a failed provider metadata refresh must preserve the replay checkpoint"
+        );
+    }
+
+    /// #707: the single-pass streaming path must advance the zone checkpoint
+    /// once the refreshed provider metadata is durable, applying the edit
+    /// without downloading media.
+    #[tokio::test]
+    async fn run_cycle_single_pass_metadata_refresh_advances_checkpoint_after_durable_state() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+
+        let db: Arc<dyn download::DownloadStore> =
+            Arc::clone(&inner) as Arc<dyn download::DownloadStore>;
+        let page = run_cycle_favourited_asset_page();
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new().ok(serde_json::json!({
+                "zones": [{
+                    "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                    "syncToken": "zone-tok-new",
+                    "moreComing": false,
+                    "records": page["records"].clone()
+                }]
+            })),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(
+            result.stats.downloaded, 0,
+            "a metadata-only edit downloads nothing"
+        );
+        assert_eq!(result.stats.state_write_failures, 0);
+        assert!(
+            inner.get_downloaded_page(0, 1).await.unwrap()[0]
+                .metadata
+                .is_favorite,
+            "the edited provider metadata must reach the catalogue"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-new"),
+            "durable provider state must allow the zone checkpoint to advance"
+        );
+    }
+
+    /// Runs one full-enumeration cycle with XMP sidecars enabled over a
+    /// downloaded asset the provider now reports as a favourite.
+    #[cfg(feature = "xmp")]
+    async fn run_full_enumeration_metadata_cycle(
+        inner: &Arc<dyn download::DownloadStore>,
+        download_dir: &std::path::Path,
+        per_pass_paths: bool,
+        controls: download::DownloadControls,
+    ) -> crate::sync_cycle::CycleResult {
+        let config = make_run_cycle_config();
+        let db: Arc<dyn download::DownloadStore> = Arc::clone(inner);
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(run_cycle_favourited_asset_page()),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir,
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                xmp_sidecar: true,
+                per_pass_paths,
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            controls,
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle")
+    }
+
+    /// #707 review: both enumeration branches defer their queue, so a full
+    /// enumeration drains once. A second drain in the same cycle would retry a
+    /// failed rewrite immediately and report it twice.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn run_cycle_full_enumeration_reports_a_failed_rewrite_once() {
+        for per_pass_paths in [false, true] {
+            let inner = make_state_db();
+            let download_dir = tempfile::tempdir().expect("download tempdir");
+            seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+            // A directory where the sidecar belongs makes the rewrite fail.
+            std::fs::create_dir(
+                download_dir
+                    .path()
+                    .join(run_cycle_expected_date_dir())
+                    .join("photo.jpg.xmp"),
+            )
+            .expect("block the sidecar path");
+
+            let result = run_full_enumeration_metadata_cycle(
+                &inner,
+                download_dir.path(),
+                per_pass_paths,
+                download::DownloadControls::download_hidden(),
+            )
+            .await;
+
+            assert_eq!(
+                result.stats.exif_failures, 1,
+                "one failing rewrite must be attempted and reported once (per_pass_paths = {per_pass_paths})"
+            );
+            assert!(
+                !inner
+                    .get_pending_metadata_rewrites_page(None, 0, 10)
+                    .await
+                    .expect("read markers")
+                    .is_empty(),
+                "the marker must survive for the next run to retry"
+            );
+        }
+    }
+
+    /// #707 review: the interleaving the maintainer described. Two passes run
+    /// concurrently over one asset carrying different provider snapshots. They
+    /// must share one drain, so a single writer owns the file, and the sidecar
+    /// must agree with whichever snapshot the row settled on with no marker
+    /// left claiming otherwise.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn run_cycle_two_passes_over_one_asset_leave_the_sidecar_matching_the_row() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+
+        let counting = FailingMetadataSetDb::without_set_failure(
+            Arc::clone(&inner),
+            "__unused_metadata_message__",
+        );
+        let drains = counting.drain_counter();
+        let db: Arc<dyn download::DownloadStore> = Arc::new(counting);
+        let pass = |name: &str, page: serde_json::Value| crate::commands::AlbumPass {
+            kind: crate::commands::PassKind::Album,
+            album: make_named_full_album_with_boxed_session(
+                "PrimarySync",
+                name,
+                Box::new(
+                    crate::test_helpers::MockPhotosSession::new()
+                        .ok(album_count_response(1))
+                        .ok(page),
+                ),
+            ),
+            exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+        };
+        let lib_state = make_run_cycle_library_state_with_passes(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            vec![
+                pass("Favourited", run_cycle_favourited_asset_page()),
+                pass("Captioned", run_cycle_captioned_asset_page()),
+            ],
+        );
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                xmp_sidecar: true,
+                per_pass_paths: true,
+                concurrent_downloads: Some(2),
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        let stored = inner
+            .get_downloaded_page(0, 10)
+            .await
+            .expect("read downloaded rows");
+        let row = stored.first().expect("the asset stays downloaded");
+        let sidecar = std::fs::read_to_string(
+            download_dir
+                .path()
+                .join(run_cycle_expected_date_dir())
+                .join("photo.jpg.xmp"),
+        )
+        .expect("the drain writes a sidecar");
+
+        assert_eq!(
+            drains.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the passes must share one drain, so a single writer owns the file"
+        );
+        assert_eq!(
+            sidecar.contains("<xmp:Rating>5</xmp:Rating>"),
+            row.metadata.rating == Some(5),
+            "the sidecar must hold the snapshot the row settled on: {sidecar}"
+        );
+        assert!(
+            inner
+                .get_metadata_retry_markers()
+                .await
+                .expect("read markers")
+                .is_empty(),
+            "no marker may survive a completed drain"
+        );
+    }
+
+    /// #707 review: a forwarded download writes the snapshot it was planned
+    /// from. If a concurrent pass has since refreshed the row and raised a
+    /// marker, the finaliser must not retire it, or the row keeps the new
+    /// metadata while the file keeps the old and nothing is left to repair it.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn run_cycle_download_does_not_retire_a_marker_raised_for_newer_metadata() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = crate::start_wiremock_or_skip!();
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+
+        // The row stays downloaded but its file is gone, so the media task is
+        // forwarded rather than skipped as already on disk.
+        let media_path = download_dir
+            .path()
+            .join(run_cycle_expected_date_dir())
+            .join("photo.jpg");
+        std::fs::remove_file(&media_path).expect("remove the media file");
+
+        let mut newer = state::AssetMetadata {
+            is_favorite: true,
+            rating: Some(5),
+            ..state::AssetMetadata::default()
+        };
+        newer.refresh_hash();
+        let db: Arc<dyn download::DownloadStore> = Arc::new(
+            FailingMetadataSetDb::without_set_failure(
+                Arc::clone(&inner),
+                "__unused_metadata_message__",
+            )
+            .with_refresh_on_mark_downloaded(newer),
+        );
+
+        let body = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        Mock::given(method("GET"))
+            .and(path("/photo.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(full_album_page_with_download(
+                    "PrimarySync",
+                    "master-PrimarySync",
+                    "zone-tok-new",
+                    &format!("{}/photo.jpg", server.uri()),
+                    body.len() as u64,
+                    // The provider reports the stored version, so the media
+                    // task is forwarded only because the file is missing. A
+                    // different checksum would make this a new version and
+                    // return the row to pending, which is a separate flow.
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                )),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                xmp_sidecar: true,
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        let row = inner
+            .get_downloaded_page(0, 10)
+            .await
+            .expect("read downloaded rows")
+            .into_iter()
+            .next()
+            .expect("the asset stays downloaded");
+        assert_eq!(
+            row.metadata.rating,
+            Some(5),
+            "precondition: the racing pass leaves the newer snapshot on the row"
+        );
+
+        let published = row.local_path.as_deref().expect("the download published");
+        let mut sidecar_name = published.file_name().expect("a file name").to_os_string();
+        sidecar_name.push(".xmp");
+        let sidecar = std::fs::read_to_string(published.with_file_name(sidecar_name))
+            .expect("sidecar written next to the media file");
+        assert!(
+            sidecar.contains("<xmp:Rating>5</xmp:Rating>"),
+            "the file must end on the snapshot the row holds: {sidecar}"
+        );
+    }
+
+    /// #707 review: deferring the drain moved it outside the pipeline, which
+    /// returns early for the read-only run modes. The drain writes sidecars,
+    /// so it must stay behind the same gate.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn run_cycle_full_enumeration_writes_no_metadata_in_read_only_modes() {
+        for controls in [
+            download::DownloadControls::dry_run_hidden(),
+            download::DownloadControls::new(
+                download::DownloadRunMode::PrintFilenames,
+                download::DownloadReporting::hidden(),
+            ),
+        ] {
+            let inner = make_state_db();
+            let download_dir = tempfile::tempdir().expect("download tempdir");
+            seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+            inner
+                .record_metadata_write_failure("PrimarySync", "master-PrimarySync", "original")
+                .await
+                .expect("queue a rewrite");
+
+            run_full_enumeration_metadata_cycle(&inner, download_dir.path(), false, controls).await;
+
+            assert!(
+                !download_dir
+                    .path()
+                    .join(run_cycle_expected_date_dir())
+                    .join("photo.jpg.xmp")
+                    .exists(),
+                "a read-only run must not write a sidecar"
+            );
+            assert!(
+                !inner
+                    .get_pending_metadata_rewrites_page(None, 0, 10)
+                    .await
+                    .expect("read markers")
+                    .is_empty(),
+                "a read-only run must not retire the marker"
+            );
+        }
+    }
+
+    /// #707: the full-enumeration path shares the streaming producer with the
+    /// single-pass path, so a failed provider-metadata refresh must equally
+    /// stop the zone checkpoint from being stored.
+    #[tokio::test]
+    async fn run_cycle_full_enumeration_metadata_refresh_failure_preserves_zone_checkpoint() {
+        let config = make_run_cycle_config();
+        let inner = make_state_db();
+        // No seeded zone token, so the cycle runs a full enumeration.
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&inner, download_dir.path()).await;
+
+        let db: Arc<dyn download::DownloadStore> = Arc::new(
+            FailingMetadataSetDb::without_set_failure(
+                Arc::clone(&inner),
+                "simulated provider metadata write failure",
+            )
+            .with_refresh_downloaded_metadata_failure(),
+        );
+        let page = run_cycle_favourited_asset_page();
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(page),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(
+            result.stats.full_enumeration_reason,
+            Some(download::FullEnumerationReason::NoStoredToken),
+            "this regression must exercise the full-enumeration path"
+        );
+        assert!(
+            result.stats.state_write_failures > 0,
+            "the full-enumeration producer must report the failed refresh as non-durable state"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token"),
+            None,
+            "a failed provider metadata refresh must not store a zone checkpoint"
         );
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4289,6 +4289,9 @@ mod tests {
         /// Counts drains: `run_pending` starts each one with an offset-zero
         /// page fetch.
         drains: Arc<std::sync::atomic::AtomicUsize>,
+        /// Fails the rewritten-media checksum write so a drain can be driven
+        /// into the window where the file changed but the row has not caught up.
+        fail_metadata_checksum_write: bool,
     }
 
     impl std::fmt::Debug for FailingMetadataSetDb {
@@ -4321,6 +4324,7 @@ mod tests {
                 fail_refresh_downloaded_metadata: false,
                 refresh_on_mark_downloaded: None,
                 drains: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                fail_metadata_checksum_write: false,
             }
         }
 
@@ -4961,6 +4965,28 @@ mod tests {
         ) -> Result<(), state::error::StateError> {
             self.inner
                 .clear_metadata_write_failure(library, asset_id, version_size)
+                .await
+        }
+
+        async fn set_metadata_rewrite_checksums(
+            &self,
+            library: &str,
+            asset_id: &str,
+            version_size: &str,
+            local_checksum: Option<&str>,
+            pre_rewrite_checksum: Option<&str>,
+        ) -> Result<(), state::error::StateError> {
+            if self.fail_metadata_checksum_write {
+                return Err(state::error::StateError::LockPoisoned(self.message.into()));
+            }
+            self.inner
+                .set_metadata_rewrite_checksums(
+                    library,
+                    asset_id,
+                    version_size,
+                    local_checksum,
+                    pre_rewrite_checksum,
+                )
                 .await
         }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -308,6 +308,7 @@ pub struct TestPhotoAsset {
     orig_checksum: String,
     orig_file_type: String,
     asset_date: f64,
+    favorite: bool,
     live_photo: Option<LivePhotoFields>,
     adjusted_version: Option<AdjustedVersionFields>,
     live_adjusted: Option<LivePhotoFields>,
@@ -345,6 +346,7 @@ impl TestPhotoAsset {
             orig_checksum: "abc123".to_string(),
             orig_file_type: "public.jpeg".to_string(),
             asset_date: 1736899200000.0,
+            favorite: false,
             live_photo: None,
             adjusted_version: None,
             live_adjusted: None,
@@ -384,6 +386,12 @@ impl TestPhotoAsset {
 
     pub fn asset_date(mut self, d: f64) -> Self {
         self.asset_date = d;
+        self
+    }
+
+    /// Toggle the source favourite flag, which iCloud maps to a 5-star rating.
+    pub fn favorite(mut self, favorite: bool) -> Self {
+        self.favorite = favorite;
         self
     }
 
@@ -484,7 +492,10 @@ impl TestPhotoAsset {
             "fields": fields,
         });
         let asset = json!({
-            "fields": {"assetDate": {"value": self.asset_date}},
+            "fields": {
+                "assetDate": {"value": self.asset_date},
+                "isFavorite": {"value": i64::from(self.favorite)},
+            },
         });
         PhotoAsset::new(master, asset)
     }


### PR DESCRIPTION
## Summary

A metadata-only iCloud edit leaves the media bytes unchanged, so the full-enumeration and paired single-pass paths skipped the asset as already on disk and left the stored catalogue holding the previous values. A queued rewrite then replayed those stale values into the sidecar or EXIF.

Both paths share the streaming producer, so changed provider metadata is applied there, before filtering and path planning. The refresh reaches every live downloaded version even when the media task is filtered or skipped as on disk, and reuses the atomic state operation from #686 so the catalogue row and the rewrite marker commit together. It triggers on hash drift, on a retry marker, or on a forced refresh: source-state transitions such as `mark_hidden_at_source` write hashed columns without recomputing `metadata_hash`, so a matching hash alone does not prove the row current.

Three further defects surfaced while proving that work, all fixed here because this change makes each of them reachable:

- Assets the provider deleted are excluded from both staleness checks. Their rows cannot be refreshed while the deletion stands, so reporting them raised a failure every cycle and held the zone checkpoint permanently. The collecting path from #706 shares those checks and is covered too.
- The unscoped pending-rewrite query did not exclude deleted rows while its scoped counterpart did. A marker outstanding when a deletion arrived therefore drained against the frozen row and published stale values.
- Metadata rewrite failures were dropped when a sync downloaded nothing, which is exactly what a metadata-only edit cycle does, so a failed sidecar write reported success.

The on-disk-skip backfill is removed. The pre-plan refresh covers every path it did, over a wider set of triggers, in one atomic write instead of two.

Starting point: `teh-hippo/kei@d275050`, cited by the issue. Its drift detection and happy-path regression intent are retained; its separate marker and `upsert_seen` sequence is replaced by the shared atomic operation, as the issue asked.

Refs #707, #674

## Contract and risk

Affected contracts: `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY`, since a failed or zero-row refresh now feeds `state_write_failures`; and `METADATA_WRITES_REQUIRE_OPT_IN`, since a rewrite is queued only when a local metadata writer is enabled while the catalogue always refreshes. `scripts/check-contracts` passes.

Behaviour changes worth calling out:

- Rewrite markers are now set on drift during ordinary syncs with writers enabled, not only under `--refresh-metadata`. This is the intended fix and matches #706.
- Rows predating the metadata hash read as drift, so the first sync after upgrade marks those assets for rewrite. The 500-per-batch limit spreads it over several cycles, but large libraries will notice.
- A filtered asset still has its catalogue refreshed and its sidecar rewritten. Acceptance criterion 4 requires this.
- `drain_scope_skips_unselected_and_soft_deleted_failures` asserted that a deleted row stays listed for rewrite. That is the behaviour being fixed, so it now asserts the row is not offered. Its library-scope half is unchanged.

Follow-ups, not included here:

- Hashed columns are mutated without recomputing `metadata_hash` (`mark_hidden_at_source`, the soft-delete paths). This is the root cause behind the retry-marker trigger; fixing it would let that trigger go.
- Restoring a deleted asset does not clear its deletion record. True on `main` today and unaffected either way.
- The streaming asset-only path refreshes metadata and then hands the same asset to the producer, which refreshes it again. A harmless duplicate write, but removing it risks changing dry-run behaviour.

Review: three independent reviewers across two model families, cycled to unanimous approval. Two of them initially passed the restore regression below on reasoning alone; it was caught by measurement, which is why every fix here is proven by reverting it.

## Test plan

```
cargo test --all-features          # 14 binaries, 2907 lib tests
cargo test --no-default-features   # 14 binaries, 2814 lib tests
cargo fmt --all --check
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --no-default-features -- -D warnings
scripts/check-contracts
just test scenario identity-deltas
just test scenario path-family
```

Acceptance criteria from the issue, each with its test:

1. Full enumeration refreshes catalogue and sidecar with zero downloads: `on_disk_skip_refreshes_catalogue_on_metadata_drift`, `metadata_drift_writes_fresh_value_into_the_sidecar`
2. Outputs disabled, catalogue only: `metadata_drift_without_writers_refreshes_catalogue_and_queues_nothing`
3. Single-pass advances after durable state: `run_cycle_single_pass_metadata_refresh_advances_checkpoint_after_durable_state`
4. Filtered media task still refreshes: `metadata_drift_refreshes_when_media_task_is_filtered`
5. Every version in one transaction: `refresh_downloaded_asset_metadata_updates_every_live_downloaded_version`
6. Failure preserves prior state and checkpoint: `metadata_drift_refresh_failure_preserves_state_and_reports_not_durable`
7. Both paths through `run_cycle`: `run_cycle_single_pass_metadata_refresh_failure_preserves_zone_checkpoint`, `run_cycle_full_enumeration_metadata_refresh_failure_preserves_zone_checkpoint`
8. Rewrite failure keeps a marker holding fresh metadata: `rewrite_failure_retains_marker_holding_fresh_metadata`
9. Unchanged metadata is a no-op: `unchanged_metadata_performs_no_catalogue_write`

Deleted-asset behaviour: `restored_soft_deleted_asset_is_skipped_without_downloading`, `restored_and_edited_asset_does_not_report_unsafe_state`, `restored_asset_is_not_rewritten_from_the_stale_catalogue`, `marker_predating_a_deletion_is_not_drained`, `staleness_checks_ignore_soft_deleted_assets`.

`just gate` does not pass, and does not pass on a clean `origin/main` either. `lint-scripts` reports pre-existing shellcheck warnings in `tests/shell/`, and clippy flags `src/icloud/photos/queries.rs:234` under Rust 1.97 while CI pins 1.94.1. That file is untouched here. Every other gate step passes, run individually and listed above.

## Regression proof

Each fix was confirmed by reverting it and observing the failure:

- Producer refresh reverted to the `--refresh-metadata` condition: 9 tests fail, including both `run_cycle` checkpoint assertions.
- Drain query filter removed: `marker_predating_a_deletion_is_not_drained` and `restored_asset_is_not_rewritten_from_the_stale_catalogue` fail, writing a sidecar for a tombstoned row.
- Staleness exclusion removed: `restored_and_edited_asset_does_not_report_unsafe_state` and `staleness_checks_ignore_soft_deleted_assets` fail.
- Rewrite-failure reporting removed: `rewrite_failure_retains_marker_holding_fresh_metadata` fails with the sync reporting `Success` despite a failed write.

The restore regression was measured directly before it was fixed. Seeding a downloaded asset, soft-deleting it, then enumerating it live gave `on_disk_skips=0` with the asset queued for download; without the defect it gives `on_disk_skips=1` and nothing queued. On the default file-match policy that produced a suffixed duplicate beside the original.

`unchanged_metadata_performs_no_catalogue_write` passes with the fix reverted, by design: it guards against over-refreshing rather than proving the fix.

## Checklist

- [ ] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
