### PR TITLE
Add `kei reset session`: discard the local session and trust tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `kei reset session` discards the local iCloud session — the cookie jar, the persisted session, and the response cache, including trust tokens — so the next `kei login` runs a clean password + 2FA flow. The stored password and the state database are kept, and a running kei instance blocks the reset via the per-account session lock. Without `--yes` it prompts on a TTY and errors under non-interactive use, matching `reset sync-token`. ([PR #717], fixes [issue #716])
+
+[issue #716]: https://github.com/rhoopr/kei/issues/716
+[PR #717]: https://github.com/rhoopr/kei/pull/717
+
 ## [0.23.0] - 2026-08-01
 
 ### Added

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -470,6 +470,19 @@ pub enum ResetCommand {
         #[arg(long, short = 'y')]
         yes: bool,
     },
+    /// Discard the local iCloud session, including trust tokens.
+    ///
+    /// Removes the cookie jar, persisted session, and response cache for the
+    /// configured account, so the next `kei login` runs the full password +
+    /// 2FA flow again. The stored password (`kei password`) and the state
+    /// database are kept. Useful when Apple rejects 2FA pushes for a stale
+    /// session. Without `--yes`, prompts for confirmation on a TTY and
+    /// errors out under non-interactive use, matching `reset sync-token`.
+    Session {
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
 }
 
 /// Config management actions.
@@ -611,7 +624,7 @@ pub enum Command {
         action: PasswordAction,
     },
 
-    /// Reset state database or sync tokens
+    /// Reset state database, sync tokens, or the local session
     #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Reset")]
     Reset {
         #[command(subcommand)]
@@ -1380,6 +1393,39 @@ mod tests {
             cli.command,
             Command::Reset {
                 what: ResetCommand::SyncToken { yes: true },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: false },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session_with_yes() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: true },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session_with_short_y() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: true },
             }
         ));
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use login::run_login;
 pub(crate) use manifest::run_manifest;
 pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
-pub(crate) use reset::{run_reset_state, run_reset_sync_token};
+pub(crate) use reset::{run_reset_session, run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
     AlbumPass, AlbumPlan, CollectionContext, MAX_REAUTH_ATTEMPTS, PassKind, PassScope,
     attempt_reauth, build_collection_context, collection_libraries, init_photos_service,

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -3,6 +3,13 @@
     reason = "CLI subcommand whose primary purpose is to print reset status to stdout"
 )]
 
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use fs4::fs_std::FileExt;
+
+use crate::auth;
+use crate::cli;
 use crate::config;
 use crate::state;
 
@@ -103,4 +110,207 @@ pub(crate) async fn run_reset_sync_token(
     );
 
     Ok(())
+}
+
+/// Session artifacts for `username` inside `cookie_directory`, in removal
+/// order: the cookie jar, the persisted session, and the response cache.
+///
+/// The password store (`<user>.credential`) and the state database are
+/// deliberately excluded: `reset session` discards Apple session state
+/// (including trust tokens) only, so `kei login` can mint a clean session
+/// afterwards.
+fn session_files(cookie_directory: &Path, username: &str) -> Vec<PathBuf> {
+    let slug = auth::session::sanitize_username(username);
+    vec![
+        cookie_directory.join(&slug),
+        cookie_directory.join(format!("{slug}.session")),
+        cookie_directory.join(format!("{slug}.cache")),
+    ]
+}
+
+/// Acquire the per-account advisory session lock, failing on contention.
+///
+/// Mirrors the lock acquisition in `auth::session::Session::new`: a held lock
+/// means another kei instance (sync, service, or login) is active for this
+/// account, and `reset session` must not remove session files from under it.
+fn acquire_session_lock(cookie_directory: &Path, slug: &str) -> anyhow::Result<std::fs::File> {
+    let lock_path = cookie_directory.join(format!("{slug}.lock"));
+    let file = std::fs::File::create(&lock_path)
+        .with_context(|| format!("Could not create session lock file {}", lock_path.display()))?;
+    let acquired = file
+        .try_lock_exclusive()
+        .with_context(|| format!("Could not acquire session lock {}", lock_path.display()))?;
+    anyhow::ensure!(
+        acquired,
+        "Another kei instance is running for this account (lock: {}). \
+         Stop it before resetting the session. If running in Docker, check \
+         for containers with `docker ps` and stop them with `docker stop <name>`.",
+        lock_path.display()
+    );
+    Ok(file)
+}
+
+/// Remove every file in `files` that exists, returning the paths removed.
+async fn discard(files: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+    for path in files {
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => removed.push(path.clone()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| format!("Could not remove {}", path.display()));
+            }
+        }
+    }
+    Ok(removed)
+}
+
+/// Run the reset-session command: discard the local session so the next
+/// `kei login` starts from a clean slate.
+///
+/// `yes` skips the confirmation prompt. Without it, prompts on a TTY and
+/// errors under non-interactive use, mirroring `reset sync-token`.
+/// Discarding the session (including trust tokens) forces the next
+/// `kei login` to run the full password + 2FA flow; the stored password
+/// and the state database are kept.
+pub(crate) async fn run_reset_session(
+    yes: bool,
+    globals: &config::GlobalArgs,
+    toml: Option<&config::TomlConfig>,
+) -> anyhow::Result<()> {
+    // Reset never authenticates; resolve_auth only reads the password from
+    // CLI/env args, so empty PasswordArgs are fine here.
+    let password_args = cli::PasswordArgs::default();
+    let (username, _, _, cookie_directory) = config::resolve_auth(globals, &password_args, toml);
+
+    if username.is_empty() {
+        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username.");
+    }
+
+    let files = session_files(&cookie_directory, &username);
+    let existing: Vec<&PathBuf> = files.iter().filter(|p| p.exists()).collect();
+
+    // Nothing to remove: report and exit before the lock and the `--yes`
+    // guard, mirroring the no-DB early return of the other reset subcommands.
+    if existing.is_empty() {
+        println!(
+            "No local session found in {} — nothing to reset.",
+            cookie_directory.display()
+        );
+        return Ok(());
+    }
+
+    // Hold the same advisory lock the sync service takes — acquired before
+    // the prompt, so no instance can start mid-confirmation and we never
+    // yank session files out from under a running one.
+    let slug = auth::session::sanitize_username(&username);
+    let _lock_file = tokio::task::spawn_blocking({
+        let cookie_directory = cookie_directory.clone();
+        move || acquire_session_lock(&cookie_directory, &slug)
+    })
+    .await??;
+
+    if !yes {
+        use std::io::IsTerminal;
+        use std::io::Write;
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "`kei reset session` needs `--yes` when stdin is not a terminal. This discards the local session and trust tokens, and the next `kei login` will run the full password + 2FA flow again."
+            );
+        }
+        println!("This will discard the local iCloud session (including trust tokens):");
+        for path in &existing {
+            println!("  {}", path.display());
+        }
+        println!();
+        println!("The stored password and the state database are kept.");
+        print!("Are you sure? [y/N] ");
+        std::io::stdout().flush()?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let removed = discard(&files).await?;
+    for path in &removed {
+        println!("Removed {}", path.display());
+    }
+    println!("Session reset. Run `kei login` to authenticate again.");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_files_cover_jar_session_and_cache_only() {
+        let dir = Path::new("/data");
+        let files = session_files(dir, "user@test.com");
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        let slug = auth::session::sanitize_username("user@test.com");
+        assert_eq!(
+            names,
+            vec![
+                slug.clone(),
+                format!("{slug}.session"),
+                format!("{slug}.cache")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_session_removes_nothing_while_the_session_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let slug = auth::session::sanitize_username("user@test.com");
+        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
+        std::fs::write(dir.path().join(format!("{slug}.session")), b"session").unwrap();
+
+        // Simulate a running instance holding the advisory lock.
+        let held = acquire_session_lock(dir.path(), &slug).unwrap();
+
+        // The reset's lock step must fail on contention, so discard never runs.
+        let err = acquire_session_lock(dir.path(), &slug).unwrap_err();
+        assert!(
+            err.to_string().contains("Another kei instance is running"),
+            "unexpected error: {err}"
+        );
+        assert!(dir.path().join(&slug).exists());
+        assert!(dir.path().join(format!("{slug}.session")).exists());
+
+        // Once the running instance goes away, the lock is acquirable again.
+        drop(held);
+        let _reacquired = acquire_session_lock(dir.path(), &slug).unwrap();
+    }
+
+    #[tokio::test]
+    async fn discard_removes_only_listed_files_and_tolerates_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let slug = auth::session::sanitize_username("user@test.com");
+        let files = session_files(dir.path(), "user@test.com");
+
+        // Present: jar + cache. Missing: .session. Bystanders: credential + db.
+        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
+        std::fs::write(dir.path().join(format!("{slug}.cache")), b"cache").unwrap();
+        let credential = dir.path().join(format!("{slug}.credential"));
+        let db = dir.path().join(format!("{slug}.db"));
+        std::fs::write(&credential, b"cred").unwrap();
+        std::fs::write(&db, b"db").unwrap();
+
+        let removed = discard(&files).await.unwrap();
+
+        assert_eq!(removed.len(), 2);
+        assert!(!dir.path().join(&slug).exists());
+        assert!(!dir.path().join(format!("{slug}.cache")).exists());
+        assert!(credential.exists(), "password store must survive the reset");
+        assert!(db.exists(), "state database must survive the reset");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,7 +513,8 @@ fn make_provider_from_auth(
 
 use commands::{
     run_config_show, run_doctor, run_import_existing, run_list, run_login, run_manifest,
-    run_password, run_reconcile, run_reset_state, run_reset_sync_token, run_status, run_verify,
+    run_password, run_reconcile, run_reset_session, run_reset_state, run_reset_sync_token,
+    run_status, run_verify,
 };
 
 /// Get the database path for a given auth config, merging with TOML defaults.
@@ -845,6 +846,9 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             }
             cli::ResetCommand::SyncToken { yes } => {
                 return run_reset_sync_token(yes, &globals, toml_config.as_ref()).await;
+            }
+            cli::ResetCommand::Session { yes } => {
+                return run_reset_session(yes, &globals, toml_config.as_ref()).await;
             }
         },
         Command::Verify(args) => {

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2254,6 +2254,105 @@ fn reset_sync_token_with_yes_clears_under_non_tty() {
     );
 }
 
+#[test]
+fn reset_session_no_session() {
+    // With no session files at all, `reset session` reports and exits 0
+    // before the confirmation/`--yes` guard fires, mirroring the no-DB
+    // early return of `reset state` / `reset sync-token`.
+    let dir = tempfile::tempdir().unwrap();
+    clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No local session found"));
+}
+
+#[test]
+fn reset_session_removes_session_files_and_keeps_bystanders() {
+    // assert_cmd pipes stdin, so this also covers `--yes` under non-TTY:
+    // the guard only fires on the missing-flag path, not in scripted use.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let slug = sanitize_username(username);
+
+    let jar = dir.path().join(&slug);
+    let session = dir.path().join(format!("{slug}.session"));
+    let cache = dir.path().join(format!("{slug}.cache"));
+    let credential = dir.path().join(format!("{slug}.credential"));
+    let db = dir.path().join(format!("{slug}.db"));
+    for (path, contents) in [
+        (&jar, "jar"),
+        (&session, "session"),
+        (&cache, "cache"),
+        (&credential, "cred"),
+        (&db, "db"),
+    ] {
+        std::fs::write(path, contents).unwrap();
+    }
+
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session", "--yes"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Removed"),
+        "stdout should report removed files: {stdout}"
+    );
+    assert!(
+        stdout.contains("kei login"),
+        "stdout should point at `kei login`: {stdout}"
+    );
+
+    assert!(!jar.exists(), "cookie jar must be removed");
+    assert!(!session.exists(), "persisted session must be removed");
+    assert!(!cache.exists(), "response cache must be removed");
+    assert!(credential.exists(), "password store must survive the reset");
+    assert!(db.exists(), "state database must survive the reset");
+}
+
+#[test]
+fn reset_session_without_yes_on_non_tty_errors() {
+    // `kei reset session` ships the same non-interactive guard as
+    // `reset sync-token`. Under non-TTY use (CI, scripts, docker exec
+    // without -t), running without `--yes` errors out instead of silently
+    // doing nothing — or worse, discarding trust tokens by accident.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let slug = sanitize_username(username);
+
+    let jar = dir.path().join(&slug);
+    let session = dir.path().join(format!("{slug}.session"));
+    std::fs::write(&jar, "jar").unwrap();
+    std::fs::write(&session, "session").unwrap();
+
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--yes"),
+        "non-tty error must mention --yes; stderr: {stderr}"
+    );
+
+    assert!(jar.exists(), "cookie jar must not be removed without --yes");
+    assert!(
+        session.exists(),
+        "persisted session must not be removed without --yes"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Password source behavior
 // ═══════════════════════════════════════════════════════════════════════

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -507,6 +507,34 @@ fn reset_sync_token_short_y_flag_parses() {
         .success();
 }
 
+#[test]
+fn reset_session_help_advertises_yes_flag() {
+    // `kei reset session` ships with `--yes` to skip the confirmation
+    // prompt, matching the other reset subcommands. Help text must surface
+    // it so users discover the safe non-interactive form.
+    common::cmd()
+        .args(["reset", "session", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--yes"));
+}
+
+#[test]
+fn reset_session_yes_flag_parses() {
+    common::cmd()
+        .args(["reset", "session", "--yes", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn reset_session_short_y_flag_parses() {
+    common::cmd()
+        .args(["reset", "session", "-y", "--help"])
+        .assert()
+        .success();
+}
+
 // ── Enum validation (rejection only — acceptance covered by unit tests) ─
 
 #[test]
@@ -1259,7 +1287,8 @@ fn reset_help_succeeds() {
         .assert()
         .success()
         .stdout(predicate::str::contains("state"))
-        .stdout(predicate::str::contains("sync-token"));
+        .stdout(predicate::str::contains("sync-token"))
+        .stdout(predicate::str::contains("session"));
 }
 
 #[test]
@@ -1275,6 +1304,14 @@ fn reset_state_new_help_succeeds() {
 fn reset_sync_token_help_succeeds() {
     common::cmd()
         .args(["reset", "sync-token", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn reset_session_help_succeeds() {
+    common::cmd()
+        .args(["reset", "session", "--help"])
         .assert()
         .success();
 }


### PR DESCRIPTION
## Summary

Adds `kei reset session [-y]`: removes the local session artifacts (cookie jar, `.session`, `.cache`) so the next `kei login` starts clean. Password store and state DB are kept. Motivation: stale trust tokens can get 2FA pushes rejected (HTTP 403), and today the only fix is deleting files by hand.

Closes #716.

## Contract and risk

After the reset, `login` runs a full SRP+2FA flow; `.credential` and the DB are untouched; a running instance blocks the reset via the same advisory lock as `Session::new`; idempotent. The confirmation contract matches `reset sync-token`: without `--yes` it prompts on a TTY and errors out under non-interactive use. No media/state paths or safety contracts touched.

## Test plan

- `cargo test reset` — parser tests in `src/cli.rs`, file-set/lock-contention/bystander unit tests in `src/commands/reset.rs`, help/parse tests in `tests/cli.rs`, and three offline end-to-end tests in `tests/behavioral.rs` (no-session exit 0; `--yes` removes exactly the three files with `.credential`/`.db` surviving; non-TTY without `--yes` errors and removes nothing).
- `just gate` on the CI-pinned `rust:1.94.1` in Docker: static checks green; tests green except 6 pre-existing environment failures (root + no D-Bus: 4 lib + 2 behavioral `password_clear_*`), identical on clean `main` (43d175f).
- Manual: `reset --help` lists `session`, non-TTY guard, exact file set, idempotent rerun.

## Regression proof

Not applicable (new command).

## Checklist

- [x] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
