### PR TITLE
Fix metadata-aware local file size checks

### DIFF
--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 use crate::cli;
 use crate::config;
+use crate::download::file::{LocalFileSizeExpectation, local_file_size_matches_state};
 use crate::state;
 use crate::state::{ReportStateStore, VersionSizeKey};
 
@@ -128,20 +129,15 @@ pub(crate) async fn classify_local_drift(
     };
 
     let actual_size = metadata.len();
-    if size_bytes > 0 && actual_size < size_bytes {
-        let metadata_changed_download = matches!(
-            (&local_checksum, &download_checksum),
-            (Some(local), Some(download)) if local != download
-        );
-        if metadata_changed_download {
-            // The provider size describes the pre-metadata download. Prove
-            // the smaller current file still matches kei's post-write bytes
-            // before treating the size difference as local damage.
-            let actual_checksum = crate::download::file::compute_sha256(&local_path).await?;
-            if local_checksum.as_deref() == Some(actual_checksum.as_str()) {
-                return Ok((None, false));
-            }
-        }
+    if !local_file_size_matches_state(
+        &local_path,
+        actual_size,
+        LocalFileSizeExpectation::AtLeastProvider(size_bytes),
+        local_checksum.as_deref(),
+        download_checksum.as_deref(),
+    )
+    .await?
+    {
         return Ok((
             Some(LocalDriftAsset {
                 library,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -764,6 +764,61 @@ pub(crate) async fn compute_sha256(path: &Path) -> anyhow::Result<String> {
     .await?
 }
 
+/// The provider-size relationship required before a local file can be used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalFileSizeExpectation {
+    /// The local file must not be shorter than the provider download.
+    AtLeastProvider(u64),
+    /// The local file must have the same size as the provider download.
+    ExactProvider(u64),
+}
+
+impl LocalFileSizeExpectation {
+    const fn accepts(self, actual_size: u64) -> bool {
+        match self {
+            Self::AtLeastProvider(provider_size) => {
+                provider_size == 0 || actual_size >= provider_size
+            }
+            Self::ExactProvider(provider_size) => actual_size == provider_size,
+        }
+    }
+}
+
+/// Return whether a local file satisfies its provider-size requirement.
+///
+/// Embedded metadata can legitimately change the final file size after kei
+/// verifies the provider download. When both stored checksums prove that kei
+/// changed the bytes, hash the current file and accept the size difference
+/// only when it still matches the recorded post-write checksum.
+///
+/// # Errors
+///
+/// Returns an error when checksum proof is required but the file cannot be
+/// read or hashed.
+#[must_use = "file-size validation determines whether existing bytes can be trusted"]
+pub(crate) async fn local_file_size_matches_state(
+    path: &Path,
+    actual_size: u64,
+    expectation: LocalFileSizeExpectation,
+    local_checksum: Option<&str>,
+    download_checksum: Option<&str>,
+) -> anyhow::Result<bool> {
+    if expectation.accepts(actual_size) {
+        return Ok(true);
+    }
+
+    let metadata_changed_download = matches!(
+        (local_checksum, download_checksum),
+        (Some(local), Some(download)) if local != download
+    );
+    if !metadata_changed_download {
+        return Ok(false);
+    }
+
+    let actual_checksum = compute_sha256(path).await?;
+    Ok(local_checksum == Some(actual_checksum.as_str()))
+}
+
 /// Decoded iCloud API checksum with its hash algorithm.
 ///
 /// Note: Apple's `fileChecksum` is an MMCS compound signature, not a

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2229,6 +2229,24 @@ impl DownloadContext {
             .and_then(|versions| versions.get(version_size.as_str()))
     }
 
+    fn pending_file_matching_checksum(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: VersionSizeKey,
+        provider_checksum: &str,
+    ) -> Option<&RecordedLocalFile> {
+        let stored_checksum = self
+            .pending_checksums
+            .get(library)
+            .and_then(|assets| assets.get(asset_id))
+            .and_then(|versions| versions.get(version_size.as_str()))?;
+        if stored_checksum.as_ref() != provider_checksum {
+            return None;
+        }
+        self.pending_file(library, asset_id, version_size)
+    }
+
     fn has_downloaded_without_metadata_hash(&self) -> bool {
         self.downloaded_without_metadata_hash
     }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -58,8 +58,8 @@ use crate::icloud::photos::{
 };
 use crate::retry::RetryConfig;
 use crate::state::{
-    DownloadStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore, SyncTokenStore,
-    VersionSizeKey,
+    DownloadContextStateStore, DownloadStateStore, MembershipStore, MetadataRewriteStore,
+    ReportStateStore, SyncTokenStore, VersionSizeKey,
 };
 use crate::types::{
     AssetVersionSize, ChangeReason, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy,
@@ -92,12 +92,18 @@ pub enum SyncMode {
 }
 
 pub(crate) trait DownloadStore:
-    DownloadStateStore + MembershipStore + MetadataRewriteStore + ReportStateStore + SyncTokenStore
+    DownloadContextStateStore
+    + DownloadStateStore
+    + MembershipStore
+    + MetadataRewriteStore
+    + ReportStateStore
+    + SyncTokenStore
 {
 }
 
 impl<T> DownloadStore for T where
-    T: DownloadStateStore
+    T: DownloadContextStateStore
+        + DownloadStateStore
         + MembershipStore
         + MetadataRewriteStore
         + ReportStateStore
@@ -1380,17 +1386,6 @@ struct RecordedLocalFile {
 type LibraryAssetVersionFileMap =
     FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, RecordedLocalFile>>>;
 
-/// Downloaded state retained while the remaining context queries finish.
-/// Keep this compact so paged loading does not retain full metadata records.
-#[derive(Debug)]
-struct DownloadedContextRecord {
-    library: Arc<str>,
-    id: Box<str>,
-    version_size: VersionSizeKey,
-    checksum: Box<str>,
-    file: Option<RecordedLocalFile>,
-}
-
 /// `library -> master_record_name -> asset_record_names`. Full enumeration
 /// uses this durable family history to keep a legacy master-keyed state row
 /// attached to the same child when CloudKit changes record order or page
@@ -1501,59 +1496,13 @@ struct DownloadContext {
     downloaded_without_metadata_hash: bool,
 }
 
-const DOWNLOAD_CONTEXT_PAGE_SIZE: u32 = 1_000;
-
-async fn load_downloaded_records<D>(
-    db: &D,
-) -> std::result::Result<Vec<DownloadedContextRecord>, crate::state::error::StateError>
-where
-    D: ReportStateStore + ?Sized,
-{
-    let mut records = Vec::new();
-    let mut offset = 0u64;
-    loop {
-        let page = db
-            .get_downloaded_page(offset, DOWNLOAD_CONTEXT_PAGE_SIZE)
-            .await?;
-        let page_len = page.len();
-        records.extend(page.into_iter().map(|record| {
-            let crate::state::AssetRecord {
-                library,
-                id,
-                version_size,
-                checksum,
-                local_path,
-                local_checksum,
-                download_checksum,
-                ..
-            } = record;
-            DownloadedContextRecord {
-                library,
-                id,
-                version_size,
-                checksum,
-                file: local_path.map(|path| RecordedLocalFile {
-                    path,
-                    local_checksum: local_checksum.map(String::into_boxed_str),
-                    download_checksum: download_checksum.map(String::into_boxed_str),
-                }),
-            }
-        }));
-        if page_len < DOWNLOAD_CONTEXT_PAGE_SIZE as usize {
-            break;
-        }
-        offset = offset.saturating_add(u64::from(DOWNLOAD_CONTEXT_PAGE_SIZE));
-    }
-    Ok(records)
-}
-
 impl DownloadContext {
     /// Load the download context from the state database. All state queries
     /// are independent and run concurrently so sync start doesn't serialize
     /// on round-trip latency across them.
     async fn load<D>(db: &D, retry_only: bool) -> Self
     where
-        D: DownloadStateStore + MetadataRewriteStore + ReportStateStore + ?Sized,
+        D: DownloadContextStateStore + DownloadStateStore + MetadataRewriteStore + ?Sized,
     {
         let known_ids_fut = async {
             if retry_only {
@@ -1577,7 +1526,7 @@ impl DownloadContext {
             legacy_owner_rows,
         ) = tokio::join!(
             async {
-                load_downloaded_records(db).await.unwrap_or_else(|e| {
+                db.get_downloaded_file_records().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load downloaded records from state DB");
                     Default::default()
                 })
@@ -1634,15 +1583,17 @@ impl DownloadContext {
         let mut downloaded_checksums: LibraryAssetVersionValueMap = FxHashMap::default();
         let mut downloaded_files: LibraryAssetVersionFileMap = FxHashMap::default();
         for record in downloaded_records {
-            let DownloadedContextRecord {
+            let crate::state::DownloadedFileRecord {
                 library,
                 id,
                 version_size,
                 checksum,
-                file,
+                local_path,
+                local_checksum,
+                download_checksum,
             } = record;
-            let lib = intern_id(&mut interner, library.to_string());
-            let id = intern_id(&mut interner, id.to_string());
+            let lib = intern_id(&mut interner, library);
+            let id = intern_id(&mut interner, id);
             let version_size: Box<str> = version_size.as_str().into();
             downloaded_ids
                 .entry(Arc::clone(&lib))
@@ -1655,14 +1606,21 @@ impl DownloadContext {
                 .or_default()
                 .entry(Arc::clone(&id))
                 .or_default()
-                .insert(version_size.clone(), checksum);
-            if let Some(file) = file {
+                .insert(version_size.clone(), checksum.into_boxed_str());
+            if let Some(path) = local_path {
                 downloaded_files
                     .entry(lib)
                     .or_default()
                     .entry(id)
                     .or_default()
-                    .insert(version_size, file);
+                    .insert(
+                        version_size,
+                        RecordedLocalFile {
+                            path,
+                            local_checksum: local_checksum.map(String::into_boxed_str),
+                            download_checksum: download_checksum.map(String::into_boxed_str),
+                        },
+                    );
             }
         }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1368,10 +1368,28 @@ type LibraryAssetAttemptCounts = FxHashMap<Arc<str>, FxHashMap<Arc<str>, u32>>;
 type LibraryAssetVersionValueMap =
     FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, Box<str>>>>;
 
-/// `library -> asset_id -> (version_size -> local_path)`. Used to confirm
-/// state-backed skips still point at the currently configured path.
-type LibraryAssetVersionPathMap =
-    FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, PathBuf>>>;
+/// Durable local-file evidence for a state-backed skip or pending adoption.
+#[derive(Debug)]
+struct RecordedLocalFile {
+    path: PathBuf,
+    local_checksum: Option<Box<str>>,
+    download_checksum: Option<Box<str>>,
+}
+
+/// `library -> asset_id -> (version_size -> recorded local-file evidence)`.
+type LibraryAssetVersionFileMap =
+    FxHashMap<Arc<str>, FxHashMap<Arc<str>, FxHashMap<Box<str>, RecordedLocalFile>>>;
+
+/// Downloaded state retained while the remaining context queries finish.
+/// Keep this compact so paged loading does not retain full metadata records.
+#[derive(Debug)]
+struct DownloadedContextRecord {
+    library: Arc<str>,
+    id: Box<str>,
+    version_size: VersionSizeKey,
+    checksum: Box<str>,
+    file: Option<RecordedLocalFile>,
+}
 
 /// `library -> master_record_name -> asset_record_names`. Full enumeration
 /// uses this durable family history to keep a legacy master-keyed state row
@@ -1427,10 +1445,10 @@ struct DownloadContext {
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> checksum).
     /// Used to detect checksum changes (CloudKit asset updated) without DB queries.
     downloaded_checksums: LibraryAssetVersionValueMap,
-    /// Nested map: `library` -> `asset_id` -> (`version_size` -> local_path).
+    /// Nested map: `library` -> `asset_id` -> (`version_size` -> local file).
     /// Used to validate path-aware filesystem skips after state says the
     /// remote bytes are unchanged.
-    downloaded_local_paths: LibraryAssetVersionPathMap,
+    downloaded_files: LibraryAssetVersionFileMap,
     /// Nested map: `library` -> `asset_id` -> (`version_size` -> metadata_hash).
     /// Used to detect metadata-only changes (favorite toggle, keywords, GPS
     /// edit, etc.) when file bytes are unchanged but CloudKit has newer
@@ -1460,6 +1478,9 @@ struct DownloadContext {
     /// to retain a compatible legacy master-keyed retry without merging a
     /// different sibling into it.
     pending_checksums: LibraryAssetVersionValueMap,
+    /// Current recorded local files for pending rows. A provider checksum
+    /// change clears `downloaded_at`, so historical paths are excluded.
+    pending_files: LibraryAssetVersionFileMap,
     /// Provider identity families recorded before this pipeline started.
     /// `None` disables legacy adoption after a mapping query failure. The
     /// snapshot intentionally excludes mappings discovered during the current
@@ -1480,13 +1501,59 @@ struct DownloadContext {
     downloaded_without_metadata_hash: bool,
 }
 
+const DOWNLOAD_CONTEXT_PAGE_SIZE: u32 = 1_000;
+
+async fn load_downloaded_records<D>(
+    db: &D,
+) -> std::result::Result<Vec<DownloadedContextRecord>, crate::state::error::StateError>
+where
+    D: ReportStateStore + ?Sized,
+{
+    let mut records = Vec::new();
+    let mut offset = 0u64;
+    loop {
+        let page = db
+            .get_downloaded_page(offset, DOWNLOAD_CONTEXT_PAGE_SIZE)
+            .await?;
+        let page_len = page.len();
+        records.extend(page.into_iter().map(|record| {
+            let crate::state::AssetRecord {
+                library,
+                id,
+                version_size,
+                checksum,
+                local_path,
+                local_checksum,
+                download_checksum,
+                ..
+            } = record;
+            DownloadedContextRecord {
+                library,
+                id,
+                version_size,
+                checksum,
+                file: local_path.map(|path| RecordedLocalFile {
+                    path,
+                    local_checksum: local_checksum.map(String::into_boxed_str),
+                    download_checksum: download_checksum.map(String::into_boxed_str),
+                }),
+            }
+        }));
+        if page_len < DOWNLOAD_CONTEXT_PAGE_SIZE as usize {
+            break;
+        }
+        offset = offset.saturating_add(u64::from(DOWNLOAD_CONTEXT_PAGE_SIZE));
+    }
+    Ok(records)
+}
+
 impl DownloadContext {
     /// Load the download context from the state database. All state queries
     /// are independent and run concurrently so sync start doesn't serialize
     /// on round-trip latency across them.
     async fn load<D>(db: &D, retry_only: bool) -> Self
     where
-        D: DownloadStateStore + MetadataRewriteStore + ?Sized,
+        D: DownloadStateStore + MetadataRewriteStore + ReportStateStore + ?Sized,
     {
         let known_ids_fut = async {
             if retry_only {
@@ -1499,10 +1566,8 @@ impl DownloadContext {
             }
         };
         let (
-            ids,
+            downloaded_records,
             soft_deleted,
-            checksums,
-            paths,
             hashes,
             markers,
             pending,
@@ -1512,26 +1577,14 @@ impl DownloadContext {
             legacy_owner_rows,
         ) = tokio::join!(
             async {
-                db.get_downloaded_ids().await.unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "Failed to load downloaded IDs from state DB");
+                load_downloaded_records(db).await.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to load downloaded records from state DB");
                     Default::default()
                 })
             },
             async {
                 db.get_soft_deleted_downloaded_ids().await.unwrap_or_else(|e| {
                     tracing::warn!(error = %e, "Failed to load soft-deleted assets from state DB");
-                    Default::default()
-                })
-            },
-            async {
-                db.get_downloaded_checksums().await.unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "Failed to load checksums from state DB");
-                    Default::default()
-                })
-            },
-            async {
-                db.get_downloaded_local_paths().await.unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "Failed to load downloaded local paths from state DB");
                     Default::default()
                 })
             },
@@ -1578,15 +1631,39 @@ impl DownloadContext {
         let mut interner: FxHashSet<Arc<str>> = FxHashSet::default();
 
         let mut downloaded_ids: LibraryAssetVersionSet = FxHashMap::default();
-        for (library, asset_id, version_size) in ids {
-            let lib = intern_id(&mut interner, library);
-            let id = intern_id(&mut interner, asset_id);
+        let mut downloaded_checksums: LibraryAssetVersionValueMap = FxHashMap::default();
+        let mut downloaded_files: LibraryAssetVersionFileMap = FxHashMap::default();
+        for record in downloaded_records {
+            let DownloadedContextRecord {
+                library,
+                id,
+                version_size,
+                checksum,
+                file,
+            } = record;
+            let lib = intern_id(&mut interner, library.to_string());
+            let id = intern_id(&mut interner, id.to_string());
+            let version_size: Box<str> = version_size.as_str().into();
             downloaded_ids
-                .entry(lib)
+                .entry(Arc::clone(&lib))
                 .or_default()
-                .entry(id)
+                .entry(Arc::clone(&id))
                 .or_default()
-                .insert(version_size.into_boxed_str());
+                .insert(version_size.clone());
+            downloaded_checksums
+                .entry(Arc::clone(&lib))
+                .or_default()
+                .entry(Arc::clone(&id))
+                .or_default()
+                .insert(version_size.clone(), checksum);
+            if let Some(file) = file {
+                downloaded_files
+                    .entry(lib)
+                    .or_default()
+                    .entry(id)
+                    .or_default()
+                    .insert(version_size, file);
+            }
         }
 
         let mut soft_deleted_ids: LibraryAssetSet = FxHashMap::default();
@@ -1594,30 +1671,6 @@ impl DownloadContext {
             let lib = intern_id(&mut interner, library);
             let id = intern_id(&mut interner, asset_id);
             soft_deleted_ids.entry(lib).or_default().insert(id);
-        }
-
-        let mut downloaded_checksums: LibraryAssetVersionValueMap = FxHashMap::default();
-        for ((library, asset_id, version_size), checksum) in checksums {
-            let lib = intern_id(&mut interner, library);
-            let id = intern_id(&mut interner, asset_id);
-            downloaded_checksums
-                .entry(lib)
-                .or_default()
-                .entry(id)
-                .or_default()
-                .insert(version_size.into_boxed_str(), checksum.into_boxed_str());
-        }
-
-        let mut downloaded_local_paths: LibraryAssetVersionPathMap = FxHashMap::default();
-        for ((library, asset_id, version_size), path) in paths {
-            let lib = intern_id(&mut interner, library);
-            let id = intern_id(&mut interner, asset_id);
-            downloaded_local_paths
-                .entry(lib)
-                .or_default()
-                .entry(id)
-                .or_default()
-                .insert(version_size.into_boxed_str(), path);
         }
 
         let mut downloaded_metadata_hashes: LibraryAssetVersionValueMap = FxHashMap::default();
@@ -1650,10 +1703,23 @@ impl DownloadContext {
         let mut pending_ids: LibraryAssetVersionSet = FxHashMap::default();
         let mut pending_filenames: LibraryAssetVersionValueMap = FxHashMap::default();
         let mut pending_checksums: LibraryAssetVersionValueMap = FxHashMap::default();
+        let mut pending_files: LibraryAssetVersionFileMap = FxHashMap::default();
         for record in pending {
-            let lib = intern_id(&mut interner, record.library.to_string());
-            let id = intern_id(&mut interner, record.id.to_string());
-            let version_size: Box<str> = record.version_size.as_str().into();
+            let crate::state::AssetRecord {
+                library,
+                id,
+                version_size,
+                checksum,
+                filename,
+                local_path,
+                local_checksum,
+                download_checksum,
+                downloaded_at,
+                ..
+            } = record;
+            let lib = intern_id(&mut interner, library.to_string());
+            let id = intern_id(&mut interner, id.to_string());
+            let version_size: Box<str> = version_size.as_str().into();
             pending_ids
                 .entry(Arc::clone(&lib))
                 .or_default()
@@ -1665,16 +1731,30 @@ impl DownloadContext {
                 .or_default()
                 .entry(Arc::clone(&id))
                 .or_default()
-                .insert(
-                    version_size.clone(),
-                    record.filename.to_string().into_boxed_str(),
-                );
+                .insert(version_size.clone(), filename);
             pending_checksums
-                .entry(lib)
+                .entry(Arc::clone(&lib))
                 .or_default()
-                .entry(id)
+                .entry(Arc::clone(&id))
                 .or_default()
-                .insert(version_size, record.checksum.to_string().into_boxed_str());
+                .insert(version_size.clone(), checksum);
+            if downloaded_at.is_some()
+                && let Some(path) = local_path
+            {
+                pending_files
+                    .entry(lib)
+                    .or_default()
+                    .entry(id)
+                    .or_default()
+                    .insert(
+                        version_size,
+                        RecordedLocalFile {
+                            path,
+                            local_checksum: local_checksum.map(String::into_boxed_str),
+                            download_checksum: download_checksum.map(String::into_boxed_str),
+                        },
+                    );
+            }
         }
 
         let asset_master_mappings = mapping_rows
@@ -1733,13 +1813,14 @@ impl DownloadContext {
         Self {
             downloaded_ids,
             downloaded_checksums,
-            downloaded_local_paths,
+            downloaded_files,
             downloaded_metadata_hashes,
             metadata_retry_markers,
             soft_deleted_ids,
             pending_ids,
             pending_filenames,
             pending_checksums,
+            pending_files,
             asset_master_mappings,
             legacy_master_state_owners,
             known_ids,
@@ -2124,17 +2205,28 @@ impl DownloadContext {
         if trust_state { Some(false) } else { None }
     }
 
-    fn downloaded_local_path(
+    fn downloaded_file(
         &self,
         library: &str,
         asset_id: &str,
         version_size: VersionSizeKey,
-    ) -> Option<&Path> {
-        self.downloaded_local_paths
+    ) -> Option<&RecordedLocalFile> {
+        self.downloaded_files
             .get(library)
             .and_then(|m| m.get(asset_id))
             .and_then(|versions| versions.get(version_size.as_str()))
-            .map(PathBuf::as_path)
+    }
+
+    fn pending_file(
+        &self,
+        library: &str,
+        asset_id: &str,
+        version_size: VersionSizeKey,
+    ) -> Option<&RecordedLocalFile> {
+        self.pending_files
+            .get(library)
+            .and_then(|m| m.get(asset_id))
+            .and_then(|versions| versions.get(version_size.as_str()))
     }
 
     fn has_downloaded_without_metadata_hash(&self) -> bool {
@@ -7690,8 +7782,10 @@ async fn download_photos_incremental_collecting_inner(
         }
 
         let mut state_skipped = 0usize;
-        plan.tasks.retain(|task| {
-            match download_ctx.should_download_fast(
+        let planned_tasks = std::mem::take(&mut plan.tasks);
+        plan.tasks.reserve(planned_tasks.len());
+        for task in planned_tasks {
+            let keep = match download_ctx.should_download_fast(
                 &task.library,
                 &task.asset_id,
                 task.version_size,
@@ -7702,21 +7796,27 @@ async fn download_photos_incremental_collecting_inner(
                     state_skipped = state_skipped.saturating_add(1);
                     false
                 }
-                None if state_confirmed_current_path_exists(
-                    &download_ctx,
-                    effective_config,
-                    asset,
-                    task,
-                    &mut task_planner,
-                )
-                .is_some() =>
-                {
-                    state_skipped = state_skipped.saturating_add(1);
-                    false
+                None => {
+                    let exists = state_confirmed_current_path_exists(
+                        &download_ctx,
+                        effective_config,
+                        asset,
+                        &task,
+                        &mut task_planner,
+                    )
+                    .await
+                    .is_some();
+                    if exists {
+                        state_skipped = state_skipped.saturating_add(1);
+                    }
+                    !exists
                 }
-                Some(true) | None => true,
+                Some(true) => true,
+            };
+            if keep {
+                plan.tasks.push(task);
             }
-        });
+        }
         skip_breakdown.by_state = skip_breakdown.by_state.saturating_add(state_skipped);
 
         for task in &plan.tasks {
@@ -12801,6 +12901,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn targeted_retry_adopts_smaller_metadata_rewritten_recorded_file() {
+        let db = Arc::new(crate::state::SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+
+        let mut records = incremental_photo_records_with_url(
+            "METADATA_REWRITTEN_RETRY",
+            "rewritten.jpg",
+            "https://p01.icloud-content.com/rewritten.jpg",
+            8,
+        );
+        records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] =
+            json!("ck_metadata_rewritten_retry");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let recorded_path = filter::expected_paths_for(&asset, &config)
+            .into_iter()
+            .next()
+            .expect("asset should derive a path")
+            .path;
+        tokio::fs::create_dir_all(recorded_path.parent().expect("recorded path parent"))
+            .await
+            .expect("create recorded path parent");
+        tokio::fs::write(&recorded_path, b"shorter")
+            .await
+            .expect("seed metadata-rewritten file");
+        let local_checksum = file::compute_sha256(&recorded_path)
+            .await
+            .expect("hash metadata-rewritten file");
+
+        let record = TestAssetRecord::new(asset.state_id())
+            .filename("rewritten.jpg")
+            .checksum("ck_metadata_rewritten_retry")
+            .size(8)
+            .build();
+        db.upsert_seen(&record).await.expect("seed state row");
+        db.mark_downloaded(
+            "PrimarySync",
+            asset.state_id(),
+            VersionSizeKey::Original.as_str(),
+            &recorded_path,
+            &local_checksum,
+            Some("download-checksum-before-metadata"),
+        )
+        .await
+        .expect("seed metadata-rewritten state");
+        db.mark_failed(
+            "PrimarySync",
+            asset.state_id(),
+            VersionSizeKey::Original.as_str(),
+            "prior false truncation",
+        )
+        .await
+        .expect("mark row failed");
+        db.prepare_for_retry(Some("PrimarySync"))
+            .await
+            .expect("prepare row for retry");
+        db.upsert_asset_master_mapping("PrimarySync", asset.asset_record_name(), asset.state_id())
+            .await
+            .expect("seed asset/master mapping");
+
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(PendingLookupSession {
+                    records: Arc::new(records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let plan = build_pending_retry_download_tasks(&passes, &config, CancellationToken::new())
+            .await
+            .expect("adopt metadata-rewritten retry");
+
+        assert!(plan.tasks.is_empty());
+        assert_eq!(tokio::fs::read(&recorded_path).await.unwrap(), b"shorter");
+        let downloaded = db.get_downloaded_page(0, 10).await.expect("downloaded row");
+        assert_eq!(downloaded.len(), 1);
+        assert_eq!(
+            downloaded[0].local_path.as_deref(),
+            Some(recorded_path.as_path())
+        );
+        assert_eq!(
+            downloaded[0].local_checksum.as_deref(),
+            Some(local_checksum.as_str())
+        );
+        assert_eq!(
+            downloaded[0].download_checksum.as_deref(),
+            Some("download-checksum-before-metadata")
+        );
+    }
+
+    #[tokio::test]
     async fn truncated_reconcile_retry_uses_safe_recorded_directory_sibling() {
         use base64::Engine as _;
         use sha2::{Digest, Sha256};
@@ -15243,6 +15439,95 @@ mod tests {
         let summary = db.get_summary().await.expect("summary");
         assert_eq!(summary.downloaded, 1);
         assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn incremental_sync_skips_smaller_metadata_rewritten_file() {
+        let mut records = incremental_photo_records_with_url(
+            "INCREMENTAL_METADATA_REWRITTEN",
+            "incremental-rewritten.jpg",
+            "https://p01.icloud-content.com/incremental-rewritten.jpg",
+            8,
+        );
+        records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] =
+            json!("ck_incremental_metadata_rewritten");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        db.upsert_asset_master_mapping("PrimarySync", asset.asset_record_name(), asset.id())
+            .await
+            .expect("seed asset/master mapping");
+        let dir = TempDir::new().expect("temp dir");
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let target_path = filter::expected_paths_for(&asset, &config)
+            .into_iter()
+            .next()
+            .expect("asset should derive a path")
+            .path;
+        tokio::fs::create_dir_all(target_path.parent().expect("target parent"))
+            .await
+            .expect("create target parent");
+        tokio::fs::write(&target_path, b"shorter")
+            .await
+            .expect("seed metadata-rewritten file");
+        let local_checksum = file::compute_sha256(&target_path)
+            .await
+            .expect("hash metadata-rewritten file");
+        let state_id = asset.asset_record_name();
+        let state_record = TestAssetRecord::new(state_id)
+            .filename("incremental-rewritten.jpg")
+            .checksum("ck_incremental_metadata_rewritten")
+            .size(8)
+            .build();
+        db.upsert_seen(&state_record)
+            .await
+            .expect("seed downloaded row");
+        db.mark_downloaded(
+            "PrimarySync",
+            state_id,
+            VersionSizeKey::Original.as_str(),
+            &target_path,
+            &local_checksum,
+            Some("download-checksum-before-metadata"),
+        )
+        .await
+        .expect("seed metadata-rewritten state");
+
+        let passes = vec![AlbumPass {
+            kind: PassKind::Unfiled,
+            album: mock_album(
+                "Library",
+                MockPhotosFlow::new()
+                    .changes_zone_page(records, "zone-token-next", false)
+                    .build(),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        }];
+        let result = download_photos_incremental_collecting_inner(
+            &Client::new(),
+            &passes,
+            &Arc::new(config),
+            "zone-token-prev",
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+            Duration::ZERO,
+        )
+        .await
+        .expect("incremental sync should skip the verified local file");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.downloaded, 0);
+        assert_eq!(result.stats.failed, 0);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        assert_eq!(tokio::fs::read(&target_path).await.unwrap(), b"shorter");
+        assert!(
+            !target_path
+                .with_file_name("incremental-rewritten-8.jpg")
+                .exists(),
+            "incremental sync must not create a size-suffixed duplicate"
+        );
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -331,7 +331,12 @@ async fn adopt_pending_on_disk_skip(
             asset,
             task_planner,
             &derived,
-            ctx.pending_file(library, asset.state_id(), derived.version_size),
+            ctx.pending_file_matching_checksum(
+                library,
+                asset.state_id(),
+                derived.version_size,
+                derived.checksum.as_ref(),
+            ),
         )
         .await
         {
@@ -516,7 +521,12 @@ async fn adopt_pending_on_disk_task(
         asset,
         task_planner,
         task,
-        ctx.pending_file(library, asset.state_id(), task.version_size),
+        ctx.pending_file_matching_checksum(
+            library,
+            asset.state_id(),
+            task.version_size,
+            task.checksum.as_ref(),
+        ),
     )
     .await
     {
@@ -540,7 +550,12 @@ async fn adopt_pending_on_disk_task(
             asset,
             task_planner,
             &derived,
-            ctx.pending_file(library, asset.state_id(), derived.version_size),
+            ctx.pending_file_matching_checksum(
+                library,
+                asset.state_id(),
+                derived.version_size,
+                derived.checksum.as_ref(),
+            ),
         )
         .await
         {
@@ -5775,8 +5790,16 @@ mod tests {
         assert_eq!(summary.failed, 0);
     }
 
-    #[tokio::test]
-    async fn producer_adopts_smaller_metadata_rewritten_pending_file() {
+    async fn run_producer_metadata_rewritten_pending_file(
+        pending_checksum: &str,
+    ) -> (
+        StreamingResult,
+        i64,
+        Arc<crate::state::SqliteStateDb>,
+        TempDir,
+        PathBuf,
+        String,
+    ) {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
         use crate::state::{SqliteStateDb, VersionSizeKey};
@@ -5819,7 +5842,7 @@ mod tests {
 
         let record = TestAssetRecord::new(asset.state_id())
             .library("SharedSync-abc")
-            .checksum("ck_metadata_rewritten_pending")
+            .checksum(pending_checksum)
             .filename("rewritten.jpg")
             .size(8)
             .build();
@@ -5849,7 +5872,7 @@ mod tests {
         let assets = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(
             metadata_rewritten_asset(),
         )]);
-        stream_and_download_from_stream(
+        let result = stream_and_download_from_stream(
             &client,
             assets,
             &config,
@@ -5859,12 +5882,28 @@ mod tests {
             StreamRuntime::new(None, None),
         )
         .await
-        .expect("sync must adopt metadata-rewritten pending file");
+        .expect("sync must process metadata-rewritten pending file");
+
+        (
+            result,
+            sync_started_at,
+            db,
+            dir,
+            target_path,
+            local_checksum,
+        )
+    }
+
+    #[tokio::test]
+    async fn producer_adopts_smaller_metadata_rewritten_pending_file() {
+        let (result, sync_started_at, db, _dir, target_path, local_checksum) =
+            run_producer_metadata_rewritten_pending_file("ck_metadata_rewritten_pending").await;
 
         assert_eq!(
             db.promote_pending_to_failed(sync_started_at).await.unwrap(),
             0
         );
+        assert!(result.failed.is_empty());
         assert_eq!(fs::read(&target_path).unwrap(), b"shorter");
         let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
         assert_eq!(downloaded.len(), 1);
@@ -5880,6 +5919,20 @@ mod tests {
             downloaded[0].download_checksum.as_deref(),
             Some("download-checksum-before-metadata")
         );
+    }
+
+    #[tokio::test]
+    async fn producer_does_not_adopt_metadata_rewritten_file_after_provider_change() {
+        let (result, _, db, _dir, target_path, _) =
+            run_producer_metadata_rewritten_pending_file("old-provider-checksum").await;
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(fs::read(&target_path).unwrap(), b"shorter");
+        assert!(db.get_downloaded_page(0, 10).await.unwrap().is_empty());
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].checksum.as_ref(), "ck_metadata_rewritten_pending");
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -4547,6 +4547,16 @@ mod tests {
     }
 
     #[async_trait::async_trait]
+    impl crate::state::DownloadContextStateStore for FailingDownloadStore {
+        async fn get_downloaded_file_records(
+            &self,
+        ) -> Result<Vec<crate::state::DownloadedFileRecord>, StateError> {
+            self.downloaded_state_loads.fetch_add(1, Ordering::Relaxed);
+            Ok(Vec::new())
+        }
+    }
+
+    #[async_trait::async_trait]
     impl ReportStateStore for FailingDownloadStore {
         #[cfg(test)]
         async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
@@ -4585,7 +4595,6 @@ mod tests {
             _offset: u64,
             _limit: u32,
         ) -> Result<Vec<AssetRecord>, StateError> {
-            self.downloaded_state_loads.fetch_add(1, Ordering::Relaxed);
             Ok(Vec::new())
         }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -21,6 +21,7 @@ use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
+use super::file::{LocalFileSizeExpectation, local_file_size_matches_state};
 use super::filter::{
     DerivedPath, DownloadTask, FilterReason, derive_expected_paths, determine_media_type,
     extract_skip_candidates, is_asset_filtered,
@@ -40,7 +41,8 @@ use super::planner::add_asset_album_with_retry;
 use super::planner::{self, ExistingPathMatch, TaskPlanner};
 use super::{
     ClaimedLegacyMasterStates, DownloadConfig, DownloadContext, DownloadControls, DownloadOutcome,
-    DownloadReporting, DownloadStore, metadata_rewrite, preload_download_context,
+    DownloadReporting, DownloadStore, RecordedLocalFile, metadata_rewrite,
+    preload_download_context,
 };
 
 pub(super) use metadata_rewrite::MetadataFlags;
@@ -323,7 +325,16 @@ async fn adopt_pending_on_disk_skip(
         if !pending_versions.contains(version_size) {
             continue;
         }
-        match adopt_pending_derived_path(db, library, asset, task_planner, &derived).await {
+        match adopt_pending_derived_path(
+            db,
+            library,
+            asset,
+            task_planner,
+            &derived,
+            ctx.pending_file(library, asset.state_id(), derived.version_size),
+        )
+        .await
+        {
             Some(PendingOnDiskAdoption::Adopted(_)) => {}
             Some(PendingOnDiskAdoption::StateWriteFailed(_)) => {
                 summary.state_write_failures += 1;
@@ -372,7 +383,7 @@ pub(super) struct PendingRetryFileEvidence<'a> {
 
 pub(super) enum PendingRetryLocalPath<'a> {
     Unrecorded,
-    Current(&'a Path),
+    Current(&'a RecordedLocalFile),
     Historical,
 }
 
@@ -388,7 +399,8 @@ pub(super) async fn adopt_pending_on_disk_for_retry(
         return PendingRetryAdoption::NotFound;
     }
 
-    if let PendingRetryLocalPath::Current(local_path) = evidence.local_path {
+    if let PendingRetryLocalPath::Current(recorded_file) = evidence.local_path {
+        let local_path = &recorded_file.path;
         let recorded_filename_matches = local_path
             .file_name()
             .and_then(|filename| filename.to_str())
@@ -405,8 +417,15 @@ pub(super) async fn adopt_pending_on_disk_for_retry(
         }) {
             let mut recorded_task = task.clone();
             recorded_task.download_path = local_path.to_path_buf();
-            if let Some(adoption) =
-                adopt_pending_task_path(db, config, asset, task_planner, &recorded_task).await
+            if let Some(adoption) = adopt_pending_task_path(
+                db,
+                config,
+                asset,
+                task_planner,
+                &recorded_task,
+                Some(recorded_file),
+            )
+            .await
             {
                 return adoption.into();
             }
@@ -428,6 +447,7 @@ pub(super) async fn adopt_pending_on_disk_for_retry(
                 task_planner,
                 &derived,
                 local_path,
+                Some(recorded_file),
             )
             .await
             {
@@ -442,7 +462,8 @@ pub(super) async fn adopt_pending_on_disk_for_retry(
             && task.checksum.as_ref() == evidence.checksum
             && task.size == evidence.size
     }) {
-        if let Some(adoption) = adopt_pending_task_path(db, config, asset, task_planner, task).await
+        if let Some(adoption) =
+            adopt_pending_task_path(db, config, asset, task_planner, task, None).await
         {
             return adoption.into();
         }
@@ -463,6 +484,7 @@ pub(super) async fn adopt_pending_on_disk_for_retry(
             asset,
             task_planner,
             &derived,
+            None,
         )
         .await
         {
@@ -488,7 +510,16 @@ async fn adopt_pending_on_disk_task(
         return None;
     }
 
-    if let Some(adoption) = adopt_pending_task_path(db, config, asset, task_planner, task).await {
+    if let Some(adoption) = adopt_pending_task_path(
+        db,
+        config,
+        asset,
+        task_planner,
+        task,
+        ctx.pending_file(library, asset.state_id(), task.version_size),
+    )
+    .await
+    {
         return Some(adoption);
     }
 
@@ -503,8 +534,15 @@ async fn adopt_pending_on_disk_task(
         }) {
             continue;
         }
-        if let Some(adoption) =
-            adopt_pending_derived_path(db, library, asset, task_planner, &derived).await
+        if let Some(adoption) = adopt_pending_derived_path(
+            db,
+            library,
+            asset,
+            task_planner,
+            &derived,
+            ctx.pending_file(library, asset.state_id(), derived.version_size),
+        )
+        .await
         {
             return Some(adoption);
         }
@@ -513,17 +551,77 @@ async fn adopt_pending_on_disk_task(
     None
 }
 
+fn path_matches_recorded_file(path: &Path, recorded_path: &Path) -> bool {
+    if path == recorded_path {
+        return true;
+    }
+    if path.parent() != recorded_path.parent() {
+        return false;
+    }
+
+    match (
+        path.file_name().and_then(|name| name.to_str()),
+        recorded_path.file_name().and_then(|name| name.to_str()),
+    ) {
+        (Some(path), Some(recorded)) => filenames_match_ampm_equivalent(path, recorded),
+        _ => false,
+    }
+}
+
+async fn pending_file_size_allows_adoption(
+    asset: &PhotoAsset,
+    version_size: &str,
+    path: &Path,
+    actual_size: u64,
+    provider_size: u64,
+    recorded_file: Option<&RecordedLocalFile>,
+) -> bool {
+    let recorded_file =
+        recorded_file.filter(|recorded| path_matches_recorded_file(path, &recorded.path));
+    let result = local_file_size_matches_state(
+        path,
+        actual_size,
+        LocalFileSizeExpectation::ExactProvider(provider_size),
+        recorded_file.and_then(|recorded| recorded.local_checksum.as_deref()),
+        recorded_file.and_then(|recorded| recorded.download_checksum.as_deref()),
+    )
+    .await;
+    match result {
+        Ok(matches) => matches,
+        Err(error) => {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size,
+                path = %path.display(),
+                error = %error,
+                "Failed to verify size-divergent pending file"
+            );
+            false
+        }
+    }
+}
+
 async fn adopt_pending_task_path(
     db: &dyn DownloadStore,
     config: &DownloadConfig,
     asset: &PhotoAsset,
     task_planner: &mut TaskPlanner,
     task: &DownloadTask,
+    recorded_file: Option<&RecordedLocalFile>,
 ) -> Option<PendingOnDiskAdoption> {
     let version_size = task.version_size.as_str();
     let (existing_path, existing_size) =
         task_planner.existing_path_with_size(&task.download_path)?;
-    if existing_size != task.size {
+    if !pending_file_size_allows_adoption(
+        asset,
+        version_size,
+        &existing_path,
+        existing_size,
+        task.size,
+        recorded_file,
+    )
+    .await
+    {
         return None;
     }
 
@@ -553,8 +651,18 @@ async fn adopt_pending_derived_path(
     asset: &PhotoAsset,
     task_planner: &mut TaskPlanner,
     derived: &DerivedPath,
+    recorded_file: Option<&RecordedLocalFile>,
 ) -> Option<PendingOnDiskAdoption> {
-    adopt_pending_derived_path_at(db, library, asset, task_planner, derived, &derived.path).await
+    adopt_pending_derived_path_at(
+        db,
+        library,
+        asset,
+        task_planner,
+        derived,
+        &derived.path,
+        recorded_file,
+    )
+    .await
 }
 
 async fn adopt_pending_derived_path_at(
@@ -564,10 +672,20 @@ async fn adopt_pending_derived_path_at(
     task_planner: &mut TaskPlanner,
     derived: &DerivedPath,
     path: &Path,
+    recorded_file: Option<&RecordedLocalFile>,
 ) -> Option<PendingOnDiskAdoption> {
     let version_size = derived.version_size.as_str();
     let (existing_path, existing_size) = task_planner.existing_path_with_size(path)?;
-    if existing_size != derived.size {
+    if !pending_file_size_allows_adoption(
+        asset,
+        version_size,
+        &existing_path,
+        existing_size,
+        derived.size,
+        recorded_file,
+    )
+    .await
+    {
         return None;
     }
 
@@ -635,25 +753,46 @@ async fn mark_pending_downloaded_from_existing_path(
     Some(PendingOnDiskAdoption::Adopted(existing_path))
 }
 
-fn state_path_size_allows_skip(
+async fn state_path_size_allows_skip(
     asset: &PhotoAsset,
     version_size: VersionSizeKey,
     path: &Path,
     on_disk_size: u64,
     expected_size: u64,
+    recorded_file: &RecordedLocalFile,
 ) -> bool {
-    if expected_size > 0 && on_disk_size < expected_size {
-        tracing::warn!(
-            asset_id = %asset.id(),
-            version_size = %version_size.as_str(),
-            path = %path.display(),
-            on_disk_size,
-            expected_size,
-            "State path is smaller than expected; re-downloading instead of skipping"
-        );
-        return false;
+    let result = local_file_size_matches_state(
+        path,
+        on_disk_size,
+        LocalFileSizeExpectation::AtLeastProvider(expected_size),
+        recorded_file.local_checksum.as_deref(),
+        recorded_file.download_checksum.as_deref(),
+    )
+    .await;
+    match result {
+        Ok(true) => true,
+        Ok(false) => {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size = %version_size.as_str(),
+                path = %path.display(),
+                on_disk_size,
+                expected_size,
+                "State path is smaller than expected; re-downloading instead of skipping"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                asset_id = %asset.id(),
+                version_size = %version_size.as_str(),
+                path = %path.display(),
+                error = %error,
+                "Failed to verify size-divergent state path; re-downloading instead of skipping"
+            );
+            false
+        }
     }
-    true
 }
 
 fn stored_path_matches_current_collision_family(
@@ -744,15 +883,15 @@ fn filenames_match_ampm_equivalent(a: &str, b: &str) -> bool {
     a == b || super::paths::normalize_ampm(a) == super::paths::normalize_ampm(b)
 }
 
-pub(super) fn state_confirmed_current_path_exists(
+pub(super) async fn state_confirmed_current_path_exists(
     ctx: &DownloadContext,
     config: &DownloadConfig,
     asset: &PhotoAsset,
     task: &DownloadTask,
     task_planner: &mut TaskPlanner,
 ) -> Option<PathBuf> {
-    let stored_path =
-        ctx.downloaded_local_path(&task.library, &task.asset_id, task.version_size)?;
+    let recorded_file = ctx.downloaded_file(&task.library, &task.asset_id, task.version_size)?;
+    let stored_path = &recorded_file.path;
     let derived_paths = derive_expected_paths(asset, config);
 
     for derived in &derived_paths {
@@ -764,14 +903,17 @@ pub(super) fn state_confirmed_current_path_exists(
         else {
             continue;
         };
-        if existing_path == stored_path {
+        if existing_path.as_path() == stored_path.as_path() {
             if state_path_size_allows_skip(
                 asset,
                 derived.version_size,
                 &existing_path,
                 existing_size,
                 derived.size,
-            ) {
+                recorded_file,
+            )
+            .await
+            {
                 return Some(existing_path);
             }
             return None;
@@ -798,7 +940,10 @@ pub(super) fn state_confirmed_current_path_exists(
             &existing_path,
             existing_size,
             derived.size,
-        ) {
+            recorded_file,
+        )
+        .await
+        {
             return Some(existing_path);
         }
         return None;
@@ -1762,6 +1907,7 @@ where
                                                 &task,
                                                 &mut task_planner,
                                             )
+                                            .await
                                         {
                                             disposition = disposition.max(AssetDisposition::OnDisk);
                                             tracing::debug!(
@@ -4197,7 +4343,7 @@ mod tests {
         calls: AtomicUsize,
         successes: AtomicUsize,
         failed_calls: AtomicUsize,
-        downloaded_id_loads: AtomicUsize,
+        downloaded_state_loads: AtomicUsize,
         track_failed_calls: bool,
         fail_complete_sync_run: bool,
     }
@@ -4209,7 +4355,7 @@ mod tests {
                 calls: AtomicUsize::new(0),
                 successes: AtomicUsize::new(0),
                 failed_calls: AtomicUsize::new(0),
-                downloaded_id_loads: AtomicUsize::new(0),
+                downloaded_state_loads: AtomicUsize::new(0),
                 track_failed_calls: false,
                 fail_complete_sync_run: false,
             }
@@ -4235,8 +4381,8 @@ mod tests {
             self.calls.load(Ordering::Relaxed)
         }
 
-        fn downloaded_id_load_count(&self) -> usize {
-            self.downloaded_id_loads.load(Ordering::Relaxed)
+        fn downloaded_state_load_count(&self) -> usize {
+            self.downloaded_state_loads.load(Ordering::Relaxed)
         }
 
         fn failed_call_count(&self) -> usize {
@@ -4314,7 +4460,6 @@ mod tests {
         async fn get_downloaded_ids(
             &self,
         ) -> Result<HashSet<(String, String, String)>, StateError> {
-            self.downloaded_id_loads.fetch_add(1, Ordering::Relaxed);
             Ok(HashSet::new())
         }
 
@@ -4425,7 +4570,8 @@ mod tests {
             _offset: u64,
             _limit: u32,
         ) -> Result<Vec<AssetRecord>, StateError> {
-            unimplemented!()
+            self.downloaded_state_loads.fetch_add(1, Ordering::Relaxed);
+            Ok(Vec::new())
         }
 
         async fn start_sync_run_at(
@@ -5627,6 +5773,113 @@ mod tests {
         assert_eq!(summary.downloaded, 1);
         assert_eq!(summary.pending, 0);
         assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn producer_adopts_smaller_metadata_rewritten_pending_file() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::{SqliteStateDb, VersionSizeKey};
+        use crate::test_helpers::TestAssetRecord;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        fn metadata_rewritten_asset() -> PhotoAsset {
+            TestPhotoAsset::new("METADATA_REWRITTEN_PENDING")
+                .filename("rewritten.jpg")
+                .item_type("public.jpeg")
+                .orig_file_type("public.jpeg")
+                .orig_size(8)
+                .orig_url("https://p01.icloud-content.com/rewritten.jpg")
+                .orig_checksum("ck_metadata_rewritten_pending")
+                .build()
+                .with_source_zone(Arc::from("SharedSync-abc"))
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let asset = metadata_rewritten_asset();
+        let target_path = crate::download::filter::expected_paths_for(&asset, config.as_ref())
+            .first()
+            .expect("test asset must derive an expected path")
+            .path
+            .clone();
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target_path, b"shorter").unwrap();
+        let local_checksum = crate::download::file::compute_sha256(&target_path)
+            .await
+            .expect("hash metadata-rewritten file");
+
+        let record = TestAssetRecord::new(asset.state_id())
+            .library("SharedSync-abc")
+            .checksum("ck_metadata_rewritten_pending")
+            .filename("rewritten.jpg")
+            .size(8)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "SharedSync-abc",
+            asset.state_id(),
+            VersionSizeKey::Original.as_str(),
+            &target_path,
+            &local_checksum,
+            Some("download-checksum-before-metadata"),
+        )
+        .await
+        .unwrap();
+        db.mark_failed(
+            "SharedSync-abc",
+            asset.state_id(),
+            VersionSizeKey::Original.as_str(),
+            "prior false truncation",
+        )
+        .await
+        .unwrap();
+        db.prepare_for_retry(Some("SharedSync-abc")).await.unwrap();
+
+        let client = reqwest::Client::new();
+        let sync_started_at = chrono::Utc::now().timestamp();
+        let assets = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(
+            metadata_rewritten_asset(),
+        )]);
+        stream_and_download_from_stream(
+            &client,
+            assets,
+            &config,
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .expect("sync must adopt metadata-rewritten pending file");
+
+        assert_eq!(
+            db.promote_pending_to_failed(sync_started_at).await.unwrap(),
+            0
+        );
+        assert_eq!(fs::read(&target_path).unwrap(), b"shorter");
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 1);
+        assert_eq!(
+            downloaded[0].local_path.as_deref(),
+            Some(target_path.as_path())
+        );
+        assert_eq!(
+            downloaded[0].local_checksum.as_deref(),
+            Some(local_checksum.as_str())
+        );
+        assert_eq!(
+            downloaded[0].download_checksum.as_deref(),
+            Some("download-checksum-before-metadata")
+        );
     }
 
     #[tokio::test]
@@ -6928,13 +7181,7 @@ mod tests {
         assert_eq!(&*failed[0].id, "DELETED");
     }
 
-    /// Metadata embedding can legitimately change the local byte size after
-    /// the downloaded bytes were verified. A later sync must use the DB row's
-    /// asset identity and recorded path to skip that current-path file instead
-    /// of treating it as a same-name/different-size collision and downloading
-    /// a `-<size>` duplicate.
-    #[tokio::test]
-    async fn metadata_mutated_downloaded_file_is_not_size_dedup_redownloaded() {
+    async fn assert_metadata_mutated_downloaded_file_is_not_redownloaded(on_disk_size: usize) {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
         use crate::state::SqliteStateDb;
@@ -6972,7 +7219,10 @@ mod tests {
             None,
         );
         fs::create_dir_all(target_path.parent().unwrap()).unwrap();
-        fs::write(&target_path, vec![0u8; 1500]).unwrap();
+        fs::write(&target_path, vec![0u8; on_disk_size]).unwrap();
+        let local_checksum = crate::download::file::compute_sha256(&target_path)
+            .await
+            .expect("hash metadata-mutated file");
 
         let record = crate::test_helpers::TestAssetRecord::new("METADATA_MUTATED")
             .checksum("ck_metadata_mutated")
@@ -6985,7 +7235,7 @@ mod tests {
             "METADATA_MUTATED",
             "original",
             &target_path,
-            "local_checksum_after_metadata_write",
+            &local_checksum,
             Some("download_checksum_before_metadata_write"),
         )
         .await
@@ -7019,6 +7269,19 @@ mod tests {
             failed.is_empty(),
             "metadata-mutated downloaded file should remain downloaded, not failed"
         );
+    }
+
+    #[tokio::test]
+    async fn metadata_mutated_downloaded_file_is_not_size_dedup_redownloaded() {
+        assert_metadata_mutated_downloaded_file_is_not_redownloaded(1500).await;
+    }
+
+    /// Metadata embedding can legitimately make the local file smaller after
+    /// the downloaded bytes were verified. A later sync must prove the current
+    /// bytes from the DB row instead of downloading a `-<size>` duplicate.
+    #[tokio::test]
+    async fn smaller_metadata_mutated_downloaded_file_is_not_redownloaded() {
+        assert_metadata_mutated_downloaded_file_is_not_redownloaded(1200).await;
     }
 
     fn identity_suffixed_path_for(bare_path: &Path, asset_id: &str) -> PathBuf {
@@ -8033,9 +8296,9 @@ mod tests {
         let config = Arc::new(raw_config);
         let preloaded = preload_download_context(&config).await;
         assert_eq!(
-            db.downloaded_id_load_count(),
+            db.downloaded_state_load_count(),
             1,
-            "preload should read downloaded IDs once"
+            "preload should read downloaded state once"
         );
 
         let client = reqwest::Client::new();
@@ -8053,7 +8316,7 @@ mod tests {
         .expect("empty stream should complete");
 
         assert_eq!(
-            db.downloaded_id_load_count(),
+            db.downloaded_state_load_count(),
             1,
             "stream should reuse the preloaded context instead of reloading the DB"
         );

--- a/src/download/retry.rs
+++ b/src/download/retry.rs
@@ -1,6 +1,6 @@
 //! Durable pending-retry identity resolution and targeted provider revalidation.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -8,8 +8,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    DownloadConfig, DownloadStore, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RetryTaskKey,
-    UrlRetrySource, build_pass_configs_resolving_deferred_excludes, filter, pipeline, planner,
+    DownloadConfig, DownloadStore, DownloadTask, PENDING_RETRY_UNMATCHED_REASON, RecordedLocalFile,
+    RetryTaskKey, UrlRetrySource, build_pass_configs_resolving_deferred_excludes, filter, pipeline,
+    planner,
 };
 use crate::icloud::photos::{PhotoAsset, ProviderRecordId, RecordLookupRequest, RecordResolution};
 use crate::state::{AssetVerificationState, VersionSizeKey};
@@ -43,7 +44,7 @@ impl PendingRetryTarget {
 struct PendingRetryEvidence {
     checksum: Arc<str>,
     filename: Arc<str>,
-    local_path: Option<PathBuf>,
+    local_file: Option<RecordedLocalFile>,
     downloaded_at: Option<chrono::DateTime<chrono::Utc>>,
     size_bytes: u64,
 }
@@ -53,15 +54,20 @@ impl PendingRetryEvidence {
         Self {
             checksum: Arc::from(record.checksum.as_ref()),
             filename: Arc::from(record.filename.as_ref()),
-            local_path: record.local_path.clone(),
+            local_file: record.local_path.clone().map(|path| RecordedLocalFile {
+                path,
+                local_checksum: record.local_checksum.as_deref().map(Into::into),
+                download_checksum: record.download_checksum.as_deref().map(Into::into),
+            }),
             downloaded_at: record.downloaded_at,
             size_bytes: record.size_bytes,
         }
     }
 
     fn local_path_under<'a>(&'a self, directory: &Path) -> Option<&'a Path> {
-        self.local_path
-            .as_deref()
+        self.local_file
+            .as_ref()
+            .map(|file| file.path.as_path())
             .filter(|path| path.starts_with(directory))
     }
 
@@ -69,11 +75,15 @@ impl PendingRetryEvidence {
         &'a self,
         directory: &Path,
     ) -> pipeline::PendingRetryLocalPath<'a> {
-        let Some(path) = self.local_path_under(directory) else {
+        let Some(file) = self
+            .local_file
+            .as_ref()
+            .filter(|file| file.path.starts_with(directory))
+        else {
             return pipeline::PendingRetryLocalPath::Unrecorded;
         };
         if self.downloaded_at.is_some() {
-            pipeline::PendingRetryLocalPath::Current(path)
+            pipeline::PendingRetryLocalPath::Current(file)
         } else {
             pipeline::PendingRetryLocalPath::Historical
         }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -64,6 +64,24 @@ pub struct ImportedRecord {
     pub imported_mtime: Option<i64>,
 }
 
+/// Compact downloaded-state projection used to preload sync decisions.
+#[derive(Debug)]
+pub(crate) struct DownloadedFileRecord {
+    pub(crate) library: String,
+    pub(crate) id: String,
+    pub(crate) version_size: VersionSizeKey,
+    pub(crate) checksum: String,
+    pub(crate) local_path: Option<PathBuf>,
+    pub(crate) local_checksum: Option<String>,
+    pub(crate) download_checksum: Option<String>,
+}
+
+/// State operation used only to preload the download context.
+#[async_trait]
+pub(crate) trait DownloadContextStateStore: Send + Sync {
+    async fn get_downloaded_file_records(&self) -> Result<Vec<DownloadedFileRecord>, StateError>;
+}
+
 /// Live album-membership row keyed by CloudKit asset record name.
 ///
 /// Album relation records refer to `PhotoAsset::asset_record_name()`, while
@@ -2163,6 +2181,39 @@ impl SqliteStateDb {
         .await
     }
 
+    pub(crate) async fn get_downloaded_file_records(
+        &self,
+    ) -> Result<Vec<DownloadedFileRecord>, StateError> {
+        self.with_conn("get_downloaded_file_records", move |conn| {
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT library, id, version_size, checksum, local_path, \
+                            local_checksum, download_checksum \
+                     FROM assets WHERE status = 'downloaded'",
+                )
+                .map_err(|e| StateError::query("get_downloaded_file_records", e))?;
+
+            stmt.query_map([], |row| {
+                let version_size: String = row.get(2)?;
+                let local_path: Option<String> = row.get(4)?;
+                Ok(DownloadedFileRecord {
+                    library: row.get(0)?,
+                    id: row.get(1)?,
+                    version_size: VersionSizeKey::from_str(&version_size)
+                        .unwrap_or(VersionSizeKey::Original),
+                    checksum: row.get(3)?,
+                    local_path: local_path.map(PathBuf::from),
+                    local_checksum: row.get(5)?,
+                    download_checksum: row.get(6)?,
+                })
+            })
+            .map_err(|e| StateError::query("get_downloaded_file_records", e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| StateError::query("get_downloaded_file_records", e))
+        })
+        .await
+    }
+
     /// Assets that still hold `status = 'downloaded'` rows after the provider
     /// reported them deleted. Soft deletion flips every version of an asset
     /// together, so this is keyed by asset rather than by version.
@@ -4223,6 +4274,13 @@ impl SyncTokenStore for SqliteStateDb {
 
     async fn list_interrupted_enumerations(&self) -> Result<Vec<String>, StateError> {
         SqliteStateDb::list_interrupted_enumerations(self).await
+    }
+}
+
+#[async_trait]
+impl DownloadContextStateStore for SqliteStateDb {
+    async fn get_downloaded_file_records(&self) -> Result<Vec<DownloadedFileRecord>, StateError> {
+        SqliteStateDb::get_downloaded_file_records(self).await
     }
 }
 
@@ -6384,6 +6442,46 @@ mod tests {
             "PENDING_1".to_string(),
             "original".to_string()
         )));
+    }
+
+    #[tokio::test]
+    async fn downloaded_file_records_return_compact_skip_evidence() {
+        let dir = test_dir();
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("DOWNLOADED")
+            .checksum("provider-checksum")
+            .filename("downloaded.jpg")
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        let path = dir.path().join("downloaded.jpg");
+        db.mark_downloaded(
+            "PrimarySync",
+            "DOWNLOADED",
+            "original",
+            &path,
+            "local-checksum",
+            Some("download-checksum"),
+        )
+        .await
+        .unwrap();
+        db.upsert_seen(&TestAssetRecord::new("PENDING").build())
+            .await
+            .unwrap();
+
+        let records = db.get_downloaded_file_records().await.unwrap();
+
+        assert_eq!(records.len(), 1);
+        let downloaded = &records[0];
+        assert_eq!(downloaded.library, "PrimarySync");
+        assert_eq!(downloaded.id, "DOWNLOADED");
+        assert_eq!(downloaded.version_size, VersionSizeKey::Original);
+        assert_eq!(downloaded.checksum, "provider-checksum");
+        assert_eq!(downloaded.local_path.as_deref(), Some(path.as_path()));
+        assert_eq!(downloaded.local_checksum.as_deref(), Some("local-checksum"));
+        assert_eq!(
+            downloaded.download_checksum.as_deref(),
+            Some("download-checksum")
+        );
     }
 
     #[tokio::test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -14,7 +14,10 @@ pub mod types;
 
 #[cfg(test)]
 pub use db::ImportedRecord;
-pub(crate) use db::{AssetVerificationState, CheckpointTransition, ScopedDbSyncToken};
+pub(crate) use db::{
+    AssetVerificationState, CheckpointTransition, DownloadContextStateStore, DownloadedFileRecord,
+    ScopedDbSyncToken,
+};
 pub use db::{
     DownloadStateStore, ImportStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore,
     SqliteStateDb, SyncTokenStore,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4631,6 +4631,15 @@ mod tests {
     }
 
     #[async_trait::async_trait]
+    impl state::DownloadContextStateStore for FailingMetadataSetDb {
+        async fn get_downloaded_file_records(
+            &self,
+        ) -> Result<Vec<state::DownloadedFileRecord>, state::error::StateError> {
+            self.inner.get_downloaded_file_records().await
+        }
+    }
+
+    #[async_trait::async_trait]
     impl state::ReportStateStore for FailingMetadataSetDb {
         async fn get_failed(
             &self,


### PR DESCRIPTION
## Summary
- Accept a provider-relative size mismatch only when durable checksum evidence shows that metadata writing changed the file and the current SHA-256 matches the stored local checksum.
- Apply this rule to downloaded-file skips, producer pending adoption, and targeted retry adoption.
- Keep historical and stale recorded paths excluded from checksum-backed adoption.
- Add production-path regressions for incremental sync, normal producer adoption, and targeted retry.

## Tests
- `cargo fmt --all --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo test --all-features metadata_rewritten -- --nocapture`
- All all-feature and no-default-feature gate test targets

## Context
Follow-up to the metadata-size analysis in rhoopr/kei#711.
