### PR TITLE
Resolve capture times from Apple's per-asset timezone offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A failed catalogue refresh now preserves the previous zone checkpoint instead of advancing past a provider edit that was never stored. ([#707])
 - Metadata rewrite failures are now reported when a sync downloads nothing. A metadata-only edit cycle transfers no media, so a failed sidecar or EXIF write was previously invisible in the sync result. ([#707])
 - An embedded metadata rewrite now records the hash of the file it leaves on disk, keeping the pre-rewrite hash as the provider download checksum, so `kei verify --checksums` and `kei reconcile` read an intentional edit as intact rather than corrupted or truncated. A file that no longer matches its recorded checksum keeps its marker and is left untouched for those commands to report. ([#707])
+- Capture times now resolve from Apple's per-asset timezone offset when it is usable, so date filters, date-based folders, embedded EXIF, and XMP sidecars use the capture-local calendar date and timestamp. Assets without a usable offset retain the backup host's local rendering, preserving the previous behaviour and icloudpd-compatible paths. Existing files are not moved, and a later full sync downloads an affected asset into its capture-local folder while leaving the earlier copy in place. A date-only `skip_created_before` or `skip_created_after` makes that full sync the next one because the bound's capture-date semantics change the config hashes. `kei sync --refresh-metadata` rewrites XMP sidecars in full. For a timestamp already present in a file, it adds the capture offset only where the timestamp reads as capture-local. When embedded datetime output is configured, a file with no capture timestamp receives one, with the offset when Apple supplied it. (fixes [#703])
+
+[#703]: https://github.com/rhoopr/kei/issues/703
 
 ## [0.23.1] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ sweep, cannot use album, smart-folder, media, or date/recent filters, and does
 not run under `kei service run`. It is a manual recovery step; the permanent
 automatic fix is tracked in [#687](https://github.com/rhoopr/kei/issues/687).
 
+Use this command after upgrading from a version that rendered capture times in
+the backup host's timezone. It rewrites XMP sidecars in full. For a timestamp
+already present in a file, it adds the capture offset only where the timestamp
+reads as capture-local, because an offset attached to a host-local timestamp
+would state a capture time the photo never had. When embedded datetime output
+is configured, a file with no capture timestamp receives one, with the offset
+when Apple supplied it. The command does not move existing media between date
+folders.
+
 ### Replace a truncated local file
 
 First, mark missing and truncated files for retry:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,38 @@ Only producer-dispatched work becomes pending through `upsert_seen`. Filtered
 or skipped assets must not be left as retryable work unless a dedicated state
 transition owns that result.
 
+Asset dates used for filtering, path rendering, file metadata, and sidecars are
+resolved from Apple's UTC instant plus the asset's `timeZoneOffset` when that
+offset is usable. Missing or invalid offsets retain host-local rendering,
+preserving the previous path and metadata behaviour. Date-only lower bounds
+use a conservative UTC enumeration bound and then apply the exact resolved
+calendar-date filter, so enumeration safety does not depend on the backup host
+timezone.
+
+Capture-local path rendering does not change the download config hash, so a
+sync that sees no other drift stays incremental and never re-enumerates an
+already-downloaded asset. A date-only created bound is hashed under its own
+tag in both the download config hash and the eligibility-config hash, so it
+drifts like any other eligibility field. For an asset carrying a usable
+offset, a path derived under host-local rendering is not a current derived
+path, so a full sweep forwards that asset and downloads it into its
+capture-local folder. The earlier copy stays where it is: kei never deletes
+local media, and no command removes a file that no longer matches a derived
+path. `import-existing` adopts through the same derivation. Assets without a
+usable offset retain host-local paths and remain compatible with icloudpd's
+date-folder layout.
+
+Existing embedded and sidecar timestamps are repaired only through the
+explicit `sync --refresh-metadata` flow, which is bounded by the same
+no-overwrite probe gate as any other embedded write. An offset tag names the
+zone of one specific timestamp, so the embed path attaches it only to a
+timestamp it writes in the same pass, or to an existing one the probe proves
+already renders the capture-local instant. When writing a timestamp into a
+file that has orphaned datetime offsets, the writer clears those offsets before
+installing the timestamp and its resolved offset. Attaching an offset to a
+wall clock left by host-local rendering would assert an instant the asset never
+had.
+
 ### Durable pending retry
 
 Failed and pending rows are not recovered by replaying the entire provider

--- a/docs/migration-from-icloudpd.md
+++ b/docs/migration-from-icloudpd.md
@@ -62,7 +62,10 @@ ICLOUD_USERNAME=you@example.com kei import-existing --config ~/.config/kei/confi
 If most files show as unmatched, stop and fix the path options before running a
 real import. A mismatch doesn't error, and it doesn't rewrite your files. It
 just leaves those assets unknown to kei, which means a later sync may download
-another copy.
+another copy. The one cause no path option fixes is a
+[date folder](#date-folders) difference, where Python filed an asset under the
+timezone of the machine it ran on and kei expects the timezone the photo was
+taken in.
 
 The import is safe to repeat. Re-importing the same files updates the existing
 state rows.
@@ -120,6 +123,28 @@ folder_structure_albums = "{album}/%Y/%m/%d"
 ```
 
 On v0.20 and later, `{album}` is only accepted in `folder_structure_albums`.
+
+### Date folders
+
+Python renders date folders in the timezone of the machine running it. kei
+renders them in the timezone the photo was taken in, from the per-asset offset
+Apple stores alongside each asset. kei therefore places an asset in the same
+folder whatever host it runs on, while Python's layout depends on how the
+machine that built the tree was configured. The two agree only where that
+machine was set to the capture timezone, so a photo taken while travelling, or
+a tree Python built on a UTC server or container, can sort into a different
+date folder under kei. Assets for which Apple supplies no usable offset keep
+host-local rendering and land where Python put them.
+
+`import-existing` adopts a file only at the path kei derives, so an asset whose
+folders differ stays unadopted. kei does not move media that already sits in a
+Python-created folder. A full sync downloads an affected asset into its
+capture-local folder and leaves the earlier copy in place, so expect both
+copies until you remove the older one.
+
+Sidecar timestamps are the exception. Python's `--xmp-sidecar` builds its
+timestamps from the same per-asset offset, so both tools record the same
+capture time and offset even where the folder dates differ.
 
 ### Filename policy
 

--- a/docs/synctoken-reference.md
+++ b/docs/synctoken-reference.md
@@ -610,7 +610,7 @@ These fields are populated when a photo has been edited in the Photos app or ano
 |-------|------|-------------|
 | `orientation` | INT64 | Current EXIF orientation |
 | `duration` | DOUBLE | Duration in seconds (videos) |
-| `timeZoneOffset` | INT64 | Timezone offset from UTC |
+| `timeZoneOffset` | INT64 | Capture timezone offset from UTC, in seconds |
 | `assetSubtype` | INT64 | Asset subtype classification |
 | `assetSubtypeV2` | INT64 | Asset subtype v2 classification |
 | `assetHDRType` | INT64 | HDR type indicator |

--- a/docs/v0.20-migration.md
+++ b/docs/v0.20-migration.md
@@ -131,6 +131,15 @@ skip_created_after = "30d"
 or smart-folder filters. Use `per-filter` when you want each selected album,
 smart folder, or unfiled pass to get its own recent window.
 
+Date-only bounds compare each asset's capture-local calendar date using
+Apple's per-asset timezone offset when it is usable. Assets without a usable
+offset retain host-local date rendering. Datetime values and relative
+intervals are instant cutoffs. Existing files are not moved when capture-local
+path rendering places an asset in a different date folder; a later full sync
+downloads it into the capture-local folder and leaves the earlier copy in
+place. Use `kei sync --refresh-metadata` to apply the resolved timestamp and
+offset to configured embedded and sidecar metadata.
+
 Selector values can be escaped with `=` when a real album, smart folder, or
 library name looks like a sentinel:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -62,19 +62,19 @@ domain = "com"
 # Option: download.folder_structure
 # Default value: %Y/%m/%d
 # Valid values: strftime template plus optional leading {library}; use "none" for no date folders
-# Description: Directory template for unfiled and library-wide files. {album} and {smart-folder} are not valid here.
+# Description: Directory template for unfiled and library-wide files. {album} and {smart-folder} are not valid here. Date tokens render the capture-local date when Apple supplies a usable timezone offset, otherwise the backup host's local date.
 folder_structure = "%Y/%m/%d"
 
 # Option: download.folder_structure_albums
 # Default value: {album}
 # Valid values: strftime template plus optional leading {library} and leading {album}
-# Description: Directory template for album passes. Put date folders after {album}, for example {album}/%Y/%m.
+# Description: Directory template for album passes. Put date folders after {album}, for example {album}/%Y/%m. Date tokens render the capture-local date when Apple supplies a usable timezone offset, otherwise the backup host's local date.
 folder_structure_albums = "{album}"
 
 # Option: download.folder_structure_smart_folders
 # Default value: {smart-folder}
 # Valid values: strftime template plus optional leading {library} and leading {smart-folder}
-# Description: Directory template for smart-folder passes. Put date folders after {smart-folder}.
+# Description: Directory template for smart-folder passes. Put date folders after {smart-folder}. Date tokens render the capture-local date when Apple supplies a usable timezone offset, otherwise the backup host's local date.
 folder_structure_smart_folders = "{smart-folder}"
 
 # Option: download.threads
@@ -160,13 +160,13 @@ filename_exclude = []
 # Option: filters.skip_created_before
 # Default value: unset
 # Valid values: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or day interval such as 30d
-# Description: Skips assets created before the resolved local timestamp.
+# Description: Skips assets created before this cutoff. Date-only values compare the capture-local calendar date; explicit datetimes and relative intervals compare the instant.
 # skip_created_before = "2024-01-01"
 
 # Option: filters.skip_created_after
 # Default value: unset
 # Valid values: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or day interval such as 7d
-# Description: Skips assets created after the resolved local timestamp.
+# Description: Skips assets created after this cutoff. Date-only values compare the capture-local calendar date; explicit datetimes and relative intervals compare the instant.
 # skip_created_after = "2024-12-31"
 
 [photos]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -241,11 +241,13 @@ pub struct SyncArgs {
     #[arg(long)]
     pub no_progress_bar: bool,
 
-    /// Skip assets created before this ISO date or interval (e.g., 2025-01-02 or 20d)
+    /// Skip assets before this cutoff. Date-only values compare the capture-local calendar date;
+    /// explicit datetimes and relative intervals compare the instant (e.g., 2025-01-02 or 20d).
     #[arg(long)]
     pub skip_created_before: Option<String>,
 
-    /// Skip assets created after this ISO date or interval (e.g., 2025-01-02 or 20d)
+    /// Skip assets after this cutoff. Date-only values compare the capture-local calendar date;
+    /// explicit datetimes and relative intervals compare the instant (e.g., 2025-01-02 or 20d).
     #[arg(long)]
     pub skip_created_after: Option<String>,
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -2878,7 +2878,8 @@ mod wiremock_tests {
         std::fs::create_dir_all(&dl).unwrap();
         let mut config = base_config(&dl);
         // 2025-06-01 cutoff; asset is dated 2025-01-14, so it must be filtered.
-        config.skip_created_before = chrono::DateTime::from_timestamp(1_748_736_000, 0);
+        config.skip_created_before = chrono::DateTime::from_timestamp(1_748_736_000, 0)
+            .map(crate::config::CreatedDateFilter::Instant);
         stage_expected(&asset.to_photo_asset(), &base_config(&dl));
 
         let db = open_db(&tmp).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use crate::types::{
     Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoResolution,
     LogLevel, PhotoResolution, RawPolicy,
 };
-use chrono::{DateTime, Local, NaiveDate, NaiveDateTime};
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -298,8 +298,8 @@ pub struct DownloadSettings {
 pub struct FilterConfig {
     pub selection: crate::selection::Selection,
     pub media: MediaSelection,
-    pub skip_created_before: Option<DateTime<Local>>,
-    pub skip_created_after: Option<DateTime<Local>>,
+    pub skip_created_before: Option<CreatedDateFilter>,
+    pub skip_created_after: Option<CreatedDateFilter>,
     pub recent: Option<u32>,
     pub recent_scope: crate::cli::RecentScope,
     pub persistent_recent: Option<crate::cli::RecentLimit>,
@@ -308,6 +308,115 @@ pub struct FilterConfig {
     pub persistent_skip_created_after: Option<String>,
     pub skip_videos: bool,
     pub skip_photos: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreatedDateFilter {
+    Instant(DateTime<Utc>),
+    CaptureDate(NaiveDate),
+}
+
+impl CreatedDateFilter {
+    pub(crate) fn excludes_before(
+        self,
+        created_at: DateTime<Utc>,
+        capture_date: NaiveDate,
+    ) -> bool {
+        match self {
+            Self::Instant(boundary) => created_at < boundary,
+            Self::CaptureDate(boundary) => capture_date < boundary,
+        }
+    }
+
+    pub(crate) fn excludes_after(self, created_at: DateTime<Utc>, capture_date: NaiveDate) -> bool {
+        match self {
+            Self::Instant(boundary) => created_at > boundary,
+            Self::CaptureDate(boundary) => capture_date > boundary,
+        }
+    }
+
+    /// True when the two bounds admit no asset at all, whatever capture
+    /// offset it carries.
+    ///
+    /// Bounds of the same form compare exactly. A capture date names a span of
+    /// instants rather than one, because the filter compares each asset's
+    /// capture-local date, so a mixed window is judged against the widest span
+    /// `FixedOffset` admits. Reporting a workable window as impossible would
+    /// be worse than staying quiet about a narrow contradictory one.
+    pub(crate) fn is_strictly_after(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Instant(before), Self::Instant(after)) => before > after,
+            (Self::CaptureDate(before), Self::CaptureDate(after)) => before > after,
+            (Self::CaptureDate(before), Self::Instant(after)) => {
+                Self::earliest_instant_on(before) > after
+            }
+            (Self::Instant(before), Self::CaptureDate(after)) => {
+                Self::first_instant_after(after).is_some_and(|end| before >= end)
+            }
+        }
+    }
+
+    /// Widest offset `chrono::FixedOffset` accepts, in seconds. A capture-local
+    /// calendar day therefore spans this much beyond the UTC day on each side.
+    const WIDEST_OFFSET_SECONDS: i64 = 86_399;
+
+    /// Earliest instant an asset can carry and still fall on `date` in
+    /// capture-local time.
+    fn earliest_instant_on(date: NaiveDate) -> DateTime<Utc> {
+        date.and_time(chrono::NaiveTime::MIN).and_utc()
+            - chrono::Duration::seconds(Self::WIDEST_OFFSET_SECONDS)
+    }
+
+    /// First instant that can no longer fall on `date` in capture-local time.
+    /// `None` only at the end of the representable calendar, where declining
+    /// to warn is the safe answer.
+    fn first_instant_after(date: NaiveDate) -> Option<DateTime<Utc>> {
+        Some(
+            date.succ_opt()?.and_time(chrono::NaiveTime::MIN).and_utc()
+                + chrono::Duration::seconds(Self::WIDEST_OFFSET_SECONDS),
+        )
+    }
+
+    /// Midnight UTC on a capture date, or the instant itself.
+    fn comparable_instant(self) -> DateTime<Utc> {
+        match self {
+            Self::Instant(boundary) => boundary,
+            Self::CaptureDate(boundary) => boundary.and_time(chrono::NaiveTime::MIN).and_utc(),
+        }
+    }
+
+    pub(crate) fn conservative_utc_lower_bound(self) -> DateTime<Utc> {
+        match self {
+            Self::Instant(boundary) => boundary,
+            Self::CaptureDate(_) => self.comparable_instant() - chrono::Duration::days(1),
+        }
+    }
+
+    /// Durable identity used by the config and coverage hashes. Keep it
+    /// separate from [`std::fmt::Display`], so rewording a diagnostic cannot
+    /// invalidate every user's incremental state.
+    pub(crate) fn fingerprint(self) -> String {
+        match self {
+            Self::Instant(boundary) => boundary.to_rfc3339(),
+            Self::CaptureDate(boundary) => format!("capture-date:{boundary}"),
+        }
+    }
+}
+
+/// Diagnostic rendering only. Each bound names its form, because the two forms
+/// compare differently and a message about a contradictory window is only
+/// readable once the reader knows which one they gave.
+impl std::fmt::Display for CreatedDateFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Instant(boundary) => write!(
+                f,
+                "instant {}",
+                boundary.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+            ),
+            Self::CaptureDate(boundary) => write!(f, "capture date {boundary}"),
+        }
+    }
 }
 
 impl FilterConfig {
@@ -1401,20 +1510,20 @@ impl Config {
 
         let skip_created_before = skip_created_before_str
             .as_deref()
-            .map(parse_date_or_interval)
+            .map(parse_created_date_filter)
             .transpose()?;
         let skip_created_after = skip_created_after_str
             .as_deref()
-            .map(parse_date_or_interval)
+            .map(parse_created_date_filter)
             .transpose()?;
 
         if let (Some(before), Some(after)) = (&skip_created_before, &skip_created_after)
-            && before >= after
+            && before.is_strictly_after(*after)
         {
             tracing::warn!(
-                before = %before.format("%Y-%m-%d"),
-                after = %after.format("%Y-%m-%d"),
-                "skip-created-before >= skip-created-after, no assets can match",
+                %before,
+                %after,
+                "skip-created-before is after skip-created-after, no assets can match",
             );
         }
 
@@ -1994,30 +2103,24 @@ pub(crate) fn persist_first_run_config(
     Ok(())
 }
 
-/// Parse a human-friendly date spec into a concrete timestamp.
-///
-/// Supports three formats to match the Python CLI's behavior:
-/// - Relative interval: `"20d"` (20 days ago from now)
-/// - ISO date: `"2025-01-02"` (midnight local time)
-/// - ISO datetime: `"2025-01-02T14:30:00"` (local time)
-pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>> {
+/// Parse a date-only capture boundary, host-local datetime, or relative interval.
+pub(crate) fn parse_created_date_filter(s: &str) -> anyhow::Result<CreatedDateFilter> {
     if let Some(days_str) = s.strip_suffix('d')
         && let Ok(days) = days_str.parse::<u64>()
     {
         let days = i64::try_from(days)
             .map_err(|_e| anyhow::anyhow!("Date interval '{s}' is too large"))?;
-        return Ok(Local::now() - chrono::Duration::days(days));
+        return Ok(CreatedDateFilter::Instant(
+            Utc::now() - chrono::Duration::days(days),
+        ));
     }
-    if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        && let Some(naive_dt) = date.and_hms_opt(0, 0, 0)
-        && let Some(dt) = naive_dt.and_local_timezone(Local).single()
-    {
-        return Ok(dt);
+    if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return Ok(CreatedDateFilter::CaptureDate(date));
     }
     if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
         && let Some(local) = dt.and_local_timezone(Local).single()
     {
-        return Ok(local);
+        return Ok(CreatedDateFilter::Instant(local.with_timezone(&Utc)));
     }
     anyhow::bail!(
         "Could not parse '{s}' as a date. Use a date like 2025-01-02, a datetime like 2025-01-02T14:30:00, or an interval like 20d."
@@ -2286,18 +2389,92 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_date_iso() {
-        let dt = parse_date_or_interval("2025-01-15").unwrap();
+    fn test_parse_date_marks_calendar_boundaries() {
         assert_eq!(
-            dt.date_naive(),
-            NaiveDate::from_ymd_opt(2025, 1, 15).unwrap()
+            parse_created_date_filter("2025-01-15").unwrap(),
+            CreatedDateFilter::CaptureDate(NaiveDate::from_ymd_opt(2025, 1, 15).unwrap())
+        );
+        assert!(matches!(
+            parse_created_date_filter("2025-01-15T00:00:00").unwrap(),
+            CreatedDateFilter::Instant(_)
+        ));
+    }
+
+    #[test]
+    fn date_only_filter_bound_is_host_timezone_independent() {
+        assert_eq!(
+            parse_created_date_filter("2025-01-15")
+                .unwrap()
+                .fingerprint(),
+            "capture-date:2025-01-15"
+        );
+    }
+
+    /// The contradictory-window warning reads back to whoever wrote the
+    /// config, so each bound has to name the form it took rather than leaning
+    /// on Rust's derived `Debug`.
+    #[test]
+    fn filter_bounds_render_their_form_for_diagnostics() {
+        assert_eq!(
+            CreatedDateFilter::CaptureDate(NaiveDate::from_ymd_opt(2025, 6, 1).unwrap())
+                .to_string(),
+            "capture date 2025-06-01"
+        );
+        assert_eq!(
+            CreatedDateFilter::Instant(
+                NaiveDate::from_ymd_opt(2025, 1, 1)
+                    .unwrap()
+                    .and_time(chrono::NaiveTime::MIN)
+                    .and_utc()
+            )
+            .to_string(),
+            "instant 2025-01-01T00:00:00Z"
         );
     }
 
     #[test]
+    fn conservative_utc_lower_bound_covers_filter_forms_and_maximum_offsets() {
+        let capture_date = NaiveDate::from_ymd_opt(2025, 2, 1).unwrap();
+        let utc_midnight = capture_date.and_time(chrono::NaiveTime::MIN).and_utc();
+        let instant = utc_midnight + chrono::Duration::hours(6);
+
+        for (name, filter, expected) in [
+            (
+                "capture date",
+                CreatedDateFilter::CaptureDate(capture_date),
+                utc_midnight - chrono::Duration::days(1),
+            ),
+            ("instant", CreatedDateFilter::Instant(instant), instant),
+        ] {
+            assert_eq!(filter.conservative_utc_lower_bound(), expected, "{name}");
+        }
+
+        let lower_bound =
+            CreatedDateFilter::CaptureDate(capture_date).conservative_utc_lower_bound();
+        for (name, offset_seconds, expected_clearance) in [
+            ("UTC+14", 50_400, chrono::Duration::hours(10)),
+            ("chrono east limit", 86_399, chrono::Duration::seconds(1)),
+        ] {
+            let offset = chrono::FixedOffset::east_opt(offset_seconds).unwrap();
+            let asset_utc = capture_date
+                .and_time(chrono::NaiveTime::MIN)
+                .and_local_timezone(offset)
+                .single()
+                .unwrap()
+                .with_timezone(&Utc);
+            assert_eq!(asset_utc - lower_bound, expected_clearance, "{name}");
+            assert!(asset_utc >= lower_bound, "{name} asset was truncated");
+        }
+    }
+
+    #[test]
     fn test_parse_datetime_iso() {
-        let dt = parse_date_or_interval("2025-06-15T14:30:00").unwrap();
-        let naive = dt.naive_local();
+        let CreatedDateFilter::Instant(dt) =
+            parse_created_date_filter("2025-06-15T14:30:00").unwrap()
+        else {
+            panic!("datetime must resolve to an instant");
+        };
+        let naive = dt.with_timezone(&Local).naive_local();
         assert_eq!(naive.date(), NaiveDate::from_ymd_opt(2025, 6, 15).unwrap());
         assert_eq!(
             naive.time(),
@@ -2307,9 +2484,11 @@ mod tests {
 
     #[test]
     fn test_parse_interval_days() {
-        let before = chrono::Local::now();
-        let dt = parse_date_or_interval("10d").unwrap();
-        let after = chrono::Local::now();
+        let before = Utc::now();
+        let CreatedDateFilter::Instant(dt) = parse_created_date_filter("10d").unwrap() else {
+            panic!("relative interval must resolve to an instant");
+        };
+        let after = Utc::now();
         let expected = before - chrono::Duration::days(10);
         assert!(dt >= expected - chrono::Duration::seconds(1));
         assert!(dt <= after - chrono::Duration::days(10) + chrono::Duration::seconds(1));
@@ -2317,14 +2496,14 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_date() {
-        assert!(parse_date_or_interval("not-a-date").is_err());
-        assert!(parse_date_or_interval("").is_err());
+        assert!(parse_created_date_filter("not-a-date").is_err());
+        assert!(parse_created_date_filter("").is_err());
     }
 
     #[test]
     fn test_parse_negative_interval_rejected() {
-        assert!(parse_date_or_interval("-5d").is_err());
-        assert!(parse_date_or_interval("-1d").is_err());
+        assert!(parse_created_date_filter("-5d").is_err());
+        assert!(parse_created_date_filter("-1d").is_err());
     }
 
     // ── TOML parsing tests ──────────────────────────────────────────
@@ -5134,13 +5313,13 @@ mod tests {
             Config::build(&default_globals(), &default_password(), sync, Some(&toml)).unwrap();
         let before = cfg.filters.skip_created_before.unwrap();
         assert_eq!(
-            before.date_naive(),
-            NaiveDate::from_ymd_opt(2023, 6, 1).unwrap()
+            before,
+            CreatedDateFilter::CaptureDate(NaiveDate::from_ymd_opt(2023, 6, 1).unwrap())
         );
         let after = cfg.filters.skip_created_after.unwrap();
         assert_eq!(
-            after.date_naive(),
-            NaiveDate::from_ymd_opt(2024, 6, 1).unwrap()
+            after,
+            CreatedDateFilter::CaptureDate(NaiveDate::from_ymd_opt(2024, 6, 1).unwrap())
         );
     }
 
@@ -5158,8 +5337,10 @@ mod tests {
             Some(&toml),
         )
         .unwrap();
-        let before = cfg.filters.skip_created_before.unwrap();
-        let expected = chrono::Local::now() - chrono::Duration::days(30);
+        let CreatedDateFilter::Instant(before) = cfg.filters.skip_created_before.unwrap() else {
+            panic!("day interval must resolve to an instant");
+        };
+        let expected = chrono::Utc::now() - chrono::Duration::days(30);
         assert!((before - expected).num_seconds().abs() < 2);
     }
 
@@ -6659,7 +6840,7 @@ mod tests {
 
     #[test]
     fn test_contradictory_date_filter_succeeds() {
-        // before >= after is a warning, not an error -- Config::build should succeed
+        // A contradictory window is a warning, not an error.
         let mut sync = default_sync();
         sync.skip_created_before = Some("2025-06-01".to_string());
         sync.skip_created_after = Some("2025-01-01".to_string());
@@ -6669,7 +6850,67 @@ mod tests {
             "Contradictory date filters should warn, not error"
         );
         let cfg = cfg.unwrap();
-        assert!(cfg.filters.skip_created_before >= cfg.filters.skip_created_after);
+        assert!(
+            cfg.filters
+                .skip_created_before
+                .unwrap()
+                .is_strictly_after(cfg.filters.skip_created_after.unwrap())
+        );
+    }
+
+    #[test]
+    fn contradictory_window_detection_spans_date_and_instant_bounds() {
+        let june = CreatedDateFilter::CaptureDate(
+            NaiveDate::from_ymd_opt(2025, 6, 1).expect("valid date"),
+        );
+        let january = CreatedDateFilter::Instant(
+            NaiveDate::from_ymd_opt(2025, 1, 1)
+                .expect("valid date")
+                .and_time(chrono::NaiveTime::MIN)
+                .and_utc(),
+        );
+
+        assert!(!june.is_strictly_after(june), "one capture day is a window");
+        assert!(june.is_strictly_after(january));
+        assert!(!january.is_strictly_after(june));
+
+        // An asset sitting exactly on an instant bound satisfies both
+        // predicates, so equal instants are a window too.
+        assert!(!january.is_strictly_after(january));
+
+        // A capture date spans the instants any offset can map onto it, so a
+        // mixed window under a day apart still admits assets. Reporting one of
+        // these as impossible would contradict what the filter actually does.
+        let capture_day = NaiveDate::from_ymd_opt(2025, 2, 1).expect("valid date");
+        let instant_at = |year, month, day, hour| {
+            CreatedDateFilter::Instant(
+                NaiveDate::from_ymd_opt(year, month, day)
+                    .expect("valid date")
+                    .and_hms_opt(hour, 0, 0)
+                    .expect("valid time")
+                    .and_utc(),
+            )
+        };
+
+        // 2025-02-01T20:00Z is 2025-02-01 locally at UTC+00.
+        assert!(
+            !instant_at(2025, 2, 1, 20)
+                .is_strictly_after(CreatedDateFilter::CaptureDate(capture_day)),
+            "a same-day capture-local asset matches this window"
+        );
+        // 2025-01-31T20:00Z is 2025-02-01 locally at UTC+14.
+        assert!(
+            !CreatedDateFilter::CaptureDate(capture_day)
+                .is_strictly_after(instant_at(2025, 1, 31, 20)),
+            "an eastward offset pulls this asset onto the capture day"
+        );
+
+        // The diagnostic still fires once no offset can bridge the gap.
+        assert!(
+            instant_at(2025, 6, 1, 0).is_strictly_after(CreatedDateFilter::CaptureDate(
+                NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date")
+            ))
+        );
     }
 
     #[test]
@@ -6960,8 +7201,10 @@ mod tests {
         );
         // The cutoff should be ~30 days ago; give it a wide window to avoid
         // flakiness on slow CI.
-        let cutoff = cfg.filters.skip_created_before.unwrap();
-        let now = chrono::Local::now();
+        let CreatedDateFilter::Instant(cutoff) = cfg.filters.skip_created_before.unwrap() else {
+            panic!("recent day window must resolve to an instant");
+        };
+        let now = chrono::Utc::now();
         let delta = now.signed_duration_since(cutoff);
         assert!(
             delta.num_days() >= 29 && delta.num_days() <= 31,

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use chrono::{DateTime, Local};
+use chrono::{DateTime, FixedOffset, Local};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::icloud::photos::VersionsMap;
@@ -50,8 +50,8 @@ pub(crate) trait PathDerivationSource {
     fn folder_structure(&self) -> &str;
     fn resolution(&self) -> crate::types::PhotoResolution;
     fn media(&self) -> &crate::config::MediaSelection;
-    fn skip_created_before(&self) -> Option<DateTime<chrono::Utc>>;
-    fn skip_created_after(&self) -> Option<DateTime<chrono::Utc>>;
+    fn skip_created_before(&self) -> Option<crate::config::CreatedDateFilter>;
+    fn skip_created_after(&self) -> Option<crate::config::CreatedDateFilter>;
     fn live_photo_mode(&self) -> LivePhotoMode;
     fn live_resolution(&self) -> AssetVersionSize;
     fn live_photo_mov_filename_policy(&self) -> LivePhotoMovFilenamePolicy;
@@ -80,8 +80,8 @@ pub(crate) struct PathDerivationConfig {
     pub(crate) folder_structure_smart_folders: Arc<str>,
     pub(crate) resolution: crate::types::PhotoResolution,
     pub(crate) media: crate::config::MediaSelection,
-    pub(crate) skip_created_before: Option<DateTime<chrono::Utc>>,
-    pub(crate) skip_created_after: Option<DateTime<chrono::Utc>>,
+    pub(crate) skip_created_before: Option<crate::config::CreatedDateFilter>,
+    pub(crate) skip_created_after: Option<crate::config::CreatedDateFilter>,
     pub(crate) live_photo_mode: LivePhotoMode,
     pub(crate) live_resolution: AssetVersionSize,
     pub(crate) live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
@@ -205,11 +205,11 @@ impl PathDerivationSource for PathDerivationConfig {
         &self.media
     }
 
-    fn skip_created_before(&self) -> Option<DateTime<chrono::Utc>> {
+    fn skip_created_before(&self) -> Option<crate::config::CreatedDateFilter> {
         self.skip_created_before
     }
 
-    fn skip_created_after(&self) -> Option<DateTime<chrono::Utc>> {
+    fn skip_created_after(&self) -> Option<crate::config::CreatedDateFilter> {
         self.skip_created_after
     }
 
@@ -279,11 +279,11 @@ impl PathDerivationSource for DownloadConfig {
         &self.media
     }
 
-    fn skip_created_before(&self) -> Option<DateTime<chrono::Utc>> {
+    fn skip_created_before(&self) -> Option<crate::config::CreatedDateFilter> {
         self.skip_created_before
     }
 
-    fn skip_created_after(&self) -> Option<DateTime<chrono::Utc>> {
+    fn skip_created_after(&self) -> Option<crate::config::CreatedDateFilter> {
         self.skip_created_after
     }
 
@@ -416,6 +416,8 @@ impl std::borrow::Borrow<str> for NormalizedPath {
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
 pub(super) struct MetadataPayload {
+    /// Source capture offset in seconds from UTC, when valid.
+    pub(super) timezone_offset: Option<i32>,
     /// 1-5 star rating (mapped from `AssetMetadata::rating` or `is_favorite`).
     pub(super) rating: Option<u8>,
     /// GPS latitude in decimal degrees, WGS84.
@@ -460,6 +462,7 @@ impl MetadataPayload {
             })
             .unwrap_or_default();
         Self {
+            timezone_offset: meta.timezone_offset,
             rating: meta.rating,
             latitude: meta.latitude,
             longitude: meta.longitude,
@@ -554,7 +557,7 @@ pub(super) struct DownloadTask {
     // 8-byte primitives
     pub(super) size: u64,
     // DateTime
-    pub(super) created_local: DateTime<Local>,
+    pub(super) created_local: DateTime<FixedOffset>,
     // 1-byte enum
     /// Version size key for state tracking.
     pub(super) version_size: VersionSizeKey,
@@ -580,7 +583,7 @@ impl DownloadTask {
                 .unwrap_or("")
                 .to_string(),
             bytes: self.size,
-            created_local: self.created_local,
+            created_local: self.created_local.with_timezone(&Local),
         }
     }
 }
@@ -718,16 +721,17 @@ pub(crate) fn is_asset_filtered(
         return Some(FilterReason::LivePhoto);
     }
     let created_utc = asset.created();
+    let created_local = asset.created_local();
     if let Some(before) = config.skip_created_before()
-        && created_utc < before
+        && before.excludes_before(created_utc, created_local.date_naive())
     {
-        tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (before date range)");
+        tracing::debug!(asset_id = %asset.id(), date = %created_local, "Skipping (before date range)");
         return Some(FilterReason::DateRange);
     }
     if let Some(after) = config.skip_created_after()
-        && created_utc > after
+        && after.excludes_after(created_utc, created_local.date_naive())
     {
-        tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (after date range)");
+        tracing::debug!(asset_id = %asset.id(), date = %created_local, "Skipping (after date range)");
         return Some(FilterReason::DateRange);
     }
     // Only check filename exclusion when the asset has a real filename.
@@ -913,7 +917,7 @@ fn usable_asset_base_filename(
 /// derivation.
 pub(super) struct DerivationContext<'a> {
     pub(super) base_filename: String,
-    pub(super) created_local: DateTime<Local>,
+    pub(super) created_local: DateTime<FixedOffset>,
     pub(super) versions: VersionsView<'a>,
 }
 
@@ -930,7 +934,7 @@ impl<'a> DerivationContext<'a> {
         };
         Self {
             base_filename,
-            created_local: asset.created().with_timezone(&Local),
+            created_local: asset.created_local(),
             versions: apply_raw_policy(asset.versions(), config.raw_policy()),
         }
     }
@@ -1391,7 +1395,7 @@ pub(super) async fn pre_ensure_asset_dir(
     asset: &crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) {
-    let created_local: DateTime<Local> = asset.created().with_timezone(&Local);
+    let created_local = asset.created_local();
     let parent = paths::local_download_dir(
         &config.directory,
         &config.folder_structure,
@@ -1442,7 +1446,7 @@ impl PathResolution {
 #[derive(Debug)]
 struct ResolveContext<'a> {
     config: &'a DownloadConfig,
-    created_local: &'a DateTime<Local>,
+    created_local: &'a DateTime<FixedOffset>,
     claimed_paths: &'a FxHashMap<NormalizedPath, u64>,
     dir_cache: &'a mut paths::DirCache,
 }
@@ -1902,7 +1906,6 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use chrono::Utc;
     use rustc_hash::FxHashSet;
 
     #[cfg(unix)]
@@ -2025,8 +2028,10 @@ mod tests {
             .build()
     }
 
-    fn date_time(s: &str) -> DateTime<Utc> {
-        DateTime::parse_from_rfc3339(s).expect("test date").into()
+    fn date_time(s: &str) -> crate::config::CreatedDateFilter {
+        crate::config::CreatedDateFilter::Instant(
+            DateTime::parse_from_rfc3339(s).expect("test date").into(),
+        )
     }
 
     fn no_config_change(_: &mut DownloadConfig) {}
@@ -2112,6 +2117,56 @@ mod tests {
         assert_eq!(&*tasks[0].url, "https://p01.icloud-content.com/orig");
         assert_eq!(&*tasks[0].checksum, "abc123");
         assert_eq!(tasks[0].size, 1000);
+    }
+
+    #[test]
+    fn capture_local_date_filters_and_paths_cover_boundaries_and_fallbacks() {
+        let check = |asset_date: f64,
+                     offset: Option<i32>,
+                     boundary: &str,
+                     expected_filter: Option<FilterReason>| {
+            let mut builder = TestPhotoAsset::new("TIMEZONE_CASE")
+                .filename("photo.jpg")
+                .asset_date(asset_date);
+            if let Some(offset) = offset {
+                builder = builder.timezone_offset(offset);
+            }
+            let asset = builder.build();
+            let boundary = boundary.parse().unwrap();
+            let mut config = test_config();
+            config.skip_created_before =
+                Some(crate::config::CreatedDateFilter::CaptureDate(boundary));
+            config.skip_created_after =
+                Some(crate::config::CreatedDateFilter::CaptureDate(boundary));
+
+            assert_eq!(is_asset_filtered(&asset, &config), expected_filter);
+            if expected_filter.is_none() {
+                let tasks = filter_asset_fresh(&asset, &config);
+                assert_eq!(tasks.len(), 1);
+                let expected_path = format!("{}/photo.JPG", boundary.format("%Y/%m/%d"));
+                assert!(
+                    tasks[0].download_path.ends_with(&expected_path),
+                    "{}",
+                    tasks[0].download_path.display()
+                );
+            }
+        };
+
+        check(1_769_898_719_000.0, Some(39_600), "2026-02-01", None);
+        check(1_767_227_400_000.0, Some(-3_600), "2025-12-31", None);
+        check(
+            1_769_898_719_000.0,
+            Some(39_600),
+            "2026-01-31",
+            Some(FilterReason::DateRange),
+        );
+        let host_boundary = DateTime::from_timestamp_millis(1_736_899_200_000)
+            .unwrap()
+            .with_timezone(&Local)
+            .date_naive()
+            .to_string();
+        check(1_736_899_200_000.0, None, &host_boundary, None);
+        check(1_736_899_200_000.0, Some(i32::MAX), &host_boundary, None);
     }
 
     #[test]
@@ -3513,28 +3568,28 @@ mod tests {
         let natural_heic = paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&Local),
+            &asset.created_local(),
             "FullSizeRender.HEIC",
             None,
         );
         let deduped_heic = paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&Local),
+            &asset.created_local(),
             "FullSizeRender-2067405.HEIC",
             None,
         );
         let natural_mov = paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&Local),
+            &asset.created_local(),
             "FullSizeRender_HEVC.MOV",
             None,
         );
         let paired_mov = paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&Local),
+            &asset.created_local(),
             "FullSizeRender-2067405_HEVC.MOV",
             None,
         );

--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -347,7 +347,7 @@ mod tests {
             library: Arc::from(LIBRARY),
             metadata: Arc::new(MetadataPayload::default()),
             size: 12,
-            created_local: Local::now(),
+            created_local: Local::now().fixed_offset(),
             version_size: VersionSizeKey::Original,
             media_type: MediaType::Photo,
         }

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Once;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, FixedOffset, NaiveDateTime};
 #[cfg(not(feature = "xmp"))]
 use little_exif::exif_tag::ExifTag;
 #[cfg(not(feature = "xmp"))]
@@ -40,6 +41,11 @@ const KEI_XMP_NS: &str = "https://github.com/rhoopr/kei/ns/1.0/";
 #[cfg(feature = "xmp")]
 const KEI_XMP_PREFIX: &str = "kei";
 #[cfg(feature = "xmp")]
+const EXIF_EX_XMP_NS: &str = "http://cipa.jp/exif/1.0/";
+#[cfg(feature = "xmp")]
+const EXIF_EX_XMP_PREFIX: &str = "exifEX";
+
+#[cfg(feature = "xmp")]
 const KEI_MANAGED_FIELDS: &str = "managedFields";
 
 #[cfg(feature = "xmp")]
@@ -49,6 +55,7 @@ enum ManagedXmpField {
     ModifyDate,
     DateTimeOriginal,
     DateCreated,
+    OffsetTimeOriginal,
     Rating,
     GpsLatitude,
     GpsLongitude,
@@ -65,11 +72,12 @@ enum ManagedXmpField {
 }
 
 #[cfg(feature = "xmp")]
-const MANAGED_XMP_FIELDS: [ManagedXmpField; 17] = [
+const MANAGED_XMP_FIELDS: [ManagedXmpField; 18] = [
     ManagedXmpField::CreateDate,
     ManagedXmpField::ModifyDate,
     ManagedXmpField::DateTimeOriginal,
     ManagedXmpField::DateCreated,
+    ManagedXmpField::OffsetTimeOriginal,
     ManagedXmpField::Rating,
     ManagedXmpField::GpsLatitude,
     ManagedXmpField::GpsLongitude,
@@ -93,6 +101,7 @@ impl ManagedXmpField {
             Self::ModifyDate => "xmp:ModifyDate",
             Self::DateTimeOriginal => "exif:DateTimeOriginal",
             Self::DateCreated => "photoshop:DateCreated",
+            Self::OffsetTimeOriginal => "exifEX:OffsetTimeOriginal",
             Self::Rating => "xmp:Rating",
             Self::GpsLatitude => "exif:GPSLatitude",
             Self::GpsLongitude => "exif:GPSLongitude",
@@ -114,6 +123,7 @@ impl ManagedXmpField {
             Self::CreateDate | Self::ModifyDate | Self::DateTimeOriginal | Self::DateCreated => {
                 write.datetime.is_some()
             }
+            Self::OffsetTimeOriginal => write.offset_time_original.is_some(),
             Self::Rating => write.rating.is_some(),
             Self::GpsLatitude | Self::GpsLongitude => write.gps.is_some(),
             Self::GpsAltitude | Self::GpsAltitudeRef => {
@@ -136,6 +146,7 @@ impl ManagedXmpField {
             Self::ModifyDate => (xmp_ns::XMP, "ModifyDate"),
             Self::DateTimeOriginal => (xmp_ns::EXIF, "DateTimeOriginal"),
             Self::DateCreated => (xmp_ns::PHOTOSHOP, "DateCreated"),
+            Self::OffsetTimeOriginal => (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
             Self::Rating => (xmp_ns::XMP, "Rating"),
             Self::GpsLatitude => (xmp_ns::EXIF, "GPSLatitude"),
             Self::GpsLongitude => (xmp_ns::EXIF, "GPSLongitude"),
@@ -169,9 +180,10 @@ static HEIF_EMBED_DISABLED_WARNING: Once = Once::new();
 fn ensure_initialized() {
     INIT.call_once(|| {
         // Registering the same namespace twice is fine; XMP Toolkit returns
-        // the existing prefix. Ignore the Result — even a failure here only
-        // disables the kei: fields, and standard XMP continues to work.
+        // the existing prefix. Ignore failures so standard XMP output still
+        // works if a custom namespace cannot be registered.
         let _ = XmpMeta::register_namespace(KEI_XMP_NS, KEI_XMP_PREFIX);
+        let _ = XmpMeta::register_namespace(EXIF_EX_XMP_NS, EXIF_EX_XMP_PREFIX);
     });
 }
 
@@ -180,7 +192,52 @@ fn ensure_initialized() {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ExifProbe {
     pub(crate) datetime_original: Option<String>,
+    pub(crate) offset_time_original: Option<String>,
+    pub(crate) has_other_datetime_offset: bool,
     pub(crate) has_gps: bool,
+}
+
+impl ExifProbe {
+    pub(crate) fn has_any_datetime_offset(&self) -> bool {
+        self.offset_time_original.is_some() || self.has_other_datetime_offset
+    }
+
+    /// True when the capture timestamp already in the file renders
+    /// `created_local`, and carries no zone that contradicts it.
+    ///
+    /// A resolved offset may only join a timestamp that satisfies this. A file
+    /// written before capture-local resolution holds a wall clock in the
+    /// backup host's timezone, so pairing Apple's offset with it would assert
+    /// an instant the asset never had.
+    pub(crate) fn denotes_capture_time(&self, created_local: &DateTime<FixedOffset>) -> bool {
+        let Some(existing) = self.datetime_original.as_deref() else {
+            return false;
+        };
+        let Some((wall_clock, zone)) = parse_capture_timestamp(existing) else {
+            return false;
+        };
+        wall_clock == created_local.naive_local()
+            && zone.is_none_or(|zone| zone == *created_local.offset())
+    }
+}
+
+/// Split a capture timestamp into its wall clock and the zone it names, if
+/// any. XMP holds ISO 8601 and the native EXIF block holds
+/// `YYYY:MM:DD HH:MM:SS`, so both forms reach the probe, and either may arrive
+/// padded with whitespace or trailing NULs.
+fn parse_capture_timestamp(value: &str) -> Option<(NaiveDateTime, Option<FixedOffset>)> {
+    let value = value.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+    if let Ok(zoned) = DateTime::parse_from_rfc3339(value) {
+        return Some((zoned.naive_local(), Some(*zoned.offset())));
+    }
+    [
+        "%Y:%m:%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+    ]
+    .into_iter()
+    .find_map(|format| NaiveDateTime::parse_from_str(value, format).ok())
+    .map(|wall_clock| (wall_clock, None))
 }
 
 /// Read the existing XMP / EXIF state of a media file.
@@ -260,10 +317,18 @@ fn probe_from_meta(meta: &XmpMeta) -> ExifProbe {
     let datetime_original = meta
         .property(xmp_ns::EXIF, "DateTimeOriginal")
         .map(|v| v.value);
+    let offset_time_original = meta
+        .property(EXIF_EX_XMP_NS, "OffsetTimeOriginal")
+        .map(|v| v.value);
+    let has_other_datetime_offset = ["OffsetTimeDigitized", "OffsetTime"]
+        .iter()
+        .any(|path| meta.contains_property(EXIF_EX_XMP_NS, path));
     let has_gps = meta.contains_property(xmp_ns::EXIF, "GPSLatitude")
         || meta.contains_property(xmp_ns::EXIF, "GPSLongitude");
     ExifProbe {
         datetime_original,
+        offset_time_original,
+        has_other_datetime_offset,
         has_gps,
     }
 }
@@ -286,6 +351,21 @@ fn probe_exif_native(path: &Path) -> ExifProbe {
             ExifTag::DateTimeOriginal(s) => Some(s.clone()),
             _ => None,
         });
+    let offset_time_original = meta
+        .get_tag(&ExifTag::OffsetTimeOriginal(String::new()))
+        .next()
+        .and_then(|tag| match tag {
+            ExifTag::OffsetTimeOriginal(s) => Some(s.clone()),
+            _ => None,
+        });
+    let has_other_datetime_offset = meta
+        .get_tag(&ExifTag::OffsetTimeDigitized(String::new()))
+        .next()
+        .is_some()
+        || meta
+            .get_tag(&ExifTag::OffsetTime(String::new()))
+            .next()
+            .is_some();
     let has_gps = meta
         .get_tag(&ExifTag::GPSLatitude(Vec::new()))
         .next()
@@ -296,6 +376,8 @@ fn probe_exif_native(path: &Path) -> ExifProbe {
             .is_some();
     ExifProbe {
         datetime_original,
+        offset_time_original,
+        has_other_datetime_offset,
         has_gps,
     }
 }
@@ -314,6 +396,10 @@ pub(crate) struct GpsCoords {
 pub(crate) struct MetadataWrite {
     /// `"YYYY:MM:DD HH:MM:SS"` EXIF-style datetime string.
     pub(crate) datetime: Option<String>,
+    /// EXIF `OffsetTimeOriginal`, formatted as `+HH:MM` or `-HH:MM`.
+    pub(crate) offset_time_original: Option<String>,
+    /// Remove offset tags before writing a replacement timestamp.
+    pub(crate) clear_datetime_offsets: bool,
     pub(crate) rating: Option<u8>,
     pub(crate) gps: Option<GpsCoords>,
     pub(crate) title: Option<String>,
@@ -331,6 +417,8 @@ pub(crate) struct MetadataWrite {
 impl MetadataWrite {
     pub(crate) fn is_empty(&self) -> bool {
         self.datetime.is_none()
+            && self.offset_time_original.is_none()
+            && !self.clear_datetime_offsets
             && self.rating.is_none()
             && self.gps.is_none()
             && self.title.is_none()
@@ -704,6 +792,21 @@ fn apply_metadata_native(path: &Path, write: &MetadataWrite, temp_suffix: &str) 
         metadata.set_tag(ExifTag::CreateDate(dt.clone()));
         metadata.set_tag(ExifTag::ModifyDate(dt.clone()));
     }
+    if write.clear_datetime_offsets {
+        metadata.remove_tag(ExifTag::OffsetTimeOriginal(String::new()));
+        metadata.remove_tag(ExifTag::OffsetTimeDigitized(String::new()));
+        metadata.remove_tag(ExifTag::OffsetTime(String::new()));
+    }
+    if let Some(offset) = &write.offset_time_original {
+        metadata.set_tag(ExifTag::OffsetTimeOriginal(offset.clone()));
+        if write.datetime.is_some() {
+            // CreateDate and ModifyDate carry their own offset tags. They
+            // share this offset only when this pass wrote all three
+            // timestamps from the same capture-local instant.
+            metadata.set_tag(ExifTag::OffsetTimeDigitized(offset.clone()));
+            metadata.set_tag(ExifTag::OffsetTime(offset.clone()));
+        }
+    }
     if let Some(desc) = &write.description {
         metadata.set_tag(ExifTag::ImageDescription(desc.clone()));
     }
@@ -815,19 +918,47 @@ const fn windows_rating_percent(rating: u16) -> u16 {
 /// through here so the two paths produce identical XMP content.
 #[cfg(feature = "xmp")]
 fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpResult<()> {
+    if write.clear_datetime_offsets {
+        for path in ["OffsetTimeOriginal", "OffsetTimeDigitized", "OffsetTime"] {
+            meta.delete_property(EXIF_EX_XMP_NS, path)?;
+        }
+    }
     if let Some(dt) = &write.datetime {
         // XMP uses ISO 8601; our stored form is EXIF-style "YYYY:MM:DD HH:MM:SS".
         // Convert for XMP, keep a local EXIF copy so XMP Toolkit's reconciler
         // writes the native block too on formats that have one.
         let iso = exif_datetime_to_iso(dt);
-        meta.set_property(xmp_ns::XMP, "CreateDate", &XmpValue::new(iso.clone()))?;
-        meta.set_property(xmp_ns::XMP, "ModifyDate", &XmpValue::new(iso.clone()))?;
+        let iso_with_offset = write
+            .offset_time_original
+            .as_ref()
+            .map_or_else(|| iso.clone(), |offset| format!("{iso}{offset}"));
+        meta.set_property(
+            xmp_ns::XMP,
+            "CreateDate",
+            &XmpValue::new(iso_with_offset.clone()),
+        )?;
+        meta.set_property(
+            xmp_ns::XMP,
+            "ModifyDate",
+            &XmpValue::new(iso_with_offset.clone()),
+        )?;
         meta.set_property(
             xmp_ns::EXIF,
             "DateTimeOriginal",
-            &XmpValue::new(iso.clone()),
+            &XmpValue::new(iso_with_offset.clone()),
         )?;
-        meta.set_property(xmp_ns::PHOTOSHOP, "DateCreated", &XmpValue::new(iso))?;
+        meta.set_property(
+            xmp_ns::PHOTOSHOP,
+            "DateCreated",
+            &XmpValue::new(iso_with_offset),
+        )?;
+    }
+    if let Some(offset) = &write.offset_time_original {
+        meta.set_property(
+            EXIF_EX_XMP_NS,
+            "OffsetTimeOriginal",
+            &XmpValue::new(offset.clone()),
+        )?;
     }
 
     if let Some(r) = write.rating {
@@ -1224,6 +1355,79 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
+    #[cfg(feature = "xmp")]
+    #[test]
+    fn xmp_datetime_includes_capture_offset() {
+        let packet = build_xmp_packet(&MetadataWrite {
+            datetime: Some("2026:02:01 09:31:59".to_string()),
+            offset_time_original: Some("+11:00".to_string()),
+            ..MetadataWrite::default()
+        })
+        .unwrap();
+        let meta = std::str::from_utf8(&packet)
+            .unwrap()
+            .parse::<XmpMeta>()
+            .unwrap();
+        assert_eq!(
+            meta.property(super::EXIF_EX_XMP_NS, "OffsetTimeOriginal")
+                .unwrap()
+                .value,
+            "+11:00"
+        );
+        let probe = super::probe_from_meta(&meta);
+        assert_eq!(probe.offset_time_original.as_deref(), Some("+11:00"));
+        assert!(meta.property(xmp_ns::EXIF, "OffsetTimeOriginal").is_none());
+        assert_eq!(
+            meta.property(xmp_ns::EXIF, "DateTimeOriginal")
+                .unwrap()
+                .value,
+            "2026-02-01T09:31:59+11:00"
+        );
+    }
+
+    /// An offset names the zone of one specific timestamp. Replacing the
+    /// timestamp orphans every offset already in the file, so they have to go
+    /// before the resolved one lands, or a stale zone qualifies a capture time
+    /// it never described.
+    #[cfg(feature = "xmp")]
+    #[test]
+    fn xmp_write_clears_offsets_orphaned_from_a_replaced_timestamp() {
+        ensure_initialized();
+        let mut meta = XmpMeta::new().unwrap();
+        for property in ["OffsetTimeOriginal", "OffsetTimeDigitized", "OffsetTime"] {
+            meta.set_property(
+                super::EXIF_EX_XMP_NS,
+                property,
+                &XmpValue::new("+02:00".to_string()),
+            )
+            .unwrap();
+        }
+
+        super::apply_to_xmp(
+            &mut meta,
+            &MetadataWrite {
+                datetime: Some("2026:02:01 09:31:59".to_string()),
+                offset_time_original: Some("+11:00".to_string()),
+                clear_datetime_offsets: true,
+                ..MetadataWrite::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            meta.property(super::EXIF_EX_XMP_NS, "OffsetTimeOriginal")
+                .unwrap()
+                .value,
+            "+11:00"
+        );
+        for property in ["OffsetTimeDigitized", "OffsetTime"] {
+            assert!(
+                !meta.contains_property(super::EXIF_EX_XMP_NS, property),
+                "{property} must not survive to qualify a timestamp it never described"
+            );
+        }
+    }
+
     #[test]
     fn apply_metadata_rating_roundtrips() {
         let dir = test_tmp_dir("meta_tests");
@@ -1393,6 +1597,8 @@ mod tests {
             &path,
             &MetadataWrite {
                 datetime: Some("2024:06:15 10:00:00".to_string()),
+                offset_time_original: None,
+                clear_datetime_offsets: false,
                 rating: Some(5),
                 gps: Some(GpsCoords {
                     latitude: 1.0,
@@ -2273,6 +2479,8 @@ mod tests {
 
         let first = MetadataWrite {
             datetime: Some("2024:06:15 10:00:00".into()),
+            offset_time_original: Some("+10:00".into()),
+            clear_datetime_offsets: false,
             rating: Some(5),
             gps: Some(GpsCoords {
                 latitude: 37.7,
@@ -2306,6 +2514,7 @@ mod tests {
         assert!(meta.contains_property(xmp_ns::EXIF, "GPSLatitude"));
         for (namespace, property) in [
             (xmp_ns::XMP, "Rating"),
+            (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
             (xmp_ns::EXIF, "GPSAltitude"),
             (xmp_ns::EXIF, "GPSAltitudeRef"),
             (xmp_ns::DC, "subject"),
@@ -2330,6 +2539,7 @@ mod tests {
         let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
         assert!(managed.contains("exif:GPSLatitude"));
         assert!(!managed.contains("xmp:Rating"));
+        assert!(!managed.contains("exifEX:OffsetTimeOriginal"));
         assert!(!managed.contains("exif:GPSAltitude"));
         assert_eq!(
             meta.property(THIRD_PARTY_NS, "developSettings")
@@ -2612,6 +2822,7 @@ mod native_tests {
             probe.datetime_original.as_deref(),
             Some("2024:06:15 10:00:00")
         );
+        assert_eq!(probe.offset_time_original, None);
         assert!(probe.has_gps);
 
         let metadata = Metadata::new_from_path(&path).unwrap();
@@ -2651,6 +2862,136 @@ mod native_tests {
             probe.datetime_original.as_deref(),
             Some("2024:06:15 10:00:00")
         );
+    }
+
+    #[test]
+    fn native_write_pairs_every_datetime_with_its_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fresh_jpeg(dir.path(), "native-offset.jpg");
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2026:02:01 09:31:59".to_string()),
+                offset_time_original: Some("+11:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        let probe = probe_exif(&path).unwrap();
+        assert_eq!(probe.offset_time_original.as_deref(), Some("+11:00"));
+        assert!(probe.has_other_datetime_offset);
+
+        let metadata = Metadata::new_from_path(&path).unwrap();
+        for template in [
+            ExifTag::OffsetTimeOriginal(String::new()),
+            ExifTag::OffsetTimeDigitized(String::new()),
+            ExifTag::OffsetTime(String::new()),
+        ] {
+            let written = metadata
+                .get_tag(&template)
+                .next()
+                .and_then(|tag| match tag {
+                    ExifTag::OffsetTimeOriginal(s)
+                    | ExifTag::OffsetTimeDigitized(s)
+                    | ExifTag::OffsetTime(s) => Some(s.as_str()),
+                    _ => None,
+                });
+            assert_eq!(
+                written,
+                Some("+11:00"),
+                "EXIF tag 0x{:04x} must carry the capture offset",
+                template.as_u16()
+            );
+        }
+
+        // Without a timestamp write, CreateDate and ModifyDate keep whatever
+        // the file already held, so only the verified DateTimeOriginal gets an
+        // offset.
+        let lone = fresh_jpeg(dir.path(), "native-lone-offset.jpg");
+        apply_metadata(
+            &lone,
+            &MetadataWrite {
+                offset_time_original: Some("+11:00".to_string()),
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        let metadata = Metadata::new_from_path(&lone).unwrap();
+        assert!(
+            metadata
+                .get_tag(&ExifTag::OffsetTimeOriginal(String::new()))
+                .next()
+                .is_some()
+        );
+        for template in [
+            ExifTag::OffsetTimeDigitized(String::new()),
+            ExifTag::OffsetTime(String::new()),
+        ] {
+            assert!(
+                metadata.get_tag(&template).next().is_none(),
+                "EXIF tag 0x{:04x} must not claim an offset for a timestamp this pass did not write",
+                template.as_u16()
+            );
+        }
+    }
+
+    /// A camera can leave offset tags behind without the capture timestamp
+    /// they qualified. Writing a resolved timestamp over that state has to
+    /// drop them first, or the file ends up claiming a zone that describes
+    /// nothing in it.
+    #[test]
+    fn native_write_clears_offsets_orphaned_from_a_replaced_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fresh_jpeg(dir.path(), "native-orphaned-offset.jpg");
+
+        let mut seed = Metadata::new();
+        seed.set_tag(ExifTag::OffsetTimeOriginal("+02:00".to_string()));
+        seed.set_tag(ExifTag::OffsetTimeDigitized("+02:00".to_string()));
+        seed.set_tag(ExifTag::OffsetTime("+02:00".to_string()));
+        seed.write_to_file(&path).unwrap();
+
+        let seeded = probe_exif(&path).unwrap();
+        assert_eq!(seeded.datetime_original, None);
+        assert!(seeded.has_any_datetime_offset());
+
+        apply_metadata(
+            &path,
+            &MetadataWrite {
+                datetime: Some("2026:02:01 09:31:59".to_string()),
+                clear_datetime_offsets: true,
+                ..MetadataWrite::default()
+            },
+            ".kei-tmp",
+        )
+        .unwrap();
+
+        let probe = probe_exif(&path).unwrap();
+        assert_eq!(
+            probe.datetime_original.as_deref(),
+            Some("2026:02:01 09:31:59")
+        );
+        assert!(
+            !probe.has_any_datetime_offset(),
+            "a stale offset must not survive to qualify the replacement timestamp"
+        );
+
+        let metadata = Metadata::new_from_path(&path).unwrap();
+        for template in [
+            ExifTag::OffsetTimeOriginal(String::new()),
+            ExifTag::OffsetTimeDigitized(String::new()),
+            ExifTag::OffsetTime(String::new()),
+        ] {
+            assert!(
+                metadata.get_tag(&template).next().is_none(),
+                "EXIF tag 0x{:04x} must be cleared",
+                template.as_u16()
+            );
+        }
     }
 
     #[test]

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use chrono::{DateTime, Local};
+use chrono::{DateTime, FixedOffset};
 use tokio_util::sync::CancellationToken;
 
 use crate::download::filter::MetadataPayload;
@@ -99,7 +99,7 @@ pub(super) struct MetadataWriteRequest<'a> {
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     pub(super) sidecar_path: Option<&'a Path>,
     pub(super) payload: Arc<MetadataPayload>,
-    pub(super) created_local: DateTime<Local>,
+    pub(super) created_local: DateTime<FixedOffset>,
     pub(super) flags: MetadataFlags,
     pub(super) temp_suffix: &'a str,
 }
@@ -147,7 +147,7 @@ pub(super) async fn write_download_metadata(
 async fn write_embed_metadata(
     path: &Path,
     payload: Arc<MetadataPayload>,
-    created_local: DateTime<Local>,
+    created_local: DateTime<FixedOffset>,
     flags: MetadataFlags,
     temp_suffix: &str,
 ) -> bool {
@@ -187,7 +187,7 @@ async fn write_embed_metadata(
 async fn write_sidecar_metadata(
     path: &Path,
     payload: Arc<MetadataPayload>,
-    created_local: DateTime<Local>,
+    created_local: DateTime<FixedOffset>,
     temp_suffix: &str,
 ) -> bool {
     let sidecar_path = path.to_path_buf();
@@ -226,15 +226,27 @@ fn gps_from_payload(payload: &MetadataPayload) -> Option<super::metadata::GpsCoo
     }
 }
 
+fn offset_time_original(payload: &MetadataPayload) -> Option<String> {
+    let offset = payload.timezone_offset.and_then(FixedOffset::east_opt)?;
+    let seconds = offset.local_minus_utc();
+    if seconds % 60 != 0 {
+        return None;
+    }
+    let minutes = i64::from(seconds).abs() / 60;
+    let sign = if seconds < 0 { '-' } else { '+' };
+    Some(format!("{sign}{:02}:{:02}", minutes / 60, minutes % 60))
+}
+
 /// Comprehensive snapshot of every field a payload can contribute. Used as
 /// the sidecar plan (sidecars are fresh files; no probe gating applies).
 #[cfg(feature = "xmp")]
 fn plan_sidecar_write(
     payload: &MetadataPayload,
-    created_local: &DateTime<Local>,
+    created_local: &DateTime<FixedOffset>,
 ) -> super::metadata::MetadataWrite {
     let mut write = super::metadata::MetadataWrite {
         datetime: Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string()),
+        offset_time_original: offset_time_original(payload),
         rating: payload.rating,
         gps: gps_from_payload(payload),
         is_hidden: payload.is_hidden,
@@ -254,19 +266,32 @@ fn plan_sidecar_write(
 ///
 /// - datetime / GPS: only when the flag is on AND the file has no existing
 ///   value (probe gate preserves camera-supplied data).
+/// - offset: only alongside a timestamp this pass writes, or one the probe
+///   proves already renders the capture-local instant.
 /// - rating / description: flag gate only - iCloud is the source of truth.
 /// - XMP-only fields (title, keywords, people, hidden/archived,
 ///   media_subtype, burst_id): gated on the `EMBED_XMP` flag.
 fn plan_metadata_write(
     flags: MetadataFlags,
     payload: &MetadataPayload,
-    created_local: &DateTime<Local>,
+    created_local: &DateTime<FixedOffset>,
     probe: &super::metadata::ExifProbe,
 ) -> super::metadata::MetadataWrite {
     let mut write = super::metadata::MetadataWrite::default();
 
-    if flags.contains(MetadataFlags::DATETIME) && probe.datetime_original.is_none() {
-        write.datetime = Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string());
+    if flags.contains(MetadataFlags::DATETIME) {
+        if probe.datetime_original.is_none() {
+            write.datetime = Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string());
+            write.clear_datetime_offsets = probe.has_any_datetime_offset();
+        }
+        // An offset describes one specific timestamp. Attach it only to a
+        // timestamp this pass writes, or to one already proven to render the
+        // capture-local instant.
+        if write.datetime.is_some()
+            || (probe.offset_time_original.is_none() && probe.denotes_capture_time(created_local))
+        {
+            write.offset_time_original = offset_time_original(payload);
+        }
     }
     if flags.contains(MetadataFlags::RATING) {
         write.rating = payload.rating;
@@ -458,7 +483,7 @@ where
         }
 
         let payload = Arc::new(MetadataPayload::from_metadata(&record.metadata));
-        let created_local: DateTime<Local> = DateTime::from(record.created_at);
+        let created_local = record.metadata.capture_local(record.created_at);
         let version_size = record.version_size;
 
         // Only an embedded write touches media bytes, so the drain needs the
@@ -608,15 +633,23 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use chrono::TimeZone;
 
-    #[cfg(feature = "xmp")]
-    fn now_local() -> DateTime<Local> {
-        Local::now()
+    /// Capture-local time for an asset whose stored offset is +11:00, which is
+    /// what every payload below carries. Production derives this offset and
+    /// the written `OffsetTimeOriginal` from that same stored value, so the
+    /// two always agree.
+    fn now_local() -> DateTime<FixedOffset> {
+        FixedOffset::east_opt(39_600)
+            .unwrap()
+            .with_ymd_and_hms(2024, 6, 15, 10, 0, 0)
+            .unwrap()
     }
 
     #[cfg(feature = "xmp")]
     fn rich_payload() -> MetadataPayload {
         MetadataPayload {
+            timezone_offset: Some(39_600),
             rating: Some(4),
             latitude: Some(37.7),
             longitude: Some(-122.4),
@@ -650,8 +683,9 @@ mod tests {
         assert!(w.keywords.is_empty());
         assert!(w.people.is_empty());
         assert!(!w.is_hidden);
+        assert!(w.offset_time_original.is_none());
 
-        let flags_embed = MetadataFlags::EMBED_XMP;
+        let flags_embed = MetadataFlags::DATETIME | MetadataFlags::EMBED_XMP;
         let w = plan_metadata_write(
             flags_embed,
             &payload,
@@ -665,23 +699,159 @@ mod tests {
         assert!(w.is_archived);
         assert_eq!(w.media_subtype.as_deref(), Some("portrait"));
         assert_eq!(w.burst_id.as_deref(), Some("b1"));
+        assert_eq!(w.offset_time_original.as_deref(), Some("+11:00"));
     }
 
-    #[cfg(feature = "xmp")]
     #[test]
     fn plan_metadata_write_respects_probe_skip_for_datetime_and_gps() {
-        let payload = rich_payload();
+        let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
+            latitude: Some(37.7),
+            longitude: Some(-122.4),
+            ..MetadataPayload::default()
+        };
         let flags = MetadataFlags::DATETIME | MetadataFlags::GPS;
-        let probe = crate::download::metadata::ExifProbe {
-            datetime_original: Some("2020:01:01 00:00:00".into()),
+        let created_local = now_local();
+        let capture_local = created_local.format("%Y:%m:%d %H:%M:%S").to_string();
+
+        let matching_clock = crate::download::metadata::ExifProbe {
+            datetime_original: Some(capture_local),
+            offset_time_original: None,
+            has_other_datetime_offset: false,
             has_gps: true,
         };
-        let w = plan_metadata_write(flags, &payload, &now_local(), &probe);
+        let write = plan_metadata_write(flags, &payload, &created_local, &matching_clock);
         assert!(
-            w.datetime.is_none(),
+            write.datetime.is_none(),
             "must skip datetime when file already has one"
         );
-        assert!(w.gps.is_none(), "must skip gps when file already has one");
+        assert_eq!(
+            write.offset_time_original.as_deref(),
+            Some("+11:00"),
+            "an offset may join a timestamp already rendering capture-local time"
+        );
+        assert!(
+            write.gps.is_none(),
+            "must skip gps when file already has one"
+        );
+
+        let existing_offset = crate::download::metadata::ExifProbe {
+            offset_time_original: Some("+10:00".into()),
+            ..matching_clock
+        };
+        let write = plan_metadata_write(flags, &payload, &created_local, &existing_offset);
+        assert!(write.datetime.is_none());
+        assert!(write.offset_time_original.is_none());
+        assert!(write.gps.is_none());
+    }
+
+    #[test]
+    fn plan_metadata_write_replaces_offsets_orphaned_from_datetime_original() {
+        let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
+            ..MetadataPayload::default()
+        };
+        let flags = MetadataFlags::DATETIME;
+        let created_local = now_local();
+
+        for probe in [
+            crate::download::metadata::ExifProbe {
+                offset_time_original: Some("+10:00".into()),
+                ..crate::download::metadata::ExifProbe::default()
+            },
+            crate::download::metadata::ExifProbe {
+                has_other_datetime_offset: true,
+                ..crate::download::metadata::ExifProbe::default()
+            },
+        ] {
+            let write = plan_metadata_write(flags, &payload, &created_local, &probe);
+            assert!(write.datetime.is_some());
+            assert!(write.clear_datetime_offsets);
+            assert_eq!(write.offset_time_original.as_deref(), Some("+11:00"));
+        }
+
+        let write = plan_metadata_write(
+            flags,
+            &MetadataPayload::default(),
+            &created_local,
+            &crate::download::metadata::ExifProbe {
+                offset_time_original: Some("+10:00".into()),
+                ..crate::download::metadata::ExifProbe::default()
+            },
+        );
+        assert!(write.datetime.is_some());
+        assert!(write.clear_datetime_offsets);
+        assert!(write.offset_time_original.is_none());
+    }
+
+    /// A file written before capture-local resolution holds a wall clock in the
+    /// backup host's timezone. Apple's offset does not describe that clock, so
+    /// pairing the two would publish an instant the asset never had.
+    #[test]
+    fn plan_metadata_write_withholds_offset_from_an_unverified_timestamp() {
+        let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
+            ..MetadataPayload::default()
+        };
+        let flags = MetadataFlags::DATETIME;
+        let created_local = now_local();
+        let host_local = (created_local - chrono::Duration::hours(11))
+            .format("%Y:%m:%d %H:%M:%S")
+            .to_string();
+
+        for existing in [
+            host_local,
+            "not a timestamp".to_string(),
+            String::new(),
+            "2024-06-15".to_string(),
+            // Capture-local wall clock, but claiming a different zone.
+            created_local.format("%Y-%m-%dT%H:%M:%S+05:00").to_string(),
+        ] {
+            let probe = crate::download::metadata::ExifProbe {
+                datetime_original: Some(existing.clone()),
+                offset_time_original: None,
+                has_other_datetime_offset: false,
+                has_gps: false,
+            };
+            let write = plan_metadata_write(flags, &payload, &created_local, &probe);
+            assert!(write.datetime.is_none());
+            assert!(
+                write.offset_time_original.is_none(),
+                "offset must not join the unverified timestamp {existing:?}"
+            );
+        }
+    }
+
+    /// XMP stores capture times as ISO 8601, and kei's own writer appends the
+    /// offset. Such a timestamp is already capture-local, so it still accepts
+    /// the offset tag.
+    #[test]
+    fn plan_metadata_write_accepts_iso_timestamps_from_the_xmp_probe() {
+        let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
+            ..MetadataPayload::default()
+        };
+        let created_local = now_local();
+
+        for existing in [
+            created_local.format("%Y-%m-%dT%H:%M:%S").to_string(),
+            created_local.format("%Y-%m-%dT%H:%M:%S+11:00").to_string(),
+            format!("  {}\0", created_local.format("%Y:%m:%d %H:%M:%S")),
+        ] {
+            let probe = crate::download::metadata::ExifProbe {
+                datetime_original: Some(existing.clone()),
+                offset_time_original: None,
+                has_other_datetime_offset: false,
+                has_gps: false,
+            };
+            let write =
+                plan_metadata_write(MetadataFlags::DATETIME, &payload, &created_local, &probe);
+            assert_eq!(
+                write.offset_time_original.as_deref(),
+                Some("+11:00"),
+                "capture-local timestamp {existing:?} must accept its offset"
+            );
+        }
     }
 
     #[cfg(feature = "xmp")]
@@ -691,6 +861,7 @@ mod tests {
         let w = plan_sidecar_write(&payload, &now_local());
         // Every payload field should land in the sidecar write, no flag gating.
         assert!(w.datetime.is_some());
+        assert_eq!(w.offset_time_original.as_deref(), Some("+11:00"));
         assert_eq!(w.rating, Some(4));
         assert!(w.gps.is_some());
         assert_eq!(w.title.as_deref(), Some("T"));
@@ -741,7 +912,7 @@ mod tests {
             embed_path: Some(&photo_path),
             sidecar_path: Some(&photo_path),
             payload: Arc::new(MetadataPayload::default()),
-            created_local: Local::now(),
+            created_local: now_local(),
             flags: MetadataFlags::default(),
             temp_suffix: ".metadata-test",
         })
@@ -760,7 +931,6 @@ mod tests {
 
     /// Minimal valid JPEG (SOI + APP0 JFIF + EOI). XMP Toolkit can write
     /// into this container; small enough to keep the test hermetic.
-    #[cfg(feature = "xmp")]
     fn minimal_jpeg_bytes() -> Vec<u8> {
         vec![
             0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
@@ -768,12 +938,84 @@ mod tests {
         ]
     }
 
+    #[tokio::test]
+    async fn embed_path_preserves_unverified_host_local_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let photo_path = dir.path().join("host-local.jpg");
+        std::fs::write(&photo_path, minimal_jpeg_bytes()).unwrap();
+        crate::download::metadata::apply_metadata(
+            &photo_path,
+            &crate::download::metadata::MetadataWrite {
+                datetime: Some("2024:06:14 23:00:00".into()),
+                ..crate::download::metadata::MetadataWrite::default()
+            },
+            ".seed-tmp",
+        )
+        .unwrap();
+        let before = crate::download::metadata::probe_exif(&photo_path).unwrap();
+        assert!(before.datetime_original.is_some());
+        assert!(before.offset_time_original.is_none());
+
+        assert!(
+            write_embed_metadata(
+                &photo_path,
+                Arc::new(MetadataPayload {
+                    timezone_offset: Some(39_600),
+                    ..MetadataPayload::default()
+                }),
+                now_local(),
+                MetadataFlags::DATETIME,
+                ".metadata-test",
+            )
+            .await
+        );
+
+        let after = crate::download::metadata::probe_exif(&photo_path).unwrap();
+        assert_eq!(after.datetime_original, before.datetime_original);
+        assert!(after.offset_time_original.is_none());
+    }
+
+    #[tokio::test]
+    async fn embed_path_replaces_orphaned_offset_before_writing_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let photo_path = dir.path().join("orphaned-offset.jpg");
+        std::fs::write(&photo_path, minimal_jpeg_bytes()).unwrap();
+        crate::download::metadata::apply_metadata(
+            &photo_path,
+            &crate::download::metadata::MetadataWrite {
+                offset_time_original: Some("+10:00".into()),
+                ..crate::download::metadata::MetadataWrite::default()
+            },
+            ".seed-tmp",
+        )
+        .unwrap();
+        let before = crate::download::metadata::probe_exif(&photo_path).unwrap();
+        assert!(before.datetime_original.is_none());
+        assert_eq!(before.offset_time_original.as_deref(), Some("+10:00"));
+
+        let created_local = now_local();
+        assert!(
+            write_embed_metadata(
+                &photo_path,
+                Arc::new(MetadataPayload {
+                    timezone_offset: Some(39_600),
+                    ..MetadataPayload::default()
+                }),
+                created_local,
+                MetadataFlags::DATETIME,
+                ".metadata-test",
+            )
+            .await
+        );
+
+        let after = crate::download::metadata::probe_exif(&photo_path).unwrap();
+        assert!(after.denotes_capture_time(&created_local));
+        assert_eq!(after.offset_time_original.as_deref(), Some("+11:00"));
+    }
+
     /// End-to-end test of the metadata-rewrite pass. Seeds a downloaded row
-    /// with a `metadata_write_failed_at` marker and a rating of 4, then
-    /// calls `run_pending` and asserts:
-    /// 1. the on-disk JPEG now carries the rating in its XMP packet,
-    /// 2. the DB marker is cleared (rewrite won't re-fire next cycle),
-    /// 3. the recorded `metadata_hash` is left in place.
+    /// with a `metadata_write_failed_at` marker, then proves the configured
+    /// metadata is applied while durable download state remains coherent.
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn run_pending_applies_embed_and_clears_marker() {
@@ -792,6 +1034,7 @@ mod tests {
         let seeded_hash = "seed_hash_before_rewrite".to_string();
         let metadata = AssetMetadata {
             rating: Some(4),
+            timezone_offset: Some(39_600),
             metadata_hash: Some(seeded_hash.clone()),
             ..AssetMetadata::default()
         };
@@ -799,6 +1042,11 @@ mod tests {
             .filename("rewrite_target.jpg")
             .checksum("rewrite_ck")
             .size(22)
+            .created_at(
+                chrono::Utc
+                    .with_ymd_and_hms(2026, 1, 31, 22, 31, 59)
+                    .unwrap(),
+            )
             .metadata(metadata)
             .build();
         db.upsert_seen(&record).await.unwrap();
@@ -821,7 +1069,7 @@ mod tests {
         assert_eq!(pending.len(), 1);
         assert_eq!(&*pending[0].id, "REWRITE_1");
 
-        let flags = MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
+        let flags = MetadataFlags::DATETIME | MetadataFlags::RATING | MetadataFlags::EMBED_XMP;
         let token = CancellationToken::new();
         run_pending(&db, flags, Arc::from(".meta-tmp"), &token).await;
 
@@ -850,7 +1098,24 @@ mod tests {
             "a successful rewrite leaves the recorded metadata_hash in place"
         );
 
-        // The file on disk now contains an XMP packet with the rating.
+        let current_checksum = crate::download::file::compute_sha256(&photo_path)
+            .await
+            .unwrap();
+        assert_ne!(current_checksum, seeded_checksum);
+        let downloaded = db.get_downloaded_page(0, 1).await.unwrap();
+        assert_eq!(downloaded[0].checksum.as_ref(), "rewrite_ck");
+        assert_eq!(
+            downloaded[0].local_checksum.as_deref(),
+            Some(current_checksum.as_str())
+        );
+
+        let probe = crate::download::metadata::probe_exif(&photo_path).unwrap();
+        assert_eq!(
+            probe.datetime_original.as_deref(),
+            Some("2026-02-01T09:31:59")
+        );
+        assert_eq!(probe.offset_time_original.as_deref(), Some("+11:00"));
+
         let bytes = std::fs::read(&photo_path).unwrap();
         let text = String::from_utf8_lossy(&bytes);
         assert!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -701,13 +701,6 @@ impl SkipBreakdown {
     }
 }
 
-/// Truncate a `DateTime<Utc>` to midnight so that relative date intervals
-/// (e.g. `20d` → `now - 20 days`) produce a stable hash within the same
-/// calendar day.
-fn truncate_date_to_day(dt: Option<DateTime<Utc>>) -> Option<chrono::NaiveDate> {
-    dt.map(|d| d.date_naive())
-}
-
 /// Hash an `Option<NaiveDate>` with a tag byte for `None`/`Some` and the
 /// "YYYY-MM-DD" Display representation for the date value.
 fn hash_optional_date(hasher: &mut sha2::Sha256, date: Option<chrono::NaiveDate>) {
@@ -784,8 +777,8 @@ struct SharedHashFields<'a> {
     alternative: bool,
     raw_policy: RawPolicy,
     keep_unicode_in_filenames: bool,
-    skip_created_before: Option<DateTime<Utc>>,
-    skip_created_after: Option<DateTime<Utc>>,
+    skip_created_before: Option<crate::config::CreatedDateFilter>,
+    skip_created_after: Option<crate::config::CreatedDateFilter>,
     force_resolution: bool,
     media: crate::config::MediaSelection,
     live_photo_mode: LivePhotoMode,
@@ -818,8 +811,8 @@ fn hash_shared_fields(hasher: &mut sha2::Sha256, f: &SharedHashFields<'_>) {
     // Dates are truncated to day precision before hashing so that relative
     // intervals like "20d" (resolved to now-minus-20-days at parse time)
     // produce a stable hash across consecutive runs on the same day.
-    hash_optional_date(hasher, truncate_date_to_day(f.skip_created_before));
-    hash_optional_date(hasher, truncate_date_to_day(f.skip_created_after));
+    hash_optional_created_date_filter(hasher, f.skip_created_before);
+    hash_optional_created_date_filter(hasher, f.skip_created_after);
     hasher.update([u8::from(f.force_resolution)]);
     hasher.update([u8::from(f.media.photos)]);
     hasher.update([u8::from(f.media.videos)]);
@@ -834,6 +827,27 @@ fn hash_shared_fields(hasher: &mut sha2::Sha256, f: &SharedHashFields<'_>) {
     sorted_excludes.sort_unstable();
     for pattern in &sorted_excludes {
         hash_bytes(hasher, pattern.as_bytes());
+    }
+}
+
+fn hash_optional_created_date_filter(
+    hasher: &mut sha2::Sha256,
+    filter: Option<crate::config::CreatedDateFilter>,
+) {
+    use crate::config::CreatedDateFilter;
+    use sha2::Digest;
+
+    match filter {
+        None => hash_optional_date(hasher, None),
+        Some(CreatedDateFilter::Instant(boundary)) => {
+            // Preserve the pre-capture-date hash shape for instant cutoffs.
+            hash_optional_date(hasher, Some(boundary.date_naive()));
+        }
+        Some(CreatedDateFilter::CaptureDate(boundary)) => {
+            // A distinct tag invalidates only filters whose semantics changed.
+            hasher.update([2]);
+            hasher.update(boundary.to_string().as_bytes());
+        }
     }
 }
 
@@ -909,11 +923,11 @@ pub(crate) fn sync_coverage_fingerprint_json(
     let skip_created_before = config
         .filters
         .skip_created_before
-        .map(|d| d.with_timezone(&chrono::Utc).to_rfc3339());
+        .map(crate::config::CreatedDateFilter::fingerprint);
     let skip_created_after = config
         .filters
         .skip_created_after
-        .map(|d| d.with_timezone(&chrono::Utc).to_rfc3339());
+        .map(crate::config::CreatedDateFilter::fingerprint);
     let mut filename_exclude: Vec<&str> = config
         .download
         .filename_exclude
@@ -1032,15 +1046,6 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     use sha2::{Digest, Sha256};
 
     let live_resolution = config.photos.live_resolution.to_asset_version_size();
-    let skip_created_before = config
-        .filters
-        .skip_created_before
-        .map(|d| d.with_timezone(&chrono::Utc));
-    let skip_created_after = config
-        .filters
-        .skip_created_after
-        .map(|d| d.with_timezone(&chrono::Utc));
-
     let mut hasher = Sha256::new();
     hasher.update([ENUMERATION_SAFETY_HASH_VERSION]);
     hasher.update([config.photos.resolution as u8]);
@@ -1048,8 +1053,8 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     hasher.update([u8::from(config.photos.edited)]);
     hasher.update([u8::from(config.photos.alternative)]);
     hasher.update([config.photos.raw_policy as u8]);
-    hash_optional_date(&mut hasher, truncate_date_to_day(skip_created_before));
-    hash_optional_date(&mut hasher, truncate_date_to_day(skip_created_after));
+    hash_optional_created_date_filter(&mut hasher, config.filters.skip_created_before);
+    hash_optional_created_date_filter(&mut hasher, config.filters.skip_created_after);
     hasher.update([u8::from(config.photos.force_resolution)]);
     hasher.update([u8::from(config.filters.media.photos)]);
     hasher.update([u8::from(config.filters.media.videos)]);
@@ -1100,8 +1105,8 @@ pub(crate) struct DownloadConfig {
     pub(crate) folder_structure_smart_folders: Arc<str>,
     pub(crate) resolution: crate::types::PhotoResolution,
     pub(crate) media: crate::config::MediaSelection,
-    pub(crate) skip_created_before: Option<DateTime<Utc>>,
-    pub(crate) skip_created_after: Option<DateTime<Utc>>,
+    pub(crate) skip_created_before: Option<crate::config::CreatedDateFilter>,
+    pub(crate) skip_created_after: Option<crate::config::CreatedDateFilter>,
     pub(crate) metadata: crate::config::MetadataConfig,
     pub(crate) refresh_metadata: bool,
     pub(crate) repair_truncated: bool,
@@ -3052,8 +3057,7 @@ async fn build_recent_frontier(
         }
         let asset = item?;
         let created = asset.created();
-        if config
-            .skip_created_before
+        if enumeration_created_lower_bound(config)
             .map(|boundary| created < boundary)
             .unwrap_or(false)
         {
@@ -3068,6 +3072,15 @@ async fn build_recent_frontier(
     }))
 }
 
+/// Convert a capture-local date lower bound into a conservative UTC
+/// enumeration bound.  Capture offsets can move the local midnight by almost
+/// a day, so stopping at the unadjusted UTC midnight could omit valid assets.
+fn enumeration_created_lower_bound(config: &DownloadConfig) -> Option<DateTime<Utc>> {
+    config
+        .skip_created_before
+        .map(crate::config::CreatedDateFilter::conservative_utc_lower_bound)
+}
+
 fn stream_created_lower_bound(
     config: &DownloadConfig,
     frontier: Option<&RecentFrontier>,
@@ -3075,7 +3088,7 @@ fn stream_created_lower_bound(
     frontier
         .and_then(|frontier| frontier.oldest_created)
         .into_iter()
-        .chain(config.skip_created_before)
+        .chain(enumeration_created_lower_bound(config))
         .max()
 }
 
@@ -8272,7 +8285,7 @@ mod tests {
             library: Arc::from("PrimarySync"),
             metadata: Arc::new(filter::MetadataPayload::default()),
             size: 1024,
-            created_local: chrono::Local::now(),
+            created_local: chrono::Local::now().fixed_offset(),
             version_size,
             media_type: crate::state::MediaType::Photo,
         }
@@ -10280,8 +10293,9 @@ mod tests {
         config.directory = Arc::from(dir.path());
         config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
         config.enum_config_hash = Some(Arc::from("hash-pr3"));
-        config.skip_created_after =
-            Some(DateTime::from_timestamp_millis(1_699_999_999_000).expect("valid timestamp"));
+        config.skip_created_after = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_699_999_999_000).expect("valid timestamp"),
+        ));
         let on_disk_asset = PhotoAsset::new(on_disk_records[0].clone(), on_disk_records[1].clone());
         seed_existing_file_for_asset(&mut config, &passes[0], &on_disk_asset).await;
 
@@ -12105,11 +12119,11 @@ mod tests {
         let mut config1 = test_config();
         config1.skip_created_before = None;
         let mut config2 = test_config();
-        config2.skip_created_before = Some(
+        config2.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
             DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),
-        );
+        ));
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
@@ -12121,14 +12135,31 @@ mod tests {
         let mut config1 = test_config();
         config1.skip_created_after = None;
         let mut config2 = test_config();
-        config2.skip_created_after = Some(
+        config2.skip_created_after = Some(crate::config::CreatedDateFilter::Instant(
             DateTime::parse_from_rfc3339("2024-12-31T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),
-        );
+        ));
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
+        );
+    }
+
+    #[test]
+    fn test_hash_download_config_distinguishes_capture_date_from_instant() {
+        let date = chrono::NaiveDate::from_ymd_opt(2025, 2, 1).unwrap();
+        let mut instant = test_config();
+        instant.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            date.and_time(chrono::NaiveTime::MIN).and_utc(),
+        ));
+        let mut capture_date = instant.clone();
+        capture_date.skip_created_before =
+            Some(crate::config::CreatedDateFilter::CaptureDate(date));
+
+        assert_ne!(
+            hash_download_config(&instant),
+            hash_download_config(&capture_date)
         );
     }
 
@@ -14147,7 +14178,9 @@ mod tests {
         config.state_db = Some(db.clone());
         config.sync_mode = SyncMode::Full;
         config.recent = Some(300);
-        config.skip_created_before = Some(Utc.timestamp_opt(1_800_000_000, 0).unwrap());
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            Utc.timestamp_opt(1_800_000_000, 0).unwrap(),
+        ));
         let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         let expected_path = filter::expected_paths_for(&asset, &config)
             .into_iter()
@@ -14233,7 +14266,9 @@ mod tests {
         config.state_db = Some(db.clone());
         config.sync_mode = SyncMode::Full;
         config.recent = Some(300);
-        config.skip_created_before = Some(Utc.timestamp_opt(1_800_000_000, 0).unwrap());
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            Utc.timestamp_opt(1_800_000_000, 0).unwrap(),
+        ));
 
         let result = download_photos_with_sync(
             &Client::new(),
@@ -14457,7 +14492,9 @@ mod tests {
             zone_sync_token: "zone-token-prev".to_string(),
         };
         config.recent = Some(300);
-        config.skip_created_before = Some(Utc.timestamp_opt(1_746_994_800, 0).unwrap());
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            Utc.timestamp_opt(1_746_994_800, 0).unwrap(),
+        ));
 
         download_photos_with_sync(
             &Client::new(),
@@ -17534,16 +17571,16 @@ mod tests {
         config.live_photo_mov_filename_policy = crate::types::LivePhotoMovFilenamePolicy::Original;
         config.raw_policy = RawPolicy::PreferJpeg;
         config.keep_unicode_in_filenames = true;
-        config.skip_created_before = Some(
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
             DateTime::parse_from_rfc3339("2020-06-15T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),
-        );
-        config.skip_created_after = Some(
+        ));
+        config.skip_created_after = Some(crate::config::CreatedDateFilter::Instant(
             DateTime::parse_from_rfc3339("2024-12-31T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),
-        );
+        ));
         config.recent = Some(500);
         config.force_resolution = true;
         config.media.videos = false;
@@ -18289,8 +18326,9 @@ mod tests {
     #[test]
     fn skip_created_before_runs_skip_pass_count_fetch() {
         let mut config = test_config();
-        config.skip_created_before =
-            Some(DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"));
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"),
+        ));
 
         assert!(
             should_skip_pass_count_fetch(&config),
@@ -18300,10 +18338,44 @@ mod tests {
     }
 
     #[test]
+    fn stream_created_lower_bound_uses_the_stricter_date_or_recent_frontier() {
+        let capture_date = chrono::NaiveDate::from_ymd_opt(2025, 2, 1).unwrap();
+        let date_bound =
+            capture_date.and_time(chrono::NaiveTime::MIN).and_utc() - chrono::Duration::days(1);
+        let mut config = test_config();
+        config.skip_created_before =
+            Some(crate::config::CreatedDateFilter::CaptureDate(capture_date));
+
+        for (name, frontier_bound, expected) in [
+            (
+                "date bound",
+                date_bound - chrono::Duration::hours(1),
+                date_bound,
+            ),
+            (
+                "recent frontier",
+                date_bound + chrono::Duration::hours(1),
+                date_bound + chrono::Duration::hours(1),
+            ),
+        ] {
+            let frontier = RecentFrontier {
+                asset_ids: Arc::new(FxHashSet::default()),
+                oldest_created: Some(frontier_bound),
+            };
+            assert_eq!(
+                stream_created_lower_bound(&config, Some(&frontier)),
+                Some(expected),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
     fn skip_created_after_runs_keep_pass_count_fetch() {
         let mut config = test_config();
-        config.skip_created_after =
-            Some(DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"));
+        config.skip_created_after = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_700_000_000_000).expect("valid test timestamp"),
+        ));
 
         assert!(
             !should_skip_pass_count_fetch(&config),
@@ -18538,8 +18610,9 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
-        config.skip_created_before =
-            Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"),
+        ));
         for asset in newer_assets.iter().map(recent_scope_photo_asset) {
             seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
         }
@@ -18592,8 +18665,9 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
-        config.skip_created_before =
-            Some(DateTime::from_timestamp_millis(1_699_000_000_000).expect("valid test timestamp"));
+        config.skip_created_before = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_699_000_000_000).expect("valid test timestamp"),
+        ));
         for asset in newer_assets.iter().map(recent_scope_photo_asset) {
             seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
         }
@@ -18632,8 +18706,9 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         config.directory = Arc::from(dir.path());
         config.concurrent_downloads = 1;
-        config.skip_created_after =
-            Some(DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"));
+        config.skip_created_after = Some(crate::config::CreatedDateFilter::Instant(
+            DateTime::from_timestamp_millis(1_699_999_000_000).expect("valid test timestamp"),
+        ));
         for asset in older_assets.iter().map(recent_scope_photo_asset) {
             seed_existing_file_for_asset(&mut config, &passes[0], &asset).await;
         }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -1,9 +1,11 @@
-use std::fmt::Write;
+use std::fmt::{Display, Write};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use base64::Engine;
-use chrono::{DateTime, Local};
+#[cfg(test)]
+use chrono::Local;
+use chrono::{DateTime, TimeZone};
 use rustc_hash::FxHashMap;
 
 /// Sentinel folder-structure value that disables the date-based directory
@@ -102,12 +104,15 @@ pub(crate) fn truncate_library_zone(zone_name: &str) -> &str {
 /// legacy Python-style `"{:%Y/%m/%d}"` wrapper is also accepted. The custom
 /// `{album}` token is expanded to the album name before strftime processing.
 /// The special value `"none"` (case-insensitive) disables date-based folders.
-pub(crate) fn local_download_dir(
+pub(crate) fn local_download_dir<Tz: TimeZone>(
     directory: &Path,
     folder_structure: &str,
-    created_date: &DateTime<Local>,
+    created_date: &DateTime<Tz>,
     album_name: Option<&str>,
-) -> PathBuf {
+) -> PathBuf
+where
+    Tz::Offset: Display,
+{
     if folder_structure.eq_ignore_ascii_case(NO_DATE_STRUCTURE) {
         return directory.to_path_buf();
     }
@@ -134,13 +139,16 @@ pub(crate) fn local_download_dir(
 /// legacy Python-style `"{:%Y/%m/%d}"` wrapper is also accepted. The custom
 /// `{album}` token is expanded to the album name before strftime processing.
 /// The special value `"none"` (case-insensitive) disables date-based folders.
-pub(crate) fn local_download_path(
+pub(crate) fn local_download_path<Tz: TimeZone>(
     directory: &Path,
     folder_structure: &str,
-    created_date: &DateTime<Local>,
+    created_date: &DateTime<Tz>,
     filename: &str,
     album_name: Option<&str>,
-) -> PathBuf {
+) -> PathBuf
+where
+    Tz::Offset: Display,
+{
     local_download_dir(directory, folder_structure, created_date, album_name)
         .join(clean_filename(filename).as_ref())
 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4070,7 +4070,7 @@ mod tests {
                                 download_path: dir.path().join("a.jpg"),
                                 publication: crate::download::file::FinalPublication::NoReplace,
                                 checksum: "aaa".into(),
-                                created_local: chrono::Local::now(),
+                                created_local: chrono::Local::now().fixed_offset(),
                                 size: 1000,
                                 asset_id: "ASSET_A".into(),
                                 asset_record_name: "ASSET_A".into(),
@@ -4084,7 +4084,7 @@ mod tests {
                                 download_path: dir.path().join("b.jpg"),
                                 publication: crate::download::file::FinalPublication::NoReplace,
                                 checksum: "bbb".into(),
-                                created_local: chrono::Local::now(),
+                                created_local: chrono::Local::now().fixed_offset(),
                                 size: 2000,
                                 asset_id: "ASSET_B".into(),
                                 asset_record_name: "ASSET_B".into(),
@@ -4138,7 +4138,7 @@ mod tests {
                             download_path: dir.path().join("c.jpg"),
                             publication: crate::download::file::FinalPublication::NoReplace,
                             checksum: "ccc".into(),
-                            created_local: chrono::Local::now(),
+                            created_local: chrono::Local::now().fixed_offset(),
                             size: 500,
                             asset_id: "ASSET_C".into(),
                             asset_record_name: "ASSET_C".into(),
@@ -5040,7 +5040,7 @@ mod tests {
             library: "PrimarySync".into(),
             metadata: Arc::new(MetadataPayload::default()),
             size: body.len() as u64,
-            created_local: chrono::Local::now(),
+            created_local: chrono::Local::now().fixed_offset(),
             version_size: VersionSizeKey::Original,
             media_type: crate::state::MediaType::Photo,
         };
@@ -5123,7 +5123,7 @@ mod tests {
                 library: "PrimarySync".into(),
                 metadata: Arc::new(MetadataPayload::default()),
                 size: jpeg_body.len() as u64,
-                created_local: chrono::Local::now(),
+                created_local: chrono::Local::now().fixed_offset(),
                 version_size: VersionSizeKey::Original,
                 media_type: crate::state::MediaType::Photo,
             })
@@ -7201,7 +7201,7 @@ mod tests {
         let target_path = crate::download::paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&chrono::Local),
+            &asset.created_local(),
             "deleted.jpg",
             None,
         );
@@ -7290,7 +7290,7 @@ mod tests {
         let target_path = crate::download::paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &existing_asset.created().with_timezone(&chrono::Local),
+            &existing_asset.created_local(),
             "IMG_4123.JPG",
             None,
         );
@@ -7412,7 +7412,7 @@ mod tests {
         crate::download::paths::local_download_path(
             &config.directory,
             &config.folder_structure,
-            &asset.created().with_timezone(&chrono::Local),
+            &asset.created_local(),
             filename,
             None,
         )
@@ -8022,6 +8022,88 @@ mod tests {
             "missing new target must be forwarded for re-download"
         );
         assert_eq!(&*failed[0].id, "OLD_DIR_SUFFIXED_B");
+    }
+
+    /// Capture-local derivation can move an asset into a different date
+    /// folder than a host-local rendering chose. The stored path is then not
+    /// a current derived path, so a full sweep forwards the asset for
+    /// download into its capture-local folder, and the earlier copy is left
+    /// untouched because kei never deletes local media.
+    #[tokio::test]
+    async fn capture_local_date_folder_forwards_and_keeps_host_local_copy() {
+        use crate::download::DownloadConfig;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        // 2026-01-31T22:31:59Z captured at +11:00 is 2026-02-01 locally.
+        let asset = TestPhotoAsset::new("CAPTURE_OFFSET_MOVE")
+            .filename("IMG_9001.JPG")
+            .orig_size(1234)
+            .orig_url("https://p01.icloud-content.com/IMG_9001.JPG")
+            .orig_checksum("ck_capture_offset_move")
+            .asset_date(1_769_898_719_000.0)
+            .timezone_offset(39_600)
+            .build();
+
+        let derived = crate::download::filter::expected_paths_for(&asset, config.as_ref())
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
+        assert!(derived.parent().is_some_and(|p| p.ends_with("2026/02/01")));
+
+        let host_local_path = dir.path().join("2026/01/31/IMG_9001.JPG");
+        fs::create_dir_all(host_local_path.parent().unwrap()).unwrap();
+        fs::write(&host_local_path, vec![7u8; 1234]).unwrap();
+
+        let record = crate::test_helpers::TestAssetRecord::new("CAPTURE_OFFSET_MOVE")
+            .checksum("ck_capture_offset_move")
+            .filename("IMG_9001.JPG")
+            .size(1234)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "CAPTURE_OFFSET_MOVE",
+            "original",
+            &host_local_path,
+            "local_checksum_for_host_local_file",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]),
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must complete");
+
+        assert_eq!(
+            result.skip_summary.on_disk, 0,
+            "a host-local stored path must not satisfy the capture-local target"
+        );
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1, "missing capture-local target is forwarded");
+        assert_eq!(&*failed[0].id, "CAPTURE_OFFSET_MOVE");
+        assert!(
+            host_local_path.exists(),
+            "the earlier copy must survive; kei does not delete local media"
+        );
     }
 
     /// Data-sacred regression for state-backed on-disk skips.

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -538,6 +538,13 @@ impl PhotoAsset {
         self.asset_date()
     }
 
+    /// Capture-local time reconstructed from Apple's instant and offset.
+    ///
+    /// Missing or invalid offsets retain host-local rendering.
+    pub(crate) fn created_local(&self) -> DateTime<chrono::FixedOffset> {
+        self.metadata().capture_local(self.created())
+    }
+
     pub fn added_date(&self) -> DateTime<Utc> {
         self.added_date_ms
             .and_then(f64_to_millis_datetime)

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -997,13 +997,13 @@ fn date_prompt(label: &str) -> anyhow::Result<Option<String>> {
     })
 }
 
-/// Accept blank or anything `config::parse_date_or_interval` parses cleanly,
+/// Accept blank or anything `config::parse_created_date_filter` parses cleanly,
 /// so a typo here surfaces with the same error the runtime would print.
 fn validate_date_or_blank(s: &str) -> Result<(), String> {
     if s.trim().is_empty() {
         return Ok(());
     }
-    crate::config::parse_date_or_interval(s.trim())
+    crate::config::parse_created_date_filter(s.trim())
         .map(|_| ())
         .map_err(|e| e.to_string())
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Local, Utc};
 
 use crate::types::AssetVersionSize;
 
@@ -282,6 +282,22 @@ impl AssetMetadata {
     pub fn refresh_hash(&mut self) {
         self.metadata_hash = Some(self.compute_hash());
     }
+
+    /// Return Apple's offset when it can be represented by chrono.
+    pub(crate) fn valid_timezone_offset(&self) -> Option<FixedOffset> {
+        self.timezone_offset.and_then(FixedOffset::east_opt)
+    }
+
+    /// Resolve an asset instant to its capture-local wall clock.
+    ///
+    /// Missing or invalid offsets retain the host-local rendering used when
+    /// Apple supplies no capture timezone.
+    pub(crate) fn capture_local(&self, created_at: DateTime<Utc>) -> DateTime<FixedOffset> {
+        self.valid_timezone_offset().map_or_else(
+            || created_at.with_timezone(&Local).fixed_offset(),
+            |offset| created_at.with_timezone(&offset),
+        )
+    }
 }
 
 fn hash_opt(hasher: &mut sha2::Sha256, tag: &str, value: Option<&str>) {
@@ -548,6 +564,7 @@ pub struct SyncSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::mem::size_of;
 
     #[test]
@@ -707,6 +724,45 @@ mod tests {
         }
         .compute_hash();
         assert_ne!(base, with_gps);
+    }
+
+    #[test]
+    fn test_asset_metadata_hash_changes_with_timezone_offset() {
+        let base = AssetMetadata::default().compute_hash();
+        let with_offset = AssetMetadata {
+            timezone_offset: Some(39_600),
+            ..AssetMetadata::default()
+        }
+        .compute_hash();
+        assert_ne!(base, with_offset);
+    }
+
+    #[test]
+    fn capture_local_uses_asset_offset_or_host_local_fallback() {
+        let created_at = Utc.with_ymd_and_hms(2025, 2, 1, 2, 0, 0).unwrap();
+        let expected_host_local = created_at.with_timezone(&Local).fixed_offset();
+
+        for metadata in [
+            AssetMetadata::default(),
+            AssetMetadata {
+                timezone_offset: Some(i32::MAX),
+                ..AssetMetadata::default()
+            },
+        ] {
+            let resolved = metadata.capture_local(created_at);
+            assert_eq!(resolved.naive_local(), expected_host_local.naive_local());
+            assert_eq!(resolved.offset(), expected_host_local.offset());
+        }
+
+        let offset = FixedOffset::east_opt(50_400).unwrap();
+        let metadata = AssetMetadata {
+            timezone_offset: Some(offset.local_minus_utc()),
+            ..AssetMetadata::default()
+        };
+        let resolved = metadata.capture_local(created_at);
+        let expected = created_at.with_timezone(&offset);
+        assert_eq!(resolved.naive_local(), expected.naive_local());
+        assert_eq!(resolved.offset(), expected.offset());
     }
 
     #[test]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -900,14 +900,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
     // Pre-compute config values used each cycle to build DownloadConfig.
     // DownloadConfig is rebuilt per-cycle so sync_mode can vary.
-    let skip_created_before = config
-        .filters
-        .skip_created_before
-        .map(|d| d.with_timezone(&chrono::Utc));
-    let skip_created_after = config
-        .filters
-        .skip_created_after
-        .map(|d| d.with_timezone(&chrono::Utc));
+    let skip_created_before = config.filters.skip_created_before;
+    let skip_created_after = config.filters.skip_created_after;
     let retry_config = api_retry_config;
     let live_resolution = config.photos.live_resolution.to_asset_version_size();
     // One shared limiter per sync run so the configured cap applies to
@@ -3515,13 +3509,11 @@ mod tests {
     /// The `assetDate`/`addedDate` embedded by [`full_album_page_with_download`].
     const RUN_CYCLE_ASSET_DATE_MS: i64 = 1_700_000_000_000;
 
-    /// The local-time `%Y/%m/%d` folder the pipeline derives for [`RUN_CYCLE_ASSET_DATE_MS`].
+    /// The host-local `%Y/%m/%d` folder for an asset without an offset.
     fn run_cycle_expected_date_dir() -> String {
-        use chrono::TimeZone;
-        chrono::Local
-            .timestamp_millis_opt(RUN_CYCLE_ASSET_DATE_MS)
-            .single()
+        chrono::DateTime::from_timestamp_millis(RUN_CYCLE_ASSET_DATE_MS)
             .expect("valid asset timestamp")
+            .with_timezone(&chrono::Local)
             .format("%Y/%m/%d")
             .to_string()
     }
@@ -3731,6 +3723,8 @@ mod tests {
         media: config::MediaSelection,
         per_pass_paths: bool,
         recent: Option<u32>,
+        skip_created_before: Option<config::CreatedDateFilter>,
+        skip_created_after: Option<config::CreatedDateFilter>,
         file_match_policy: Option<crate::types::FileMatchPolicy>,
         #[cfg(feature = "xmp")]
         xmp_sidecar: bool,
@@ -3793,6 +3787,8 @@ mod tests {
                 config.metadata.xmp_sidecar = options.xmp_sidecar;
             }
             config.recent = options.recent;
+            config.skip_created_before = options.skip_created_before;
+            config.skip_created_after = options.skip_created_after;
             if let Some(concurrent_downloads) = options.concurrent_downloads {
                 config.concurrent_downloads = concurrent_downloads;
             }
@@ -3840,6 +3836,122 @@ mod tests {
             None,
         )
         .expect("test config")
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn run_cycle_capture_offset_drives_date_filter_path_and_sidecar() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        use xmp_toolkit::{XmpMeta, xmp_ns};
+
+        let server = crate::start_wiremock_or_skip!();
+        let body = [
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+        ];
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(body));
+        Mock::given(method("GET"))
+            .and(path("/capture-offset.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let capture_date = chrono::NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+        let mut page = full_album_page_with_download(
+            "PrimarySync",
+            "capture-offset",
+            "zone-token",
+            &format!("{}/capture-offset.jpg", server.uri()),
+            body.len() as u64,
+            &checksum,
+        );
+        page["records"][1]["fields"]["assetDate"]["value"] =
+            serde_json::json!(1_769_898_719_000_i64);
+        page["records"][1]["fields"]["addedDate"]["value"] =
+            serde_json::json!(1_769_898_719_000_i64);
+        page["records"][1]["fields"]["timeZoneOffset"] =
+            serde_json::json!({"value": 39_600, "type": "INT64"});
+
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(page),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let db = make_state_db();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let boundary = config::CreatedDateFilter::CaptureDate(capture_date);
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                skip_created_before: Some(boundary),
+                skip_created_after: Some(boundary),
+                xmp_sidecar: true,
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let mut config = make_run_cycle_config();
+        config.filters.skip_created_before = Some(boundary);
+        config.filters.skip_created_after = Some(boundary);
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run capture-offset cycle");
+
+        assert_eq!(result.stats.downloaded, 1);
+        let downloaded = db.get_downloaded_page(0, 1).await.expect("downloaded row");
+        let media_path = downloaded[0].local_path.as_ref().expect("downloaded path");
+        assert!(
+            media_path
+                .parent()
+                .is_some_and(|parent| parent.ends_with("2026/02/01"))
+        );
+        assert_eq!(std::fs::read(media_path).expect("downloaded media"), body);
+
+        let sidecar = std::fs::read_to_string(media_path.with_file_name(format!(
+            "{}.xmp",
+            media_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("media filename")
+        )))
+        .expect("capture-offset sidecar");
+        let metadata = sidecar.parse::<XmpMeta>().expect("valid XMP sidecar");
+        assert_eq!(
+            metadata
+                .property(xmp_ns::EXIF, "DateTimeOriginal")
+                .expect("DateTimeOriginal")
+                .value,
+            "2026-02-01T09:31:59+11:00"
+        );
+        assert_eq!(
+            metadata
+                .property("http://cipa.jp/exif/1.0/", "OffsetTimeOriginal")
+                .expect("OffsetTimeOriginal")
+                .value,
+            "+11:00"
+        );
     }
 
     async fn run_full_cycle_with_album(

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -308,6 +308,7 @@ pub struct TestPhotoAsset {
     orig_checksum: String,
     orig_file_type: String,
     asset_date: f64,
+    timezone_offset: Option<i32>,
     favorite: bool,
     live_photo: Option<LivePhotoFields>,
     adjusted_version: Option<AdjustedVersionFields>,
@@ -346,6 +347,7 @@ impl TestPhotoAsset {
             orig_checksum: "abc123".to_string(),
             orig_file_type: "public.jpeg".to_string(),
             asset_date: 1736899200000.0,
+            timezone_offset: None,
             favorite: false,
             live_photo: None,
             adjusted_version: None,
@@ -386,6 +388,11 @@ impl TestPhotoAsset {
 
     pub fn asset_date(mut self, d: f64) -> Self {
         self.asset_date = d;
+        self
+    }
+
+    pub fn timezone_offset(mut self, seconds: i32) -> Self {
+        self.timezone_offset = Some(seconds);
         self
     }
 
@@ -491,12 +498,15 @@ impl TestPhotoAsset {
             "recordName": self.record_name,
             "fields": fields,
         });
-        let asset = json!({
+        let mut asset = json!({
             "fields": {
                 "assetDate": {"value": self.asset_date},
                 "isFavorite": {"value": i64::from(self.favorite)},
             },
         });
+        if let Some(offset) = self.timezone_offset {
+            asset["fields"]["timeZoneOffset"] = json!({"value": offset});
+        }
         PhotoAsset::new(master, asset)
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -117,6 +117,9 @@ fn sync_help_succeeds() {
         .success()
         .stdout(predicate::str::contains("--friendly"))
         .stdout(predicate::str::contains("--recent"))
+        .stdout(predicate::str::contains("capture-local calendar date"))
+        .stdout(predicate::str::contains("explicit datetimes"))
+        .stdout(predicate::str::contains("relative intervals"))
         .stdout(predicate::str::contains("--download-dir").not());
 }
 


### PR DESCRIPTION
## Summary

kei now works out when a photo was actually taken, using the per-asset
`timeZoneOffset` Apple stores next to each asset.  Previously it rendered the
capture instant in whatever timezone the backup host happened to be set to, so
the same library sorted differently depending on the machine that synced it.

The resolved capture-local time drives date filters, date folders, embedded
EXIF, and XMP sidecars.  Where Apple supplies no usable offset, nothing
changes: those assets keep host-local rendering and their existing paths.

Fixes #703

## Contract and risk

No existing media is moved or deleted.  For an asset that does carry an
offset, its old host-local path is no longer a path kei derives, so a later
full sweep downloads it into the capture-local folder and leaves the earlier
copy where it is.  Expect two copies until you remove one yourself.

The download config hash is unchanged, so this does not set off a bulk
re-download on its own.  A date-only `skip_created_before` or
`skip_created_after` does change both config hashes, because what those bounds
compare has changed.

`sync --refresh-metadata` repairs files already on disk.  It attaches an
offset to a timestamp that is already in a file only when the probe proves
that timestamp reads as capture-local.  Pairing Apple's offset with a
host-local wall clock would assert an instant the photo never had, so kei
leaves that file alone instead.

## Test plan

Rust 1.94.1 throughout.

```text
just gate
```

`cargo test --all-features` 3299 passed, `cargo test --no-default-features`
3191 passed, both 0 failed.  `lint-scripts` is the one unchecked item: it fails
on pre-existing shellcheck findings in `tests/shell/lib.sh` and
`tests/shell/state-machine.sh`.  This branch touches no shell files and CI does
not run shellcheck.

Also run under `TZ=UTC` and `TZ=Pacific/Auckland` to confirm the host timezone
no longer decides the outcome.

## Regression proof

Each guard was checked against a deliberately reintroduced defect and observed
to fail:

- UTC fallback instead of host-local, on a Los Angeles host
- an unverified timestamp accepting an offset
- an orphaned offset surviving a newly written timestamp
- a narrowed UTC enumeration margin
- a stream bound that ignores the stricter of its two inputs

The metadata tests run through the production call graph on real JPEGs, via
`apply_metadata`, `probe_exif`, planning, and the embed writer, under both the
XMP Toolkit and native EXIF builds.

## Checklist

- [x] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
