### PR TITLE
Make headless authentication fail fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Headless foreground login and one-shot sync now exit immediately with auth code 3 when 2FA needs operator action. The error prints the `kei login get-code` and `kei login submit-code <CODE>` flow. Watch and service processes keep their durable wait-and-resume behavior. `kei password set` now accepts password-file and password-command sources, and fails before prompting when stdin is not a terminal. ([#698])
 - A filtered sibling can no longer displace the child that owns a legacy master-keyed state row on the next sync. kei records the owner before planning downloads and reuses it during full sync, incremental sync, and pending retry. ([#721], fixes [#691])
 - A metadata-only iCloud edit (favourite, rating, keywords, caption, GPS) on an unchanged file now refreshes the catalogue during full enumeration and single-pass incremental sync. Changed provider metadata is applied before filtering and path planning, so the refresh reaches every downloaded version of the asset even when its media task is skipped as already on disk or excluded by a filter. The catalogue row and the rewrite marker commit together, so a queued sidecar or EXIF rewrite reads the corrected values instead of replaying stale ones, and no media is re-downloaded. ([#707], refs [#674])
 - A failed catalogue refresh now preserves the previous zone checkpoint instead of advancing past a provider edit that was never stored. ([#707])
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An embedded metadata rewrite now records the hash of the file it leaves on disk, keeping the pre-rewrite hash as the provider download checksum, so `kei verify --checksums` and `kei reconcile` read an intentional edit as intact rather than corrupted or truncated. A file that no longer matches its recorded checksum keeps its marker and is left untouched for those commands to report. ([#707])
 - Capture times now resolve from Apple's per-asset timezone offset when it is usable, so date filters, date-based folders, embedded EXIF, and XMP sidecars use the capture-local calendar date and timestamp. Assets without a usable offset retain the backup host's local rendering, preserving the previous behaviour and icloudpd-compatible paths. Existing files are not moved, and a later full sync downloads an affected asset into its capture-local folder while leaving the earlier copy in place. A date-only `skip_created_before` or `skip_created_after` makes that full sync the next one because the bound's capture-date semantics change the config hashes. `kei sync --refresh-metadata` rewrites XMP sidecars in full. For a timestamp already present in a file, it adds the capture offset only where the timestamp reads as capture-local. When embedded datetime output is configured, a file with no capture timestamp receives one, with the offset when Apple supplied it. (fixes [#703])
 
+[#698]: https://github.com/rhoopr/kei/issues/698
 [#703]: https://github.com/rhoopr/kei/issues/703
 
 ## [0.23.1] - 2026-08-16

--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ kei sync --recent 30d
 kei list albums
 ```
 
+### Headless authentication
+
+Use a password file or password command when stdin is not a terminal. To copy
+a password from a file into kei's credential store, run:
+
+```sh
+kei password --password-file /run/secrets/icloud_password set
+```
+
+If a foreground `login` or one-shot `sync` needs 2FA, kei exits with auth code
+`3` and prints the recovery commands. Complete the login, then retry the
+foreground command:
+
+```sh
+kei login get-code
+kei login submit-code 123456
+```
+
+Watch and service processes stay running while they wait for the submitted
+code. They resume from the saved authentication state.
+
 ## What kei gives you
 
 - Fast, parallel downloads for large cloud photo libraries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,14 @@ The CLI requires a subcommand. `kei sync` enters the sync path. Commands such
 as `status`, `doctor`, and `manifest` read local state without entering the
 normal iCloud sync loop.
 
+`main_inner` records whether stdin is interactive before it starts the async
+runtime. Command owners use that single input mode for password and 2FA
+prompts. A foreground command returns `TwoFactorRequired` to the exit
+classifier, which reports auth exit code 3 and the `login get-code` and
+`login submit-code` recovery flow. Only the sync owner may convert that error
+into a durable wait, and only when the resolved configuration is in watch or
+service mode.
+
 ### Sync and provider checkpoints
 
 ```text
@@ -284,6 +292,10 @@ uses a redacting writer as a backstop, but code must not send Apple IDs,
 passwords, session cookies, bearer tokens, or unredacted provider identifiers
 to logs or machine output. Preserve process hardening that limits credential
 exposure through core dumps.
+
+`password set` prompts only in interactive input mode. Headless callers must
+use a password file or password command. The command resolves the secret and
+passes it directly to the credential store without printing it.
 
 ## Safety contract catalog
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -21,7 +21,6 @@ pub(crate) const AUTH_RETRY_CONFIG: RetryConfig = RetryConfig {
     max_delay_secs: 30,
 };
 
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -107,9 +106,12 @@ fn classify_auth_flow_error(err: &anyhow::Error) -> AuthFlowErrorClass {
 ///    otherwise prompts the user interactively.
 /// 5. Returns the authenticated session and account data.
 ///
-/// When `code` is `None` and 2FA is required but stdin is not a TTY,
-/// returns `AuthError::TwoFactorRequired` so the caller can handle it
-/// (e.g., fire a notification script and wait).
+/// When `code` is `None` and the captured input mode disallows prompts,
+/// returns `AuthError::TwoFactorRequired` so the caller can handle it.
+#[allow(
+    dead_code,
+    reason = "kept as the default-input wrapper for internal auth integrations; CLI owners use the startup snapshot"
+)]
 pub async fn authenticate(
     cookie_dir: &Path,
     apple_id: &str,
@@ -119,7 +121,7 @@ pub async fn authenticate(
     timeout_secs: Option<u64>,
     code: Option<&str>,
 ) -> Result<AuthResult> {
-    authenticate_with_mode(
+    authenticate_with_modes(
         cookie_dir,
         apple_id,
         password_provider,
@@ -128,6 +130,32 @@ pub async fn authenticate(
         timeout_secs,
         code,
         crate::personality::Mode::Off,
+        crate::InputMode::detect(),
+    )
+    .await
+}
+
+/// Authenticate using the process input mode captured at startup.
+pub(crate) async fn authenticate_in_input_mode(
+    cookie_dir: &Path,
+    apple_id: &str,
+    password_provider: &crate::password::PasswordProvider,
+    domain: &str,
+    client_id: Option<String>,
+    timeout_secs: Option<u64>,
+    code: Option<&str>,
+    input_mode: crate::InputMode,
+) -> Result<AuthResult> {
+    authenticate_with_modes(
+        cookie_dir,
+        apple_id,
+        password_provider,
+        domain,
+        client_id,
+        timeout_secs,
+        code,
+        crate::personality::Mode::Off,
+        input_mode,
     )
     .await
 }
@@ -139,6 +167,10 @@ pub async fn authenticate(
     clippy::too_many_arguments,
     reason = "mode is a UX gate that doesn't fit any existing struct param without muddying its semantics"
 )]
+#[allow(
+    dead_code,
+    reason = "kept as the output-mode wrapper for internal auth integrations; CLI owners also pass the startup input snapshot"
+)]
 pub async fn authenticate_with_mode(
     cookie_dir: &Path,
     apple_id: &str,
@@ -149,6 +181,42 @@ pub async fn authenticate_with_mode(
     code: Option<&str>,
     mode: crate::personality::Mode,
 ) -> Result<AuthResult> {
+    authenticate_with_modes(
+        cookie_dir,
+        apple_id,
+        password_provider,
+        domain,
+        client_id,
+        timeout_secs,
+        code,
+        mode,
+        crate::InputMode::detect(),
+    )
+    .await
+}
+
+/// Authenticate with caller-resolved output and input modes.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "input and personality modes are independent startup policies"
+)]
+pub(crate) async fn authenticate_with_modes(
+    cookie_dir: &Path,
+    apple_id: &str,
+    password_provider: &crate::password::PasswordProvider,
+    domain: &str,
+    client_id: Option<String>,
+    timeout_secs: Option<u64>,
+    code: Option<&str>,
+    mode: crate::personality::Mode,
+    input_mode: crate::InputMode,
+) -> Result<AuthResult> {
+    #[cfg(debug_assertions)]
+    if std::env::var("KEI_UNSTABLE_FAKE_TWO_FACTOR_REQUIRED_FOR_TESTS").as_deref() == Ok("1") {
+        tracing::warn!("Offline 2FA-required test seam enabled; skipping Apple authentication");
+        return Err(AuthError::TwoFactorRequired.into());
+    }
+
     let endpoints = Endpoints::for_domain(domain)?;
     let session = Session::new(cookie_dir, apple_id, endpoints.home, timeout_secs).await?;
     authenticate_inner(
@@ -160,6 +228,7 @@ pub async fn authenticate_with_mode(
         client_id,
         code,
         mode,
+        input_mode,
     )
     .await
 }
@@ -177,6 +246,7 @@ async fn authenticate_inner(
     client_id: Option<String>,
     code: Option<&str>,
     mode: crate::personality::Mode,
+    input_mode: crate::InputMode,
 ) -> Result<AuthResult> {
     // Prefer persisted client_id to maintain session continuity across runs
     let client_id = session
@@ -354,7 +424,7 @@ async fn authenticate_inner(
 
         // Headless with no code: bail without any Apple API calls.
         // The user triggers the push manually via `get-code`.
-        if code.is_none() && !std::io::stdin().is_terminal() {
+        if code.is_none() && !input_mode.can_prompt() {
             return Err(AuthError::TwoFactorRequired.into());
         }
 
@@ -1031,6 +1101,7 @@ mod tests {
             None,
             None,
             crate::personality::Mode::Off,
+            crate::InputMode::Interactive,
         )
         .await
         .expect("live validate success should authenticate the persisted session");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -453,7 +453,10 @@ pub enum ListCommand {
 /// Password management actions.
 #[derive(Subcommand, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PasswordAction {
-    /// Store a password in the credential store (prompts interactively)
+    /// Store a password from a prompt, password file, or password command
+    #[command(
+        after_help = "Headless examples:\n  kei password --password-file <PATH> set\n  kei password --password-command <COMMAND> set"
+    )]
     Set,
     /// Remove a stored password
     Clear,

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -841,6 +841,7 @@ pub(crate) async fn run_import_existing(
     args: cli::ImportArgs,
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let shutdown_token = crate::shutdown::install_signal_handler(
         SystemdNotifier::new(false),
@@ -885,9 +886,10 @@ pub(crate) async fn run_import_existing(
         &username,
         &cookie_directory,
         toml,
+        input_mode,
     );
 
-    let auth_result = auth::authenticate(
+    let auth_result = auth::authenticate_in_input_mode(
         &cookie_directory,
         &username,
         &password_provider,
@@ -895,6 +897,7 @@ pub(crate) async fn run_import_existing(
         None,
         None,
         None,
+        input_mode,
     )
     .await?;
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -18,6 +18,7 @@ pub(crate) async fn run_list(
     cli_libraries: Vec<String>,
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
@@ -27,11 +28,17 @@ pub(crate) async fn run_list(
         );
     }
 
-    let password_provider =
-        super::super::make_provider_from_auth(pw, password, &username, &cookie_directory, toml);
+    let password_provider = super::super::make_provider_from_auth(
+        pw,
+        password,
+        &username,
+        &cookie_directory,
+        toml,
+        input_mode,
+    );
 
     let auth_result = retry_on_lock_contention(|| {
-        auth::authenticate(
+        auth::authenticate_in_input_mode(
             &cookie_directory,
             &username,
             &password_provider,
@@ -39,6 +46,7 @@ pub(crate) async fn run_list(
             None,
             None,
             None,
+            input_mode,
         )
     })
     .await?;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -15,6 +15,7 @@ pub(crate) async fn run_login(
     pw: &cli::PasswordArgs,
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let (username, password, domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
@@ -24,8 +25,14 @@ pub(crate) async fn run_login(
         );
     }
 
-    let password_provider =
-        super::super::make_provider_from_auth(pw, password, &username, &cookie_directory, toml);
+    let password_provider = super::super::make_provider_from_auth(
+        pw,
+        password,
+        &username,
+        &cookie_directory,
+        toml,
+        input_mode,
+    );
 
     match subcommand {
         Some(cli::LoginCommand::GetCode) => {
@@ -43,7 +50,7 @@ pub(crate) async fn run_login(
         }
         Some(cli::LoginCommand::SubmitCode { code }) => {
             let result = retry_on_lock_contention(|| {
-                auth::authenticate(
+                auth::authenticate_in_input_mode(
                     &cookie_directory,
                     &username,
                     &password_provider,
@@ -51,6 +58,7 @@ pub(crate) async fn run_login(
                     None,
                     None,
                     Some(&code),
+                    input_mode,
                 )
             })
             .await?;
@@ -63,7 +71,7 @@ pub(crate) async fn run_login(
         None => {
             // Bare "kei login" = auth-only
             retry_on_lock_contention(|| {
-                auth::authenticate(
+                auth::authenticate_in_input_mode(
                     &cookie_directory,
                     &username,
                     &password_provider,
@@ -71,6 +79,7 @@ pub(crate) async fn run_login(
                     None,
                     None,
                     None,
+                    input_mode,
                 )
             })
             .await?;

--- a/src/commands/password.rs
+++ b/src/commands/password.rs
@@ -6,6 +6,7 @@
 use crate::cli;
 use crate::config;
 use crate::credential;
+use crate::password::{self, ExposeSecret, SecretString};
 
 /// Run the password subcommand: set, clear, or show backend.
 pub(crate) fn run_password(
@@ -13,6 +14,7 @@ pub(crate) fn run_password(
     globals: &config::GlobalArgs,
     pw: &cli::PasswordArgs,
     toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let (username, _password, _domain, cookie_directory) = config::resolve_auth(globals, pw, toml);
 
@@ -26,10 +28,8 @@ pub(crate) fn run_password(
 
     match action {
         cli::PasswordAction::Set => {
-            let input = rpassword::prompt_password("iCloud Password: ")
-                .map_err(|e| anyhow::anyhow!("Could not read password: {e}"))?;
-            anyhow::ensure!(!input.is_empty(), "Password cannot be empty.");
-            let backend = store.store(&input)?;
+            let input = password_set_input(pw, toml, input_mode)?;
+            let backend = store.store(input.expose_secret())?;
             println!("Password stored in {} backend.", backend.as_str());
         }
         cli::PasswordAction::Clear => {
@@ -41,4 +41,29 @@ pub(crate) fn run_password(
         }
     }
     Ok(())
+}
+
+fn password_set_input(
+    pw: &cli::PasswordArgs,
+    toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
+) -> anyhow::Result<SecretString> {
+    let toml_auth = toml.and_then(|config| config.auth.as_ref());
+    if let Some(command) = config::resolve_password_command(pw, toml_auth) {
+        return password::run_password_command(&command);
+    }
+    if let Some(path) = config::resolve_password_file(pw, toml_auth) {
+        return password::read_password_file(&path);
+    }
+
+    if !input_mode.can_prompt() {
+        anyhow::bail!(
+            "`kei password set` cannot prompt because stdin is not a terminal. Use `kei password --password-file <PATH> set` or `kei password --password-command <COMMAND> set` to provide the password from a safe headless source."
+        );
+    }
+
+    let input = rpassword::prompt_password("iCloud Password: ")
+        .map_err(|e| anyhow::anyhow!("Could not read password: {e}"))?;
+    anyhow::ensure!(!input.is_empty(), "Password cannot be empty.");
+    Ok(SecretString::from(input))
 }

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -59,6 +59,7 @@ pub(crate) async fn run_reset_sync_token(
     yes: bool,
     globals: &config::GlobalArgs,
     toml: Option<&config::TomlConfig>,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let db_path = super::super::get_db_path(globals, toml)?;
 
@@ -68,9 +69,8 @@ pub(crate) async fn run_reset_sync_token(
     }
 
     if !yes {
-        use std::io::IsTerminal;
         use std::io::Write;
-        if !std::io::stdin().is_terminal() {
+        if !input_mode.can_prompt() {
             anyhow::bail!(
                 "`kei reset sync-token` needs `--yes` when stdin is not a terminal. The next sync will re-enumerate every asset, which can take a long time on a large library."
             );

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -160,6 +160,7 @@ pub(crate) async fn attempt_reauth(
     username: &str,
     domain: &str,
     password_provider: &crate::password::PasswordProvider,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let mut session = shared_session.write().await;
 
@@ -180,7 +181,7 @@ pub(crate) async fn attempt_reauth(
     session.release_lock()?;
     drop(session);
 
-    let new_auth = auth::authenticate(
+    let new_auth = auth::authenticate_in_input_mode(
         cookie_directory,
         username,
         password_provider,
@@ -188,6 +189,7 @@ pub(crate) async fn attempt_reauth(
         None,
         None,
         None, // no code — interactive prompt or TwoFactorRequired
+        input_mode,
     )
     .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,35 @@ use std::sync::Arc;
 
 use password::{ExposeSecret, SecretString};
 
+/// Whether this process can ask the operator for input.
+///
+/// Detect this once before the async runtime starts, then pass the result to
+/// command owners. This prevents prompt and wait policy from drifting when a
+/// command runs under cron, CI, Docker, or a service manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputMode {
+    Interactive,
+    NoInput,
+}
+
+impl InputMode {
+    #[must_use]
+    fn detect() -> Self {
+        use std::io::IsTerminal;
+
+        if std::io::stdin().is_terminal() {
+            Self::Interactive
+        } else {
+            Self::NoInput
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn can_prompt(self) -> bool {
+        matches!(self, Self::Interactive)
+    }
+}
+
 /// A writer wrapper that redacts a password string from log output.
 ///
 /// Wraps any `io::Write` implementor and replaces occurrences of the
@@ -294,14 +323,9 @@ const EXIT_TERMINAL_AUTH: u8 = 4;
 #[error("{0} sync failures")]
 struct PartialSyncError(usize);
 
-/// Maps a fatal `Err` from `run` to an exit code and decides whether to
-/// log it. `TwoFactorRequired` is the non-obvious case: exit 0, no log.
+/// Maps a fatal `Err` from `run` to an exit code and decides whether to log it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExitClassification {
-    /// Exit 0 with no error log: kei already told the user how to
-    /// proceed, and `restart: on-failure` would loop Apple's auth
-    /// endpoint if 2FA were treated as a failure.
-    TwoFactorRequired,
     Partial,
     Auth,
     TerminalAuth,
@@ -311,7 +335,6 @@ enum ExitClassification {
 impl ExitClassification {
     const fn exit_code(self) -> u8 {
         match self {
-            Self::TwoFactorRequired => 0,
             Self::Partial => EXIT_PARTIAL,
             Self::Auth => EXIT_AUTH,
             Self::TerminalAuth => EXIT_TERMINAL_AUTH,
@@ -320,7 +343,7 @@ impl ExitClassification {
     }
 
     const fn should_log(self) -> bool {
-        !matches!(self, Self::TwoFactorRequired)
+        true
     }
 
     const fn should_suggest_diagnostics(self) -> bool {
@@ -332,7 +355,7 @@ fn classify_exit_error(e: &anyhow::Error) -> ExitClassification {
     if e.downcast_ref::<auth::error::AuthError>()
         .is_some_and(auth::error::AuthError::is_two_factor_required)
     {
-        ExitClassification::TwoFactorRequired
+        ExitClassification::Auth
     } else if e
         .downcast_ref::<auth::error::AuthError>()
         .is_some_and(auth::error::AuthError::is_terminal_apple_auth)
@@ -479,8 +502,11 @@ pub(crate) fn check_min_disk_space(available_bytes: u64, directory: &Path) -> an
 /// path can dispatch invocations through `spawn_blocking` (see
 /// [`password::invoke_password_provider`]) instead of calling the
 /// blocking `resolve()` directly on a tokio worker.
-fn make_password_provider(source: password::PasswordSource) -> password::PasswordProvider {
-    std::sync::Arc::new(move || match source.resolve() {
+fn make_password_provider(
+    source: password::PasswordSource,
+    input_mode: InputMode,
+) -> password::PasswordProvider {
+    std::sync::Arc::new(move || match source.resolve_in_mode(input_mode) {
         Ok(pw) => pw,
         Err(e) => {
             tracing::error!(error = %e, "Password source resolution failed");
@@ -498,6 +524,7 @@ fn make_provider_from_auth(
     username: &str,
     cookie_directory: &Path,
     toml: Option<&config::TomlConfig>,
+    input_mode: InputMode,
 ) -> password::PasswordProvider {
     let toml_auth = toml.and_then(|t| t.auth.as_ref());
     let password_command = config::resolve_password_command(pw, toml_auth);
@@ -508,7 +535,7 @@ fn make_provider_from_auth(
         password_file.as_deref(),
         credential::CredentialStore::new(username, cookie_directory),
     );
-    make_password_provider(source)
+    make_password_provider(source, input_mode)
 }
 
 use commands::{
@@ -614,6 +641,8 @@ impl Drop for PidFileGuard {
 /// of the lib so it's reachable from integration tests, fuzz harnesses,
 /// and any future companion binaries.
 pub fn main_inner() -> ExitCode {
+    let input_mode = InputMode::detect();
+
     // Snapshot and scrub the password env var while truly single-threaded,
     // before the tokio runtime creates worker threads.
     let env_password = std::env::var("ICLOUD_PASSWORD")
@@ -631,7 +660,7 @@ pub fn main_inner() -> ExitCode {
         .build()
         .expect("Failed to create tokio runtime");
 
-    match rt.block_on(run(env_password)) {
+    match rt.block_on(run(env_password, input_mode)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             if let Some(parse_exit) = classify_cli_parse_exit(&e) {
@@ -670,7 +699,7 @@ pub fn main_inner() -> ExitCode {
     }
 }
 
-async fn run(env_password: Option<String>) -> anyhow::Result<()> {
+async fn run(env_password: Option<String>, input_mode: InputMode) -> anyhow::Result<()> {
     let cli = cli::parse_cli_with_sources(std::env::args_os()).map_err(|e| anyhow::anyhow!(e))?;
 
     // Load TOML config early so it can influence log level.
@@ -844,7 +873,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 return run_reset_state(yes, &globals, toml_config.as_ref()).await;
             }
             cli::ResetCommand::SyncToken { yes } => {
-                return run_reset_sync_token(yes, &globals, toml_config.as_ref()).await;
+                return run_reset_sync_token(yes, &globals, toml_config.as_ref(), input_mode).await;
             }
         },
         Command::Verify(args) => {
@@ -854,23 +883,44 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             return run_reconcile(args, &globals, toml_config.as_ref()).await;
         }
         Command::ImportExisting(args) => {
-            return run_import_existing(args, &globals, toml_config.as_ref()).await;
+            return run_import_existing(args, &globals, toml_config.as_ref(), input_mode).await;
         }
         Command::Login {
             password,
             subcommand,
         } => {
-            return run_login(subcommand, &password, &globals, toml_config.as_ref()).await;
+            return run_login(
+                subcommand,
+                &password,
+                &globals,
+                toml_config.as_ref(),
+                input_mode,
+            )
+            .await;
         }
         Command::Password { password, action } => {
-            return run_password(action, &globals, &password, toml_config.as_ref());
+            return run_password(
+                action,
+                &globals,
+                &password,
+                toml_config.as_ref(),
+                input_mode,
+            );
         }
         Command::List {
             password,
             libraries,
             what,
         } => {
-            return run_list(what, &password, libraries, &globals, toml_config.as_ref()).await;
+            return run_list(
+                what,
+                &password,
+                libraries,
+                &globals,
+                toml_config.as_ref(),
+                input_mode,
+            )
+            .await;
         }
         Command::Config { action } => match action {
             cli::ConfigAction::Show => {
@@ -878,7 +928,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             }
             cli::ConfigAction::Setup { output } => {
                 let path = output.map_or_else(|| config_path.clone(), |o| config::expand_tilde(&o));
-                match setup::run_setup(&path)? {
+                match setup::run_setup(&path, input_mode)? {
                     setup::SetupResult::SyncNow {
                         config_path: cfg_path,
                         one_shot_password,
@@ -921,6 +971,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                         // already Off here, but pass through for symmetry.
                         personality_mode,
                         friendly_request,
+                        input_mode,
                     },
                 ))
                 .await;
@@ -941,6 +992,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             redact_password: Arc::clone(&redact_password),
             personality_mode,
             friendly_request,
+            input_mode,
         },
     ))
     .await
@@ -950,6 +1002,12 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use tracing_subscriber::EnvFilter;
+
+    #[test]
+    fn input_mode_only_allows_interactive_prompts() {
+        assert!(InputMode::Interactive.can_prompt());
+        assert!(!InputMode::NoInput.can_prompt());
+    }
 
     #[test]
     fn pid_file_guard_creates_and_removes() {
@@ -1338,7 +1396,7 @@ mod tests {
     #[test]
     fn make_password_provider_with_direct_source() {
         let source = password::PasswordSource::Direct(Arc::new(SecretString::from("mypass")));
-        let provider = make_password_provider(source);
+        let provider = make_password_provider(source, InputMode::Interactive);
         let result = provider().unwrap();
         assert_eq!(result.expose_secret(), "mypass");
         // Can be called multiple times
@@ -1353,7 +1411,7 @@ mod tests {
     #[test]
     fn make_password_provider_with_command_source() {
         let source = password::PasswordSource::Command("echo cmd_test".to_string());
-        let provider = make_password_provider(source);
+        let provider = make_password_provider(source, InputMode::Interactive);
         let result = provider().unwrap();
         assert_eq!(result.expose_secret(), "cmd_test");
     }
@@ -1490,15 +1548,12 @@ mod tests {
     }
 
     #[test]
-    fn classify_exit_error_two_factor_required_is_suppressed_success() {
+    fn classify_exit_error_two_factor_required_uses_auth_failure() {
         let e: anyhow::Error = auth::error::AuthError::TwoFactorRequired.into();
         let c = classify_exit_error(&e);
-        assert_eq!(c, ExitClassification::TwoFactorRequired);
-        assert_eq!(c.exit_code(), 0);
-        assert!(
-            !c.should_log(),
-            "2FA-required must not emit a final error log; that path is the success branch"
-        );
+        assert_eq!(c, ExitClassification::Auth);
+        assert_eq!(c.exit_code(), EXIT_AUTH);
+        assert!(c.should_log());
     }
 
     #[test]
@@ -1584,9 +1639,8 @@ mod tests {
             .context("during startup");
         assert_eq!(
             classify_exit_error(&e),
-            ExitClassification::TwoFactorRequired,
-            "AuthError wrapped in .context() must still classify as 2FA-required; \
-             otherwise context-wrapping at any call site silently flips exit 0 -> exit 1"
+            ExitClassification::Auth,
+            "context-wrapped 2FA-required must keep the documented auth exit code"
         );
 
         let e: anyhow::Error =
@@ -1605,7 +1659,6 @@ mod tests {
     #[test]
     fn classify_exit_error_codes_are_distinct() {
         let codes = [
-            ExitClassification::TwoFactorRequired.exit_code(),
             ExitClassification::Partial.exit_code(),
             ExitClassification::Auth.exit_code(),
             ExitClassification::TerminalAuth.exit_code(),

--- a/src/password.rs
+++ b/src/password.rs
@@ -8,7 +8,6 @@
 //! command, credential store, interactive prompt) and evaluates lazily — the
 //! password is only fetched at auth time and released immediately after.
 
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 // Permissive-mode warnings are unix-only (Windows has no POSIX mode bits).
@@ -115,14 +114,26 @@ impl PasswordSource {
     /// For [`Command`](Self::Command) and [`File`](Self::File) sources, this
     /// re-executes the command or re-reads the file each time, supporting
     /// password rotation and external secret managers.
+    #[allow(
+        dead_code,
+        reason = "kept as the default-input wrapper; CLI providers use the startup input snapshot"
+    )]
     pub fn resolve(&self) -> anyhow::Result<Option<SecretString>> {
+        self.resolve_in_mode(crate::InputMode::detect())
+    }
+
+    /// Evaluate the source using the input mode captured at process startup.
+    pub(crate) fn resolve_in_mode(
+        &self,
+        input_mode: crate::InputMode,
+    ) -> anyhow::Result<Option<SecretString>> {
         match self {
             Self::Direct(s) => Ok(Some(SecretString::from(s.expose_secret().to_owned()))),
             Self::Command(cmd) => run_password_command(cmd).map(Some),
             Self::File(path) => read_password_file(path).map(Some),
             Self::Store(store) => store.retrieve(),
             Self::Interactive => {
-                if !std::io::stdin().is_terminal() {
+                if !input_mode.can_prompt() {
                     anyhow::bail!(
                         "No iCloud password is configured, and kei cannot prompt because stdin is not a terminal. \
                          Set a password with one of:\n  \
@@ -628,6 +639,15 @@ mod tests {
             }
             other => panic!("expected SkipWithWarning, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn interactive_source_rejects_no_input_mode_before_prompting() {
+        let error = PasswordSource::Interactive
+            .resolve_in_mode(crate::InputMode::NoInput)
+            .expect_err("headless password lookup must not prompt");
+
+        assert!(error.to_string().contains("stdin is not a terminal"));
     }
 
     // ── check_password_file_mode (unix-only) ────────────────────────

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,7 +4,6 @@
 )]
 
 use std::fmt::Write as FmtWrite;
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -232,8 +231,11 @@ fn print_toml_preview(toml_content: &str) {
     println!();
 }
 
-pub(crate) fn run_setup(config_path: &Path) -> anyhow::Result<SetupResult> {
-    if !std::io::stdin().is_terminal() {
+pub(crate) fn run_setup(
+    config_path: &Path,
+    input_mode: crate::InputMode,
+) -> anyhow::Result<SetupResult> {
+    if !input_mode.can_prompt() {
         bail!("The setup wizard needs an interactive terminal.");
     }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -82,6 +82,12 @@ fn classify_sync_auth_error(err: &anyhow::Error) -> SyncAuthErrorClass {
     }
 }
 
+fn two_factor_recovery_message(username: &str) -> String {
+    format!(
+        "2FA required for {username}. Run `kei login get-code`, then `kei login submit-code <CODE>`."
+    )
+}
+
 impl WatchPrecheck {
     fn proceed_all() -> Self {
         Self::Proceed {
@@ -497,6 +503,8 @@ pub(crate) struct SyncArgs {
     /// resolved Config exposes the same intent the gate saw, useful for
     /// downstream code that wants to know whether the user opted in.
     pub friendly_request: Option<bool>,
+    /// Whether startup detected a terminal on stdin.
+    pub input_mode: crate::InputMode,
 }
 
 /// Run the sync command: authenticate, enumerate photos, download, and
@@ -513,6 +521,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         redact_password,
         personality_mode,
         friendly_request,
+        input_mode,
     } = args;
 
     let is_retry_failed = sync.retry_failed;
@@ -569,6 +578,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             "service mode: applied default watch interval"
         );
     }
+    let is_watch_mode = config.watch.interval.is_some();
 
     // Install password redaction now that we know the password
     if let Some(pw) = &config.auth.password
@@ -664,9 +674,9 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .auth
         .save_password
         .then(|| password::decide_save_password_action(&source));
-    let password_provider = make_password_provider(source);
+    let password_provider = make_password_provider(source, input_mode);
 
-    let auth_result = match auth::authenticate_with_mode(
+    let auth_result = match auth::authenticate_with_modes(
         &config.auth.cookie_directory,
         &config.auth.username,
         &password_provider,
@@ -675,15 +685,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         None,
         None,
         config.ui.personality_mode,
+        input_mode,
     )
     .await
     {
         Ok(result) => result,
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
-            let msg = format!(
-                "2FA required for {u}. Run: kei login get-code",
-                u = config.auth.username
-            );
+            if !should_wait_for_2fa(is_watch_mode, &e) {
+                return Err(e);
+            }
+            let msg = two_factor_recovery_message(&config.auth.username);
             tracing::warn!(message = %msg, "2FA required");
             notifier.notify(
                 notifications::Event::TwoFaRequired,
@@ -694,7 +705,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             );
 
             wait_and_retry_2fa(&config.auth.cookie_directory, &config.auth.username, || {
-                auth::authenticate_with_mode(
+                auth::authenticate_with_modes(
                     &config.auth.cookie_directory,
                     &config.auth.username,
                     &password_provider,
@@ -703,6 +714,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     None,
                     None,
                     config.ui.personality_mode,
+                    input_mode,
                 )
             })
             .await?
@@ -770,8 +782,15 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 );
                 retried_after_session_error = true;
                 pending_auth = Some(
-                    reauth_after_session_error(&config, &password_provider, &notifier, None)
-                        .await?,
+                    reauth_after_session_error(
+                        &config,
+                        &password_provider,
+                        &notifier,
+                        None,
+                        is_watch_mode,
+                        input_mode,
+                    )
+                    .await?,
                 );
                 continue;
             }
@@ -791,6 +810,8 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                         &password_provider,
                         &notifier,
                         Some((ss, ps)),
+                        is_watch_mode,
+                        input_mode,
                     )
                     .await?,
                 );
@@ -1004,7 +1025,6 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         None
     };
 
-    let is_watch_mode = config.watch.interval.is_some();
     let mut reauth_attempts = 0u32;
     // Sum of per-cycle failed_counts across the lifetime of this process.
     // Surfaced at exit so watch-mode daemons don't mask earlier-cycle
@@ -1320,6 +1340,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     &config.auth.username,
                     config.auth.domain.as_str(),
                     &password_provider,
+                    input_mode,
                 )
                 .await
                 {
@@ -1336,10 +1357,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                         // can't exhaust the limit.
                         reauth_attempts -= 1;
 
-                        let msg = format!(
-                            "2FA required for {u}. Run: kei login get-code",
-                            u = config.auth.username
-                        );
+                        let msg = two_factor_recovery_message(&config.auth.username);
                         tracing::warn!(message = %msg, "2FA required");
                         notifier.notify(
                             notifications::Event::TwoFaRequired,
@@ -1362,6 +1380,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                                     &config.auth.username,
                                     config.auth.domain.as_str(),
                                     &password_provider,
+                                    input_mode,
                                 )
                             },
                         )
@@ -1434,7 +1453,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             }
 
             // Validate session before next cycle; re-authenticate if expired.
-            reacquire_session(&shared_session, &config, &password_provider).await?;
+            reacquire_session(&shared_session, &config, &password_provider, input_mode).await?;
 
             // Mark album/pass plans stale after an idle sleep, but defer the
             // CloudKit refresh until `changes/database` says a selected
@@ -1556,6 +1575,8 @@ async fn reauth_after_session_error(
     password_provider: &crate::password::PasswordProvider,
     notifier: &Notifier,
     live: Option<(auth::SharedSession, crate::icloud::photos::PhotosService)>,
+    is_watch_mode: bool,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<auth::AuthResult> {
     if let Some((ss, ps)) = live {
         ss.read().await.release_lock()?;
@@ -1564,15 +1585,19 @@ async fn reauth_after_session_error(
     }
 
     clear_validation_cache_for_reauth(&config.auth.cookie_directory, &config.auth.username).await;
-    match authenticate_sync_session(config, password_provider).await {
+    match authenticate_sync_session(config, password_provider, input_mode).await {
         Ok(result) => return Ok(result),
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
             if let Some(result) =
-                retry_persisted_session_after_two_factor(config, password_provider).await
+                retry_persisted_session_after_two_factor(config, password_provider, input_mode)
+                    .await
             {
                 return Ok(result);
             }
-            return notify_and_wait_for_2fa(config, password_provider, notifier).await;
+            if !should_wait_for_2fa(is_watch_mode, &e) {
+                return Err(e);
+            }
+            return notify_and_wait_for_2fa(config, password_provider, notifier, input_mode).await;
         }
         Err(e) => {
             tracing::warn!(
@@ -1586,15 +1611,19 @@ async fn reauth_after_session_error(
         auth::session_file_path(&config.auth.cookie_directory, &config.auth.username);
     auth::strip_session_routing_state(&session_file).await;
 
-    match authenticate_sync_session(config, password_provider).await {
+    match authenticate_sync_session(config, password_provider, input_mode).await {
         Ok(result) => Ok(result),
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
             if let Some(result) =
-                retry_persisted_session_after_two_factor(config, password_provider).await
+                retry_persisted_session_after_two_factor(config, password_provider, input_mode)
+                    .await
             {
                 return Ok(result);
             }
-            notify_and_wait_for_2fa(config, password_provider, notifier).await
+            if !should_wait_for_2fa(is_watch_mode, &e) {
+                return Err(e);
+            }
+            notify_and_wait_for_2fa(config, password_provider, notifier, input_mode).await
         }
         Err(e) => Err(e),
     }
@@ -1618,8 +1647,9 @@ async fn clear_validation_cache_for_reauth(cookie_dir: &std::path::Path, usernam
 async fn authenticate_sync_session(
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<auth::AuthResult> {
-    auth::authenticate_with_mode(
+    auth::authenticate_with_modes(
         &config.auth.cookie_directory,
         &config.auth.username,
         password_provider,
@@ -1628,6 +1658,7 @@ async fn authenticate_sync_session(
         None,
         None,
         config.ui.personality_mode,
+        input_mode,
     )
     .await
 }
@@ -1635,12 +1666,13 @@ async fn authenticate_sync_session(
 async fn retry_persisted_session_after_two_factor(
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
+    input_mode: crate::InputMode,
 ) -> Option<auth::AuthResult> {
     tracing::debug!(
         "2FA-required auth wrote session state; retrying persisted-session auth once before waiting"
     );
     clear_validation_cache_for_reauth(&config.auth.cookie_directory, &config.auth.username).await;
-    match authenticate_sync_session(config, password_provider).await {
+    match authenticate_sync_session(config, password_provider, input_mode).await {
         Ok(result) => Some(result),
         Err(e) => {
             tracing::debug!(
@@ -1656,11 +1688,9 @@ async fn notify_and_wait_for_2fa(
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
     notifier: &Notifier,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<auth::AuthResult> {
-    let msg = format!(
-        "2FA required for {u}. Run: kei login get-code",
-        u = config.auth.username
-    );
+    let msg = two_factor_recovery_message(&config.auth.username);
     tracing::warn!(message = %msg, "2FA required");
     notifier.notify(
         notifications::Event::TwoFaRequired,
@@ -1670,7 +1700,7 @@ async fn notify_and_wait_for_2fa(
         None,
     );
     wait_and_retry_2fa(&config.auth.cookie_directory, &config.auth.username, || {
-        authenticate_sync_session(config, password_provider)
+        authenticate_sync_session(config, password_provider, input_mode)
     })
     .await
 }
@@ -1938,12 +1968,9 @@ pub(crate) fn should_reconcile_this_cycle(cycle_index: u64, every_n: Option<u64>
 /// a cron, the systemd unit's first start) needs the error so it can exit
 /// non-zero and the operator can run `kei login get-code`.
 ///
-/// Note that the **entry-point** auth path (`run_sync`'s initial
-/// `auth::authenticate` call) intentionally does NOT use this predicate --
-/// it always parks on `wait_and_retry_2fa` because the user is presumed
-/// present at a terminal during the initial command. This helper exists
-/// because the *reauth* branch fires mid-cycle, by which point a one-shot
-/// caller has long since detached and there is no operator to type a code.
+/// The initial-auth, provider-session recovery, and mid-cycle reauth paths all
+/// use this predicate. Keeping the wait decision in the sync owner prevents a
+/// foreground error from being reclassified globally as service success.
 pub(crate) fn should_wait_for_2fa(is_watch_mode: bool, err: &anyhow::Error) -> bool {
     is_watch_mode && classify_sync_auth_error(err) == SyncAuthErrorClass::TwoFactorRequired
 }
@@ -2282,6 +2309,7 @@ async fn reacquire_session(
     shared_session: &auth::SharedSession,
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
+    input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     reacquire_session_lock_after_idle(shared_session).await?;
 
@@ -2291,6 +2319,7 @@ async fn reacquire_session(
         &config.auth.username,
         config.auth.domain.as_str(),
         password_provider,
+        input_mode,
     )
     .await
     {
@@ -4342,7 +4371,7 @@ mod tests {
             .find("clear_validation_cache_for_reauth")
             .expect("session-error reauth must clear cache before retrying auth");
         let lenient_auth = body
-            .find("authenticate_sync_session(config, password_provider)")
+            .find("authenticate_sync_session(config, password_provider, input_mode)")
             .expect("session-error reauth must try persisted-session auth");
         let strip = body
             .find("auth::strip_session_routing_state")

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -42,6 +42,7 @@ fn clean_cmd() -> assert_cmd::Command {
         .env_remove("KEI_DOWNLOAD_DIR")
         .env_remove("KEI_LOG_LEVEL")
         .env_remove("KEI_NO_AUTO_CONFIG")
+        .env_remove("KEI_UNSTABLE_FAKE_TWO_FACTOR_REQUIRED_FOR_TESTS")
         .env("KEI_DATA_DIR", default_data_dir)
         .timeout(TIMEOUT);
     cmd
@@ -705,6 +706,134 @@ fn password_set_requires_username() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Set your iCloud username"));
+}
+
+#[test]
+fn password_set_headless_accepts_password_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let password_file = dir.path().join("icloud-password");
+    let data_dir = dir.path().join("data");
+    let secret = "file-source-secret";
+    std::fs::write(&password_file, format!("{secret}\n")).unwrap();
+
+    clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", &data_dir)
+        .args([
+            "password",
+            "--password-file",
+            password_file.to_str().unwrap(),
+            "set",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Password stored in"))
+        .stdout(predicate::str::contains(secret).not())
+        .stderr(predicate::str::contains(secret).not());
+}
+
+#[test]
+fn password_set_headless_without_source_fails_before_prompt() {
+    let dir = tempfile::tempdir().unwrap();
+
+    clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["password", "set"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("stdin is not a terminal"))
+        .stderr(predicate::str::contains(
+            "kei password --password-file <PATH> set",
+        ))
+        .stderr(predicate::str::contains(
+            "kei password --password-command <COMMAND> set",
+        ));
+}
+
+fn write_fake_two_factor_config(dir: &std::path::Path, username: &str) -> std::path::PathBuf {
+    let download_dir = dir.join("photos");
+    std::fs::create_dir_all(&download_dir).unwrap();
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[auth]\nusername = {}\n\n[download]\ndirectory = {}\n",
+            common::toml_string(username),
+            common::toml_string(&download_dir.to_string_lossy()),
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
+fn assert_foreground_two_factor_failure(command: &str) {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = write_fake_two_factor_config(dir.path(), "test@example.com");
+
+    clean_cmd()
+        .env("KEI_DATA_DIR", dir.path().join("data"))
+        .env("KEI_UNSTABLE_FAKE_TWO_FACTOR_REQUIRED_FOR_TESTS", "1")
+        .args([command, "--config", config_path.to_str().unwrap()])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("kei login get-code"))
+        .stderr(predicate::str::contains("kei login submit-code <CODE>"));
+}
+
+#[test]
+fn login_two_factor_required_exits_with_auth_code() {
+    assert_foreground_two_factor_failure("login");
+}
+
+#[test]
+fn one_shot_sync_two_factor_required_exits_with_auth_code() {
+    assert_foreground_two_factor_failure("sync");
+}
+
+#[test]
+fn service_two_factor_required_keeps_waiting_for_submitted_code() {
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let config_path = write_fake_two_factor_config(dir.path(), username);
+    let data_dir = dir.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    std::fs::write(
+        data_dir.join(format!("{}.session", sanitize_username(username))),
+        "{}\n",
+    )
+    .unwrap();
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_kei"))
+        .env_remove("ICLOUD_USERNAME")
+        .env_remove("ICLOUD_PASSWORD")
+        .env_remove("KEI_CONFIG")
+        .env("KEI_DATA_DIR", &data_dir)
+        .env("KEI_UNSTABLE_FAKE_TWO_FACTOR_REQUIRED_FOR_TESTS", "1")
+        .args(["service", "run", "--config", config_path.to_str().unwrap()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(1));
+    if let Some(status) = child.try_wait().unwrap() {
+        let output = child.wait_with_output().unwrap();
+        panic!(
+            "service exited instead of waiting for 2FA: {status}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    child.kill().unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Waiting for 2FA code submission"),
+        "service did not enter durable 2FA wait:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
 }
 #[test]
 fn password_clear_requires_username() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -352,6 +352,20 @@ fn submit_code_help_succeeds() {
 }
 
 #[test]
+fn password_set_help_documents_headless_sources() {
+    common::cmd()
+        .args(["password", "set", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "kei password --password-file <PATH> set",
+        ))
+        .stdout(predicate::str::contains(
+            "kei password --password-command <COMMAND> set",
+        ));
+}
+
+#[test]
 fn legacy_retry_failed_help_fails() {
     common::cmd()
         .args(["retry-failed", "--help"])


### PR DESCRIPTION
## Summary
- Return auth exit code 3 with actionable 2FA commands for foreground login and one-shot sync.
- Keep durable 2FA wait and resume behavior for watch and service processes.
- Let `password set` use password-file and password-command sources without a terminal.
- Record input mode once at startup and use it across prompt decisions.
- Add binary-boundary coverage and operator documentation.

Fixes #698.

## Tests
- `just gate`

## Review notes
- Binary 2FA tests use a debug-only environment seam. Release builds cannot bypass authentication through this seam.
