### PR TITLE
Download the adjusted video of an edited Live Photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Edited Live Photos now download their adjusted motion video. `LiveAdjusted` resolved `resVidFullRes`, which Apple only populates on video assets, so the adjusted video was never found and an edited Live Photo arrived as a still with no companion `.MOV`. A photo asset exposes it as `resVidComplRes` on the CPLAsset, which was also missing from `desiredKeys`. Existing libraries need one `kei reset sync-token --yes` to revisit already-synced assets. ([#713])
+
+[#713]: https://github.com/rhoopr/kei/issues/713
+
 ## [0.23.0] - 2026-08-01
 
 ### Added

--- a/docs/synctoken-reference.md
+++ b/docs/synctoken-reference.md
@@ -471,6 +471,7 @@ There are 11 resource size variants on CPLMaster records. Not all variants are p
 | `resOriginal` | Original full-resolution file | All photos and videos |
 | `resOriginalAlt` | Alternative original (e.g., RAW+JPEG pair) | Photos with alternative originals |
 | `resOriginalVidCompl` | "Video Complement" - the motion video of a Live Photo | Live Photos only |
+| `resVidCompl` | The adjusted motion video of an edited Live Photo (CPLAsset) | Edited Live Photos only |
 | `resJPEGFull` | Full-size JPEG rendition (also the edited/adjusted version) | Photos |
 | `resJPEGLarge` | Large JPEG rendition | Photos |
 | `resJPEGMed` | Medium JPEG rendition | Photos |
@@ -485,7 +486,7 @@ Photos and videos use different subsets of these variants:
 | Asset type | Resource variants |
 |------------|------------------|
 | Standard photo | `resOriginal`, `resOriginalAlt`, `resJPEGFull`, `resJPEGLarge`, `resJPEGMed`, `resJPEGThumb`, `resSidecar` |
-| Live Photo | All photo variants + `resOriginalVidCompl`, `resVidMed`, `resVidSmall` |
+| Live Photo | All photo variants + `resOriginalVidCompl`, `resVidCompl` (when edited), `resVidMed`, `resVidSmall` |
 | Video | `resOriginal`, `resVidFull`, `resVidMed`, `resVidSmall` |
 
 ### Version Size Mapping
@@ -501,6 +502,7 @@ For download purposes, logical version names map to resource field prefixes:
 | Adjusted | `resJPEGFull` | Apple's pre-rendered edited version |
 | Medium | `resJPEGMed` | Medium JPEG |
 | Thumb | `resJPEGThumb` | Thumbnail JPEG |
+| LiveAdjusted | `resVidCompl` | Apple's pre-rendered edited Live Photo video |
 | LiveOriginal | `resOriginalVidCompl` | Live Photo video (original quality) |
 | LiveMedium | `resVidMed` | Live Photo video (medium quality) |
 | LiveThumb | `resVidSmall` | Live Photo video (small/thumbnail) |
@@ -680,6 +682,7 @@ resOriginalWidth, resOriginalHeight, resOriginalFileType, resOriginalFingerprint
 resOriginalAltWidth, resOriginalAltHeight, resOriginalAltFileType, resOriginalAltFingerprint, resOriginalAltRes,
 resOriginalVidComplWidth, resOriginalVidComplHeight, resOriginalVidComplFileType,
 resOriginalVidComplFingerprint, resOriginalVidComplRes,
+resVidComplWidth, resVidComplHeight, resVidComplFileType, resVidComplFingerprint, resVidComplRes,
 isDeleted, isExpunged, dateExpunged, remappedRef,
 recordName, recordType, recordChangeTag,
 masterRef, adjustmentRenderType,

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -4019,12 +4019,12 @@ mod tests {
                     "fileChecksum": "live_med_ck"
                 }},
                 "resVidMedFileType": {"value": "com.apple.quicktime-movie"},
-                "resVidFullRes": {"value": {
+                "resVidComplRes": {"value": {
                     "size": 2500_u64,
                     "downloadURL": "https://p01.icloud-content.com/live_adjusted",
                     "fileChecksum": "live_adjusted_ck"
                 }},
-                "resVidFullFileType": {"value": "com.apple.quicktime-movie"}
+                "resVidComplFileType": {"value": "com.apple.quicktime-movie"}
             }}),
             json!({"fields": {"assetDate": {"value": 1_736_899_200_000.0_f64}}}),
         );
@@ -4044,6 +4044,50 @@ mod tests {
         );
         assert_eq!(&*paths[1].checksum, "live_adjusted_ck");
         assert_eq!(&*paths[2].checksum, "live_med_ck");
+    }
+
+    #[test]
+    fn live_edited_extra_reads_vidcompl_not_vidfull() {
+        let asset = PhotoAsset::new(
+            json!({"recordName": "PR4_LIVE_EDITED_VIDCOMPL", "fields": {
+                "filenameEnc": {"value": "IMG_LIVE_EDITED.HEIC", "type": "STRING"},
+                "itemType": {"value": "public.heic"},
+                "resOriginalRes": {"value": {
+                    "size": 4000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/heic_orig",
+                    "fileChecksum": "heic_ck"
+                }},
+                "resOriginalFileType": {"value": "public.heic"},
+                "resOriginalVidComplRes": {"value": {
+                    "size": 3000_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_orig",
+                    "fileChecksum": "live_orig_ck"
+                }},
+                "resOriginalVidComplFileType": {"value": "com.apple.quicktime-movie"},
+                "resVidComplRes": {"value": {
+                    "size": 2500_u64,
+                    "downloadURL": "https://p01.icloud-content.com/live_adjusted",
+                    "fileChecksum": "live_adjusted_ck"
+                }},
+                "resVidComplFileType": {"value": "com.apple.quicktime-movie"},
+                "resVidFullRes": {"value": {
+                    "size": 2400_u64,
+                    "downloadURL": "https://p01.icloud-content.com/vid_full",
+                    "fileChecksum": "vid_full_ck"
+                }},
+                "resVidFullFileType": {"value": "com.apple.quicktime-movie"}
+            }}),
+            json!({"fields": {"assetDate": {"value": 1_736_899_200_000.0_f64}}}),
+        );
+        let mut config = test_config();
+        config.edited = true;
+
+        let paths = expected_paths_for(&asset, &config);
+        let adjusted = paths
+            .iter()
+            .find(|path| path.version_size == VersionSizeKey::LiveAdjusted)
+            .expect("edited live photo must yield a LiveAdjusted task");
+        assert_eq!(&*adjusted.checksum, "live_adjusted_ck");
     }
 
     #[test]

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -68,6 +68,11 @@ pub(crate) const DESIRED_KEYS: &[&str] = &[
     "resOriginalVidComplFileType",
     "resOriginalVidComplFingerprint",
     "resOriginalVidComplRes",
+    "resVidComplWidth",
+    "resVidComplHeight",
+    "resVidComplFileType",
+    "resVidComplFingerprint",
+    "resVidComplRes",
     "isDeleted",
     "isExpunged",
     "dateExpunged",
@@ -171,10 +176,13 @@ pub(crate) const PHOTO_VERSION_LOOKUP: &[(AssetVersionSize, &str, &str)] = &[
         "resJPEGFullRes",
         "resJPEGFullFileType",
     ),
+    // `resVidFull` is the video-asset spelling of an adjusted rendition; a
+    // photo asset's adjusted live video is `resVidCompl` on the CPLAsset,
+    // mirroring `resOriginalVidCompl` on the CPLMaster.
     (
         AssetVersionSize::LiveAdjusted,
-        "resVidFullRes",
-        "resVidFullFileType",
+        "resVidComplRes",
+        "resVidComplFileType",
     ),
     (
         AssetVersionSize::LiveOriginal,
@@ -446,6 +454,32 @@ mod tests {
                 "Missing critical field: {field}"
             );
         }
+    }
+
+    #[test]
+    fn live_adjusted_maps_to_the_photo_asset_vidcompl_fields() {
+        let (_, res_field, type_field) = PHOTO_VERSION_LOOKUP
+            .iter()
+            .find(|(size, ..)| *size == AssetVersionSize::LiveAdjusted)
+            .expect("LiveAdjusted must be mapped");
+        assert_eq!(*res_field, "resVidComplRes");
+        assert_eq!(*type_field, "resVidComplFileType");
+        for field in ["resVidComplRes", "resVidComplFileType"] {
+            assert!(
+                DESIRED_KEYS.contains(&field),
+                "LiveAdjusted field not requested: {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn adjusted_video_asset_still_maps_to_the_vidfull_fields() {
+        let (_, res_field, type_field) = VIDEO_VERSION_LOOKUP
+            .iter()
+            .find(|(size, ..)| *size == AssetVersionSize::Adjusted)
+            .expect("Adjusted must be mapped");
+        assert_eq!(*res_field, "resVidFullRes");
+        assert_eq!(*type_field, "resVidFullFileType");
     }
 
     #[test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -462,12 +462,12 @@ impl TestPhotoAsset {
         }
 
         if let Some(lp) = &self.live_adjusted {
-            fields["resVidFullRes"] = json!({"value": {
+            fields["resVidComplRes"] = json!({"value": {
                 "size": lp.size,
                 "downloadURL": lp.url,
                 "fileChecksum": lp.checksum,
             }});
-            fields["resVidFullFileType"] = json!({"value": "com.apple.quicktime-movie"});
+            fields["resVidComplFileType"] = json!({"value": "com.apple.quicktime-movie"});
         }
 
         if let Some(alt) = &self.alt_version {


### PR DESCRIPTION
Fixes #713

## What changed

`PHOTO_VERSION_LOOKUP` resolved `AssetVersionSize::LiveAdjusted` to `resVidFullRes`. Apple only populates `resVidFull*` on video assets - on a photo asset the adjusted live video is `resVidComplRes` on the CPLAsset, mirroring `resOriginalVidComplRes` on the CPLMaster. Because the field was never found (and was not in `desiredKeys` either), an edited Live Photo downloaded as a still with no companion `.MOV`, and no `live_adjusted` state row was ever written.

The mapping now points at `resVidCompl*`, and those five fields were added to `DESIRED_KEYS`. `VIDEO_VERSION_LOOKUP` still uses `resVidFull*` for `Adjusted`, which is correct for video assets and is now covered by a test.

Everything downstream - `select_live_edited_extra`, `derive_live_edited_extra`, state, and path derivation - was already correct and needed no change.

## Evidence

I dumped raw `/records/query` responses for my library with the `desiredKeys` projection removed, so CloudKit returned every field. Across every edited Live Photo:

- `resVidComplRes` present on the CPLAsset: **18 of 18** edits
- `resVidFullRes` present: **0 of 19** CPLAssets

For a Live Photo whose edit rotates the framing (CPLMaster `AZD7/30IK0sfsGfCfrE14Hz/j086`), the master carries `resOriginalVidComplRes` 1744x1308 / 3,680,979 B and the asset carries `resVidComplRes` 1308x1744 / 4,333,319 B. I downloaded the latter: it is real HEVC, byte-exact to `resVidComplFileSize`, with `Rotation 90` where the original live video has `Rotation 0`, and its `ContentIdentifier` is the *edited* still's, not the original's. So it is unambiguously the edit's motion half, rendered to the edit's framing.

A colour-only edit (no framing change) also gets its own `resVidComplRes`: same dimensions as the original, different fingerprint and length (1.69 s vs 1.76 s), i.e. re-encoded with the edit baked in.

Built at v0.23.0 with the mapping changed and dry-run against a copy of a real session, every affected asset picks up its adjusted video:

```text
[DRY RUN] Would download path=.../IMG_1698.HEIC
[DRY RUN] Would download path=.../IMG_1698_edited.HEIC
[DRY RUN] Would download path=.../IMG_1698_edited.MOV      <- new
[DRY RUN] Would download path=.../IMG_1698_HEVC.MOV
```

## Tests

- `queries::live_adjusted_maps_to_the_photo_asset_vidcompl_fields` - the mapping and its `DESIRED_KEYS` entries
- `queries::adjusted_video_asset_still_maps_to_the_vidfull_fields` - guards the video path from this change
- `filter::live_edited_extra_reads_vidcompl_not_vidfull` - a record carrying **both** fields still selects the `resVidCompl` asset

Ran `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` on the pinned 1.94.1 toolchain: fmt and clippy clean, 2890 pass. Four keyring/permission tests fail in my container because it runs as root with no D-Bus; they fail identically on an unmodified `main`, so they are environmental.

## Risk and migration

No state, checkpoint, or serialization change; this only widens the requested field set and corrects one field name. The new download is additive - the still and the original live video are unaffected.

Existing libraries need one `kei reset sync-token --yes` after upgrading, because there is no `live_adjusted` state row to invalidate and incremental syncs skip unchanged assets. Worth calling out in the release notes.

## One question

The adjusted companion derives as `IMG_1698_edited.MOV` while the original companion is `IMG_1698_HEVC.MOV`. Consumers pairing by filename stem plus a known suffix might expect `IMG_1698_edited_HEVC.MOV`. I left the existing derivation alone since it is what `derive_live_edited_extra` already produced - happy to change it if you would rather have the symmetry.
