### PR TITLE
Recover missing asset-only delta identities

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,10 +95,10 @@ are diagnostics. Recoverable pass-token gaps can be retried in the same cycle.
 Incremental enumeration consumes changes/zone events. It persists provider
 identity mappings before applying created, soft-deleted, hard-deleted, or
 hidden transitions. An asset-only `CPLAsset` creation hydrates its paired
-master through `masterRef` or the durable mapping before routing; an
-inconclusive lookup preserves the prior zone checkpoint. Album snapshots and
-smart folders may require targeted refresh work before or alongside the
-incremental stream.
+master through `masterRef`, the durable mapping, or a targeted identity lookup
+before routing; an inconclusive lookup preserves the prior zone checkpoint.
+Album snapshots and smart folders may require targeted refresh work before or
+alongside the incremental stream.
 
 Recent and date-bounded runs may advance only when the producer proves the
 bound did not truncate the stream.

--- a/scripts/test-scenarios/identity-deltas.sh
+++ b/scripts/test-scenarios/identity-deltas.sh
@@ -7,5 +7,6 @@ source "$script_dir/lib.sh"
 run_scenario_test lib sibling_cplassets
 run_scenario_test lib sibling_assets
 run_scenario_test lib hard_delete
+run_scenario_test lib asset_only_delta
 run_scenario_test lib selected_relation_add_without_photo
 run_scenario_test lib master_family_soft_delete

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3075,7 +3075,8 @@ pub(crate) async fn reconcile_catalog_paths(
                 }
                 targets.retain(|target| target.asset_id.as_ref() != id);
             }
-            RecordResolution::MasterPresent
+            RecordResolution::AssetPresent { .. }
+            | RecordResolution::MasterPresent
             | RecordResolution::Unknown
             | RecordResolution::TransientFailure(_) => {}
         }
@@ -5825,17 +5826,31 @@ impl IncrementalDeltaSummary {
         asset: &PhotoAsset,
         config: &DownloadConfig,
     ) {
+        let library = asset.source_zone().unwrap_or(&config.library);
+        self.persist_asset_master_mapping(asset.asset_record_name(), asset.id(), library, config)
+            .await;
+    }
+
+    async fn persist_asset_master_mapping(
+        &mut self,
+        asset_record_name: &str,
+        master_record_name: &str,
+        library: &str,
+        config: &DownloadConfig,
+    ) {
         let Some(db) = &config.state_db else {
             return;
         };
-        let library = asset.source_zone().unwrap_or(&config.library);
-        if let Err(e) = planner::upsert_asset_master_mapping(db.as_ref(), library, asset).await {
+        if let Err(e) = db
+            .upsert_asset_master_mapping(library, asset_record_name, master_record_name)
+            .await
+        {
             self.state_transition_failures += 1;
             self.token_unsafe_reason
                 .get_or_insert(ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON);
             tracing::warn!(
-                asset_id = %asset.id(),
-                asset_record_name = %asset.asset_record_name(),
+                asset_id = master_record_name,
+                asset_record_name,
                 library,
                 error = %e,
                 "Failed to record asset/master mapping from incremental delta"
@@ -6186,6 +6201,7 @@ async fn hydrate_unpaired_created_asset_deltas(
     summary: &mut IncrementalDeltaSummary,
 ) -> Option<Arc<DownloadContext>> {
     let mut pending = Vec::new();
+    let mut unresolved: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (index, event) in events.iter().enumerate() {
         if event.reason != ChangeReason::Created
             || event.asset.is_some()
@@ -6220,21 +6236,18 @@ async fn hydrate_unpaired_created_asset_deltas(
             None
         };
 
-        let Some(master_record_name) = master_record_name else {
-            summary
-                .token_unsafe_reason
-                .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
-            tracing::warn!(
-                asset_record_name = %event.record_name,
-                library = %config.library,
-                "Asset-only delta had no usable master identity"
-            );
-            continue;
-        };
-        pending.push((index, event.record_name.to_string(), master_record_name));
+        match master_record_name {
+            Some(master_record_name) => {
+                pending.push((index, event.record_name.to_string(), master_record_name));
+            }
+            None => unresolved
+                .entry(event.record_name.to_string())
+                .or_default()
+                .push(index),
+        }
     }
 
-    if pending.is_empty() {
+    if pending.is_empty() && unresolved.is_empty() {
         return None;
     }
     let Some(pass) = pass else {
@@ -6243,6 +6256,89 @@ async fn hydrate_unpaired_created_asset_deltas(
             .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
         return None;
     };
+
+    if !unresolved.is_empty() {
+        let requests: Vec<RecordLookupRequest> = unresolved
+            .keys()
+            .map(|record_name| {
+                RecordLookupRequest::asset_only(ProviderRecordId::new(record_name.as_str()))
+            })
+            .collect();
+        let identity_resolutions = pass.album.resolve_records(&requests).await;
+        for (state_id, resolution) in identity_resolutions.results {
+            let Some(indices) = unresolved.remove(state_id.as_str()) else {
+                summary
+                    .token_unsafe_reason
+                    .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
+                continue;
+            };
+            match resolution {
+                RecordResolution::AssetPresent { master_record_name } => {
+                    summary
+                        .persist_asset_master_mapping(
+                            state_id.as_str(),
+                            master_record_name.as_str(),
+                            &config.library,
+                            config,
+                        )
+                        .await;
+                    pending.extend(indices.into_iter().map(|index| {
+                        (
+                            index,
+                            state_id.as_str().to_string(),
+                            master_record_name.as_str().to_string(),
+                        )
+                    }));
+                }
+                RecordResolution::Deleted {
+                    master_family: false,
+                    ..
+                } => {
+                    tracing::debug!(
+                        asset_record_name = state_id.as_str(),
+                        library = %config.library,
+                        "Asset-only delta disappeared before identity recovery"
+                    );
+                }
+                RecordResolution::TransientFailure(error) => {
+                    summary
+                        .token_unsafe_reason
+                        .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
+                    tracing::warn!(
+                        asset_record_name = state_id.as_str(),
+                        library = %config.library,
+                        error = %error,
+                        "Failed to recover master identity for asset-only delta"
+                    );
+                }
+                RecordResolution::Present(_)
+                | RecordResolution::MasterPresent
+                | RecordResolution::Deleted {
+                    master_family: true,
+                    ..
+                }
+                | RecordResolution::Unknown => {
+                    summary
+                        .token_unsafe_reason
+                        .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
+                    tracing::warn!(
+                        asset_record_name = state_id.as_str(),
+                        library = %config.library,
+                        "Asset-only delta had no usable master identity"
+                    );
+                }
+            }
+        }
+        if !unresolved.is_empty() {
+            summary
+                .token_unsafe_reason
+                .get_or_insert(ASSET_DELTA_HYDRATION_INCOMPLETE_REASON);
+        }
+    }
+
+    if pending.is_empty() {
+        return None;
+    }
     let download_ctx = preload_download_context(config).await;
     let requests: Vec<RecordLookupRequest> = pending
         .iter()
@@ -6327,6 +6423,7 @@ async fn hydrate_unpaired_created_asset_deltas(
                 }
             }
             RecordResolution::Present(_)
+            | RecordResolution::AssetPresent { .. }
             | RecordResolution::MasterPresent
             | RecordResolution::Unknown
             | RecordResolution::TransientFailure(_) => {
@@ -13212,8 +13309,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn asset_only_delta_hydrates_refreshes_metadata_and_advances_token() {
-        for use_master_ref in [true, false] {
+    async fn asset_only_delta_recovers_identity_refreshes_metadata_and_advances_token() {
+        #[derive(Debug, Clone, Copy)]
+        enum IdentitySource {
+            Delta,
+            State,
+            ProviderLookup,
+        }
+
+        for identity_source in [
+            IdentitySource::Delta,
+            IdentitySource::State,
+            IdentitySource::ProviderLookup,
+        ] {
             let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
             let dir = TempDir::new().expect("temp dir");
             let stored_records = incremental_photo_records_with_favorite("ASSET_ONLY", false);
@@ -13221,11 +13329,13 @@ mod tests {
                 PhotoAsset::new(stored_records[0].clone(), stored_records[1].clone());
             let changed_records = incremental_photo_records_with_favorite("ASSET_ONLY", true);
             let mut delta_record = changed_records[1].clone();
-            if !use_master_ref {
+            if !matches!(identity_source, IdentitySource::Delta) {
                 delta_record["fields"]
                     .as_object_mut()
                     .expect("asset fields")
                     .remove("masterRef");
+            }
+            if matches!(identity_source, IdentitySource::State) {
                 db.upsert_asset_master_mapping("PrimarySync", "asset-ASSET_ONLY", "ASSET_ONLY")
                     .await
                     .expect("seed durable mapping");
@@ -13236,6 +13346,7 @@ mod tests {
                 json!({"records": changed_records}),
                 0,
             );
+            let session_probe = session.clone();
             let pass = AlbumPass {
                 kind: PassKind::Unfiled,
                 album: changes_album("", session),
@@ -13259,9 +13370,25 @@ mod tests {
             .expect("asset-only delta should hydrate");
 
             assert!(matches!(result.outcome, DownloadOutcome::Success));
-            assert_eq!(result.stats.downloaded, 0, "masterRef: {use_master_ref}");
+            assert_eq!(result.stats.downloaded, 0, "{identity_source:?}");
             assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
             assert!(!result.stats.sync_token_blocked);
+            assert_eq!(
+                session_probe.records_query_count(),
+                match identity_source {
+                    IdentitySource::ProviderLookup => 2,
+                    IdentitySource::Delta | IdentitySource::State => 1,
+                },
+                "{identity_source:?}"
+            );
+            assert_eq!(
+                db.get_master_record_name_for_asset("PrimarySync", "asset-ASSET_ONLY")
+                    .await
+                    .expect("read durable mapping")
+                    .as_deref(),
+                Some("ASSET_ONLY"),
+                "{identity_source:?}"
+            );
             let refreshed = db
                 .get_downloaded_page(0, 1)
                 .await

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -499,7 +499,7 @@ pub(super) async fn build_pending_retry_download_tasks(
                     "Pending asset cleared: provider confirmed source deletion"
                 );
             }
-            RecordResolution::Unknown => {
+            RecordResolution::AssetPresent { .. } | RecordResolution::Unknown => {
                 // CONTRACT: UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING
                 set_verification_for_state_id(
                     db.as_ref(),

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 
-use super::asset::{ChangeEvent, DeltaRecordBuffer, PhotoAsset};
+use super::asset::{ChangeEvent, DeltaRecordBuffer, PhotoAsset, extract_master_ref};
 use super::cloudkit::ChangesZoneResponse;
 use super::queries::{DESIRED_KEYS_VALUES, build_changes_zone_request, encode_params};
 use super::session::{PhotosSession, check_changes_zone_error};
@@ -58,6 +58,13 @@ pub(crate) struct RecordLookupRequest {
     pub(crate) state_id: ProviderRecordId,
     pub(crate) master_record_name: ProviderRecordId,
     pub(crate) asset_record_name: Option<ProviderRecordId>,
+    target: RecordLookupTarget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordLookupTarget {
+    Master,
+    Asset,
 }
 
 impl RecordLookupRequest {
@@ -70,6 +77,7 @@ impl RecordLookupRequest {
             state_id,
             master_record_name,
             asset_record_name: Some(asset_record_name),
+            target: RecordLookupTarget::Master,
         }
     }
 
@@ -81,6 +89,16 @@ impl RecordLookupRequest {
             state_id,
             master_record_name,
             asset_record_name: None,
+            target: RecordLookupTarget::Master,
+        }
+    }
+
+    pub(crate) fn asset_only(asset_record_name: ProviderRecordId) -> Self {
+        Self {
+            state_id: asset_record_name.clone(),
+            master_record_name: asset_record_name,
+            asset_record_name: None,
+            target: RecordLookupTarget::Asset,
         }
     }
 }
@@ -118,6 +136,9 @@ fn classify_provider_lookup_error(error: &anyhow::Error) -> ProviderLookupError 
 #[derive(Debug)]
 pub(crate) enum RecordResolution {
     Present(PhotoAsset),
+    AssetPresent {
+        master_record_name: ProviderRecordId,
+    },
     MasterPresent,
     Deleted {
         deleted_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -138,6 +159,7 @@ enum ResolutionEvidence {
     ChildDeleted,
     Inconclusive,
     MasterPresent,
+    AssetPresent,
     MasterDeleted,
     Present,
 }
@@ -145,6 +167,7 @@ enum ResolutionEvidence {
 fn resolution_evidence(resolution: &RecordResolution) -> ResolutionEvidence {
     match resolution {
         RecordResolution::Present(_) => ResolutionEvidence::Present,
+        RecordResolution::AssetPresent { .. } => ResolutionEvidence::AssetPresent,
         RecordResolution::MasterPresent => ResolutionEvidence::MasterPresent,
         RecordResolution::Deleted {
             master_family: true,
@@ -984,12 +1007,13 @@ impl PhotoAlbum {
                         .and_then(chrono::DateTime::<chrono::Utc>::from_timestamp_millis)
                 });
 
-                let master_deleted = explicit_not_found(master) || tombstoned(master);
+                let primary_deleted = explicit_not_found(master) || tombstoned(master);
                 let asset_deleted = explicit_not_found(asset) || tombstoned(asset);
-                let resolution = if master_deleted || asset_deleted {
+                let resolution = if primary_deleted || asset_deleted {
                     RecordResolution::Deleted {
                         deleted_at,
-                        master_family: master_deleted,
+                        master_family: primary_deleted
+                            && request.target == RecordLookupTarget::Master,
                     }
                 } else if let Some(master) = master {
                     match (
@@ -1015,6 +1039,17 @@ impl PhotoAlbum {
                         {
                             RecordResolution::MasterPresent
                         }
+                        (Ok(asset), None)
+                            if request.target == RecordLookupTarget::Asset
+                                && asset.record_type == "CPLAsset" =>
+                        {
+                            extract_master_ref(&asset.fields).map_or(
+                                RecordResolution::Unknown,
+                                |master_record_name| RecordResolution::AssetPresent {
+                                    master_record_name: ProviderRecordId::new(master_record_name),
+                                },
+                            )
+                        }
                         _ => RecordResolution::Unknown,
                     }
                 } else {
@@ -1022,6 +1057,7 @@ impl PhotoAlbum {
                 };
                 let outcome = match &resolution {
                     RecordResolution::Present(_) => "present",
+                    RecordResolution::AssetPresent { .. } => "asset_present",
                     RecordResolution::MasterPresent => "master_present_unpaired",
                     RecordResolution::Deleted { .. } => "deleted",
                     RecordResolution::Unknown => "unknown",
@@ -2889,6 +2925,7 @@ mod tests {
         let master_only_state_id = "live-master-only";
         let requests = [
             lookup_request(asset.id(), asset.id(), asset.asset_record_name()),
+            RecordLookupRequest::asset_only(ProviderRecordId::new(asset.asset_record_name())),
             RecordLookupRequest::master_only(
                 ProviderRecordId::new(master_only_state_id),
                 ProviderRecordId::new(asset.id()),
@@ -2911,6 +2948,15 @@ mod tests {
                 .iter()
                 .find(|(id, _)| id.as_str() == asset.id()),
             Some((_, RecordResolution::Present(_)))
+        ));
+        assert!(matches!(
+            result.results.iter().find(|(id, _)|
+                id.as_str() == asset.asset_record_name()
+            ),
+            Some((
+                _,
+                RecordResolution::AssetPresent { master_record_name }
+            )) if master_record_name.as_str() == asset.id()
         ));
         assert!(matches!(
             result
@@ -3026,6 +3072,32 @@ mod tests {
         assert!(matches!(
             batch.results.as_slice(),
             [(_, RecordResolution::MasterPresent)]
+        ));
+    }
+
+    #[tokio::test]
+    async fn asset_only_delta_targeted_lookup_recovers_master_identity() {
+        let response = json!({
+            "records": [test_asset_record_for("asset-present", "master-present")]
+        });
+        let album = make_album_with_session(100, Box::new(MockPhotosSession::new().ok(response)));
+
+        let batch = album
+            .resolve_records(&[RecordLookupRequest::asset_only(ProviderRecordId::new(
+                "asset-present",
+            ))])
+            .await;
+
+        assert!(
+            !batch.complete,
+            "identity lookup still needs the master pair"
+        );
+        assert!(matches!(
+            batch.results.as_slice(),
+            [(
+                _,
+                RecordResolution::AssetPresent { master_record_name }
+            )] if master_record_name.as_str() == "master-present"
         ));
     }
 

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -631,7 +631,7 @@ pub(crate) fn classify_change_reason(record: &Record) -> ChangeReason {
 }
 
 /// Extract the `masterRef` record name from a `CPLAsset`'s fields.
-fn extract_master_ref(fields: &Value) -> Option<String> {
+pub(super) fn extract_master_ref(fields: &Value) -> Option<String> {
     fields
         .get("masterRef")
         .and_then(|r| r.get("value"))


### PR DESCRIPTION
## Summary
- Recover a missing `CPLAsset` master identity through a targeted provider lookup before paired hydration.
- Persist recovered asset-to-master mappings so later deltas can resolve directly.
- Preserve the prior provider checkpoint when identity recovery or hydration remains inconclusive.
- Add the regression path to the `identity-deltas` test slice.

Fixes #719

## Tests
- `just test scenario identity-deltas`
- `just gate`

## Risk
- Adds one targeted provider lookup only when an asset-only delta has neither `masterRef` nor a durable mapping.
- Does not change the schema, CLI, configuration, or local media files.
