### PR TITLE
Add source EXIF GPS facts to XMP sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- XMP sidecars now carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error, read from the media's own EXIF alongside the CloudKit location. A HEIC, AVIF, or PNG without a readable EXIF block still receives its sidecar with the CloudKit metadata. ([#725])
+- XMP sidecars carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error from the media's own EXIF alongside the CloudKit
+  location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` property. A photo without readable EXIF still receives its
+  sidecar with the CloudKit metadata. Source EXIF is read without buffering the complete media file. ([#725])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- XMP sidecars now carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error, read from the media's own EXIF alongside the CloudKit location. A HEIC, AVIF, or PNG without a readable EXIF block still receives its sidecar with the CloudKit metadata. ([#725])
+
 ### Changed
 
 - State databases now use schema version 17 to record which iCloud asset owns an adopted legacy master row. Older kei versions reject a version 17 database instead of opening it. To downgrade, restore a state DB backup made before the upgrade; downloaded media files are unchanged. ([#721])
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#719]: https://github.com/rhoopr/kei/issues/719
 [#720]: https://github.com/rhoopr/kei/pull/720
 [#721]: https://github.com/rhoopr/kei/pull/721
+[#725]: https://github.com/rhoopr/kei/issues/725
 [#691]: https://github.com/rhoopr/kei/issues/691
 [@mmenanno]: https://github.com/mmenanno
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - XMP sidecars carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error from the media's own EXIF alongside the CloudKit
-  location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` and `exifEX:GPSHPositioningError` properties. A photo without
+  location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` and `exif:GPSHPositioningError` properties. A photo without
   readable EXIF still receives its sidecar with the CloudKit metadata. Source EXIF is read without buffering the complete media file. ([#725])
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - XMP sidecars carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error from the media's own EXIF alongside the CloudKit
-  location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` property. A photo without readable EXIF still receives its
-  sidecar with the CloudKit metadata. Source EXIF is read without buffering the complete media file. ([#725])
+  location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` and `exifEX:GPSHPositioningError` properties. A photo without
+  readable EXIF still receives its sidecar with the CloudKit metadata. Source EXIF is read without buffering the complete media file. ([#725])
 
 ### Changed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,15 @@ A later rewrite deletes a cleared property only when that marker proves kei
 owned the prior value. Unmarked standard properties and unrelated third-party
 namespaces remain unchanged.
 
+Source GPS facts for sidecars are read through file-backed parsers. JPEG APP1,
+TIFF-based RAW, PNG `eXIf`, and HEIF Exif items use checked seeks and
+fixed-size TIFF fields. HEIF atom and item-location counts are streamed without
+allocating from provider-controlled lengths.
+Source I/O failures still publish current CloudKit metadata, preserve prior
+kei-owned source GPS fields as unknown, and retain the metadata retry marker.
+Readable unsupported or malformed metadata permits a CloudKit-only sidecar.
+Source media is never opened for writing on this path.
+
 A drain only rewrites a file whose bytes still match the checksum on its row,
 because the alternative is embedding into damage and then vouching for it. A
 file that no longer matches keeps its marker and its recorded checksum, so

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -312,9 +312,7 @@ CloudKit is authoritative for the currently decoded coordinates, altitude, and
 capture timestamps. The location decoder currently maps only `lat`, `lon`, and
 `alt` from `locationEnc`, so source EXIF supplies GPS receiver time, speed,
 speed units, and horizontal positioning error. No coordinate matching or
-tolerance is applied for minor Photos location edits. If kei later decodes
-CloudKit values for those same GPS measurement fields, CloudKit takes
-precedence.
+tolerance is applied for minor Photos location edits.
 Source I/O failures still publish current CloudKit metadata, preserve prior
 kei-owned source GPS fields as unknown, and retain the metadata retry marker.
 Readable unsupported or malformed metadata permits a CloudKit-only sidecar.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,6 +308,13 @@ Source GPS facts for sidecars are read through file-backed parsers. JPEG APP1,
 TIFF-based RAW, PNG `eXIf`, and HEIF Exif items use checked seeks and
 fixed-size TIFF fields. HEIF atom and item-location counts are streamed without
 allocating from provider-controlled lengths.
+CloudKit is authoritative for the currently decoded coordinates, altitude, and
+capture timestamps. The location decoder currently maps only `lat`, `lon`, and
+`alt` from `locationEnc`, so source EXIF supplies GPS receiver time, speed,
+speed units, and horizontal positioning error. No coordinate matching or
+tolerance is applied for minor Photos location edits. If kei later decodes
+CloudKit values for those same GPS measurement fields, CloudKit takes
+precedence.
 Source I/O failures still publish current CloudKit metadata, preserve prior
 kei-owned source GPS fields as unknown, and retain the metadata retry marker.
 Readable unsupported or malformed metadata permits a CloudKit-only sidecar.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -54,7 +54,7 @@ are gitignored.
 | `cloudkit_json` | every CloudKit response type (`ZoneListResponse`, `QueryResponse`, `Record`, `ChangesDatabaseResponse`, etc.) via `serde_json::from_slice` | `src/icloud/photos/cloudkit.rs` |
 | `enc_decoders` | `decode_string`, `decode_keywords`, `decode_location`, `decode_location_with_fallback` - both the JSON-shape path and the bplist-via-base64 path | `src/icloud/photos/enc.rs` |
 | `paths_sanitization` | `clean_filename`, `sanitize_path_component`, `expand_album_token`, `add_dedup_suffix`, `strip_python_wrapper`, `remove_unicode_chars` | `src/download/paths.rs` |
-| `heif_atoms` | `extract_xmp_bytes` and `is_heif_content` - mp4-atom walks the ISO-BMFF box tree on attacker-controlled HEIC bytes | `src/download/heif.rs` |
+| `heif_atoms` | XMP extraction, file-backed EXIF extent location, fixed-buffer TIFF GPS parsing, and HEIF content detection over attacker-controlled bytes | `src/download/heif.rs`, `src/download/metadata.rs` |
 | `xmp_packet` | `XmpMeta::from_str` directly - drives Adobe's vendored XMP Toolkit (C++ via FFI) on arbitrary UTF-8. cargo-fuzz only instruments Rust code, so libfuzzer is blind to coverage inside the C++ and this target is effectively dumb-fuzzed (ASan still catches memory bugs). A starter seed lives at `fuzz/seeds/xmp_packet/minimal.xmp`. | `xmp_toolkit` crate |
 | `heif_xmp_probe` | full `probe_exif_heif` pipeline: extract XMP from HEIC bytes, then parse it through xmp_toolkit | `src/download/heif.rs` + `xmp_toolkit` |
 | `toml_config` | `TomlConfig` deserializer + custom field deserializers (`folder_structure`, `RecentLimit`) + `deny_unknown_fields` boundary checks | `src/config.rs` |

--- a/fuzz/fuzz_targets/heif_atoms.rs
+++ b/fuzz/fuzz_targets/heif_atoms.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-// Drives `extract_xmp_bytes` and `is_heif_content` from
+// Drives the XMP and EXIF item locators plus `is_heif_content` from
 // `src/download/heif.rs` over arbitrary bytes. Bug #274 (panic on `uri `
 // infe items in iOS-17 HEICs) lived here, and the upstream mp4-atom
 // `parse_vorbis_comment` OOM (kixelated/mp4-atom#154) shows up here too.
@@ -11,5 +11,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let _ = kei::__fuzz::heif_extract_xmp(data);
+    kei::__fuzz::heif_locate_exif(data);
     let _ = kei::__fuzz::heif_is_heif_content(data);
+    kei::__fuzz::tiff_source_gps(data);
 });

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -64,6 +64,25 @@ pub(crate) enum HeifError {
     Io(#[from] std::io::Error),
 }
 
+#[derive(Debug)]
+pub(crate) enum HeifExifError {
+    Io(std::io::Error),
+    Malformed,
+}
+
+impl From<std::io::Error> for HeifExifError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FileAtom {
+    kind: [u8; 4],
+    body_start: u64,
+    end: u64,
+}
+
 /// Whether this path's extension is HEIF / HEIC / HIF / AVIF — formats
 /// that XMP Toolkit's bundled handlers can't open, handled here instead.
 ///
@@ -114,6 +133,348 @@ pub(crate) fn is_heif_content(bytes: &[u8]) -> bool {
             | b"avif"
             | b"avis"
     )
+}
+
+pub(crate) fn locate_exif_tiff<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    file_len: u64,
+) -> Result<Option<(u64, u64)>, HeifExifError> {
+    let mut offset = 0_u64;
+    let mut meta = None;
+    while let Some(atom) = read_file_atom(source, offset, file_len)? {
+        if atom.kind == *b"meta" {
+            if meta.is_some() {
+                return Err(HeifExifError::Malformed);
+            }
+            meta = Some(atom);
+        }
+        offset = atom.end;
+    }
+    let Some(meta) = meta else {
+        return Ok(None);
+    };
+
+    let (iinf, iloc) = locate_meta_control_atoms(source, meta)?;
+    let (Some(iinf), Some(iloc)) = (iinf, iloc) else {
+        return Ok(None);
+    };
+    let Some(item_id) = read_exif_item_id(source, iinf)? else {
+        return Ok(None);
+    };
+    let Some((base_offset, extent_offset, extent_length)) =
+        read_exif_item_location(source, iloc, item_id)?
+    else {
+        return Ok(None);
+    };
+
+    let extent_start = base_offset
+        .checked_add(extent_offset)
+        .ok_or(HeifExifError::Malformed)?;
+    let extent_end = extent_start
+        .checked_add(extent_length)
+        .filter(|end| *end <= file_len)
+        .ok_or(HeifExifError::Malformed)?;
+    if extent_length < 4 {
+        return Err(HeifExifError::Malformed);
+    }
+    let mut prefix = [0_u8; 4];
+    read_file_exact(source, file_len, extent_start, &mut prefix)?;
+    let tiff_offset = u64::from(u32::from_be_bytes(prefix));
+    let tiff_start = extent_start
+        .checked_add(4)
+        .and_then(|start| start.checked_add(tiff_offset))
+        .filter(|start| *start <= extent_end)
+        .ok_or(HeifExifError::Malformed)?;
+    let tiff_len = extent_end
+        .checked_sub(tiff_start)
+        .ok_or(HeifExifError::Malformed)?;
+    Ok(Some((tiff_start, tiff_len)))
+}
+
+fn locate_meta_control_atoms<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    meta: FileAtom,
+) -> Result<(Option<FileAtom>, Option<FileAtom>), HeifExifError> {
+    let mut prefix = [0_u8; 8];
+    let prefix_len = usize::try_from((meta.end - meta.body_start).min(8))
+        .map_err(|_error| HeifExifError::Malformed)?;
+    let prefix_output = prefix
+        .get_mut(..prefix_len)
+        .ok_or(HeifExifError::Malformed)?;
+    read_file_exact(source, meta.end, meta.body_start, prefix_output)?;
+    let mut offset = if prefix.get(4..8) == Some(b"hdlr".as_slice()) {
+        meta.body_start
+    } else {
+        meta.body_start
+            .checked_add(4)
+            .filter(|offset| *offset <= meta.end)
+            .ok_or(HeifExifError::Malformed)?
+    };
+    let Some(handler) = read_file_atom(source, offset, meta.end)? else {
+        return Ok((None, None));
+    };
+    if handler.kind != *b"hdlr" {
+        return Err(HeifExifError::Malformed);
+    }
+    offset = handler.end;
+
+    let mut iinf = None;
+    let mut iloc = None;
+    while let Some(atom) = read_file_atom(source, offset, meta.end)? {
+        match &atom.kind {
+            b"iinf" if iinf.replace(atom).is_some() => {
+                return Err(HeifExifError::Malformed);
+            }
+            b"iloc" if iloc.replace(atom).is_some() => {
+                return Err(HeifExifError::Malformed);
+            }
+            _ => {}
+        }
+        offset = atom.end;
+    }
+    Ok((iinf, iloc))
+}
+
+fn read_exif_item_id<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    iinf: FileAtom,
+) -> Result<Option<u32>, HeifExifError> {
+    let mut full_box = [0_u8; 8];
+    read_file_exact(source, iinf.end, iinf.body_start, &mut full_box[..6])?;
+    let version = full_box[0];
+    let (entry_count, mut offset) = if version == 0 {
+        (
+            u32::from(u16::from_be_bytes([full_box[4], full_box[5]])),
+            iinf.body_start
+                .checked_add(6)
+                .ok_or(HeifExifError::Malformed)?,
+        )
+    } else if version == 1 {
+        read_file_exact(source, iinf.end, iinf.body_start, &mut full_box)?;
+        (
+            u32::from_be_bytes([full_box[4], full_box[5], full_box[6], full_box[7]]),
+            iinf.body_start
+                .checked_add(8)
+                .ok_or(HeifExifError::Malformed)?,
+        )
+    } else {
+        return Err(HeifExifError::Malformed);
+    };
+
+    let mut exif_id = None;
+    for _ in 0..entry_count {
+        let Some(entry) = read_file_atom(source, offset, iinf.end)? else {
+            return Err(HeifExifError::Malformed);
+        };
+        if entry.kind != *b"infe" {
+            return Err(HeifExifError::Malformed);
+        }
+        let mut fields = [0_u8; 14];
+        let available = usize::try_from((entry.end - entry.body_start).min(fields.len() as u64))
+            .map_err(|_error| HeifExifError::Malformed)?;
+        let fields_output = fields
+            .get_mut(..available)
+            .ok_or(HeifExifError::Malformed)?;
+        read_file_exact(source, entry.end, entry.body_start, fields_output)?;
+        let item_id = match fields.first().copied() {
+            Some(2) if available >= 12 => u32::from(u16::from_be_bytes([fields[4], fields[5]])),
+            Some(3) if available >= 14 => {
+                u32::from_be_bytes([fields[4], fields[5], fields[6], fields[7]])
+            }
+            _ => {
+                offset = entry.end;
+                continue;
+            }
+        };
+        let item_type_offset = if fields[0] == 2 { 8 } else { 10 };
+        if fields.get(item_type_offset..item_type_offset + 4) == Some(b"Exif".as_slice())
+            && exif_id.replace(item_id).is_some()
+        {
+            return Err(HeifExifError::Malformed);
+        }
+        offset = entry.end;
+    }
+    Ok(exif_id)
+}
+
+fn read_exif_item_location<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    iloc: FileAtom,
+    target_item_id: u32,
+) -> Result<Option<(u64, u64, u64)>, HeifExifError> {
+    let mut header = [0_u8; 10];
+    read_file_exact(source, iloc.end, iloc.body_start, &mut header[..8])?;
+    let version = header[0];
+    if version > 2 {
+        return Err(HeifExifError::Malformed);
+    }
+    let offset_size = header[4] >> 4;
+    let length_size = header[4] & 0x0F;
+    let base_offset_size = header[5] >> 4;
+    let index_size = if version == 0 { 0 } else { header[5] & 0x0F };
+    for size in [offset_size, length_size, base_offset_size, index_size] {
+        if !matches!(size, 0 | 4 | 8) {
+            return Err(HeifExifError::Malformed);
+        }
+    }
+    let (item_count, mut cursor) = if version < 2 {
+        (
+            u32::from(u16::from_be_bytes([header[6], header[7]])),
+            iloc.body_start
+                .checked_add(8)
+                .ok_or(HeifExifError::Malformed)?,
+        )
+    } else {
+        read_file_exact(source, iloc.end, iloc.body_start, &mut header)?;
+        (
+            u32::from_be_bytes([header[6], header[7], header[8], header[9]]),
+            iloc.body_start
+                .checked_add(10)
+                .ok_or(HeifExifError::Malformed)?,
+        )
+    };
+
+    let mut found = None;
+    for _ in 0..item_count {
+        let item_id = u32::try_from(read_sized_integer(
+            source,
+            iloc.end,
+            &mut cursor,
+            if version < 2 { 2 } else { 4 },
+        )?)
+        .map_err(|_error| HeifExifError::Malformed)?;
+        let construction_method = if version == 0 {
+            0
+        } else {
+            u8::try_from(read_sized_integer(source, iloc.end, &mut cursor, 2)? & 0x0F)
+                .map_err(|_error| HeifExifError::Malformed)?
+        };
+        let data_reference_index =
+            u16::try_from(read_sized_integer(source, iloc.end, &mut cursor, 2)?)
+                .map_err(|_error| HeifExifError::Malformed)?;
+        let base_offset = read_sized_integer(source, iloc.end, &mut cursor, base_offset_size)?;
+        let extent_count = u16::try_from(read_sized_integer(source, iloc.end, &mut cursor, 2)?)
+            .map_err(|_error| HeifExifError::Malformed)?;
+        let per_extent_size = u64::from(index_size)
+            .checked_add(u64::from(offset_size))
+            .and_then(|size| size.checked_add(u64::from(length_size)))
+            .ok_or(HeifExifError::Malformed)?;
+        if extent_count > 0 && per_extent_size == 0 {
+            return Err(HeifExifError::Malformed);
+        }
+        cursor
+            .checked_add(
+                u64::from(extent_count)
+                    .checked_mul(per_extent_size)
+                    .ok_or(HeifExifError::Malformed)?,
+            )
+            .filter(|end| *end <= iloc.end)
+            .ok_or(HeifExifError::Malformed)?;
+        let mut selected_extent = None;
+        for extent_index in 0..extent_count {
+            let item_reference_index =
+                read_sized_integer(source, iloc.end, &mut cursor, index_size)?;
+            let extent_offset = read_sized_integer(source, iloc.end, &mut cursor, offset_size)?;
+            let extent_length = read_sized_integer(source, iloc.end, &mut cursor, length_size)?;
+            if item_id == target_item_id && extent_index == 0 {
+                if item_reference_index != 0 {
+                    return Err(HeifExifError::Malformed);
+                }
+                selected_extent = Some((extent_offset, extent_length));
+            }
+        }
+        if item_id == target_item_id {
+            if found.is_some()
+                || construction_method != 0
+                || data_reference_index != 0
+                || extent_count != 1
+            {
+                return Err(HeifExifError::Malformed);
+            }
+            let Some((extent_offset, extent_length)) = selected_extent else {
+                return Err(HeifExifError::Malformed);
+            };
+            found = Some((base_offset, extent_offset, extent_length));
+        }
+    }
+    Ok(found)
+}
+
+fn read_sized_integer<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    parent_end: u64,
+    cursor: &mut u64,
+    size: u8,
+) -> Result<u64, HeifExifError> {
+    let mut bytes = [0_u8; 8];
+    let size = usize::from(size);
+    if size == 0 {
+        return Ok(0);
+    }
+    let start = 8_usize.checked_sub(size).ok_or(HeifExifError::Malformed)?;
+    let output = bytes.get_mut(start..).ok_or(HeifExifError::Malformed)?;
+    read_file_exact(source, parent_end, *cursor, output)?;
+    *cursor = cursor
+        .checked_add(u64::try_from(size).map_err(|_error| HeifExifError::Malformed)?)
+        .ok_or(HeifExifError::Malformed)?;
+    Ok(u64::from_be_bytes(bytes))
+}
+
+fn read_file_atom<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    offset: u64,
+    parent_end: u64,
+) -> Result<Option<FileAtom>, HeifExifError> {
+    if offset == parent_end {
+        return Ok(None);
+    }
+    let mut header = [0_u8; 16];
+    read_file_exact(source, parent_end, offset, &mut header[..8])?;
+    let size32 = u32::from_be_bytes([header[0], header[1], header[2], header[3]]);
+    let kind = [header[4], header[5], header[6], header[7]];
+    let (header_len, total_len) = match size32 {
+        0 => (8_u64, parent_end - offset),
+        1 => {
+            read_file_exact(source, parent_end, offset, &mut header)?;
+            let extended_size: [u8; 8] = header
+                .get(8..16)
+                .and_then(|bytes| bytes.try_into().ok())
+                .ok_or(HeifExifError::Malformed)?;
+            (16, u64::from_be_bytes(extended_size))
+        }
+        size => (8, u64::from(size)),
+    };
+    if total_len < header_len {
+        return Err(HeifExifError::Malformed);
+    }
+    let end = offset
+        .checked_add(total_len)
+        .filter(|end| *end <= parent_end)
+        .ok_or(HeifExifError::Malformed)?;
+    let body_start = offset
+        .checked_add(header_len)
+        .ok_or(HeifExifError::Malformed)?;
+    Ok(Some(FileAtom {
+        kind,
+        body_start,
+        end,
+    }))
+}
+
+fn read_file_exact<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    parent_end: u64,
+    offset: u64,
+    output: &mut [u8],
+) -> Result<(), HeifExifError> {
+    let output_len = u64::try_from(output.len()).map_err(|_error| HeifExifError::Malformed)?;
+    offset
+        .checked_add(output_len)
+        .filter(|end| *end <= parent_end)
+        .ok_or(HeifExifError::Malformed)?;
+    source.seek(std::io::SeekFrom::Start(offset))?;
+    source.read_exact(output)?;
+    Ok(())
 }
 
 /// Locate the XMP packet bytes embedded in a HEIC file, if any. Returns the
@@ -751,6 +1112,291 @@ fn push_iloc_entry(meta: &mut Meta, loc: ItemLocation) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn atom(kind: &[u8; 4], body: &[u8]) -> Vec<u8> {
+        let size = u32::try_from(body.len() + 8).expect("test atom size");
+        let mut bytes = Vec::with_capacity(size as usize);
+        bytes.extend_from_slice(&size.to_be_bytes());
+        bytes.extend_from_slice(kind);
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    fn exif_infe(item_id: u32, version: u8) -> Vec<u8> {
+        let mut infe_body = vec![version, 0, 0, 0];
+        if version == 2 {
+            infe_body.extend_from_slice(
+                &u16::try_from(item_id)
+                    .expect("version 2 item id")
+                    .to_be_bytes(),
+            );
+        } else {
+            infe_body.extend_from_slice(&item_id.to_be_bytes());
+        }
+        infe_body.extend_from_slice(&0_u16.to_be_bytes());
+        infe_body.extend_from_slice(b"Exif");
+        infe_body.push(0);
+        atom(b"infe", &infe_body)
+    }
+
+    fn exif_iinf() -> Vec<u8> {
+        exif_iinf_entries(&[exif_infe(1, 2)])
+    }
+
+    fn exif_iinf_entries(entries: &[Vec<u8>]) -> Vec<u8> {
+        let mut iinf_body = vec![0, 0, 0, 0];
+        iinf_body.extend_from_slice(
+            &u16::try_from(entries.len())
+                .expect("iinf entry count")
+                .to_be_bytes(),
+        );
+        for entry in entries {
+            iinf_body.extend_from_slice(entry);
+        }
+        atom(b"iinf", &iinf_body)
+    }
+
+    fn exif_iloc(extent_offset: u32, extent_length: u32, extent_count: u16) -> Vec<u8> {
+        exif_iloc_options(extent_offset, extent_length, extent_count, 0, 0, 0)
+    }
+
+    fn exif_iloc_options(
+        extent_offset: u32,
+        extent_length: u32,
+        extent_count: u16,
+        version: u8,
+        construction_method: u16,
+        data_reference_index: u16,
+    ) -> Vec<u8> {
+        let mut body = vec![version, 0, 0, 0, 0x44, 0];
+        if version == 2 {
+            body.extend_from_slice(&1_u32.to_be_bytes());
+            body.extend_from_slice(&1_u32.to_be_bytes());
+        } else {
+            body.extend_from_slice(&1_u16.to_be_bytes());
+            body.extend_from_slice(&1_u16.to_be_bytes());
+        }
+        if version > 0 {
+            body.extend_from_slice(&construction_method.to_be_bytes());
+        }
+        body.extend_from_slice(&data_reference_index.to_be_bytes());
+        body.extend_from_slice(&extent_count.to_be_bytes());
+        for _ in 0..extent_count {
+            body.extend_from_slice(&extent_offset.to_be_bytes());
+            body.extend_from_slice(&extent_length.to_be_bytes());
+        }
+        atom(b"iloc", &body)
+    }
+
+    fn heif_with_exif(
+        tiff: &[u8],
+        tiff_header_offset: u32,
+        extent_count: u16,
+        trailing_media: usize,
+    ) -> Vec<u8> {
+        let ftyp = ftyp_prefix(b"heic");
+        let build_meta = |extent_offset| {
+            let mut body = vec![0, 0, 0, 0];
+            body.extend_from_slice(&atom(b"hdlr", &[]));
+            body.extend_from_slice(&exif_iinf());
+            body.extend_from_slice(&exif_iloc(
+                extent_offset,
+                u32::try_from(4 + tiff_header_offset as usize + tiff.len())
+                    .expect("EXIF extent length"),
+                extent_count,
+            ));
+            atom(b"meta", &body)
+        };
+        let placeholder_meta = build_meta(0);
+        let extent_offset =
+            u32::try_from(ftyp.len() + placeholder_meta.len() + 8).expect("EXIF file offset");
+        let meta = build_meta(extent_offset);
+        assert_eq!(meta.len(), placeholder_meta.len());
+
+        let mut mdat_body = Vec::new();
+        mdat_body.extend_from_slice(&tiff_header_offset.to_be_bytes());
+        mdat_body.resize(4 + tiff_header_offset as usize, 0);
+        mdat_body.extend_from_slice(tiff);
+        mdat_body.resize(mdat_body.len() + trailing_media, 0);
+
+        [ftyp, meta, atom(b"mdat", &mdat_body)].concat()
+    }
+
+    struct CountingCursor {
+        inner: std::io::Cursor<Vec<u8>>,
+        bytes_read: usize,
+    }
+
+    impl std::io::Read for CountingCursor {
+        fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+            let read = std::io::Read::read(&mut self.inner, output)?;
+            self.bytes_read += read;
+            Ok(read)
+        }
+    }
+
+    impl std::io::Seek for CountingCursor {
+        fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+            std::io::Seek::seek(&mut self.inner, position)
+        }
+    }
+
+    #[test]
+    fn locate_exif_tiff_streams_control_data_and_honours_prefix_offset() {
+        let tiff = crate::test_helpers::minimal_tiff_with_source_gps();
+        let bytes = heif_with_exif(&tiff, 7, 1, 1024 * 1024);
+        let len = bytes.len() as u64;
+        let mut source = CountingCursor {
+            inner: std::io::Cursor::new(bytes),
+            bytes_read: 0,
+        };
+
+        let (start, tiff_len) = locate_exif_tiff(&mut source, len)
+            .expect("locate HEIF EXIF")
+            .expect("HEIF EXIF extent");
+        let mut actual = vec![0_u8; tiff.len()];
+        read_file_exact(&mut source, len, start, &mut actual).expect("read located TIFF");
+
+        assert_eq!(tiff_len, tiff.len() as u64);
+        assert_eq!(actual, tiff);
+        assert!(
+            source.bytes_read < 512,
+            "HEIF EXIF location read {} bytes",
+            source.bytes_read
+        );
+    }
+
+    #[test]
+    fn locate_exif_tiff_rejects_out_of_file_and_multiple_extents() {
+        let tiff = crate::test_helpers::minimal_tiff_with_source_gps();
+        let mut out_of_file = heif_with_exif(&tiff, 0, 1, 0);
+        let iloc_kind = out_of_file
+            .windows(4)
+            .position(|window| window == b"iloc")
+            .expect("iloc atom");
+        out_of_file[iloc_kind + 22..iloc_kind + 26].copy_from_slice(&u32::MAX.to_be_bytes());
+        let len = out_of_file.len() as u64;
+        assert!(matches!(
+            locate_exif_tiff(&mut std::io::Cursor::new(out_of_file), len),
+            Err(HeifExifError::Malformed)
+        ));
+
+        let multiple = heif_with_exif(&tiff, 0, 2, 0);
+        let len = multiple.len() as u64;
+        assert!(matches!(
+            locate_exif_tiff(&mut std::io::Cursor::new(multiple), len),
+            Err(HeifExifError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn read_exif_item_location_supports_versions_and_rejects_non_file_locations() {
+        for version in 0..=2 {
+            let bytes = exif_iloc_options(123, 45, 1, version, 0, 0);
+            let atom = FileAtom {
+                kind: *b"iloc",
+                body_start: 8,
+                end: bytes.len() as u64,
+            };
+            assert_eq!(
+                read_exif_item_location(&mut std::io::Cursor::new(bytes), atom, 1)
+                    .expect("parse iloc"),
+                Some((0, 123, 45))
+            );
+        }
+
+        for (construction_method, data_reference_index) in [(1, 0), (0, 1)] {
+            let bytes = exif_iloc_options(123, 45, 1, 1, construction_method, data_reference_index);
+            let atom = FileAtom {
+                kind: *b"iloc",
+                body_start: 8,
+                end: bytes.len() as u64,
+            };
+            assert!(matches!(
+                read_exif_item_location(&mut std::io::Cursor::new(bytes), atom, 1),
+                Err(HeifExifError::Malformed)
+            ));
+        }
+    }
+
+    #[test]
+    fn read_exif_item_location_rejects_zero_width_extents_before_iteration() {
+        let mut body = vec![0, 0, 0, 0, 0, 0];
+        body.extend_from_slice(&1_u16.to_be_bytes());
+        body.extend_from_slice(&1_u16.to_be_bytes());
+        body.extend_from_slice(&0_u16.to_be_bytes());
+        body.extend_from_slice(&u16::MAX.to_be_bytes());
+        let bytes = atom(b"iloc", &body);
+        let atom = FileAtom {
+            kind: *b"iloc",
+            body_start: 8,
+            end: bytes.len() as u64,
+        };
+
+        assert!(matches!(
+            read_exif_item_location(&mut std::io::Cursor::new(bytes), atom, 1),
+            Err(HeifExifError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn read_exif_item_id_supports_versions_and_rejects_ambiguity() {
+        for (version, item_id) in [(2, 1), (3, 70_000)] {
+            let bytes = exif_iinf_entries(&[exif_infe(item_id, version)]);
+            let atom = FileAtom {
+                kind: *b"iinf",
+                body_start: 8,
+                end: bytes.len() as u64,
+            };
+            assert_eq!(
+                read_exif_item_id(&mut std::io::Cursor::new(bytes), atom).expect("parse iinf"),
+                Some(item_id)
+            );
+        }
+
+        let duplicate = exif_iinf_entries(&[exif_infe(1, 2), exif_infe(2, 2)]);
+        let atom = FileAtom {
+            kind: *b"iinf",
+            body_start: 8,
+            end: duplicate.len() as u64,
+        };
+        assert!(matches!(
+            read_exif_item_id(&mut std::io::Cursor::new(duplicate), atom),
+            Err(HeifExifError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn read_file_atom_handles_extended_and_parent_sized_atoms() {
+        let mut extended = Vec::new();
+        extended.extend_from_slice(&1_u32.to_be_bytes());
+        extended.extend_from_slice(b"meta");
+        extended.extend_from_slice(&24_u64.to_be_bytes());
+        extended.extend_from_slice(&[0_u8; 8]);
+        let atom = read_file_atom(
+            &mut std::io::Cursor::new(&extended),
+            0,
+            extended.len() as u64,
+        )
+        .expect("read extended atom")
+        .expect("extended atom");
+        assert_eq!(atom.body_start, 16);
+        assert_eq!(atom.end, 24);
+
+        let mut parent_sized = Vec::new();
+        parent_sized.extend_from_slice(&0_u32.to_be_bytes());
+        parent_sized.extend_from_slice(b"mdat");
+        parent_sized.extend_from_slice(&[0_u8; 8]);
+        let atom = read_file_atom(
+            &mut std::io::Cursor::new(&parent_sized),
+            0,
+            parent_sized.len() as u64,
+        )
+        .expect("read parent-sized atom")
+        .expect("parent-sized atom");
+        assert_eq!(atom.body_start, 8);
+        assert_eq!(atom.end, parent_sized.len() as u64);
+    }
 
     #[test]
     fn is_heif_path_recognises_heic_variants() {

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -16,15 +16,11 @@ use std::sync::Once;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
-#[cfg(not(feature = "xmp"))]
 use little_exif::exif_tag::ExifTag;
-#[cfg(not(feature = "xmp"))]
 use little_exif::filetype::FileExtension;
 #[cfg(not(feature = "xmp"))]
 use little_exif::ifd::ExifTagGroup;
-#[cfg(not(feature = "xmp"))]
 use little_exif::metadata::Metadata;
-#[cfg(not(feature = "xmp"))]
 use little_exif::rational::uR64;
 #[cfg(feature = "xmp")]
 use xmp_toolkit::{OpenFileOptions, XmpFile, XmpMeta, XmpValue, xmp_ns};
@@ -56,6 +52,10 @@ enum ManagedXmpField {
     DateTimeOriginal,
     DateCreated,
     OffsetTimeOriginal,
+    GpsDateTime,
+    GpsSpeed,
+    GpsSpeedRef,
+    GpsHPositioningError,
     Rating,
     GpsLatitude,
     GpsLongitude,
@@ -72,12 +72,16 @@ enum ManagedXmpField {
 }
 
 #[cfg(feature = "xmp")]
-const MANAGED_XMP_FIELDS: [ManagedXmpField; 18] = [
+const MANAGED_XMP_FIELDS: [ManagedXmpField; 22] = [
     ManagedXmpField::CreateDate,
     ManagedXmpField::ModifyDate,
     ManagedXmpField::DateTimeOriginal,
     ManagedXmpField::DateCreated,
     ManagedXmpField::OffsetTimeOriginal,
+    ManagedXmpField::GpsDateTime,
+    ManagedXmpField::GpsSpeed,
+    ManagedXmpField::GpsSpeedRef,
+    ManagedXmpField::GpsHPositioningError,
     ManagedXmpField::Rating,
     ManagedXmpField::GpsLatitude,
     ManagedXmpField::GpsLongitude,
@@ -102,6 +106,10 @@ impl ManagedXmpField {
             Self::DateTimeOriginal => "exif:DateTimeOriginal",
             Self::DateCreated => "photoshop:DateCreated",
             Self::OffsetTimeOriginal => "exifEX:OffsetTimeOriginal",
+            Self::GpsDateTime => "exif:GPSDateTime",
+            Self::GpsSpeed => "exif:GPSSpeed",
+            Self::GpsSpeedRef => "exif:GPSSpeedRef",
+            Self::GpsHPositioningError => "exif:GPSHPositioningError",
             Self::Rating => "xmp:Rating",
             Self::GpsLatitude => "exif:GPSLatitude",
             Self::GpsLongitude => "exif:GPSLongitude",
@@ -124,6 +132,10 @@ impl ManagedXmpField {
                 write.datetime.is_some()
             }
             Self::OffsetTimeOriginal => write.offset_time_original.is_some(),
+            Self::GpsDateTime => write.gps_datetime.is_some(),
+            Self::GpsSpeed => write.gps_speed.is_some(),
+            Self::GpsSpeedRef => write.gps_speed_ref.is_some(),
+            Self::GpsHPositioningError => write.gps_h_positioning_error.is_some(),
             Self::Rating => write.rating.is_some(),
             Self::GpsLatitude | Self::GpsLongitude => write.gps.is_some(),
             Self::GpsAltitude | Self::GpsAltitudeRef => {
@@ -147,6 +159,10 @@ impl ManagedXmpField {
             Self::DateTimeOriginal => (xmp_ns::EXIF, "DateTimeOriginal"),
             Self::DateCreated => (xmp_ns::PHOTOSHOP, "DateCreated"),
             Self::OffsetTimeOriginal => (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
+            Self::GpsDateTime => (xmp_ns::EXIF, "GPSDateTime"),
+            Self::GpsSpeed => (xmp_ns::EXIF, "GPSSpeed"),
+            Self::GpsSpeedRef => (xmp_ns::EXIF, "GPSSpeedRef"),
+            Self::GpsHPositioningError => (xmp_ns::EXIF, "GPSHPositioningError"),
             Self::Rating => (xmp_ns::XMP, "Rating"),
             Self::GpsLatitude => (xmp_ns::EXIF, "GPSLatitude"),
             Self::GpsLongitude => (xmp_ns::EXIF, "GPSLongitude"),
@@ -333,6 +349,195 @@ fn probe_from_meta(meta: &XmpMeta) -> ExifProbe {
     }
 }
 
+#[cfg(feature = "xmp")]
+pub(crate) fn read_source_gps(path: &Path) -> Result<SourceGpsMetadata> {
+    let extension_type = source_file_type_from_extension(path);
+    if path.extension().is_some() && extension_type.is_none() {
+        return Ok(SourceGpsMetadata::default());
+    }
+
+    let mut head = [0_u8; 12];
+    let bytes_read = std::fs::File::open(path)
+        .and_then(|mut file| {
+            use std::io::Read;
+            file.read(&mut head)
+        })
+        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
+    let file_type = source_file_type(head.get(..bytes_read).unwrap_or_default());
+    let Some(file_type) = file_type else {
+        return Ok(SourceGpsMetadata::default());
+    };
+
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
+    // An absent or unreadable EXIF block is normal: many HEIC, AVIF and PNG
+    // files carry no EXIF, and a truncated media file cannot yield one. The
+    // sidecar still carries the CloudKit payload, so a parse failure degrades
+    // to no source GPS rather than suppressing the whole sidecar and stranding
+    // a retry marker.
+    let Ok(metadata) = Metadata::new_from_vec(&bytes, file_type) else {
+        return Ok(SourceGpsMetadata::default());
+    };
+    Ok(source_gps_from_exif(&metadata))
+}
+
+#[cfg(feature = "xmp")]
+fn source_file_type_from_extension(path: &Path) -> Option<FileExtension> {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .and_then(|extension| match extension.to_ascii_lowercase().as_str() {
+            "heic" | "heif" | "hif" | "avif" => Some(FileExtension::HEIF),
+            "jpg" | "jpeg" => Some(FileExtension::JPEG),
+            "tif" | "tiff" => Some(FileExtension::TIFF),
+            "png" => Some(FileExtension::PNG {
+                as_zTXt_chunk: true,
+            }),
+            _ => None,
+        })
+}
+
+#[cfg(feature = "xmp")]
+fn source_file_type(bytes: &[u8]) -> Option<FileExtension> {
+    if heif::is_heif_content(bytes) {
+        return Some(FileExtension::HEIF);
+    }
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some(FileExtension::JPEG);
+    }
+    if bytes.starts_with(b"II*\0") || bytes.starts_with(b"MM\0*") {
+        return Some(FileExtension::TIFF);
+    }
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some(FileExtension::PNG {
+            as_zTXt_chunk: true,
+        });
+    }
+    None
+}
+
+#[cfg(feature = "xmp")]
+fn source_gps_from_exif(metadata: &Metadata) -> SourceGpsMetadata {
+    let gps_datetime = source_gps_datetime(metadata);
+    let speed = first_rational(metadata, ExifTag::GPSSpeed(Vec::new()));
+    let speed_ref = first_string(metadata, ExifTag::GPSSpeedRef(String::new()))
+        .map(|value| value.trim_matches('\0').trim().to_ascii_uppercase())
+        .filter(|value| matches!(value.as_str(), "K" | "M" | "N"));
+    // A speed without a unit is unusable, and `first_rational` guarantees a
+    // non-zero denominator.
+    let speed = match (speed, speed_ref.as_ref()) {
+        (Some(value), Some(_)) => Some(value),
+        (Some(_), None) => {
+            tracing::warn!("Source EXIF GPSSpeedRef is missing or unsupported");
+            None
+        }
+        (None, _) => None,
+    };
+    let speed_ref = speed.as_ref().and(speed_ref);
+    let horizontal_positioning_error =
+        first_rational(metadata, ExifTag::GPSHPositioningError(Vec::new()));
+    SourceGpsMetadata {
+        datetime: gps_datetime,
+        speed,
+        speed_ref,
+        horizontal_positioning_error,
+    }
+}
+
+#[cfg(feature = "xmp")]
+fn first_rational(metadata: &Metadata, requested: ExifTag) -> Option<XmpRational> {
+    metadata.get_tag(&requested).next().and_then(|tag| {
+        let values = match tag {
+            ExifTag::GPSSpeed(values) | ExifTag::GPSHPositioningError(values) => values,
+            _ => return None,
+        };
+        values.first().and_then(XmpRational::from_exif)
+    })
+}
+
+#[cfg(feature = "xmp")]
+fn first_string(metadata: &Metadata, requested: ExifTag) -> Option<String> {
+    metadata
+        .get_tag(&requested)
+        .next()
+        .and_then(|tag| match tag {
+            ExifTag::GPSSpeedRef(value) => Some(value.clone()),
+            ExifTag::GPSDateStamp(value) => Some(value.clone()),
+            _ => None,
+        })
+}
+
+/// `uR64` is a pair of `u32`, so a non-zero denominator always yields a finite
+/// non-negative quotient.
+#[cfg(feature = "xmp")]
+fn rational_to_f64(value: &uR64) -> Option<f64> {
+    if value.denominator == 0 {
+        return None;
+    }
+    Some(f64::from(value.nominator) / f64::from(value.denominator))
+}
+
+#[cfg(feature = "xmp")]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "validated GPS hour, minute, and second ranges make these conversions bounded and non-negative"
+)]
+fn source_gps_datetime(metadata: &Metadata) -> Option<String> {
+    let date = first_string(metadata, ExifTag::GPSDateStamp(String::new()))?;
+    let date = chrono::NaiveDate::parse_from_str(date.trim_matches('\0').trim(), "%Y:%m:%d")
+        .ok()
+        .or_else(|| {
+            tracing::warn!("Source EXIF GPSDateStamp is malformed");
+            None
+        })?;
+    let time_tag = metadata
+        .get_tag(&ExifTag::GPSTimeStamp(Vec::new()))
+        .next()?;
+    let ExifTag::GPSTimeStamp(times) = time_tag else {
+        return None;
+    };
+    let [hour_value, minute_value, seconds_value] = times.as_slice() else {
+        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
+        return None;
+    };
+    let Some(hour) = rational_to_f64(hour_value) else {
+        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
+        return None;
+    };
+    let Some(minute) = rational_to_f64(minute_value) else {
+        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
+        return None;
+    };
+    let Some(seconds) = rational_to_f64(seconds_value) else {
+        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
+        return None;
+    };
+    if hour.fract() != 0.0
+        || minute.fract() != 0.0
+        || !(0.0..=23.0).contains(&hour)
+        || !(0.0..=59.0).contains(&minute)
+        || !(0.0..60.0).contains(&seconds)
+    {
+        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
+        return None;
+    }
+    let whole_seconds = seconds.trunc() as u32;
+    let nanos = ((seconds.fract() * 1_000_000_000.0).round() as u32).min(999_999_999);
+    let fraction = if nanos == 0 {
+        String::new()
+    } else {
+        format!(".{nanos:09}").trim_end_matches('0').to_string()
+    };
+    Some(format!(
+        "{}T{:02}:{:02}:{:02}{}Z",
+        date.format("%Y-%m-%d"),
+        hour as u32,
+        minute as u32,
+        whole_seconds,
+        fraction
+    ))
+}
+
 #[cfg(not(feature = "xmp"))]
 fn probe_exif_native(path: &Path) -> ExifProbe {
     let Ok(input) = std::fs::read(path) else {
@@ -390,6 +595,35 @@ pub(crate) struct GpsCoords {
     pub(crate) altitude: Option<f64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct XmpRational {
+    numerator: u32,
+    denominator: u32,
+}
+
+#[cfg(feature = "xmp")]
+impl XmpRational {
+    fn from_exif(value: &uR64) -> Option<Self> {
+        (value.denominator != 0).then_some(Self {
+            numerator: value.nominator,
+            denominator: value.denominator,
+        })
+    }
+
+    fn encode(&self) -> String {
+        format!("{}/{}", self.numerator, self.denominator)
+    }
+}
+
+#[cfg(feature = "xmp")]
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct SourceGpsMetadata {
+    pub(crate) datetime: Option<String>,
+    pub(crate) speed: Option<XmpRational>,
+    pub(crate) speed_ref: Option<String>,
+    pub(crate) horizontal_positioning_error: Option<XmpRational>,
+}
+
 /// Bundle of every field the writer knows how to embed. Empty / default
 /// fields are skipped.
 #[derive(Debug, Default, Clone)]
@@ -400,6 +634,14 @@ pub(crate) struct MetadataWrite {
     pub(crate) offset_time_original: Option<String>,
     /// Remove offset tags before writing a replacement timestamp.
     pub(crate) clear_datetime_offsets: bool,
+    /// GPS fix timestamp in ISO 8601 UTC form.
+    pub(crate) gps_datetime: Option<String>,
+    /// GPS receiver speed as an XMP rational in the units named by `gps_speed_ref`.
+    pub(crate) gps_speed: Option<XmpRational>,
+    /// GPS receiver speed units: K, M, or N.
+    pub(crate) gps_speed_ref: Option<String>,
+    /// Horizontal positioning error in metres as an XMP rational.
+    pub(crate) gps_h_positioning_error: Option<XmpRational>,
     pub(crate) rating: Option<u8>,
     pub(crate) gps: Option<GpsCoords>,
     pub(crate) title: Option<String>,
@@ -419,6 +661,10 @@ impl MetadataWrite {
         self.datetime.is_none()
             && self.offset_time_original.is_none()
             && !self.clear_datetime_offsets
+            && self.gps_datetime.is_none()
+            && self.gps_speed.is_none()
+            && self.gps_speed_ref.is_none()
+            && self.gps_h_positioning_error.is_none()
             && self.rating.is_none()
             && self.gps.is_none()
             && self.title.is_none()
@@ -961,6 +1207,28 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
         )?;
     }
 
+    if let Some(dt) = &write.gps_datetime {
+        meta.set_property(xmp_ns::EXIF, "GPSDateTime", &XmpValue::new(dt.clone()))?;
+    }
+
+    if let Some(speed) = &write.gps_speed {
+        meta.set_property(xmp_ns::EXIF, "GPSSpeed", &XmpValue::new(speed.encode()))?;
+    }
+    if let Some(speed_ref) = &write.gps_speed_ref {
+        meta.set_property(
+            xmp_ns::EXIF,
+            "GPSSpeedRef",
+            &XmpValue::new(speed_ref.clone()),
+        )?;
+    }
+    if let Some(error) = &write.gps_h_positioning_error {
+        meta.set_property(
+            xmp_ns::EXIF,
+            "GPSHPositioningError",
+            &XmpValue::new(error.encode()),
+        )?;
+    }
+
     if let Some(r) = write.rating {
         meta.set_property_i32(xmp_ns::XMP, "Rating", &XmpValue::new(i32::from(r.min(5))))?;
     }
@@ -1153,9 +1421,22 @@ mod tests {
         super::write_sidecar(path, write, ".meta-tmp")
     }
 
+    fn xmp_rational(numerator: u32, denominator: u32) -> XmpRational {
+        XmpRational {
+            numerator,
+            denominator,
+        }
+    }
+
     use super::*;
     use std::fs;
     use std::path::PathBuf;
+
+    use crate::test_helpers::{
+        SOURCE_GPS_DATETIME, SOURCE_GPS_H_POSITIONING_ERROR, SOURCE_GPS_SPEED,
+        SOURCE_GPS_SPEED_REF, exif_with_source_gps, heif_ftyp_without_meta_bytes,
+        minimal_jpeg_with_source_gps, source_gps_without_time_stamp, ur64,
+    };
 
     fn test_tmp_dir(subdir: &str) -> PathBuf {
         std::env::temp_dir().join("claude").join(subdir)
@@ -1281,6 +1562,210 @@ mod tests {
             0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
         ]
+    }
+
+    #[test]
+    fn source_gps_omits_absent_heic_fixture_fields() {
+        let path = Path::new("tests/data/sample.heic");
+        let gps = read_source_gps(path).expect("sample HEIC source metadata");
+        assert_eq!(gps, SourceGpsMetadata::default());
+    }
+
+    #[test]
+    fn source_gps_skips_unsupported_media_before_reading_it() {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let path = dir.path().join("video.mov");
+        let gps = read_source_gps(&path).expect("unsupported media should be ignored");
+        assert_eq!(gps, SourceGpsMetadata::default());
+    }
+
+    #[test]
+    fn source_gps_degrades_unparsable_media_to_empty() {
+        // A recognised format whose bytes cannot yield an EXIF block must
+        // degrade to no source GPS rather than an error, so the sidecar is
+        // still written from the CloudKit payload and no retry marker is
+        // stranded. Covers a truncated JPEG, an EXIF-less PNG, an `ftyp`-only
+        // HEIC, and a TIFF recognised by extension and magic. The TIFF row is
+        // the format-detection path DNG downloads exercise.
+        let cases: [(&str, Vec<u8>); 4] = [
+            ("truncated.jpg", vec![0xFF, 0xD8, 0xFF]),
+            (
+                "no-exif.png",
+                vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+            ),
+            ("ftyp-only.heic", heif_ftyp_without_meta_bytes()),
+            (
+                "recognised.tif",
+                vec![b'I', b'I', 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00],
+            ),
+        ];
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        for (name, bytes) in cases {
+            let path = dir.path().join(name);
+            std::fs::write(&path, bytes).expect("write case media");
+            let gps = read_source_gps(&path).expect("unparsable media must not error");
+            assert_eq!(gps, SourceGpsMetadata::default(), "{name}");
+        }
+    }
+
+    fn assert_standard_source_gps(gps: &SourceGpsMetadata) {
+        assert_eq!(gps.datetime.as_deref(), Some(SOURCE_GPS_DATETIME));
+        assert_eq!(
+            gps.speed.as_ref().map(XmpRational::encode).as_deref(),
+            Some(SOURCE_GPS_SPEED)
+        );
+        assert_eq!(gps.speed_ref.as_deref(), Some(SOURCE_GPS_SPEED_REF));
+        assert_eq!(
+            gps.horizontal_positioning_error
+                .as_ref()
+                .map(XmpRational::encode)
+                .as_deref(),
+            Some(SOURCE_GPS_H_POSITIONING_ERROR)
+        );
+    }
+
+    #[test]
+    fn source_gps_composes_utc_timestamps() {
+        assert_standard_source_gps(&source_gps_from_exif(&exif_with_source_gps()));
+        // A whole-second GPS timestamp renders without a fractional part.
+        let mut metadata = exif_with_source_gps();
+        metadata.set_tag(ExifTag::GPSTimeStamp(vec![
+            ur64(11, 1),
+            ur64(22, 1),
+            ur64(33, 1),
+        ]));
+        let gps = source_gps_from_exif(&metadata);
+        assert_eq!(gps.datetime.as_deref(), Some("2024-06-15T11:22:33Z"));
+    }
+
+    #[test]
+    fn source_gps_reads_exif_from_media_path() {
+        // `read_source_gps` recovers the same facts from JPEG and HEIC media,
+        // exercising both magic-byte detections through the public reader.
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let mut heic = std::fs::read("tests/data/sample.heic").expect("read sample HEIC");
+        exif_with_source_gps()
+            .write_to_vec(&mut heic, FileExtension::HEIF)
+            .expect("write HEIC EXIF");
+        for (name, bytes) in [
+            ("source.jpg", minimal_jpeg_with_source_gps()),
+            ("source.heic", heic),
+        ] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, bytes).expect("write source media");
+            assert_standard_source_gps(&read_source_gps(&path).expect("read source EXIF"));
+        }
+    }
+
+    #[test]
+    fn source_gps_omits_malformed_timestamp_variants() {
+        // A valid date with a malformed GPSTimeStamp, or a malformed date,
+        // yields no GPS datetime while the other source fields survive. One
+        // row per rejection branch: bad date, wrong arity, a non-rational
+        // hour, minute, or second, and an out-of-range hour.
+        let bad = |n: u32| ur64(n, 0);
+        let cases: [(&str, Option<&str>, Vec<uR64>); 6] = [
+            (
+                "malformed date",
+                Some("not-a-date"),
+                vec![ur64(10, 1), ur64(20, 1), ur64(30, 1)],
+            ),
+            ("wrong arity", None, vec![ur64(10, 1), ur64(20, 1)]),
+            (
+                "non-rational hour",
+                None,
+                vec![bad(10), ur64(20, 1), ur64(30, 1)],
+            ),
+            (
+                "non-rational minute",
+                None,
+                vec![ur64(10, 1), bad(20), ur64(30, 1)],
+            ),
+            (
+                "non-rational seconds",
+                None,
+                vec![ur64(10, 1), ur64(20, 1), bad(30)],
+            ),
+            (
+                "hour out of range",
+                None,
+                vec![ur64(25, 1), ur64(20, 1), ur64(30, 1)],
+            ),
+        ];
+        for (name, date, times) in cases {
+            let mut metadata = exif_with_source_gps();
+            if let Some(date) = date {
+                metadata.set_tag(ExifTag::GPSDateStamp(date.into()));
+            }
+            metadata.set_tag(ExifTag::GPSTimeStamp(times));
+            let gps = source_gps_from_exif(&metadata);
+            assert_eq!(gps.datetime, None, "{name}");
+            assert_eq!(
+                gps.speed.as_ref().map(XmpRational::encode).as_deref(),
+                Some(SOURCE_GPS_SPEED),
+                "{name}"
+            );
+            assert_eq!(
+                gps.speed_ref.as_deref(),
+                Some(SOURCE_GPS_SPEED_REF),
+                "{name}"
+            );
+        }
+
+        // A date with no GPSTimeStamp at all cannot compose a timestamp.
+        let gps = source_gps_from_exif(&source_gps_without_time_stamp());
+        assert_eq!(gps.datetime, None);
+        assert_eq!(
+            gps.speed.as_ref().map(XmpRational::encode).as_deref(),
+            Some(SOURCE_GPS_SPEED)
+        );
+    }
+
+    #[test]
+    fn source_gps_omits_unsupported_speed_ref_and_malformed_error() {
+        let mut metadata = exif_with_source_gps();
+        // An unsupported speed unit drops both the speed and the unit.
+        metadata.set_tag(ExifTag::GPSSpeedRef("Y".into()));
+        // A zero-denominator positioning error is dropped.
+        metadata.set_tag(ExifTag::GPSHPositioningError(vec![ur64(1, 0)]));
+
+        let gps = source_gps_from_exif(&metadata);
+        assert_eq!(gps.speed, None);
+        assert_eq!(gps.speed_ref, None);
+        assert_eq!(gps.horizontal_positioning_error, None);
+    }
+
+    #[test]
+    fn source_gps_field_readers_reject_mismatched_tag_types() {
+        let metadata = exif_with_source_gps();
+        // `first_rational` decodes only rational GPS tags; a string tag is None.
+        assert_eq!(
+            first_rational(&metadata, ExifTag::GPSDateStamp(String::new())),
+            None
+        );
+        // `first_string` decodes only string GPS tags; a rational tag is None.
+        assert_eq!(first_string(&metadata, ExifTag::GPSSpeed(Vec::new())), None);
+    }
+
+    #[test]
+    fn gps_datetime_serialises_as_typed_xmp_date() {
+        // The sidecar-write test proves the GPS property values reach XMP. This
+        // pins the packet-level detail that GPSDateTime is a typed XMP date, not
+        // plain text, so downstream tools read it as a date.
+        let gps = source_gps_from_exif(&exif_with_source_gps());
+        let packet = build_xmp_packet(&MetadataWrite {
+            gps_datetime: gps.datetime,
+            ..MetadataWrite::default()
+        })
+        .expect("XMP packet");
+        let meta = std::str::from_utf8(&packet)
+            .expect("XMP UTF-8")
+            .parse::<XmpMeta>()
+            .expect("parse XMP packet");
+        assert!(
+            meta.property_date(xmp_ns::EXIF, "GPSDateTime").is_some(),
+            "GPSDateTime must be serialised as an XMP date"
+        );
     }
 
     fn fresh_jpeg(dir: &Path, name: &str) -> PathBuf {
@@ -1613,6 +2098,7 @@ mod tests {
                 is_archived: true,
                 media_subtype: Some("live_photo".into()),
                 burst_id: None,
+                ..MetadataWrite::default()
             },
         )
         .unwrap();
@@ -1787,17 +2273,6 @@ mod tests {
         path
     }
 
-    fn heif_ftyp_without_meta() -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&24u32.to_be_bytes());
-        bytes.extend_from_slice(b"ftyp");
-        bytes.extend_from_slice(b"heic");
-        bytes.extend_from_slice(&0u32.to_be_bytes());
-        bytes.extend_from_slice(b"heic");
-        bytes.extend_from_slice(b"mif1");
-        bytes
-    }
-
     fn assert_heif_embed_skip_preserves(path: &Path, write: &MetadataWrite) {
         let original = fs::read(path).unwrap();
         apply_metadata_with_default_suffix(path, write).expect("HEIC metadata skip should succeed");
@@ -1954,7 +2429,7 @@ mod tests {
         let dir = test_tmp_dir("meta_heic_tests");
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("missing_meta.heic");
-        let original = heif_ftyp_without_meta();
+        let original = heif_ftyp_without_meta_bytes();
         fs::write(&path, &original).unwrap();
 
         assert_heif_embed_skip_preserves(
@@ -2481,6 +2956,10 @@ mod tests {
             datetime: Some("2024:06:15 10:00:00".into()),
             offset_time_original: Some("+10:00".into()),
             clear_datetime_offsets: false,
+            gps_datetime: Some("2024-06-15T10:00:01Z".into()),
+            gps_speed: Some(xmp_rational(25, 2)),
+            gps_speed_ref: Some("K".into()),
+            gps_h_positioning_error: Some(xmp_rational(13, 4)),
             rating: Some(5),
             gps: Some(GpsCoords {
                 latitude: 37.7,
@@ -2515,6 +2994,10 @@ mod tests {
         for (namespace, property) in [
             (xmp_ns::XMP, "Rating"),
             (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
+            (xmp_ns::EXIF, "GPSDateTime"),
+            (xmp_ns::EXIF, "GPSSpeed"),
+            (xmp_ns::EXIF, "GPSSpeedRef"),
+            (xmp_ns::EXIF, "GPSHPositioningError"),
             (xmp_ns::EXIF, "GPSAltitude"),
             (xmp_ns::EXIF, "GPSAltitudeRef"),
             (xmp_ns::DC, "subject"),
@@ -2540,6 +3023,10 @@ mod tests {
         assert!(managed.contains("exif:GPSLatitude"));
         assert!(!managed.contains("xmp:Rating"));
         assert!(!managed.contains("exifEX:OffsetTimeOriginal"));
+        assert!(!managed.contains("exif:GPSDateTime"));
+        assert!(!managed.contains("exif:GPSSpeed"));
+        assert!(!managed.contains("exif:GPSSpeedRef"));
+        assert!(!managed.contains("exif:GPSHPositioningError"));
         assert!(!managed.contains("exif:GPSAltitude"));
         assert_eq!(
             meta.property(THIRD_PARTY_NS, "developSettings")
@@ -2570,6 +3057,22 @@ mod tests {
         let mut seed = XmpMeta::new().unwrap();
         seed.set_property_i32(xmp_ns::XMP, "Rating", &XmpValue::new(5))
             .unwrap();
+        seed.set_property(
+            xmp_ns::EXIF,
+            "GPSDateTime",
+            &XmpValue::new("2024-06-15T10:00:01Z".to_string()),
+        )
+        .unwrap();
+        seed.set_property(xmp_ns::EXIF, "GPSSpeed", &XmpValue::new("25/2".to_string()))
+            .unwrap();
+        seed.set_property(xmp_ns::EXIF, "GPSSpeedRef", &XmpValue::new("K".to_string()))
+            .unwrap();
+        seed.set_property(
+            xmp_ns::EXIF,
+            "GPSHPositioningError",
+            &XmpValue::new("13/4".to_string()),
+        )
+        .unwrap();
         seed.set_localized_text(
             xmp_ns::DC,
             "description",
@@ -2595,6 +3098,17 @@ mod tests {
             5,
             "an unmarked rating may belong to another application"
         );
+        for property in [
+            "GPSDateTime",
+            "GPSSpeed",
+            "GPSSpeedRef",
+            "GPSHPositioningError",
+        ] {
+            assert!(
+                meta.contains_property(xmp_ns::EXIF, property),
+                "an unmarked GPS property may belong to another application: {property}"
+            );
+        }
         assert_eq!(
             meta.localized_text(xmp_ns::DC, "description", None, "x-default")
                 .unwrap()
@@ -2606,6 +3120,10 @@ mod tests {
         let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
         assert!(!managed.contains("xmp:Rating"));
         assert!(!managed.contains("dc:description"));
+        assert!(!managed.contains("exif:GPSDateTime"));
+        assert!(!managed.contains("exif:GPSSpeed"));
+        assert!(!managed.contains("exif:GPSSpeedRef"));
+        assert!(!managed.contains("exif:GPSHPositioningError"));
 
         fs::remove_file(&sidecar_path).ok();
         fs::remove_file(&media_path).ok();

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -112,7 +112,7 @@ impl ManagedXmpField {
             Self::GpsDateTime => "exif:GPSTimeStamp",
             Self::GpsSpeed => "exif:GPSSpeed",
             Self::GpsSpeedRef => "exif:GPSSpeedRef",
-            Self::GpsHPositioningError => "exif:GPSHPositioningError",
+            Self::GpsHPositioningError => "exifEX:GPSHPositioningError",
             Self::Rating => "xmp:Rating",
             Self::GpsLatitude => "exif:GPSLatitude",
             Self::GpsLongitude => "exif:GPSLongitude",
@@ -172,7 +172,7 @@ impl ManagedXmpField {
             Self::GpsDateTime => (xmp_ns::EXIF, "GPSTimeStamp"),
             Self::GpsSpeed => (xmp_ns::EXIF, "GPSSpeed"),
             Self::GpsSpeedRef => (xmp_ns::EXIF, "GPSSpeedRef"),
-            Self::GpsHPositioningError => (xmp_ns::EXIF, "GPSHPositioningError"),
+            Self::GpsHPositioningError => (EXIF_EX_XMP_NS, "GPSHPositioningError"),
             Self::Rating => (xmp_ns::XMP, "Rating"),
             Self::GpsLatitude => (xmp_ns::EXIF, "GPSLatitude"),
             Self::GpsLongitude => (xmp_ns::EXIF, "GPSLongitude"),
@@ -617,12 +617,21 @@ impl<R: std::io::Read + std::io::Seek> TiffGpsReader<'_, R> {
     fn entry_value<const N: usize>(
         &mut self,
         entry: &[u8; 12],
+        tag_name: &'static str,
         expected_type: u16,
         expected_count: u32,
     ) -> Result<Option<[u8; N]>, TiffGpsError> {
-        if tiff_u16(self.endian, [entry[2], entry[3]]) != expected_type
-            || tiff_u32(self.endian, [entry[4], entry[5], entry[6], entry[7]]) != expected_count
-        {
+        let actual_type = tiff_u16(self.endian, [entry[2], entry[3]]);
+        let actual_count = tiff_u32(self.endian, [entry[4], entry[5], entry[6], entry[7]]);
+        if actual_type != expected_type || actual_count != expected_count {
+            tracing::warn!(
+                tag = tag_name,
+                expected_type,
+                actual_type,
+                expected_count,
+                actual_count,
+                "Source EXIF GPS tag has an unexpected type or count"
+            );
             return Ok(None);
         }
         let mut value = [0_u8; N];
@@ -698,12 +707,12 @@ fn read_tiff_source_gps<R: std::io::Read + std::io::Seek>(
         let entry = reader.read_ifd_entry(gps_ifd_offset, index)?;
         match tiff_u16(reader.endian, [entry[0], entry[1]]) {
             0x0007 if time.is_none() => {
-                if let Some(value) = reader.entry_value::<24>(&entry, 5, 3)? {
+                if let Some(value) = reader.entry_value::<24>(&entry, "GPSTimeStamp", 5, 3)? {
                     time = tiff_rational_triplet(reader.endian, &value);
                 }
             }
             0x000C if speed_ref.is_none() => {
-                if let Some(value) = reader.entry_value::<2>(&entry, 2, 2)? {
+                if let Some(value) = reader.entry_value::<2>(&entry, "GPSSpeedRef", 2, 2)? {
                     speed_ref = std::str::from_utf8(&value)
                         .ok()
                         .map(|value| value.trim_matches('\0').trim().to_ascii_uppercase())
@@ -711,19 +720,21 @@ fn read_tiff_source_gps<R: std::io::Read + std::io::Seek>(
                 }
             }
             0x000D if speed.is_none() => {
-                if let Some(value) = reader.entry_value::<8>(&entry, 5, 1)? {
+                if let Some(value) = reader.entry_value::<8>(&entry, "GPSSpeed", 5, 1)? {
                     speed = tiff_rational(reader.endian, &value);
                 }
             }
             0x001D if date.is_none() => {
-                if let Some(value) = reader.entry_value::<11>(&entry, 2, 11)? {
+                if let Some(value) = reader.entry_value::<11>(&entry, "GPSDateStamp", 2, 11)? {
                     date = std::str::from_utf8(&value)
                         .ok()
                         .map(|value| value.trim_matches('\0').trim().to_owned());
                 }
             }
             0x001F if horizontal_positioning_error.is_none() => {
-                if let Some(value) = reader.entry_value::<8>(&entry, 5, 1)? {
+                if let Some(value) =
+                    reader.entry_value::<8>(&entry, "GPSHPositioningError", 5, 1)?
+                {
                     horizontal_positioning_error = tiff_rational(reader.endian, &value);
                 }
             }
@@ -801,78 +812,6 @@ fn tiff_rational_triplet(endian: TiffEndian, bytes: &[u8; 24]) -> Option<[XmpRat
         tiff_rational(endian, bytes[8..16].try_into().ok()?)?,
         tiff_rational(endian, bytes[16..24].try_into().ok()?)?,
     ])
-}
-
-#[cfg(all(feature = "xmp", test))]
-fn source_gps_from_exif(metadata: &Metadata) -> SourceGpsMetadata {
-    let gps_datetime = source_gps_datetime(metadata);
-    let speed = first_rational(metadata, ExifTag::GPSSpeed(Vec::new()));
-    let speed_ref = first_string(metadata, ExifTag::GPSSpeedRef(String::new()))
-        .map(|value| value.trim_matches('\0').trim().to_ascii_uppercase())
-        .filter(|value| matches!(value.as_str(), "K" | "M" | "N"));
-    // A speed without a unit is unusable, and `first_rational` guarantees a
-    // non-zero denominator.
-    let speed = match (speed, speed_ref.as_ref()) {
-        (Some(value), Some(_)) => Some(value),
-        (Some(_), None) => {
-            tracing::warn!("Source EXIF GPSSpeedRef is missing or unsupported");
-            None
-        }
-        (None, _) => None,
-    };
-    let speed_ref = speed.as_ref().and(speed_ref);
-    let horizontal_positioning_error =
-        first_rational(metadata, ExifTag::GPSHPositioningError(Vec::new()));
-    SourceGpsMetadata {
-        datetime: gps_datetime,
-        speed,
-        speed_ref,
-        horizontal_positioning_error,
-    }
-}
-
-#[cfg(all(feature = "xmp", test))]
-fn first_rational(metadata: &Metadata, requested: ExifTag) -> Option<XmpRational> {
-    metadata.get_tag(&requested).next().and_then(|tag| {
-        let values = match tag {
-            ExifTag::GPSSpeed(values) | ExifTag::GPSHPositioningError(values) => values,
-            _ => return None,
-        };
-        values.first().and_then(XmpRational::from_exif)
-    })
-}
-
-#[cfg(all(feature = "xmp", test))]
-fn first_string(metadata: &Metadata, requested: ExifTag) -> Option<String> {
-    metadata
-        .get_tag(&requested)
-        .next()
-        .and_then(|tag| match tag {
-            ExifTag::GPSSpeedRef(value) => Some(value.clone()),
-            ExifTag::GPSDateStamp(value) => Some(value.clone()),
-            _ => None,
-        })
-}
-
-#[cfg(all(feature = "xmp", test))]
-fn source_gps_datetime(metadata: &Metadata) -> Option<String> {
-    let date = first_string(metadata, ExifTag::GPSDateStamp(String::new()))?;
-    let time_tag = metadata
-        .get_tag(&ExifTag::GPSTimeStamp(Vec::new()))
-        .next()?;
-    let ExifTag::GPSTimeStamp(times) = time_tag else {
-        return None;
-    };
-    let [hour_value, minute_value, seconds_value] = times.as_slice() else {
-        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
-        return None;
-    };
-    let values = [
-        XmpRational::from_exif(hour_value)?,
-        XmpRational::from_exif(minute_value)?,
-        XmpRational::from_exif(seconds_value)?,
-    ];
-    source_gps_datetime_values(date.trim_matches('\0').trim(), &values)
 }
 
 #[cfg(feature = "xmp")]
@@ -987,14 +926,6 @@ pub(crate) struct XmpRational {
 
 #[cfg(feature = "xmp")]
 impl XmpRational {
-    #[cfg(test)]
-    fn from_exif(value: &uR64) -> Option<Self> {
-        (value.denominator != 0).then_some(Self {
-            numerator: value.nominator,
-            denominator: value.denominator,
-        })
-    }
-
     fn as_f64(&self) -> f64 {
         f64::from(self.numerator) / f64::from(self.denominator)
     }
@@ -1619,7 +1550,7 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
     }
     if let Some(error) = &write.gps_h_positioning_error {
         meta.set_property(
-            xmp_ns::EXIF,
+            EXIF_EX_XMP_NS,
             "GPSHPositioningError",
             &XmpValue::new(error.encode()),
         )?;
@@ -2049,6 +1980,24 @@ mod tests {
         );
     }
 
+    fn read_source_gps_from_test_exif(metadata: &Metadata, name: &str) -> SourceGpsMetadata {
+        let mut bytes = minimal_jpeg();
+        metadata
+            .write_to_vec(&mut bytes, FileExtension::JPEG)
+            .expect("serialise source EXIF");
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).expect("write source media");
+        read_source_gps(&path).expect("read source EXIF through production parser")
+    }
+
+    fn read_source_gps_from_test_tiff(bytes: &[u8], name: &str) -> SourceGpsMetadata {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).expect("write source TIFF");
+        read_source_gps(&path).expect("read source TIFF through production parser")
+    }
+
     fn png_with_source_gps() -> Vec<u8> {
         fn crc32(bytes: &[u8]) -> u32 {
             let mut crc = u32::MAX;
@@ -2136,7 +2085,10 @@ mod tests {
 
     #[test]
     fn source_gps_composes_utc_timestamps() {
-        assert_standard_source_gps(&source_gps_from_exif(&exif_with_source_gps()));
+        assert_standard_source_gps(&read_source_gps_from_test_exif(
+            &exif_with_source_gps(),
+            "standard.jpg",
+        ));
         // A whole-second GPS timestamp renders without a fractional part.
         let mut metadata = exif_with_source_gps();
         metadata.set_tag(ExifTag::GPSTimeStamp(vec![
@@ -2144,7 +2096,7 @@ mod tests {
             ur64(22, 1),
             ur64(33, 1),
         ]));
-        let gps = source_gps_from_exif(&metadata);
+        let gps = read_source_gps_from_test_exif(&metadata, "whole-second.jpg");
         assert_eq!(gps.datetime.as_deref(), Some("2024-06-15T11:22:33Z"));
     }
 
@@ -2210,11 +2162,11 @@ mod tests {
     #[test]
     fn source_gps_omits_malformed_timestamp_variants() {
         // A valid date with a malformed GPSTimeStamp, or a malformed date,
-        // yields no GPS datetime while the other source fields survive. One
-        // row per rejection branch: bad date, wrong arity, a non-rational
-        // hour, minute, or second, and an out-of-range hour.
+        // yields no GPS datetime while sibling source fields prove the GPS IFD
+        // was serialised and parsed. `not-a-date` is deliberately ten bytes so
+        // its EXIF ASCII count is the required 11 including the trailing NUL.
         let bad = |n: u32| ur64(n, 0);
-        let cases: [(&str, Option<&str>, Vec<uR64>); 6] = [
+        let cases: [(&str, Option<&str>, Vec<uR64>); 8] = [
             (
                 "malformed date",
                 Some("not-a-date"),
@@ -2222,24 +2174,34 @@ mod tests {
             ),
             ("wrong arity", None, vec![ur64(10, 1), ur64(20, 1)]),
             (
-                "non-rational hour",
+                "zero denominator",
                 None,
                 vec![bad(10), ur64(20, 1), ur64(30, 1)],
             ),
             (
-                "non-rational minute",
+                "fractional hour",
                 None,
-                vec![ur64(10, 1), bad(20), ur64(30, 1)],
+                vec![ur64(21, 2), ur64(20, 1), ur64(30, 1)],
             ),
             (
-                "non-rational seconds",
+                "minute out of range",
                 None,
-                vec![ur64(10, 1), ur64(20, 1), bad(30)],
+                vec![ur64(10, 1), ur64(60, 1), ur64(30, 1)],
+            ),
+            (
+                "seconds out of range",
+                None,
+                vec![ur64(10, 1), ur64(20, 1), ur64(60, 1)],
             ),
             (
                 "hour out of range",
                 None,
                 vec![ur64(25, 1), ur64(20, 1), ur64(30, 1)],
+            ),
+            (
+                "minute zero denominator",
+                None,
+                vec![ur64(10, 1), bad(20), ur64(30, 1)],
             ),
         ];
         for (name, date, times) in cases {
@@ -2248,7 +2210,7 @@ mod tests {
                 metadata.set_tag(ExifTag::GPSDateStamp(date.into()));
             }
             metadata.set_tag(ExifTag::GPSTimeStamp(times));
-            let gps = source_gps_from_exif(&metadata);
+            let gps = read_source_gps_from_test_exif(&metadata, &format!("{name}.jpg"));
             assert_eq!(gps.datetime, None, "{name}");
             assert_eq!(
                 gps.speed.as_ref().map(XmpRational::encode).as_deref(),
@@ -2263,7 +2225,8 @@ mod tests {
         }
 
         // A date with no GPSTimeStamp at all cannot compose a timestamp.
-        let gps = source_gps_from_exif(&source_gps_without_time_stamp());
+        let gps =
+            read_source_gps_from_test_exif(&source_gps_without_time_stamp(), "missing-time.jpg");
         assert_eq!(gps.datetime, None);
         assert_eq!(
             gps.speed.as_ref().map(XmpRational::encode).as_deref(),
@@ -2279,29 +2242,58 @@ mod tests {
         // A zero-denominator positioning error is dropped.
         metadata.set_tag(ExifTag::GPSHPositioningError(vec![ur64(1, 0)]));
 
-        let gps = source_gps_from_exif(&metadata);
+        let gps = read_source_gps_from_test_exif(&metadata, "invalid-speed-error.jpg");
         assert_eq!(gps.speed, None);
         assert_eq!(gps.speed_ref, None);
         assert_eq!(gps.horizontal_positioning_error, None);
+        assert_eq!(gps.datetime.as_deref(), Some(SOURCE_GPS_DATETIME));
     }
 
     #[test]
-    fn source_gps_field_readers_reject_mismatched_tag_types() {
-        let metadata = exif_with_source_gps();
-        // `first_rational` decodes only rational GPS tags; a string tag is None.
-        assert_eq!(
-            first_rational(&metadata, ExifTag::GPSDateStamp(String::new())),
-            None
-        );
-        // `first_string` decodes only string GPS tags; a rational tag is None.
-        assert_eq!(first_string(&metadata, ExifTag::GPSSpeed(Vec::new())), None);
+    fn source_gps_rejects_wrong_tiff_types_and_counts() {
+        let cases = [
+            ("timestamp type", 30, 2_u16, None, true),
+            (
+                "speed reference type",
+                42,
+                5_u16,
+                Some(SOURCE_GPS_DATETIME),
+                false,
+            ),
+            ("speed type", 54, 2_u16, Some(SOURCE_GPS_DATETIME), false),
+        ];
+        for (name, type_offset, value_type, datetime, speed_survives) in cases {
+            let mut bytes = minimal_tiff_with_source_gps();
+            bytes[type_offset..type_offset + 2].copy_from_slice(&value_type.to_le_bytes());
+            let gps = read_source_gps_from_test_tiff(&bytes, &format!("{name}.DNG"));
+            assert_eq!(gps.datetime.as_deref(), datetime, "{name}");
+            assert_eq!(gps.speed.is_some(), speed_survives, "{name}");
+            assert!(
+                gps.horizontal_positioning_error.is_some(),
+                "{name}: sibling field must survive"
+            );
+        }
+
+        for (name, count_offset, count) in
+            [("timestamp count", 32, 2_u32), ("date count", 68, 10_u32)]
+        {
+            let mut bytes = minimal_tiff_with_source_gps();
+            bytes[count_offset..count_offset + 4].copy_from_slice(&count.to_le_bytes());
+            let gps = read_source_gps_from_test_tiff(&bytes, &format!("{name}.DNG"));
+            assert_eq!(gps.datetime, None, "{name}");
+            assert_eq!(
+                gps.speed.as_ref().map(XmpRational::encode).as_deref(),
+                Some(SOURCE_GPS_SPEED),
+                "{name}: sibling field must survive"
+            );
+        }
     }
 
     #[test]
     fn gps_datetime_serialises_as_typed_xmp_date() {
         // The sidecar-write test proves the GPS property values reach XMP. This
         // pins the standard property ID and its typed date value.
-        let gps = source_gps_from_exif(&exif_with_source_gps());
+        let gps = read_source_gps_from_test_exif(&exif_with_source_gps(), "typed-date.jpg");
         let packet = build_xmp_packet(&MetadataWrite {
             gps_datetime: gps.datetime,
             ..MetadataWrite::default()
@@ -3544,7 +3536,7 @@ mod tests {
             (xmp_ns::EXIF, "GPSTimeStamp"),
             (xmp_ns::EXIF, "GPSSpeed"),
             (xmp_ns::EXIF, "GPSSpeedRef"),
-            (xmp_ns::EXIF, "GPSHPositioningError"),
+            (EXIF_EX_XMP_NS, "GPSHPositioningError"),
             (xmp_ns::EXIF, "GPSAltitude"),
             (xmp_ns::EXIF, "GPSAltitudeRef"),
             (xmp_ns::DC, "subject"),
@@ -3573,7 +3565,7 @@ mod tests {
         assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
-        assert!(!managed.contains("exif:GPSHPositioningError"));
+        assert!(!managed.contains("exifEX:GPSHPositioningError"));
         assert!(!managed.contains("exif:GPSAltitude"));
         assert_eq!(
             meta.property(THIRD_PARTY_NS, "developSettings")
@@ -3615,7 +3607,7 @@ mod tests {
         seed.set_property(xmp_ns::EXIF, "GPSSpeedRef", &XmpValue::new("K".to_string()))
             .unwrap();
         seed.set_property(
-            xmp_ns::EXIF,
+            EXIF_EX_XMP_NS,
             "GPSHPositioningError",
             &XmpValue::new("13/4".to_string()),
         )
@@ -3645,17 +3637,16 @@ mod tests {
             5,
             "an unmarked rating may belong to another application"
         );
-        for property in [
-            "GPSTimeStamp",
-            "GPSSpeed",
-            "GPSSpeedRef",
-            "GPSHPositioningError",
-        ] {
+        for property in ["GPSTimeStamp", "GPSSpeed", "GPSSpeedRef"] {
             assert!(
                 meta.contains_property(xmp_ns::EXIF, property),
                 "an unmarked GPS property may belong to another application: {property}"
             );
         }
+        assert!(
+            meta.contains_property(EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            "an unmarked GPS property may belong to another application: GPSHPositioningError"
+        );
         assert_eq!(
             meta.localized_text(xmp_ns::DC, "description", None, "x-default")
                 .unwrap()
@@ -3670,7 +3661,7 @@ mod tests {
         assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
-        assert!(!managed.contains("exif:GPSHPositioningError"));
+        assert!(!managed.contains("exifEX:GPSHPositioningError"));
 
         fs::remove_file(&sidecar_path).ok();
         fs::remove_file(&media_path).ok();
@@ -3706,23 +3697,22 @@ mod tests {
         .unwrap();
 
         let meta = read_sidecar_meta(&media_path);
-        for property in [
-            "GPSTimeStamp",
-            "GPSSpeed",
-            "GPSSpeedRef",
-            "GPSHPositioningError",
-        ] {
+        for property in ["GPSTimeStamp", "GPSSpeed", "GPSSpeedRef"] {
             assert!(
                 meta.contains_property(xmp_ns::EXIF, property),
                 "unknown source state must preserve {property}"
             );
         }
+        assert!(
+            meta.contains_property(EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            "unknown source state must preserve GPSHPositioningError"
+        );
         let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
         for token in [
             "exif:GPSTimeStamp",
             "exif:GPSSpeed",
             "exif:GPSSpeedRef",
-            "exif:GPSHPositioningError",
+            "exifEX:GPSHPositioningError",
         ] {
             assert!(
                 managed.split(',').any(|value| value == token),

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -112,7 +112,9 @@ impl ManagedXmpField {
             Self::GpsDateTime => "exif:GPSTimeStamp",
             Self::GpsSpeed => "exif:GPSSpeed",
             Self::GpsSpeedRef => "exif:GPSSpeedRef",
-            Self::GpsHPositioningError => "exifEX:GPSHPositioningError",
+            // CIPA Table 17 and Apple Photos retain GPS tag 31 in exif,
+            // unlike the exifEX-only OffsetTime fields above.
+            Self::GpsHPositioningError => "exif:GPSHPositioningError",
             Self::Rating => "xmp:Rating",
             Self::GpsLatitude => "exif:GPSLatitude",
             Self::GpsLongitude => "exif:GPSLongitude",
@@ -172,7 +174,7 @@ impl ManagedXmpField {
             Self::GpsDateTime => (xmp_ns::EXIF, "GPSTimeStamp"),
             Self::GpsSpeed => (xmp_ns::EXIF, "GPSSpeed"),
             Self::GpsSpeedRef => (xmp_ns::EXIF, "GPSSpeedRef"),
-            Self::GpsHPositioningError => (EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            Self::GpsHPositioningError => (xmp_ns::EXIF, "GPSHPositioningError"),
             Self::Rating => (xmp_ns::XMP, "Rating"),
             Self::GpsLatitude => (xmp_ns::EXIF, "GPSLatitude"),
             Self::GpsLongitude => (xmp_ns::EXIF, "GPSLongitude"),
@@ -1550,7 +1552,7 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
     }
     if let Some(error) = &write.gps_h_positioning_error {
         meta.set_property(
-            EXIF_EX_XMP_NS,
+            xmp_ns::EXIF,
             "GPSHPositioningError",
             &XmpValue::new(error.encode()),
         )?;
@@ -3536,7 +3538,7 @@ mod tests {
             (xmp_ns::EXIF, "GPSTimeStamp"),
             (xmp_ns::EXIF, "GPSSpeed"),
             (xmp_ns::EXIF, "GPSSpeedRef"),
-            (EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            (xmp_ns::EXIF, "GPSHPositioningError"),
             (xmp_ns::EXIF, "GPSAltitude"),
             (xmp_ns::EXIF, "GPSAltitudeRef"),
             (xmp_ns::DC, "subject"),
@@ -3565,7 +3567,7 @@ mod tests {
         assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
-        assert!(!managed.contains("exifEX:GPSHPositioningError"));
+        assert!(!managed.contains("exif:GPSHPositioningError"));
         assert!(!managed.contains("exif:GPSAltitude"));
         assert_eq!(
             meta.property(THIRD_PARTY_NS, "developSettings")
@@ -3607,7 +3609,7 @@ mod tests {
         seed.set_property(xmp_ns::EXIF, "GPSSpeedRef", &XmpValue::new("K".to_string()))
             .unwrap();
         seed.set_property(
-            EXIF_EX_XMP_NS,
+            xmp_ns::EXIF,
             "GPSHPositioningError",
             &XmpValue::new("13/4".to_string()),
         )
@@ -3644,7 +3646,8 @@ mod tests {
             );
         }
         assert!(
-            meta.contains_property(EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            meta.property(xmp_ns::EXIF, "GPSHPositioningError")
+                .is_some_and(|property| property.value == "13/4"),
             "an unmarked GPS property may belong to another application: GPSHPositioningError"
         );
         assert_eq!(
@@ -3661,7 +3664,7 @@ mod tests {
         assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
-        assert!(!managed.contains("exifEX:GPSHPositioningError"));
+        assert!(!managed.contains("exif:GPSHPositioningError"));
 
         fs::remove_file(&sidecar_path).ok();
         fs::remove_file(&media_path).ok();
@@ -3704,7 +3707,7 @@ mod tests {
             );
         }
         assert!(
-            meta.contains_property(EXIF_EX_XMP_NS, "GPSHPositioningError"),
+            meta.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
             "unknown source state must preserve GPSHPositioningError"
         );
         let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
@@ -3712,7 +3715,7 @@ mod tests {
             "exif:GPSTimeStamp",
             "exif:GPSSpeed",
             "exif:GPSSpeedRef",
-            "exifEX:GPSHPositioningError",
+            "exif:GPSHPositioningError",
         ] {
             assert!(
                 managed.split(',').any(|value| value == token),

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -16,11 +16,14 @@ use std::sync::Once;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
+#[cfg(any(not(feature = "xmp"), test))]
 use little_exif::exif_tag::ExifTag;
 use little_exif::filetype::FileExtension;
 #[cfg(not(feature = "xmp"))]
 use little_exif::ifd::ExifTagGroup;
+#[cfg(any(not(feature = "xmp"), test))]
 use little_exif::metadata::Metadata;
+#[cfg(any(not(feature = "xmp"), test))]
 use little_exif::rational::uR64;
 #[cfg(feature = "xmp")]
 use xmp_toolkit::{OpenFileOptions, XmpFile, XmpMeta, XmpValue, xmp_ns};
@@ -106,7 +109,7 @@ impl ManagedXmpField {
             Self::DateTimeOriginal => "exif:DateTimeOriginal",
             Self::DateCreated => "photoshop:DateCreated",
             Self::OffsetTimeOriginal => "exifEX:OffsetTimeOriginal",
-            Self::GpsDateTime => "exif:GPSDateTime",
+            Self::GpsDateTime => "exif:GPSTimeStamp",
             Self::GpsSpeed => "exif:GPSSpeed",
             Self::GpsSpeedRef => "exif:GPSSpeedRef",
             Self::GpsHPositioningError => "exif:GPSHPositioningError",
@@ -152,6 +155,13 @@ impl ManagedXmpField {
         }
     }
 
+    const fn is_source_gps(self) -> bool {
+        matches!(
+            self,
+            Self::GpsDateTime | Self::GpsSpeed | Self::GpsSpeedRef | Self::GpsHPositioningError
+        )
+    }
+
     fn delete(self, meta: &mut XmpMeta) -> xmp_toolkit::XmpResult<()> {
         let (namespace, path) = match self {
             Self::CreateDate => (xmp_ns::XMP, "CreateDate"),
@@ -159,7 +169,7 @@ impl ManagedXmpField {
             Self::DateTimeOriginal => (xmp_ns::EXIF, "DateTimeOriginal"),
             Self::DateCreated => (xmp_ns::PHOTOSHOP, "DateCreated"),
             Self::OffsetTimeOriginal => (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
-            Self::GpsDateTime => (xmp_ns::EXIF, "GPSDateTime"),
+            Self::GpsDateTime => (xmp_ns::EXIF, "GPSTimeStamp"),
             Self::GpsSpeed => (xmp_ns::EXIF, "GPSSpeed"),
             Self::GpsSpeedRef => (xmp_ns::EXIF, "GPSSpeedRef"),
             Self::GpsHPositioningError => (xmp_ns::EXIF, "GPSHPositioningError"),
@@ -351,49 +361,86 @@ fn probe_from_meta(meta: &XmpMeta) -> ExifProbe {
 
 #[cfg(feature = "xmp")]
 pub(crate) fn read_source_gps(path: &Path) -> Result<SourceGpsMetadata> {
-    let extension_type = source_file_type_from_extension(path);
-    if path.extension().is_some() && extension_type.is_none() {
+    let mut source = std::fs::File::open(path)
+        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
+    let mut head = [0_u8; 12];
+    let bytes_read = std::io::Read::read(&mut source, &mut head)
+        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
+    let Some(file_type) = source_file_type(head.get(..bytes_read).unwrap_or_default()) else {
         return Ok(SourceGpsMetadata::default());
+    };
+
+    if file_type == FileExtension::JPEG {
+        let source_len = source
+            .metadata()
+            .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?
+            .len();
+        return match read_jpeg_source_gps(&mut source, source_len) {
+            Ok(metadata) => Ok(metadata),
+            Err(TiffGpsError::Malformed) => Ok(SourceGpsMetadata::default()),
+            Err(TiffGpsError::Io(error)) => Err(error).with_context(|| {
+                format!("Could not read {} for source GPS metadata", path.display())
+            }),
+        };
     }
 
-    let mut head = [0_u8; 12];
-    let bytes_read = std::fs::File::open(path)
-        .and_then(|mut file| {
-            use std::io::Read;
-            file.read(&mut head)
-        })
-        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
-    let file_type = source_file_type(head.get(..bytes_read).unwrap_or_default());
-    let Some(file_type) = file_type else {
-        return Ok(SourceGpsMetadata::default());
-    };
-
-    let bytes = std::fs::read(path)
-        .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?;
-    // An absent or unreadable EXIF block is normal: many HEIC, AVIF and PNG
-    // files carry no EXIF, and a truncated media file cannot yield one. The
-    // sidecar still carries the CloudKit payload, so a parse failure degrades
-    // to no source GPS rather than suppressing the whole sidecar and stranding
-    // a retry marker.
-    let Ok(metadata) = Metadata::new_from_vec(&bytes, file_type) else {
-        return Ok(SourceGpsMetadata::default());
-    };
-    Ok(source_gps_from_exif(&metadata))
-}
-
-#[cfg(feature = "xmp")]
-fn source_file_type_from_extension(path: &Path) -> Option<FileExtension> {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .and_then(|extension| match extension.to_ascii_lowercase().as_str() {
-            "heic" | "heif" | "hif" | "avif" => Some(FileExtension::HEIF),
-            "jpg" | "jpeg" => Some(FileExtension::JPEG),
-            "tif" | "tiff" => Some(FileExtension::TIFF),
-            "png" => Some(FileExtension::PNG {
-                as_zTXt_chunk: true,
+    if file_type == FileExtension::TIFF {
+        let source_len = source
+            .metadata()
+            .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?
+            .len();
+        return match read_tiff_source_gps(&mut source, 0, source_len) {
+            Ok(metadata) => Ok(metadata),
+            Err(TiffGpsError::Malformed) => Ok(SourceGpsMetadata::default()),
+            Err(TiffGpsError::Io(error)) => Err(error).with_context(|| {
+                format!("Could not read {} for source GPS metadata", path.display())
             }),
-            _ => None,
-        })
+        };
+    }
+
+    if matches!(file_type, FileExtension::PNG { .. }) {
+        let source_len = source
+            .metadata()
+            .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?
+            .len();
+        return match read_png_source_gps(&mut source, source_len) {
+            Ok(metadata) => Ok(metadata),
+            Err(TiffGpsError::Malformed) => Ok(SourceGpsMetadata::default()),
+            Err(TiffGpsError::Io(error)) => Err(error).with_context(|| {
+                format!("Could not read {} for source GPS metadata", path.display())
+            }),
+        };
+    }
+
+    if file_type == FileExtension::HEIF {
+        let source_len = source
+            .metadata()
+            .with_context(|| format!("Could not read {} for source GPS metadata", path.display()))?
+            .len();
+        let extent = match heif::locate_exif_tiff(&mut source, source_len) {
+            Ok(extent) => extent,
+            Err(heif::HeifExifError::Malformed) => {
+                return Ok(SourceGpsMetadata::default());
+            }
+            Err(heif::HeifExifError::Io(error)) => {
+                return Err(error).with_context(|| {
+                    format!("Could not read {} for source GPS metadata", path.display())
+                });
+            }
+        };
+        let Some((tiff_start, tiff_len)) = extent else {
+            return Ok(SourceGpsMetadata::default());
+        };
+        return match read_tiff_source_gps(&mut source, tiff_start, tiff_len) {
+            Ok(metadata) => Ok(metadata),
+            Err(TiffGpsError::Malformed) => Ok(SourceGpsMetadata::default()),
+            Err(TiffGpsError::Io(error)) => Err(error).with_context(|| {
+                format!("Could not read {} for source GPS metadata", path.display())
+            }),
+        };
+    }
+
+    Ok(SourceGpsMetadata::default())
 }
 
 #[cfg(feature = "xmp")]
@@ -416,6 +463,347 @@ fn source_file_type(bytes: &[u8]) -> Option<FileExtension> {
 }
 
 #[cfg(feature = "xmp")]
+fn read_jpeg_source_gps<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    source_len: u64,
+) -> Result<SourceGpsMetadata, TiffGpsError> {
+    let mut offset = 2_u64;
+    while offset < source_len {
+        let mut marker = [0_u8; 1];
+        read_exact_file_range(source, source_len, offset, &mut marker)?;
+        if marker[0] != 0xFF {
+            return Err(TiffGpsError::Malformed);
+        }
+        while marker[0] == 0xFF {
+            offset = offset.checked_add(1).ok_or(TiffGpsError::Malformed)?;
+            read_exact_file_range(source, source_len, offset, &mut marker)?;
+        }
+        let marker_code = marker[0];
+        offset = offset.checked_add(1).ok_or(TiffGpsError::Malformed)?;
+        if marker_code == 0xD9 || marker_code == 0xDA {
+            return Ok(SourceGpsMetadata::default());
+        }
+        if marker_code == 0x01 || (0xD0..=0xD7).contains(&marker_code) {
+            continue;
+        }
+
+        let mut length = [0_u8; 2];
+        read_exact_file_range(source, source_len, offset, &mut length)?;
+        let segment_len = u64::from(u16::from_be_bytes(length));
+        if segment_len < 2 {
+            return Err(TiffGpsError::Malformed);
+        }
+        let data_start = offset.checked_add(2).ok_or(TiffGpsError::Malformed)?;
+        let data_len = segment_len - 2;
+        let next = data_start
+            .checked_add(data_len)
+            .filter(|end| *end <= source_len)
+            .ok_or(TiffGpsError::Malformed)?;
+        if marker_code == 0xE1 && data_len >= 6 {
+            let mut signature = [0_u8; 6];
+            read_exact_file_range(source, source_len, data_start, &mut signature)?;
+            if signature == *b"Exif\0\0" {
+                return read_tiff_source_gps(source, data_start + 6, data_len - 6);
+            }
+        }
+        offset = next;
+    }
+    Ok(SourceGpsMetadata::default())
+}
+
+#[cfg(feature = "xmp")]
+fn read_png_source_gps<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    source_len: u64,
+) -> Result<SourceGpsMetadata, TiffGpsError> {
+    let mut offset = 8_u64;
+    while offset < source_len {
+        let mut header = [0_u8; 8];
+        read_exact_file_range(source, source_len, offset, &mut header)?;
+        let data_len = u64::from(u32::from_be_bytes([
+            header[0], header[1], header[2], header[3],
+        ]));
+        let data_start = offset.checked_add(8).ok_or(TiffGpsError::Malformed)?;
+        let next = data_start
+            .checked_add(data_len)
+            .and_then(|end| end.checked_add(4))
+            .filter(|end| *end <= source_len)
+            .ok_or(TiffGpsError::Malformed)?;
+        if &header[4..8] == b"eXIf" {
+            return read_tiff_source_gps(source, data_start, data_len);
+        }
+        if &header[4..8] == b"IEND" {
+            return Ok(SourceGpsMetadata::default());
+        }
+        offset = next;
+    }
+    Ok(SourceGpsMetadata::default())
+}
+
+#[cfg(feature = "xmp")]
+fn read_exact_file_range<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    source_len: u64,
+    offset: u64,
+    output: &mut [u8],
+) -> Result<(), TiffGpsError> {
+    let output_len = u64::try_from(output.len()).map_err(|_error| TiffGpsError::Malformed)?;
+    offset
+        .checked_add(output_len)
+        .filter(|end| *end <= source_len)
+        .ok_or(TiffGpsError::Malformed)?;
+    source.seek(std::io::SeekFrom::Start(offset))?;
+    source.read_exact(output)?;
+    Ok(())
+}
+
+#[cfg(feature = "xmp")]
+#[derive(Clone, Copy)]
+enum TiffEndian {
+    Little,
+    Big,
+}
+
+#[cfg(feature = "xmp")]
+#[derive(Debug)]
+enum TiffGpsError {
+    Io(std::io::Error),
+    Malformed,
+}
+
+#[cfg(feature = "xmp")]
+impl From<std::io::Error> for TiffGpsError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[cfg(feature = "xmp")]
+struct TiffGpsReader<'a, R> {
+    source: &'a mut R,
+    base: u64,
+    len: u64,
+    endian: TiffEndian,
+}
+
+#[cfg(feature = "xmp")]
+impl<R: std::io::Read + std::io::Seek> TiffGpsReader<'_, R> {
+    fn read_exact_at(&mut self, offset: u64, output: &mut [u8]) -> Result<(), TiffGpsError> {
+        let length = u64::try_from(output.len()).map_err(|_error| TiffGpsError::Malformed)?;
+        let end = offset
+            .checked_add(length)
+            .filter(|end| *end <= self.len)
+            .ok_or(TiffGpsError::Malformed)?;
+        let absolute = self
+            .base
+            .checked_add(offset)
+            .filter(|_| end <= self.len)
+            .ok_or(TiffGpsError::Malformed)?;
+        self.source.seek(std::io::SeekFrom::Start(absolute))?;
+        self.source.read_exact(output)?;
+        Ok(())
+    }
+
+    fn read_ifd_entry(&mut self, ifd_offset: u64, index: u16) -> Result<[u8; 12], TiffGpsError> {
+        let entry_offset = u64::from(index)
+            .checked_mul(12)
+            .and_then(|offset| ifd_offset.checked_add(2)?.checked_add(offset))
+            .ok_or(TiffGpsError::Malformed)?;
+        let mut entry = [0_u8; 12];
+        self.read_exact_at(entry_offset, &mut entry)?;
+        Ok(entry)
+    }
+
+    fn entry_value<const N: usize>(
+        &mut self,
+        entry: &[u8; 12],
+        expected_type: u16,
+        expected_count: u32,
+    ) -> Result<Option<[u8; N]>, TiffGpsError> {
+        if tiff_u16(self.endian, [entry[2], entry[3]]) != expected_type
+            || tiff_u32(self.endian, [entry[4], entry[5], entry[6], entry[7]]) != expected_count
+        {
+            return Ok(None);
+        }
+        let mut value = [0_u8; N];
+        if N <= 4 {
+            let inline = entry
+                .get(8..)
+                .and_then(|bytes| bytes.get(..N))
+                .ok_or(TiffGpsError::Malformed)?;
+            value.copy_from_slice(inline);
+        } else {
+            let offset = u64::from(tiff_u32(
+                self.endian,
+                [entry[8], entry[9], entry[10], entry[11]],
+            ));
+            self.read_exact_at(offset, &mut value)?;
+        }
+        Ok(Some(value))
+    }
+}
+
+#[cfg(feature = "xmp")]
+fn read_tiff_source_gps<R: std::io::Read + std::io::Seek>(
+    source: &mut R,
+    base: u64,
+    len: u64,
+) -> Result<SourceGpsMetadata, TiffGpsError> {
+    let mut header = [0_u8; 8];
+    let mut reader = TiffGpsReader {
+        source,
+        base,
+        len,
+        endian: TiffEndian::Little,
+    };
+    reader.read_exact_at(0, &mut header)?;
+    reader.endian = match &header[..2] {
+        b"II" => TiffEndian::Little,
+        b"MM" => TiffEndian::Big,
+        _ => return Err(TiffGpsError::Malformed),
+    };
+    if tiff_u16(reader.endian, [header[2], header[3]]) != 42 {
+        return Err(TiffGpsError::Malformed);
+    }
+    let ifd0_offset = u64::from(tiff_u32(
+        reader.endian,
+        [header[4], header[5], header[6], header[7]],
+    ));
+    let ifd0_count = read_tiff_ifd_count(&mut reader, ifd0_offset)?;
+    let mut gps_ifd_offset = None;
+    for index in 0..ifd0_count {
+        let entry = reader.read_ifd_entry(ifd0_offset, index)?;
+        if tiff_u16(reader.endian, [entry[0], entry[1]]) == 0x8825
+            && tiff_u16(reader.endian, [entry[2], entry[3]]) == 4
+            && tiff_u32(reader.endian, [entry[4], entry[5], entry[6], entry[7]]) == 1
+        {
+            gps_ifd_offset = Some(u64::from(tiff_u32(
+                reader.endian,
+                [entry[8], entry[9], entry[10], entry[11]],
+            )));
+            break;
+        }
+    }
+    let Some(gps_ifd_offset) = gps_ifd_offset else {
+        return Ok(SourceGpsMetadata::default());
+    };
+
+    let gps_count = read_tiff_ifd_count(&mut reader, gps_ifd_offset)?;
+    let mut date = None;
+    let mut time = None;
+    let mut speed = None;
+    let mut speed_ref = None;
+    let mut horizontal_positioning_error = None;
+    for index in 0..gps_count {
+        let entry = reader.read_ifd_entry(gps_ifd_offset, index)?;
+        match tiff_u16(reader.endian, [entry[0], entry[1]]) {
+            0x0007 if time.is_none() => {
+                if let Some(value) = reader.entry_value::<24>(&entry, 5, 3)? {
+                    time = tiff_rational_triplet(reader.endian, &value);
+                }
+            }
+            0x000C if speed_ref.is_none() => {
+                if let Some(value) = reader.entry_value::<2>(&entry, 2, 2)? {
+                    speed_ref = std::str::from_utf8(&value)
+                        .ok()
+                        .map(|value| value.trim_matches('\0').trim().to_ascii_uppercase())
+                        .filter(|value| matches!(value.as_str(), "K" | "M" | "N"));
+                }
+            }
+            0x000D if speed.is_none() => {
+                if let Some(value) = reader.entry_value::<8>(&entry, 5, 1)? {
+                    speed = tiff_rational(reader.endian, &value);
+                }
+            }
+            0x001D if date.is_none() => {
+                if let Some(value) = reader.entry_value::<11>(&entry, 2, 11)? {
+                    date = std::str::from_utf8(&value)
+                        .ok()
+                        .map(|value| value.trim_matches('\0').trim().to_owned());
+                }
+            }
+            0x001F if horizontal_positioning_error.is_none() => {
+                if let Some(value) = reader.entry_value::<8>(&entry, 5, 1)? {
+                    horizontal_positioning_error = tiff_rational(reader.endian, &value);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let datetime = date
+        .as_deref()
+        .zip(time.as_ref())
+        .and_then(|(date, time)| source_gps_datetime_values(date, time));
+    let speed = match (speed, speed_ref.as_ref()) {
+        (Some(value), Some(_)) => Some(value),
+        (Some(_), None) => {
+            tracing::warn!("Source EXIF GPSSpeedRef is missing or unsupported");
+            None
+        }
+        (None, _) => None,
+    };
+    let speed_ref = speed.as_ref().and(speed_ref);
+    Ok(SourceGpsMetadata {
+        datetime,
+        speed,
+        speed_ref,
+        horizontal_positioning_error,
+    })
+}
+
+#[cfg(feature = "__fuzz_internals")]
+pub(crate) fn fuzz_tiff_source_gps(bytes: &[u8]) {
+    let mut source = std::io::Cursor::new(bytes);
+    let _ = read_tiff_source_gps(&mut source, 0, bytes.len() as u64);
+}
+
+#[cfg(feature = "xmp")]
+fn read_tiff_ifd_count<R: std::io::Read + std::io::Seek>(
+    reader: &mut TiffGpsReader<'_, R>,
+    offset: u64,
+) -> Result<u16, TiffGpsError> {
+    let mut count = [0_u8; 2];
+    reader.read_exact_at(offset, &mut count)?;
+    Ok(tiff_u16(reader.endian, count))
+}
+
+#[cfg(feature = "xmp")]
+const fn tiff_u16(endian: TiffEndian, bytes: [u8; 2]) -> u16 {
+    match endian {
+        TiffEndian::Little => u16::from_le_bytes(bytes),
+        TiffEndian::Big => u16::from_be_bytes(bytes),
+    }
+}
+
+#[cfg(feature = "xmp")]
+const fn tiff_u32(endian: TiffEndian, bytes: [u8; 4]) -> u32 {
+    match endian {
+        TiffEndian::Little => u32::from_le_bytes(bytes),
+        TiffEndian::Big => u32::from_be_bytes(bytes),
+    }
+}
+
+#[cfg(feature = "xmp")]
+fn tiff_rational(endian: TiffEndian, bytes: &[u8; 8]) -> Option<XmpRational> {
+    let numerator = tiff_u32(endian, [bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let denominator = tiff_u32(endian, [bytes[4], bytes[5], bytes[6], bytes[7]]);
+    (denominator != 0).then_some(XmpRational {
+        numerator,
+        denominator,
+    })
+}
+
+#[cfg(feature = "xmp")]
+fn tiff_rational_triplet(endian: TiffEndian, bytes: &[u8; 24]) -> Option<[XmpRational; 3]> {
+    Some([
+        tiff_rational(endian, bytes[0..8].try_into().ok()?)?,
+        tiff_rational(endian, bytes[8..16].try_into().ok()?)?,
+        tiff_rational(endian, bytes[16..24].try_into().ok()?)?,
+    ])
+}
+
+#[cfg(all(feature = "xmp", test))]
 fn source_gps_from_exif(metadata: &Metadata) -> SourceGpsMetadata {
     let gps_datetime = source_gps_datetime(metadata);
     let speed = first_rational(metadata, ExifTag::GPSSpeed(Vec::new()));
@@ -443,7 +831,7 @@ fn source_gps_from_exif(metadata: &Metadata) -> SourceGpsMetadata {
     }
 }
 
-#[cfg(feature = "xmp")]
+#[cfg(all(feature = "xmp", test))]
 fn first_rational(metadata: &Metadata, requested: ExifTag) -> Option<XmpRational> {
     metadata.get_tag(&requested).next().and_then(|tag| {
         let values = match tag {
@@ -454,7 +842,7 @@ fn first_rational(metadata: &Metadata, requested: ExifTag) -> Option<XmpRational
     })
 }
 
-#[cfg(feature = "xmp")]
+#[cfg(all(feature = "xmp", test))]
 fn first_string(metadata: &Metadata, requested: ExifTag) -> Option<String> {
     metadata
         .get_tag(&requested)
@@ -466,30 +854,9 @@ fn first_string(metadata: &Metadata, requested: ExifTag) -> Option<String> {
         })
 }
 
-/// `uR64` is a pair of `u32`, so a non-zero denominator always yields a finite
-/// non-negative quotient.
-#[cfg(feature = "xmp")]
-fn rational_to_f64(value: &uR64) -> Option<f64> {
-    if value.denominator == 0 {
-        return None;
-    }
-    Some(f64::from(value.nominator) / f64::from(value.denominator))
-}
-
-#[cfg(feature = "xmp")]
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    reason = "validated GPS hour, minute, and second ranges make these conversions bounded and non-negative"
-)]
+#[cfg(all(feature = "xmp", test))]
 fn source_gps_datetime(metadata: &Metadata) -> Option<String> {
     let date = first_string(metadata, ExifTag::GPSDateStamp(String::new()))?;
-    let date = chrono::NaiveDate::parse_from_str(date.trim_matches('\0').trim(), "%Y:%m:%d")
-        .ok()
-        .or_else(|| {
-            tracing::warn!("Source EXIF GPSDateStamp is malformed");
-            None
-        })?;
     let time_tag = metadata
         .get_tag(&ExifTag::GPSTimeStamp(Vec::new()))
         .next()?;
@@ -500,18 +867,35 @@ fn source_gps_datetime(metadata: &Metadata) -> Option<String> {
         tracing::warn!("Source EXIF GPSTimeStamp is malformed");
         return None;
     };
-    let Some(hour) = rational_to_f64(hour_value) else {
+    let values = [
+        XmpRational::from_exif(hour_value)?,
+        XmpRational::from_exif(minute_value)?,
+        XmpRational::from_exif(seconds_value)?,
+    ];
+    source_gps_datetime_values(date.trim_matches('\0').trim(), &values)
+}
+
+#[cfg(feature = "xmp")]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "validated GPS hour, minute, and second ranges make these conversions bounded and non-negative"
+)]
+fn source_gps_datetime_values(date: &str, time: &[XmpRational; 3]) -> Option<String> {
+    let date = chrono::NaiveDate::parse_from_str(date, "%Y:%m:%d")
+        .ok()
+        .or_else(|| {
+            tracing::warn!("Source EXIF GPSDateStamp is malformed");
+            None
+        })?;
+    let [hour_value, minute_value, seconds_value] = time;
+    let hour = hour_value.as_f64();
+    let minute = minute_value.as_f64();
+    let seconds = seconds_value.as_f64();
+    if !hour.is_finite() || !minute.is_finite() || !seconds.is_finite() {
         tracing::warn!("Source EXIF GPSTimeStamp is malformed");
         return None;
-    };
-    let Some(minute) = rational_to_f64(minute_value) else {
-        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
-        return None;
-    };
-    let Some(seconds) = rational_to_f64(seconds_value) else {
-        tracing::warn!("Source EXIF GPSTimeStamp is malformed");
-        return None;
-    };
+    }
     if hour.fract() != 0.0
         || minute.fract() != 0.0
         || !(0.0..=23.0).contains(&hour)
@@ -603,11 +987,16 @@ pub(crate) struct XmpRational {
 
 #[cfg(feature = "xmp")]
 impl XmpRational {
+    #[cfg(test)]
     fn from_exif(value: &uR64) -> Option<Self> {
         (value.denominator != 0).then_some(Self {
             numerator: value.nominator,
             denominator: value.denominator,
         })
+    }
+
+    fn as_f64(&self) -> f64 {
+        f64::from(self.numerator) / f64::from(self.denominator)
     }
 
     fn encode(&self) -> String {
@@ -642,6 +1031,9 @@ pub(crate) struct MetadataWrite {
     pub(crate) gps_speed_ref: Option<String>,
     /// Horizontal positioning error in metres as an XMP rational.
     pub(crate) gps_h_positioning_error: Option<XmpRational>,
+    /// Preserve prior kei-owned source GPS fields because the source could not
+    /// be read and their current absence is unknown.
+    pub(crate) preserve_source_gps: bool,
     pub(crate) rating: Option<u8>,
     pub(crate) gps: Option<GpsCoords>,
     pub(crate) title: Option<String>,
@@ -665,6 +1057,7 @@ impl MetadataWrite {
             && self.gps_speed.is_none()
             && self.gps_speed_ref.is_none()
             && self.gps_h_positioning_error.is_none()
+            && !self.preserve_source_gps
             && self.rating.is_none()
             && self.gps.is_none()
             && self.title.is_none()
@@ -888,7 +1281,10 @@ fn apply_to_owned_sidecar(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_tool
         .collect();
 
     for field in MANAGED_XMP_FIELDS {
-        if previous_tokens.contains(&field.token()) && !field.is_present(write) {
+        if previous_tokens.contains(&field.token())
+            && !field.is_present(write)
+            && !(write.preserve_source_gps && field.is_source_gps())
+        {
             field.delete(meta)?;
         }
     }
@@ -898,9 +1294,9 @@ fn apply_to_owned_sidecar(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_tool
     let mut current_tokens: Vec<String> = previous_tokens
         .into_iter()
         .filter(|token| {
-            !MANAGED_XMP_FIELDS
-                .iter()
-                .any(|field| field.token() == *token)
+            !MANAGED_XMP_FIELDS.iter().any(|field| {
+                field.token() == *token && !(write.preserve_source_gps && field.is_source_gps())
+            })
         })
         .map(str::to_owned)
         .collect();
@@ -1208,7 +1604,7 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
     }
 
     if let Some(dt) = &write.gps_datetime {
-        meta.set_property(xmp_ns::EXIF, "GPSDateTime", &XmpValue::new(dt.clone()))?;
+        meta.set_property(xmp_ns::EXIF, "GPSTimeStamp", &XmpValue::new(dt.clone()))?;
     }
 
     if let Some(speed) = &write.gps_speed {
@@ -1435,7 +1831,8 @@ mod tests {
     use crate::test_helpers::{
         SOURCE_GPS_DATETIME, SOURCE_GPS_H_POSITIONING_ERROR, SOURCE_GPS_SPEED,
         SOURCE_GPS_SPEED_REF, exif_with_source_gps, heif_ftyp_without_meta_bytes,
-        minimal_jpeg_with_source_gps, source_gps_without_time_stamp, ur64,
+        minimal_big_endian_tiff_with_source_gps, minimal_jpeg_with_source_gps,
+        minimal_tiff_with_source_gps, source_gps_without_time_stamp, ur64,
     };
 
     fn test_tmp_dir(subdir: &str) -> PathBuf {
@@ -1572,11 +1969,31 @@ mod tests {
     }
 
     #[test]
-    fn source_gps_skips_unsupported_media_before_reading_it() {
+    fn source_gps_rejects_readable_unsupported_content() {
         let dir = tempfile::tempdir().expect("metadata temp dir");
         let path = dir.path().join("video.mov");
+        std::fs::write(&path, b"\0\0\0\x14ftypqt  \0\0\0\0qt  ").expect("write QuickTime header");
         let gps = read_source_gps(&path).expect("unsupported media should be ignored");
         assert_eq!(gps, SourceGpsMetadata::default());
+    }
+
+    #[test]
+    fn source_gps_read_errors_preserve_retry_evidence_for_every_path() {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        for name in [
+            "video.mov",
+            "source.DNG",
+            "source.NEF",
+            "source.SRW",
+            "extensionless",
+        ] {
+            let path = dir.path().join(name);
+            std::fs::create_dir(&path).expect("create unreadable source");
+            assert!(
+                read_source_gps(&path).is_err(),
+                "{name} must retain retry evidence after a read failure"
+            );
+        }
     }
 
     #[test]
@@ -1585,17 +2002,25 @@ mod tests {
         // degrade to no source GPS rather than an error, so the sidecar is
         // still written from the CloudKit payload and no retry marker is
         // stranded. Covers a truncated JPEG, an EXIF-less PNG, an `ftyp`-only
-        // HEIC, and a TIFF recognised by extension and magic. The TIFF row is
-        // the format-detection path DNG downloads exercise.
-        let cases: [(&str, Vec<u8>); 4] = [
+        // HEIC, and a DNG recognised by TIFF magic.
+        let cases: [(&str, Vec<u8>); 5] = [
             ("truncated.jpg", vec![0xFF, 0xD8, 0xFF]),
             (
                 "no-exif.png",
                 vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
             ),
+            (
+                "oversized-exif-chunk.png",
+                [
+                    b"\x89PNG\r\n\x1a\n".as_slice(),
+                    &u32::MAX.to_be_bytes(),
+                    b"eXIf",
+                ]
+                .concat(),
+            ),
             ("ftyp-only.heic", heif_ftyp_without_meta_bytes()),
             (
-                "recognised.tif",
+                "recognised.DNG",
                 vec![b'I', b'I', 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00],
             ),
         ];
@@ -1624,6 +2049,91 @@ mod tests {
         );
     }
 
+    fn png_with_source_gps() -> Vec<u8> {
+        fn crc32(bytes: &[u8]) -> u32 {
+            let mut crc = u32::MAX;
+            for byte in bytes {
+                crc ^= u32::from(*byte);
+                for _ in 0..8 {
+                    crc = if crc & 1 == 0 {
+                        crc >> 1
+                    } else {
+                        (crc >> 1) ^ 0xEDB8_8320
+                    };
+                }
+            }
+            !crc
+        }
+
+        let mut png = std::fs::read("assets/logo3.png").expect("read PNG fixture");
+        let tiff = minimal_tiff_with_source_gps();
+        let ihdr_len = u32::from_be_bytes(png[8..12].try_into().expect("PNG IHDR length")) as usize;
+        let insert_at = 8 + 12 + ihdr_len;
+        let mut chunk = Vec::with_capacity(12 + tiff.len());
+        chunk.extend_from_slice(
+            &u32::try_from(tiff.len())
+                .expect("TIFF fixture length")
+                .to_be_bytes(),
+        );
+        chunk.extend_from_slice(b"eXIf");
+        chunk.extend_from_slice(&tiff);
+        chunk.extend_from_slice(&crc32(&chunk[4..]).to_be_bytes());
+        png.splice(insert_at..insert_at, chunk);
+        png
+    }
+
+    struct CountingCursor {
+        inner: std::io::Cursor<Vec<u8>>,
+        bytes_read: usize,
+    }
+
+    impl std::io::Read for CountingCursor {
+        fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+            let read = std::io::Read::read(&mut self.inner, output)?;
+            self.bytes_read += read;
+            Ok(read)
+        }
+    }
+
+    impl std::io::Seek for CountingCursor {
+        fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+            std::io::Seek::seek(&mut self.inner, position)
+        }
+    }
+
+    #[test]
+    fn tiff_source_gps_reads_fixed_metadata_not_trailing_media() {
+        let mut bytes = minimal_tiff_with_source_gps();
+        bytes.resize(1024 * 1024, 0);
+        let len = bytes.len() as u64;
+        let mut source = CountingCursor {
+            inner: std::io::Cursor::new(bytes),
+            bytes_read: 0,
+        };
+
+        let gps = read_tiff_source_gps(&mut source, 0, len).expect("stream TIFF GPS");
+
+        assert_standard_source_gps(&gps);
+        assert!(
+            source.bytes_read < 256,
+            "TIFF GPS parsing read {} bytes",
+            source.bytes_read
+        );
+    }
+
+    #[test]
+    fn tiff_source_gps_rejects_attacker_sized_ifd_count_without_allocation() {
+        let mut bytes = minimal_tiff_with_source_gps();
+        bytes[26..28].copy_from_slice(&u16::MAX.to_le_bytes());
+        let len = bytes.len() as u64;
+        let mut source = std::io::Cursor::new(bytes);
+
+        assert!(matches!(
+            read_tiff_source_gps(&mut source, 0, len),
+            Err(TiffGpsError::Malformed)
+        ));
+    }
+
     #[test]
     fn source_gps_composes_utc_timestamps() {
         assert_standard_source_gps(&source_gps_from_exif(&exif_with_source_gps()));
@@ -1640,8 +2150,9 @@ mod tests {
 
     #[test]
     fn source_gps_reads_exif_from_media_path() {
-        // `read_source_gps` recovers the same facts from JPEG and HEIC media,
-        // exercising both magic-byte detections through the public reader.
+        // `read_source_gps` recovers the same facts from JPEG, HEIC, and
+        // TIFF-based DNG media. A DNG path holding JPEG bytes proves content
+        // selects the parser instead of the extension hint.
         let dir = tempfile::tempdir().expect("metadata temp dir");
         let mut heic = std::fs::read("tests/data/sample.heic").expect("read sample HEIC");
         exif_with_source_gps()
@@ -1649,12 +2160,51 @@ mod tests {
             .expect("write HEIC EXIF");
         for (name, bytes) in [
             ("source.jpg", minimal_jpeg_with_source_gps()),
+            ("jpeg-content.DNG", minimal_jpeg_with_source_gps()),
+            ("source.DNG", minimal_tiff_with_source_gps()),
+            ("source.NEF", minimal_tiff_with_source_gps()),
+            ("big-endian.DNG", minimal_big_endian_tiff_with_source_gps()),
+            ("source.png", png_with_source_gps()),
             ("source.heic", heic),
         ] {
             let path = dir.path().join(name);
             std::fs::write(&path, bytes).expect("write source media");
-            assert_standard_source_gps(&read_source_gps(&path).expect("read source EXIF"));
+            let gps = read_source_gps(&path).expect("read source EXIF");
+            assert_eq!(
+                gps.datetime.as_deref(),
+                Some(SOURCE_GPS_DATETIME),
+                "{name}: {gps:?}"
+            );
+            assert_standard_source_gps(&gps);
         }
+    }
+
+    #[test]
+    fn jpeg_source_gps_does_not_substitute_camera_datetime_for_gps_date() {
+        let mut metadata = Metadata::new();
+        metadata.set_tag(ExifTag::DateTimeOriginal("2024:06:16 08:00:00".into()));
+        metadata.set_tag(ExifTag::GPSTimeStamp(vec![
+            ur64(21, 1),
+            ur64(0, 1),
+            ur64(0, 1),
+        ]));
+        metadata.set_tag(ExifTag::GPSSpeedRef("K".into()));
+        metadata.set_tag(ExifTag::GPSSpeed(vec![ur64(12_345, 100)]));
+        let mut bytes = minimal_jpeg();
+        metadata
+            .write_to_vec(&mut bytes, FileExtension::JPEG)
+            .expect("write JPEG EXIF");
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let path = dir.path().join("source.jpg");
+        std::fs::write(&path, bytes).expect("write source JPEG");
+
+        let gps = read_source_gps(&path).expect("read source EXIF");
+
+        assert!(gps.datetime.is_none());
+        assert_eq!(
+            gps.speed.as_ref().map(XmpRational::encode).as_deref(),
+            Some(SOURCE_GPS_SPEED)
+        );
     }
 
     #[test]
@@ -1750,22 +2300,18 @@ mod tests {
     #[test]
     fn gps_datetime_serialises_as_typed_xmp_date() {
         // The sidecar-write test proves the GPS property values reach XMP. This
-        // pins the packet-level detail that GPSDateTime is a typed XMP date, not
-        // plain text, so downstream tools read it as a date.
+        // pins the standard property ID and its typed date value.
         let gps = source_gps_from_exif(&exif_with_source_gps());
         let packet = build_xmp_packet(&MetadataWrite {
             gps_datetime: gps.datetime,
             ..MetadataWrite::default()
         })
         .expect("XMP packet");
-        let meta = std::str::from_utf8(&packet)
-            .expect("XMP UTF-8")
-            .parse::<XmpMeta>()
-            .expect("parse XMP packet");
-        assert!(
-            meta.property_date(xmp_ns::EXIF, "GPSDateTime").is_some(),
-            "GPSDateTime must be serialised as an XMP date"
-        );
+        let packet = std::str::from_utf8(&packet).expect("XMP UTF-8");
+        let meta = packet.parse::<XmpMeta>().expect("parse XMP packet");
+        assert!(packet.contains("<exif:GPSTimeStamp>"));
+        assert!(meta.property_date(xmp_ns::EXIF, "GPSTimeStamp").is_some());
+        assert!(!meta.contains_property(xmp_ns::EXIF, "GPSDateTime"));
     }
 
     fn fresh_jpeg(dir: &Path, name: &str) -> PathBuf {
@@ -2960,6 +3506,7 @@ mod tests {
             gps_speed: Some(xmp_rational(25, 2)),
             gps_speed_ref: Some("K".into()),
             gps_h_positioning_error: Some(xmp_rational(13, 4)),
+            preserve_source_gps: false,
             rating: Some(5),
             gps: Some(GpsCoords {
                 latitude: 37.7,
@@ -2994,7 +3541,7 @@ mod tests {
         for (namespace, property) in [
             (xmp_ns::XMP, "Rating"),
             (EXIF_EX_XMP_NS, "OffsetTimeOriginal"),
-            (xmp_ns::EXIF, "GPSDateTime"),
+            (xmp_ns::EXIF, "GPSTimeStamp"),
             (xmp_ns::EXIF, "GPSSpeed"),
             (xmp_ns::EXIF, "GPSSpeedRef"),
             (xmp_ns::EXIF, "GPSHPositioningError"),
@@ -3023,7 +3570,7 @@ mod tests {
         assert!(managed.contains("exif:GPSLatitude"));
         assert!(!managed.contains("xmp:Rating"));
         assert!(!managed.contains("exifEX:OffsetTimeOriginal"));
-        assert!(!managed.contains("exif:GPSDateTime"));
+        assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
         assert!(!managed.contains("exif:GPSHPositioningError"));
@@ -3059,7 +3606,7 @@ mod tests {
             .unwrap();
         seed.set_property(
             xmp_ns::EXIF,
-            "GPSDateTime",
+            "GPSTimeStamp",
             &XmpValue::new("2024-06-15T10:00:01Z".to_string()),
         )
         .unwrap();
@@ -3099,7 +3646,7 @@ mod tests {
             "an unmarked rating may belong to another application"
         );
         for property in [
-            "GPSDateTime",
+            "GPSTimeStamp",
             "GPSSpeed",
             "GPSSpeedRef",
             "GPSHPositioningError",
@@ -3120,10 +3667,69 @@ mod tests {
         let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
         assert!(!managed.contains("xmp:Rating"));
         assert!(!managed.contains("dc:description"));
-        assert!(!managed.contains("exif:GPSDateTime"));
+        assert!(!managed.contains("exif:GPSTimeStamp"));
         assert!(!managed.contains("exif:GPSSpeed"));
         assert!(!managed.contains("exif:GPSSpeedRef"));
         assert!(!managed.contains("exif:GPSHPositioningError"));
+
+        fs::remove_file(&sidecar_path).ok();
+        fs::remove_file(&media_path).ok();
+    }
+
+    #[test]
+    fn write_sidecar_preserves_owned_source_gps_when_source_state_is_unknown() {
+        let dir = test_tmp_dir("sidecar_preserve_unknown_source_gps");
+        fs::create_dir_all(&dir).unwrap();
+        let media_path = dir.join("unknown-source.jpg");
+        let sidecar_path = dir.join("unknown-source.jpg.xmp");
+        fs::write(&media_path, b"placeholder").unwrap();
+
+        write_sidecar_with_default_suffix(
+            &media_path,
+            &MetadataWrite {
+                gps_datetime: Some("2024-06-15T10:00:01Z".into()),
+                gps_speed: Some(xmp_rational(25, 2)),
+                gps_speed_ref: Some("K".into()),
+                gps_h_positioning_error: Some(xmp_rational(13, 4)),
+                ..MetadataWrite::default()
+            },
+        )
+        .unwrap();
+        write_sidecar_with_default_suffix(
+            &media_path,
+            &MetadataWrite {
+                rating: Some(5),
+                preserve_source_gps: true,
+                ..MetadataWrite::default()
+            },
+        )
+        .unwrap();
+
+        let meta = read_sidecar_meta(&media_path);
+        for property in [
+            "GPSTimeStamp",
+            "GPSSpeed",
+            "GPSSpeedRef",
+            "GPSHPositioningError",
+        ] {
+            assert!(
+                meta.contains_property(xmp_ns::EXIF, property),
+                "unknown source state must preserve {property}"
+            );
+        }
+        let managed = meta.property(KEI_XMP_NS, KEI_MANAGED_FIELDS).unwrap().value;
+        for token in [
+            "exif:GPSTimeStamp",
+            "exif:GPSSpeed",
+            "exif:GPSSpeedRef",
+            "exif:GPSHPositioningError",
+        ] {
+            assert!(
+                managed.split(',').any(|value| value == token),
+                "unknown source state must preserve {token}"
+            );
+        }
+        assert_eq!(meta.property_i32(xmp_ns::XMP, "Rating").unwrap().value, 5);
 
         fs::remove_file(&sidecar_path).ok();
         fs::remove_file(&media_path).ok();

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -203,17 +203,25 @@ async fn write_sidecar_metadata(
     let sidecar_path = path.to_path_buf();
     let sidecar_temp_suffix = temp_suffix.to_string();
     let log_path = sidecar_path.clone();
-    match tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-        let write = plan_sidecar_write(&sidecar_path, &payload, &created_local)?;
+    match tokio::task::spawn_blocking(move || -> anyhow::Result<Option<anyhow::Error>> {
+        let (write, source_error) = plan_sidecar_write(&sidecar_path, &payload, &created_local);
         if write.is_empty() {
-            return Ok(true);
+            return Ok(source_error);
         }
         super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix)?;
-        Ok(true)
+        Ok(source_error)
     })
     .await
     {
-        Ok(Ok(ok)) => ok,
+        Ok(Ok(None)) => true,
+        Ok(Ok(Some(error))) => {
+            tracing::warn!(
+                path = %log_path.display(),
+                error = %error,
+                "Source GPS read failed after sidecar publication; leaving marker for retry"
+            );
+            false
+        }
         Ok(Err(e)) => {
             tracing::warn!(path = %log_path.display(), error = %e, "Failed to write XMP sidecar");
             false
@@ -256,8 +264,11 @@ fn plan_sidecar_write(
     path: &Path,
     payload: &MetadataPayload,
     created_local: &DateTime<FixedOffset>,
-) -> anyhow::Result<super::metadata::MetadataWrite> {
-    let source_gps = super::metadata::read_source_gps(path)?;
+) -> (super::metadata::MetadataWrite, Option<anyhow::Error>) {
+    let (source_gps, source_error) = match super::metadata::read_source_gps(path) {
+        Ok(metadata) => (metadata, None),
+        Err(error) => (super::metadata::SourceGpsMetadata::default(), Some(error)),
+    };
     let mut write = super::metadata::MetadataWrite {
         datetime: Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string()),
         offset_time_original: offset_time_original(payload),
@@ -265,6 +276,7 @@ fn plan_sidecar_write(
         gps_speed: source_gps.speed,
         gps_speed_ref: source_gps.speed_ref,
         gps_h_positioning_error: source_gps.horizontal_positioning_error,
+        preserve_source_gps: source_error.is_some(),
         rating: payload.rating,
         gps: gps_from_payload(payload),
         is_hidden: payload.is_hidden,
@@ -277,7 +289,7 @@ fn plan_sidecar_write(
     write.people.clone_from(&payload.people);
     write.media_subtype.clone_from(&payload.media_subtype);
     write.burst_id.clone_from(&payload.burst_id);
-    Ok(write)
+    (write, source_error)
 }
 
 /// Plan the embed-path write. Per-tag gates:
@@ -940,7 +952,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("photo.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
-        let w = plan_sidecar_write(&path, &payload, &now_local()).unwrap();
+        let (w, source_error) = plan_sidecar_write(&path, &payload, &now_local());
+        assert!(source_error.is_none());
         // Every payload field should land in the sidecar write, no flag gating.
         assert!(w.datetime.is_some());
         assert_eq!(w.offset_time_original.as_deref(), Some("+11:00"));
@@ -963,7 +976,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("photo.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
-        let w = plan_sidecar_write(&path, &MetadataPayload::default(), &now_local()).unwrap();
+        let (w, source_error) =
+            plan_sidecar_write(&path, &MetadataPayload::default(), &now_local());
+        assert!(source_error.is_none());
         assert!(w.datetime.is_some());
         assert!(w.gps_datetime.is_none());
         assert!(w.gps_speed.is_none());
@@ -1194,6 +1209,57 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     #[tokio::test]
+    async fn sidecar_write_reads_source_gps_from_dng_content() {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let media_path = dir.path().join("source.DNG");
+        let source_bytes = crate::test_helpers::minimal_tiff_with_source_gps();
+        std::fs::write(&media_path, &source_bytes).expect("write source DNG");
+        let payload = MetadataPayload {
+            rating: Some(4),
+            latitude: Some(12.3456),
+            longitude: Some(-78.9012),
+            altitude: Some(9.25),
+            ..MetadataPayload::default()
+        };
+
+        let outcome = write_download_metadata(MetadataWriteRequest {
+            final_path: &media_path,
+            embed_path: None,
+            sidecar_path: Some(&media_path),
+            payload: Arc::new(payload),
+            created_local: now_local(),
+            flags: MetadataFlags::XMP_SIDECAR,
+            temp_suffix: ".gps-dng-test",
+        })
+        .await;
+
+        assert!(!outcome.any_failed());
+        let sidecar_path = media_path.with_file_name("source.DNG.xmp");
+        let xmp = std::fs::read_to_string(&sidecar_path)
+            .expect("read DNG sidecar")
+            .parse::<XmpMeta>()
+            .expect("parse DNG sidecar");
+        crate::test_helpers::assert_source_gps_in_xmp(&xmp);
+        let value = |namespace, name| xmp.property(namespace, name).expect(name).value;
+        assert_eq!(value(xmp_ns::XMP, "Rating"), "4");
+        assert_eq!(value(xmp_ns::EXIF, "GPSLatitude"), "12,20.7360N");
+        assert_eq!(value(xmp_ns::EXIF, "GPSLongitude"), "78,54.0720W");
+        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "9250/1000");
+        assert_eq!(
+            std::fs::read(&media_path).expect("read source DNG after sidecar"),
+            source_bytes,
+            "sidecar-only metadata must not alter DNG bytes"
+        );
+        assert!(
+            !media_path
+                .with_file_name("source.DNG.xmp.gps-dng-test")
+                .exists(),
+            "successful sidecar publication must remove its temporary file"
+        );
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
     async fn sidecar_retry_recovers_exif_less_media_and_keeps_marker_for_unreadable_source() {
         use crate::state::{AssetMetadata, SqliteStateDb};
 
@@ -1264,10 +1330,10 @@ mod tests {
             "EXIF-less media must still publish its sidecar"
         );
         assert!(
-            !unreadable_path
+            unreadable_path
                 .with_file_name("unreadable.heic.xmp")
                 .exists(),
-            "an unreadable source must not publish a sidecar"
+            "an unreadable source still publishes the CloudKit-only sidecar"
         );
 
         let pending = db

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -738,6 +738,41 @@ mod tests {
     }
 
     #[cfg(feature = "xmp")]
+    fn authority_cloudkit_time() -> DateTime<FixedOffset> {
+        FixedOffset::east_opt(39_600)
+            .unwrap()
+            .with_ymd_and_hms(2019, 3, 4, 5, 6, 7)
+            .unwrap()
+    }
+
+    #[cfg(feature = "xmp")]
+    fn assert_cloudkit_authority_with_source_gps(meta: &XmpMeta) {
+        const CAPTURE: &str = "2019-03-04T05:06:07+11:00";
+        for (namespace, property) in [
+            (xmp_ns::XMP, "CreateDate"),
+            (xmp_ns::XMP, "ModifyDate"),
+            (xmp_ns::EXIF, "DateTimeOriginal"),
+            (xmp_ns::PHOTOSHOP, "DateCreated"),
+        ] {
+            assert_eq!(
+                meta.property(namespace, property).expect(property).value,
+                CAPTURE
+            );
+        }
+        let coordinate = |name: &str| meta.property(xmp_ns::EXIF, name).expect(name).value;
+        assert_eq!(coordinate("GPSLatitude"), "12,20.7360N");
+        assert_eq!(coordinate("GPSLongitude"), "78,54.0720W");
+        assert_eq!(coordinate("GPSAltitude"), "9250/1000");
+        crate::test_helpers::assert_source_gps_in_xmp(meta);
+        assert_ne!(
+            meta.property(xmp_ns::EXIF, "GPSTimeStamp")
+                .expect("GPSTimeStamp")
+                .value,
+            CAPTURE
+        );
+    }
+
+    #[cfg(feature = "xmp")]
     fn rich_payload() -> MetadataPayload {
         MetadataPayload {
             timezone_offset: Some(39_600),
@@ -1122,20 +1157,22 @@ mod tests {
     async fn sidecar_write_carries_source_gps_and_corrected_coordinates() {
         let dir = tempfile::tempdir().expect("metadata temp dir");
         let media_path = dir.path().join("source.jpg");
-        let source_bytes = crate::test_helpers::minimal_jpeg_with_source_gps();
+        let source_bytes = crate::test_helpers::minimal_jpeg_with_source_gps_and_location();
         std::fs::write(&media_path, &source_bytes).expect("write source media");
         let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
             latitude: Some(12.3456),
             longitude: Some(-78.9012),
             altitude: Some(9.25),
             ..MetadataPayload::default()
         };
+        let cloudkit_created = authority_cloudkit_time();
         let request = || MetadataWriteRequest {
             final_path: &media_path,
             embed_path: None,
             sidecar_path: Some(&media_path),
             payload: Arc::new(payload.clone()),
-            created_local: now_local(),
+            created_local: cloudkit_created,
             flags: MetadataFlags::XMP_SIDECAR,
             temp_suffix: ".gps-sidecar-test",
         };
@@ -1148,11 +1185,7 @@ mod tests {
             .expect("sidecar UTF-8")
             .parse::<XmpMeta>()
             .expect("parse generated sidecar");
-        crate::test_helpers::assert_source_gps_in_xmp(&xmp);
-        let coord = |name: &str| xmp.property(xmp_ns::EXIF, name).expect(name).value;
-        assert_eq!(coord("GPSLatitude"), "12,20.7360N");
-        assert_eq!(coord("GPSLongitude"), "78,54.0720W");
-        assert_eq!(coord("GPSAltitude"), "9250/1000");
+        assert_cloudkit_authority_with_source_gps(&xmp);
         assert_eq!(
             std::fs::read(&media_path).expect("read media after sidecar"),
             source_bytes
@@ -1178,12 +1211,14 @@ mod tests {
             &media_path,
             &checksum,
             AssetMetadata {
+                timezone_offset: Some(39_600),
                 latitude: Some(12.3456),
                 longitude: Some(-78.9012),
                 altitude: Some(9.25),
                 metadata_hash: Some("gps-retry-hash".into()),
                 ..AssetMetadata::default()
             },
+            Some(cloudkit_created.with_timezone(&chrono::Utc)),
         )
         .await;
         run_pending(
@@ -1204,7 +1239,7 @@ mod tests {
             .expect("read sidecar after retry")
             .parse::<XmpMeta>()
             .expect("parse sidecar after retry");
-        crate::test_helpers::assert_source_gps_in_xmp(&retry_xmp);
+        assert_cloudkit_authority_with_source_gps(&retry_xmp);
     }
 
     #[cfg(feature = "xmp")]
@@ -1294,6 +1329,7 @@ mod tests {
                 metadata_hash: Some("exif-less-hash".into()),
                 ..AssetMetadata::default()
             },
+            None,
         )
         .await;
         seed_downloaded_marker(
@@ -1306,6 +1342,7 @@ mod tests {
                 metadata_hash: Some("unreadable-hash".into()),
                 ..AssetMetadata::default()
             },
+            None,
         )
         .await;
 
@@ -2007,11 +2044,13 @@ mod tests {
         path: &std::path::Path,
         checksum: &str,
         metadata: crate::state::types::AssetMetadata,
+        created_at: Option<chrono::DateTime<chrono::Utc>>,
     ) {
-        let record = crate::test_helpers::TestAssetRecord::new(asset_id)
-            .filename(filename)
-            .metadata(metadata)
-            .build();
+        let mut record = crate::test_helpers::TestAssetRecord::new(asset_id).filename(filename);
+        if let Some(created_at) = created_at {
+            record = record.created_at(created_at);
+        }
+        let record = record.metadata(metadata).build();
         db.upsert_seen(&record).await.unwrap();
         db.mark_downloaded("PrimarySync", asset_id, "original", path, checksum, None)
             .await
@@ -2051,6 +2090,7 @@ mod tests {
                 metadata_hash: Some("fresh-hash".to_string()),
                 ..AssetMetadata::default()
             },
+            None,
         )
         .await;
 

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -202,22 +202,22 @@ async fn write_sidecar_metadata(
 ) -> bool {
     let sidecar_path = path.to_path_buf();
     let sidecar_temp_suffix = temp_suffix.to_string();
-    match tokio::task::spawn_blocking(move || {
-        let write = plan_sidecar_write(&payload, &created_local);
+    let log_path = sidecar_path.clone();
+    match tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+        let write = plan_sidecar_write(&sidecar_path, &payload, &created_local)?;
         if write.is_empty() {
-            return true;
+            return Ok(true);
         }
-        match super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix) {
-            Err(e) => {
-                tracing::warn!(path = %sidecar_path.display(), error = %e, "Failed to write XMP sidecar");
-                false
-            }
-            Ok(()) => true,
-        }
+        super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix)?;
+        Ok(true)
     })
     .await
     {
-        Ok(ok) => ok,
+        Ok(Ok(ok)) => ok,
+        Ok(Err(e)) => {
+            tracing::warn!(path = %log_path.display(), error = %e, "Failed to write XMP sidecar");
+            false
+        }
         Err(e) => {
             tracing::warn!(error = %e, "XMP sidecar task panicked");
             false
@@ -249,14 +249,22 @@ fn offset_time_original(payload: &MetadataPayload) -> Option<String> {
 
 /// Comprehensive snapshot of every field a payload can contribute. Used as
 /// the sidecar plan (sidecars are fresh files; no probe gating applies).
+/// Source-media GPS facts are read here on every attempt so metadata-only
+/// retries do not depend on a reduced durable payload.
 #[cfg(feature = "xmp")]
 fn plan_sidecar_write(
+    path: &Path,
     payload: &MetadataPayload,
     created_local: &DateTime<FixedOffset>,
-) -> super::metadata::MetadataWrite {
+) -> anyhow::Result<super::metadata::MetadataWrite> {
+    let source_gps = super::metadata::read_source_gps(path)?;
     let mut write = super::metadata::MetadataWrite {
         datetime: Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string()),
         offset_time_original: offset_time_original(payload),
+        gps_datetime: source_gps.datetime,
+        gps_speed: source_gps.speed,
+        gps_speed_ref: source_gps.speed_ref,
+        gps_h_positioning_error: source_gps.horizontal_positioning_error,
         rating: payload.rating,
         gps: gps_from_payload(payload),
         is_hidden: payload.is_hidden,
@@ -269,7 +277,7 @@ fn plan_sidecar_write(
     write.people.clone_from(&payload.people);
     write.media_subtype.clone_from(&payload.media_subtype);
     write.burst_id.clone_from(&payload.burst_id);
-    write
+    Ok(write)
 }
 
 /// Plan the embed-path write. Per-tag gates:
@@ -700,6 +708,9 @@ mod tests {
     #[cfg(feature = "xmp")]
     use std::sync::Arc;
 
+    #[cfg(feature = "xmp")]
+    use xmp_toolkit::{XmpMeta, xmp_ns};
+
     use super::*;
     use chrono::TimeZone;
 
@@ -926,7 +937,10 @@ mod tests {
     #[test]
     fn plan_sidecar_write_is_comprehensive_regardless_of_flags() {
         let payload = rich_payload();
-        let w = plan_sidecar_write(&payload, &now_local());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("photo.jpg");
+        std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
+        let w = plan_sidecar_write(&path, &payload, &now_local()).unwrap();
         // Every payload field should land in the sidecar write, no flag gating.
         assert!(w.datetime.is_some());
         assert_eq!(w.offset_time_original.as_deref(), Some("+11:00"));
@@ -946,8 +960,15 @@ mod tests {
     #[test]
     fn plan_sidecar_write_empty_payload_yields_datetime_only() {
         // datetime comes from the local clock; the rest stays empty.
-        let w = plan_sidecar_write(&MetadataPayload::default(), &now_local());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("photo.jpg");
+        std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
+        let w = plan_sidecar_write(&path, &MetadataPayload::default(), &now_local()).unwrap();
         assert!(w.datetime.is_some());
+        assert!(w.gps_datetime.is_none());
+        assert!(w.gps_speed.is_none());
+        assert!(w.gps_speed_ref.is_none());
+        assert!(w.gps_h_positioning_error.is_none());
         assert!(w.rating.is_none());
         assert!(w.gps.is_none());
         assert!(w.title.is_none());
@@ -1079,6 +1100,190 @@ mod tests {
         let after = crate::download::metadata::probe_exif(&photo_path).unwrap();
         assert!(after.denotes_capture_time(&created_local));
         assert_eq!(after.offset_time_original.as_deref(), Some("+11:00"));
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn sidecar_write_carries_source_gps_and_corrected_coordinates() {
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+        let media_path = dir.path().join("source.jpg");
+        let source_bytes = crate::test_helpers::minimal_jpeg_with_source_gps();
+        std::fs::write(&media_path, &source_bytes).expect("write source media");
+        let payload = MetadataPayload {
+            latitude: Some(12.3456),
+            longitude: Some(-78.9012),
+            altitude: Some(9.25),
+            ..MetadataPayload::default()
+        };
+        let request = || MetadataWriteRequest {
+            final_path: &media_path,
+            embed_path: None,
+            sidecar_path: Some(&media_path),
+            payload: Arc::new(payload.clone()),
+            created_local: now_local(),
+            flags: MetadataFlags::XMP_SIDECAR,
+            temp_suffix: ".gps-sidecar-test",
+        };
+
+        let outcome = write_download_metadata(request()).await;
+        assert!(!outcome.any_failed());
+        let sidecar_path = media_path.with_file_name("source.jpg.xmp");
+        let first = std::fs::read(&sidecar_path).expect("read generated sidecar");
+        let xmp = String::from_utf8(first.clone())
+            .expect("sidecar UTF-8")
+            .parse::<XmpMeta>()
+            .expect("parse generated sidecar");
+        crate::test_helpers::assert_source_gps_in_xmp(&xmp);
+        let coord = |name: &str| xmp.property(xmp_ns::EXIF, name).expect(name).value;
+        assert_eq!(coord("GPSLatitude"), "12,20.7360N");
+        assert_eq!(coord("GPSLongitude"), "78,54.0720W");
+        assert_eq!(coord("GPSAltitude"), "9250/1000");
+        assert_eq!(
+            std::fs::read(&media_path).expect("read media after sidecar"),
+            source_bytes
+        );
+
+        let second_outcome = write_download_metadata(request()).await;
+        assert!(!second_outcome.any_failed());
+        assert_eq!(
+            std::fs::read(&sidecar_path).expect("read repeated sidecar"),
+            first,
+            "repeating the same sidecar write must be idempotent"
+        );
+
+        use crate::state::{AssetMetadata, SqliteStateDb};
+        let db = SqliteStateDb::open_in_memory().expect("metadata state DB");
+        let checksum = crate::download::file::compute_sha256(&media_path)
+            .await
+            .expect("media checksum");
+        seed_downloaded_marker(
+            &db,
+            "GPS_RETRY",
+            "source.jpg",
+            &media_path,
+            &checksum,
+            AssetMetadata {
+                latitude: Some(12.3456),
+                longitude: Some(-78.9012),
+                altitude: Some(9.25),
+                metadata_hash: Some("gps-retry-hash".into()),
+                ..AssetMetadata::default()
+            },
+        )
+        .await;
+        run_pending(
+            &db,
+            MetadataFlags::XMP_SIDECAR,
+            Arc::from(".gps-retry-test"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .expect("read retry markers")
+                .is_empty(),
+            "successful sidecar retry must retire its marker"
+        );
+        let retry_xmp = std::fs::read_to_string(&sidecar_path)
+            .expect("read sidecar after retry")
+            .parse::<XmpMeta>()
+            .expect("parse sidecar after retry");
+        crate::test_helpers::assert_source_gps_in_xmp(&retry_xmp);
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn sidecar_retry_recovers_exif_less_media_and_keeps_marker_for_unreadable_source() {
+        use crate::state::{AssetMetadata, SqliteStateDb};
+
+        let dir = tempfile::tempdir().expect("metadata temp dir");
+
+        // A structurally valid HEIC with no EXIF block. There is no source GPS
+        // to read, so the sidecar carries only the CloudKit payload and the
+        // marker must retire.
+        let exif_less_path = dir.path().join("exif-less.heic");
+        std::fs::write(
+            &exif_less_path,
+            crate::test_helpers::heif_ftyp_without_meta_bytes(),
+        )
+        .expect("write EXIF-less HEIC");
+
+        // A source the reader cannot open at all. Planning the sidecar fails,
+        // so the durable marker survives for a future retry.
+        let unreadable_path = dir.path().join("unreadable.heic");
+        std::fs::create_dir(&unreadable_path).expect("create unreadable source");
+
+        let db = SqliteStateDb::open_in_memory().expect("metadata state DB");
+        let exif_less_checksum = crate::download::file::compute_sha256(&exif_less_path)
+            .await
+            .expect("media checksum");
+        seed_downloaded_marker(
+            &db,
+            "GPS_EXIF_LESS",
+            "exif-less.heic",
+            &exif_less_path,
+            &exif_less_checksum,
+            AssetMetadata {
+                metadata_hash: Some("exif-less-hash".into()),
+                ..AssetMetadata::default()
+            },
+        )
+        .await;
+        seed_downloaded_marker(
+            &db,
+            "GPS_UNREADABLE",
+            "unreadable.heic",
+            &unreadable_path,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            AssetMetadata {
+                metadata_hash: Some("unreadable-hash".into()),
+                ..AssetMetadata::default()
+            },
+        )
+        .await;
+
+        let pass = run_pending(
+            &db,
+            MetadataFlags::XMP_SIDECAR,
+            Arc::from(".gps-parse-retry-test"),
+            &CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(
+            pass.applied, 1,
+            "EXIF-less media must still complete its sidecar"
+        );
+        assert_eq!(
+            pass.failed, 1,
+            "an unreadable source must fail so the retry marker survives"
+        );
+        assert!(
+            exif_less_path.with_file_name("exif-less.heic.xmp").exists(),
+            "EXIF-less media must still publish its sidecar"
+        );
+        assert!(
+            !unreadable_path
+                .with_file_name("unreadable.heic.xmp")
+                .exists(),
+            "an unreadable source must not publish a sidecar"
+        );
+
+        let pending = db
+            .get_pending_metadata_rewrites(10)
+            .await
+            .expect("read retry markers");
+        assert_eq!(
+            pending.len(),
+            1,
+            "only the unreadable source keeps its durable marker"
+        );
+        assert_eq!(
+            pending[0].id.as_ref(),
+            "GPS_UNREADABLE",
+            "the retained marker must be the unreadable source"
+        );
     }
 
     /// End-to-end test of the metadata-rewrite pass. Seeds a downloaded row
@@ -1723,6 +1928,33 @@ mod tests {
         assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
     }
 
+    /// Seeds one downloaded asset carrying a rewrite marker into `db`, running
+    /// the same sequence a real download failure leaves behind: `upsert_seen`,
+    /// `mark_downloaded`, then `record_metadata_write_failure`. The caller
+    /// supplies the on-disk path and its checksum so both readable media and
+    /// deliberately unreadable sources can be staged.
+    #[cfg(feature = "xmp")]
+    async fn seed_downloaded_marker(
+        db: &crate::state::SqliteStateDb,
+        asset_id: &str,
+        filename: &str,
+        path: &std::path::Path,
+        checksum: &str,
+        metadata: crate::state::types::AssetMetadata,
+    ) {
+        let record = crate::test_helpers::TestAssetRecord::new(asset_id)
+            .filename(filename)
+            .metadata(metadata)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded("PrimarySync", asset_id, "original", path, checksum, None)
+            .await
+            .unwrap();
+        db.record_metadata_write_failure("PrimarySync", asset_id, "original")
+            .await
+            .unwrap();
+    }
+
     /// Seeds a downloaded JPEG carrying a rewrite marker. Returns the
     /// database, the media path, and the checksum recorded for the file.
     /// `rating` drives whether the embedded writer has anything to write.
@@ -1742,21 +1974,19 @@ mod tests {
         // File backed so a test can reopen it and drop connection-scoped
         // failure triggers between passes.
         let db = SqliteStateDb::open(&dir.join("state.db")).await.unwrap();
-        let record = crate::test_helpers::TestAssetRecord::new(asset_id)
-            .filename(&format!("{asset_id}.jpg"))
-            .metadata(AssetMetadata {
+        seed_downloaded_marker(
+            &db,
+            asset_id,
+            &format!("{asset_id}.jpg"),
+            &path,
+            &recorded,
+            AssetMetadata {
                 rating,
                 metadata_hash: Some("fresh-hash".to_string()),
                 ..AssetMetadata::default()
-            })
-            .build();
-        db.upsert_seen(&record).await.unwrap();
-        db.mark_downloaded("PrimarySync", asset_id, "original", &path, &recorded, None)
-            .await
-            .unwrap();
-        db.record_metadata_write_failure("PrimarySync", asset_id, "original")
-            .await
-            .unwrap();
+            },
+        )
+        .await;
 
         (db, path, recorded)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1776,6 +1776,17 @@ pub mod __fuzz {
         crate::download::heif::extract_xmp_bytes(bytes)
     }
 
+    /// Locate a HEIF EXIF TIFF range through the file-backed parser.
+    pub fn heif_locate_exif(bytes: &[u8]) {
+        let mut source = std::io::Cursor::new(bytes);
+        let _ = crate::download::heif::locate_exif_tiff(&mut source, bytes.len() as u64);
+    }
+
+    /// Parse arbitrary bytes through the fixed-buffer TIFF GPS reader.
+    pub fn tiff_source_gps(bytes: &[u8]) {
+        crate::download::metadata::fuzz_tiff_source_gps(bytes);
+    }
+
     /// Cheap content-sniff check for HEIC/HEIF/AVIF magic bytes.
     pub fn heif_is_heif_content(bytes: &[u8]) -> bool {
         crate::download::heif::is_heif_content(bytes)

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -984,6 +984,99 @@ impl PhotosSession for MockPhotosSession {
     }
 }
 
+// ── Source EXIF GPS fixtures ────────────────────────────────────────
+
+/// Facts that `exif_with_source_gps` yields once read and composed.
+#[cfg(feature = "xmp")]
+pub const SOURCE_GPS_DATETIME: &str = "2024-06-15T10:20:30.125Z";
+#[cfg(feature = "xmp")]
+pub const SOURCE_GPS_SPEED: &str = "12345/100";
+#[cfg(feature = "xmp")]
+pub const SOURCE_GPS_SPEED_REF: &str = "K";
+#[cfg(feature = "xmp")]
+pub const SOURCE_GPS_H_POSITIONING_ERROR: &str = "3/2";
+
+/// EXIF `uR64` rational from a numerator and denominator.
+#[cfg(feature = "xmp")]
+pub fn ur64(nominator: u32, denominator: u32) -> little_exif::rational::uR64 {
+    little_exif::rational::uR64 {
+        nominator,
+        denominator,
+    }
+}
+
+/// EXIF metadata carrying the standard source GPS facts: GPSDateStamp
+/// 2024:06:15, GPSTimeStamp 10:20:30.125, GPSSpeedRef K, GPSSpeed 123.45,
+/// GPSHPositioningError 1.5.
+#[cfg(feature = "xmp")]
+pub fn exif_with_source_gps() -> little_exif::metadata::Metadata {
+    use little_exif::exif_tag::ExifTag;
+    use little_exif::metadata::Metadata;
+
+    let mut metadata = Metadata::new();
+    metadata.set_tag(ExifTag::GPSDateStamp("2024:06:15".into()));
+    metadata.set_tag(ExifTag::GPSTimeStamp(vec![
+        ur64(10, 1),
+        ur64(20, 1),
+        ur64(30_125, 1_000),
+    ]));
+    metadata.set_tag(ExifTag::GPSSpeedRef("K".into()));
+    metadata.set_tag(ExifTag::GPSSpeed(vec![ur64(12_345, 100)]));
+    metadata.set_tag(ExifTag::GPSHPositioningError(vec![ur64(3, 2)]));
+    metadata
+}
+
+/// The standard source GPS EXIF without a `GPSTimeStamp`, so a date alone
+/// cannot compose a timestamp.
+#[cfg(feature = "xmp")]
+pub fn source_gps_without_time_stamp() -> little_exif::metadata::Metadata {
+    use little_exif::exif_tag::ExifTag;
+    use little_exif::metadata::Metadata;
+
+    let mut metadata = Metadata::new();
+    metadata.set_tag(ExifTag::GPSDateStamp("2024:06:15".into()));
+    metadata.set_tag(ExifTag::GPSSpeedRef("K".into()));
+    metadata.set_tag(ExifTag::GPSSpeed(vec![ur64(12_345, 100)]));
+    metadata.set_tag(ExifTag::GPSHPositioningError(vec![ur64(3, 2)]));
+    metadata
+}
+
+/// Minimal JPEG (SOI + APP0 JFIF + EOI) carrying the standard source GPS EXIF.
+#[cfg(feature = "xmp")]
+pub fn minimal_jpeg_with_source_gps() -> Vec<u8> {
+    let mut bytes = vec![
+        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+    ];
+    exif_with_source_gps()
+        .write_to_vec(&mut bytes, little_exif::filetype::FileExtension::JPEG)
+        .expect("write source GPS EXIF into minimal JPEG");
+    bytes
+}
+
+/// Structurally valid `ftyp`-only HEIC with no `meta` box, so it carries no
+/// EXIF item. Readers must treat it as media with no source GPS, not an error.
+#[cfg(feature = "xmp")]
+pub fn heif_ftyp_without_meta_bytes() -> Vec<u8> {
+    vec![
+        0, 0, 0, 24, b'f', b't', b'y', b'p', b'h', b'e', b'i', b'c', 0, 0, 0, 0, b'h', b'e', b'i',
+        b'c', b'm', b'i', b'f', b'1',
+    ]
+}
+
+/// Asserts an XMP packet carries the standard source GPS facts with the values
+/// `exif_with_source_gps` yields.
+#[cfg(feature = "xmp")]
+pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
+    use xmp_toolkit::xmp_ns;
+
+    let text = |name: &str| meta.property(xmp_ns::EXIF, name).expect(name).value;
+    assert_eq!(text("GPSDateTime"), SOURCE_GPS_DATETIME);
+    assert_eq!(text("GPSSpeedRef"), SOURCE_GPS_SPEED_REF);
+    assert_eq!(text("GPSSpeed"), SOURCE_GPS_SPEED);
+    assert_eq!(text("GPSHPositioningError"), SOURCE_GPS_H_POSITIONING_ERROR);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1054,6 +1054,39 @@ pub fn minimal_jpeg_with_source_gps() -> Vec<u8> {
     bytes
 }
 
+/// Minimal JPEG whose source EXIF location and capture time deliberately
+/// differ from the CloudKit values used by metadata writer tests.
+#[cfg(feature = "xmp")]
+pub fn minimal_jpeg_with_source_gps_and_location() -> Vec<u8> {
+    use little_exif::exif_tag::ExifTag;
+
+    let mut metadata = exif_with_source_gps();
+    metadata.set_tag(ExifTag::DateTimeOriginal("2030:01:02 03:04:05".into()));
+    metadata.set_tag(ExifTag::GPSLatitudeRef("N".into()));
+    metadata.set_tag(ExifTag::GPSLatitude(vec![
+        ur64(1, 1),
+        ur64(30, 1),
+        ur64(0, 1),
+    ]));
+    metadata.set_tag(ExifTag::GPSLongitudeRef("E".into()));
+    metadata.set_tag(ExifTag::GPSLongitude(vec![
+        ur64(2, 1),
+        ur64(30, 1),
+        ur64(0, 1),
+    ]));
+    metadata.set_tag(ExifTag::GPSAltitudeRef(vec![0]));
+    metadata.set_tag(ExifTag::GPSAltitude(vec![ur64(333, 1)]));
+
+    let mut bytes = vec![
+        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+    ];
+    metadata
+        .write_to_vec(&mut bytes, little_exif::filetype::FileExtension::JPEG)
+        .expect("write conflicting source EXIF into minimal JPEG");
+    bytes
+}
+
 /// Minimal little-endian TIFF carrying the standard source GPS EXIF.
 #[cfg(feature = "xmp")]
 pub fn minimal_tiff_with_source_gps() -> Vec<u8> {
@@ -1170,7 +1203,12 @@ pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
     assert_eq!(text("GPSTimeStamp"), SOURCE_GPS_DATETIME);
     assert_eq!(text("GPSSpeedRef"), SOURCE_GPS_SPEED_REF);
     assert_eq!(text("GPSSpeed"), SOURCE_GPS_SPEED);
-    assert_eq!(text("GPSHPositioningError"), SOURCE_GPS_H_POSITIONING_ERROR);
+    assert_eq!(
+        meta.property("http://cipa.jp/exif/1.0/", "GPSHPositioningError")
+            .expect("GPSHPositioningError")
+            .value,
+        SOURCE_GPS_H_POSITIONING_ERROR
+    );
 }
 
 #[cfg(test)]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1054,6 +1054,102 @@ pub fn minimal_jpeg_with_source_gps() -> Vec<u8> {
     bytes
 }
 
+/// Minimal little-endian TIFF carrying the standard source GPS EXIF.
+#[cfg(feature = "xmp")]
+pub fn minimal_tiff_with_source_gps() -> Vec<u8> {
+    minimal_tiff_with_source_gps_endian(false)
+}
+
+/// Minimal big-endian TIFF carrying the standard source GPS EXIF.
+#[cfg(feature = "xmp")]
+pub fn minimal_big_endian_tiff_with_source_gps() -> Vec<u8> {
+    minimal_tiff_with_source_gps_endian(true)
+}
+
+#[cfg(feature = "xmp")]
+fn minimal_tiff_with_source_gps_endian(big_endian: bool) -> Vec<u8> {
+    fn push_u16(bytes: &mut Vec<u8>, value: u16, big_endian: bool) {
+        let encoded = if big_endian {
+            value.to_be_bytes()
+        } else {
+            value.to_le_bytes()
+        };
+        bytes.extend_from_slice(&encoded);
+    }
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32, big_endian: bool) {
+        let encoded = if big_endian {
+            value.to_be_bytes()
+        } else {
+            value.to_le_bytes()
+        };
+        bytes.extend_from_slice(&encoded);
+    }
+
+    fn push_ifd_entry(
+        bytes: &mut Vec<u8>,
+        tag: u16,
+        value_type: u16,
+        count: u32,
+        value: u32,
+        big_endian: bool,
+    ) {
+        push_u16(bytes, tag, big_endian);
+        push_u16(bytes, value_type, big_endian);
+        push_u32(bytes, count, big_endian);
+        push_u32(bytes, value, big_endian);
+    }
+
+    const IFD0_OFFSET: u32 = 8;
+    const GPS_IFD_OFFSET: u32 = 26;
+    const GPS_DATE_OFFSET: u32 = 92;
+    const GPS_TIME_OFFSET: u32 = 104;
+    const GPS_SPEED_OFFSET: u32 = 128;
+    const GPS_ERROR_OFFSET: u32 = 136;
+
+    let mut bytes = Vec::with_capacity(144);
+    bytes.extend_from_slice(if big_endian { b"MM" } else { b"II" });
+    push_u16(&mut bytes, 42, big_endian);
+    push_u32(&mut bytes, IFD0_OFFSET, big_endian);
+
+    push_u16(&mut bytes, 1, big_endian);
+    push_ifd_entry(&mut bytes, 0x8825, 4, 1, GPS_IFD_OFFSET, big_endian);
+    push_u32(&mut bytes, 0, big_endian);
+
+    push_u16(&mut bytes, 5, big_endian);
+    push_ifd_entry(&mut bytes, 0x0007, 5, 3, GPS_TIME_OFFSET, big_endian);
+    push_ifd_entry(
+        &mut bytes,
+        0x000C,
+        2,
+        2,
+        if big_endian {
+            u32::from_be_bytes([b'K', 0, 0, 0])
+        } else {
+            u32::from_le_bytes([b'K', 0, 0, 0])
+        },
+        big_endian,
+    );
+    push_ifd_entry(&mut bytes, 0x000D, 5, 1, GPS_SPEED_OFFSET, big_endian);
+    push_ifd_entry(&mut bytes, 0x001D, 2, 11, GPS_DATE_OFFSET, big_endian);
+    push_ifd_entry(&mut bytes, 0x001F, 5, 1, GPS_ERROR_OFFSET, big_endian);
+    push_u32(&mut bytes, 0, big_endian);
+
+    bytes.extend_from_slice(b"2024:06:15\0");
+    bytes.push(0);
+    for (numerator, denominator) in [(10, 1), (20, 1), (30_125, 1_000)] {
+        push_u32(&mut bytes, numerator, big_endian);
+        push_u32(&mut bytes, denominator, big_endian);
+    }
+    push_u32(&mut bytes, 12_345, big_endian);
+    push_u32(&mut bytes, 100, big_endian);
+    push_u32(&mut bytes, 3, big_endian);
+    push_u32(&mut bytes, 2, big_endian);
+
+    debug_assert_eq!(bytes.len(), 144);
+    bytes
+}
+
 /// Structurally valid `ftyp`-only HEIC with no `meta` box, so it carries no
 /// EXIF item. Readers must treat it as media with no source GPS, not an error.
 #[cfg(feature = "xmp")]
@@ -1071,7 +1167,7 @@ pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
     use xmp_toolkit::xmp_ns;
 
     let text = |name: &str| meta.property(xmp_ns::EXIF, name).expect(name).value;
-    assert_eq!(text("GPSDateTime"), SOURCE_GPS_DATETIME);
+    assert_eq!(text("GPSTimeStamp"), SOURCE_GPS_DATETIME);
     assert_eq!(text("GPSSpeedRef"), SOURCE_GPS_SPEED_REF);
     assert_eq!(text("GPSSpeed"), SOURCE_GPS_SPEED);
     assert_eq!(text("GPSHPositioningError"), SOURCE_GPS_H_POSITIONING_ERROR);

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1203,11 +1203,10 @@ pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
     assert_eq!(text("GPSTimeStamp"), SOURCE_GPS_DATETIME);
     assert_eq!(text("GPSSpeedRef"), SOURCE_GPS_SPEED_REF);
     assert_eq!(text("GPSSpeed"), SOURCE_GPS_SPEED);
-    assert_eq!(
-        meta.property("http://cipa.jp/exif/1.0/", "GPSHPositioningError")
-            .expect("GPSHPositioningError")
-            .value,
-        SOURCE_GPS_H_POSITIONING_ERROR
+    assert_eq!(text("GPSHPositioningError"), SOURCE_GPS_H_POSITIONING_ERROR);
+    assert!(
+        !meta.contains_property("http://cipa.jp/exif/1.0/", "GPSHPositioningError"),
+        "Apple-compatible sidecars must not duplicate GPSHPositioningError in exifEX"
     );
 }
 


### PR DESCRIPTION
## Summary

XMP sidecars carried the CloudKit coordinates but nothing from the photo's own EXIF GPS block.  A comparison against icloudpd found 169 images where the GPS fix time, speed, and horizontal accuracy were simply missing.

kei now reads those tags from the downloaded file and writes them alongside the location.  `GPSSpeedRef` comes along too, since EXIF allows km/h, mph, or knots and a bare speed means nothing without it.

Media with no readable EXIF still gets its sidecar with the CloudKit metadata as before.

Fixes #725

## Contract and risk

`METADATA_WRITES_REQUIRE_OPT_IN` is unchanged.  Sidecars are separate files, so no media bytes are touched.

The four properties are registered in `MANAGED_XMP_FIELDS`, taking it from 17 to 21.  Without that kei could write them but never clear them.

One behaviour change: a file that exists but cannot be read now fails the sidecar and keeps its retry marker, instead of quietly writing a sidecar without the GPS facts.  Missing files are still skipped as before.

## Test plan

Rust 1.94.1 throughout.

```text
just gate
```

All steps pass except `lint-scripts`, which fails on pre-existing shellcheck findings in `tests/shell/`.  This branch touches no shell files and CI does not run shellcheck.

Verified against ExifTool 13.55.  A sidecar written through the production path reads back as `123.45 km/h`, `1.5 m`, and `2024:06:15 10:20:30.125Z`, matching the source EXIF exactly.  `exiftool -validate` returns OK.

## Regression proof

Focused tests cover the malformed cases one branch at a time: bad date, wrong timestamp arity, zero denominators, out-of-range hour, unsupported speed unit.  Each drops only the affected field and leaves the rest intact.

Two end-to-end tests run the real writer: one proves the facts reach the sidecar and survive a metadata retry, the other proves an EXIF-less HEIC still completes while an unreadable source keeps its marker.

## Checklist

- [x] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
