### PR TITLE
Automatically repair stale captured metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,6 +246,24 @@ recovery work needed after that checkpoint is durable.
 
 Provider metadata may be captured in SQLite without changing local media.
 Embedding EXIF/XMP or writing sidecars requires explicit configuration.
+`METADATA_CAPTURE_REVISION` identifies the catalogue semantics produced by the
+current binary. Schema v18 stores per-asset revisions and per-library active
+and pending repair state. A normal sync hydrates stale downloaded rows in
+bounded provider-lookup batches, independent of album, media, and date filters.
+Only an identity that cannot be resolved from durable asset/master evidence
+uses the bounded legacy hydration path. Unselected libraries keep separate
+pending state and do not force work in selected libraries.
+
+The watch pre-check includes only libraries with pending capture or rewrite
+work, even when iCloud reports no provider changes. A capture refresh preserves
+download status, paths, checksums, and media bytes. It stores corrected
+catalogue metadata, the current revision, and any configured rewrite marker
+before the library revision can become active. Lookup or state failures leave
+the row stale, report the remaining work, and preserve the affected provider
+checkpoint. A library promotes its active revision only when every live
+downloaded row is current. Persisted rewrite markers may drain later because
+they are durable recovery evidence.
+
 Metadata failure markers must survive so a later run can retry metadata
 without downloading the media again. Full enumeration, single-pass incremental,
 and collecting incremental sync all commit changed catalogue metadata and its
@@ -309,6 +327,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 | `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY` | `src/sync_cycle.rs`, `src/download/mod.rs` | A zone checkpoint advances only with complete token evidence and durable recovery for unfinished work. |
 | `UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING` | `src/download/retry.rs` | Inconclusive provider identity retains the pending row and records verification evidence. |
 | `METADATA_WRITES_REQUIRE_OPT_IN` | `src/download/metadata_rewrite.rs` | Media and sidecar metadata writes run only for explicitly enabled metadata flags. |
+| `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE` | `src/download/mod.rs`, `src/state/db.rs` | Revision repair updates catalogue metadata and configured rewrite evidence before promotion, stays library-scoped, and preserves the provider checkpoint on unresolved work. |
 
 ## Change-impact checklist
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -61,6 +61,30 @@ pub(crate) async fn run_status(
     {
         println!("Last recovery action: {action}");
     }
+    if !summary.metadata_capture.is_empty() {
+        println!("Metadata capture:");
+        for capture in &summary.metadata_capture {
+            if let Some(pending) = capture.pending_revision {
+                println!(
+                    "  {}: revision {} -> {}; {} processed, {} failed, {} remaining",
+                    capture.library,
+                    capture.active_revision,
+                    pending,
+                    capture.processed_assets,
+                    capture.failed_assets,
+                    capture.remaining_assets
+                );
+                if let Some(error) = &capture.last_error {
+                    println!("    Last error: {error}");
+                }
+            } else {
+                println!(
+                    "  {}: revision {} current",
+                    capture.library, capture.active_revision
+                );
+            }
+        }
+    }
     println!("{}", backup_status_line(&summary));
     println!();
 
@@ -196,6 +220,34 @@ fn backup_status_line(summary: &state::types::SyncSummary) -> String {
         reasons.push(format!(
             "{} awaiting provider verification",
             count_phrase(summary.awaiting_provider_verification, "asset")
+        ));
+    }
+    let metadata_capture_remaining: u64 = summary
+        .metadata_capture
+        .iter()
+        .map(|capture| capture.remaining_assets)
+        .sum();
+    if metadata_capture_remaining > 0 {
+        reasons.push(format!(
+            "{} metadata capture {}",
+            count_phrase(metadata_capture_remaining, "asset"),
+            remain_verb(metadata_capture_remaining)
+        ));
+    }
+    let metadata_capture_failures: u64 = summary
+        .metadata_capture
+        .iter()
+        .map(|capture| capture.failed_assets)
+        .sum();
+    if metadata_capture_failures > 0 {
+        reasons.push(format!(
+            "{} metadata capture failure{} recorded",
+            metadata_capture_failures,
+            if metadata_capture_failures == 1 {
+                ""
+            } else {
+                "s"
+            }
         ));
     }
     if summary.last_inventory_drop_detected {

--- a/src/cycle_reporter.rs
+++ b/src/cycle_reporter.rs
@@ -282,7 +282,7 @@ where
         };
         let (failed_assets, failed_assets_truncated) = self.failed_asset_sample().await;
         let report = report::SyncReport {
-            version: "2",
+            version: "3",
             kei_version: env!("CARGO_PKG_VERSION"),
             timestamp: chrono::Utc::now().to_rfc3339(),
             status: input.status.as_report_str().to_string(),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -289,6 +289,11 @@ pub struct SyncStats {
     pub bytes_downloaded: u64,
     pub disk_bytes_written: u64,
     pub exif_failures: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_capture_revision: Option<i64>,
+    pub metadata_capture_refreshed: usize,
+    pub metadata_capture_failures: usize,
+    pub metadata_capture_remaining: u64,
     pub state_write_failures: usize,
     pub enumeration_errors: usize,
     /// Best-effort count-probe failures observed before full enumeration.
@@ -441,6 +446,12 @@ impl SyncStats {
         self.bytes_downloaded += other.bytes_downloaded;
         self.disk_bytes_written += other.disk_bytes_written;
         self.exif_failures += other.exif_failures;
+        self.metadata_capture_revision = self
+            .metadata_capture_revision
+            .max(other.metadata_capture_revision);
+        self.metadata_capture_refreshed += other.metadata_capture_refreshed;
+        self.metadata_capture_failures += other.metadata_capture_failures;
+        self.metadata_capture_remaining += other.metadata_capture_remaining;
         self.state_write_failures += other.state_write_failures;
         self.enumeration_errors += other.enumeration_errors;
         self.count_probe_failures += other.count_probe_failures;
@@ -522,6 +533,7 @@ const ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON: &str =
     "asset_master_mapping_state_write_failed";
 const ASSET_DELTA_HYDRATION_INCOMPLETE_REASON: &str = "asset_delta_hydration_incomplete";
 const PROVIDER_METADATA_STATE_WRITE_FAILED_REASON: &str = "provider_metadata_state_write_failed";
+const METADATA_CAPTURE_REPAIR_FAILED_REASON: &str = "metadata_capture_repair_failed";
 const INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON: &str = "incremental_delete_state_write_failed";
 const INCREMENTAL_DELETE_ZERO_ROWS_REASON: &str = "incremental_delete_no_matching_state";
 const INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON: &str = "incremental_hidden_state_write_failed";
@@ -542,6 +554,7 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
         | ASSET_DELTA_HYDRATION_INCOMPLETE_REASON
         | ASSET_MASTER_MAPPING_STATE_WRITE_FAILED_REASON
         | PROVIDER_METADATA_STATE_WRITE_FAILED_REASON
+        | METADATA_CAPTURE_REPAIR_FAILED_REASON
         | DATE_BOUNDED_FULL_ENUMERATION_REASON
         | INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON
         | INCREMENTAL_HIDDEN_STATE_WRITE_FAILED_REASON
@@ -613,6 +626,9 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
         }
         PROVIDER_METADATA_STATE_WRITE_FAILED_REASON => {
             "kei could not persist changed provider metadata safely"
+        }
+        METADATA_CAPTURE_REPAIR_FAILED_REASON => {
+            "kei could not complete automatic metadata-capture repair safely"
         }
         INCREMENTAL_DELETE_STATE_WRITE_FAILED_REASON => {
             "kei could not persist an incremental source-delete safely"
@@ -4100,6 +4116,405 @@ async fn has_metadata_backfill_work(config: &DownloadConfig) -> bool {
     }
 }
 
+const METADATA_CAPTURE_BATCH: usize = 500;
+
+#[derive(Default)]
+struct MetadataCaptureRepair {
+    stats: SyncStats,
+    failures: usize,
+}
+
+fn metadata_capture_candidate_matches(
+    asset: &PhotoAsset,
+    candidate: &crate::state::MetadataCaptureCandidate,
+) -> bool {
+    candidate.versions.iter().any(|evidence| {
+        asset.versions().iter().any(|(version_size, version)| {
+            VersionSizeKey::from(*version_size) == evidence.version_size
+                && version.size == evidence.size_bytes
+                && version.checksum.as_ref() == evidence.checksum
+        })
+    })
+}
+
+async fn record_metadata_capture_failure(
+    db: &dyn DownloadStore,
+    library: &str,
+    error: &str,
+    repair: &mut MetadataCaptureRepair,
+) {
+    repair.failures = repair.failures.saturating_add(1);
+    repair.stats.metadata_capture_failures =
+        repair.stats.metadata_capture_failures.saturating_add(1);
+    if let Err(state_error) = db
+        .record_metadata_capture_failure(library, crate::state::METADATA_CAPTURE_REVISION, error)
+        .await
+    {
+        repair.stats.state_write_failures = repair.stats.state_write_failures.saturating_add(1);
+        tracing::warn!(error = %state_error, "Failed to persist metadata-capture repair failure");
+    }
+}
+
+async fn refresh_metadata_capture_candidate(
+    db: &dyn DownloadStore,
+    config: &DownloadConfig,
+    candidate: &crate::state::MetadataCaptureCandidate,
+    asset: PhotoAsset,
+    repair: &mut MetadataCaptureRepair,
+) {
+    if let Err(error) = db
+        .upsert_asset_master_mapping(&candidate.library, asset.asset_record_name(), asset.id())
+        .await
+    {
+        let message = error.to_string();
+        record_metadata_capture_failure(db, &candidate.library, &message, repair).await;
+        return;
+    }
+    let mark_for_rewrite = MetadataFlags::from(config).has_any_write();
+    match db
+        .refresh_downloaded_asset_metadata(
+            &candidate.library,
+            &candidate.asset_id,
+            asset.metadata(),
+            mark_for_rewrite,
+            crate::state::METADATA_CAPTURE_REVISION,
+        )
+        .await
+    {
+        Ok(updated) if updated > 0 => {
+            repair.stats.metadata_capture_refreshed =
+                repair.stats.metadata_capture_refreshed.saturating_add(1);
+        }
+        Ok(_) => {
+            record_metadata_capture_failure(
+                db,
+                &candidate.library,
+                "provider metadata matched no live downloaded catalogue row",
+                repair,
+            )
+            .await;
+        }
+        Err(error) => {
+            let message = error.to_string();
+            record_metadata_capture_failure(db, &candidate.library, &message, repair).await;
+        }
+    }
+}
+
+async fn run_metadata_capture_repair(
+    passes: &[crate::commands::AlbumPass],
+    config: &DownloadConfig,
+    controls: DownloadControls,
+    shutdown_token: &CancellationToken,
+) -> MetadataCaptureRepair {
+    // CONTRACT: METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE
+    let mut repair = MetadataCaptureRepair::default();
+    repair.stats.metadata_capture_revision = Some(crate::state::METADATA_CAPTURE_REVISION);
+    if !controls.run_mode.downloads_files() || config.refresh_metadata {
+        return repair;
+    }
+    let Some(db) = &config.state_db else {
+        return repair;
+    };
+    let library = config.library.as_ref();
+    let initial = match db
+        .begin_metadata_capture_revision(library, crate::state::METADATA_CAPTURE_REVISION)
+        .await
+    {
+        Ok(status) => status,
+        Err(error) => {
+            repair.failures = 1;
+            repair.stats.metadata_capture_failures = 1;
+            repair.stats.state_write_failures = 1;
+            tracing::warn!(error = %error, library, "Could not initialize metadata-capture repair");
+            block_sync_token_for_incremental_delta(
+                &mut repair.stats,
+                METADATA_CAPTURE_REPAIR_FAILED_REASON,
+            );
+            return repair;
+        }
+    };
+    repair.stats.metadata_capture_remaining = initial.remaining_assets;
+    if initial.remaining_assets == 0 {
+        return repair;
+    }
+    let Some(provider_pass) = passes.first() else {
+        record_metadata_capture_failure(
+            db.as_ref(),
+            library,
+            "selected library has no provider pass for metadata hydration",
+            &mut repair,
+        )
+        .await;
+        block_sync_token_for_incremental_delta(
+            &mut repair.stats,
+            METADATA_CAPTURE_REPAIR_FAILED_REASON,
+        );
+        return repair;
+    };
+    let candidates = match db
+        .get_metadata_capture_candidates(
+            library,
+            crate::state::METADATA_CAPTURE_REVISION,
+            METADATA_CAPTURE_BATCH,
+        )
+        .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            let message = error.to_string();
+            record_metadata_capture_failure(db.as_ref(), library, &message, &mut repair).await;
+            block_sync_token_for_incremental_delta(
+                &mut repair.stats,
+                METADATA_CAPTURE_REPAIR_FAILED_REASON,
+            );
+            return repair;
+        }
+    };
+    let mut candidates_by_id: FxHashMap<String, crate::state::MetadataCaptureCandidate> =
+        candidates
+            .into_iter()
+            .map(|candidate| (candidate.asset_id.clone(), candidate))
+            .collect();
+    let requests: Vec<RecordLookupRequest> = candidates_by_id
+        .values()
+        .map(|candidate| match &candidate.asset_record_name {
+            Some(asset_record_name) => RecordLookupRequest::paired(
+                ProviderRecordId::new(candidate.asset_id.as_str()),
+                ProviderRecordId::new(candidate.master_record_name.as_str()),
+                ProviderRecordId::new(asset_record_name.as_str()),
+            ),
+            None => RecordLookupRequest::master_only(
+                ProviderRecordId::new(candidate.asset_id.as_str()),
+                ProviderRecordId::new(candidate.master_record_name.as_str()),
+            ),
+        })
+        .collect();
+    let resolutions = provider_pass.album.resolve_records(&requests).await;
+    let mut legacy_masters = FxHashSet::default();
+    for (state_id, resolution) in resolutions.results {
+        if shutdown_token.is_cancelled() {
+            break;
+        }
+        let Some(candidate) = candidates_by_id.remove(state_id.as_str()) else {
+            continue;
+        };
+        match resolution {
+            RecordResolution::Present(asset) => {
+                refresh_metadata_capture_candidate(
+                    db.as_ref(),
+                    config,
+                    &candidate,
+                    asset,
+                    &mut repair,
+                )
+                .await;
+            }
+            RecordResolution::MasterPresent => {
+                legacy_masters.insert(candidate.master_record_name.clone());
+                candidates_by_id.insert(candidate.asset_id.clone(), candidate);
+            }
+            RecordResolution::Deleted {
+                deleted_at,
+                master_family,
+            } => {
+                let result = if master_family {
+                    db.resolve_master_family_source_deleted_affected(
+                        &candidate.library,
+                        &candidate.master_record_name,
+                        deleted_at,
+                    )
+                    .await
+                } else {
+                    db.resolve_source_deleted_affected(
+                        &candidate.library,
+                        &candidate.asset_id,
+                        deleted_at,
+                    )
+                    .await
+                };
+                match result {
+                    Ok(_) => {}
+                    Err(error) => {
+                        let message = error.to_string();
+                        record_metadata_capture_failure(
+                            db.as_ref(),
+                            &candidate.library,
+                            &message,
+                            &mut repair,
+                        )
+                        .await;
+                    }
+                }
+            }
+            RecordResolution::AssetPresent { .. } | RecordResolution::Unknown => {
+                record_metadata_capture_failure(
+                    db.as_ref(),
+                    &candidate.library,
+                    "provider lookup did not return a complete photo record",
+                    &mut repair,
+                )
+                .await;
+            }
+            RecordResolution::TransientFailure(error) => {
+                let message = error.to_string();
+                record_metadata_capture_failure(
+                    db.as_ref(),
+                    &candidate.library,
+                    &message,
+                    &mut repair,
+                )
+                .await;
+            }
+        }
+    }
+
+    if !legacy_masters.is_empty() && !shutdown_token.is_cancelled() {
+        match provider_pass
+            .album
+            .hydrate_matching_master_assets_from_changes(&legacy_masters, shutdown_token)
+            .await
+        {
+            Ok(assets) => {
+                let mut assets_by_master: FxHashMap<String, Vec<PhotoAsset>> = FxHashMap::default();
+                for asset in assets {
+                    assets_by_master
+                        .entry(asset.id().to_owned())
+                        .or_default()
+                        .push(asset);
+                }
+                let legacy_ids: Vec<String> = candidates_by_id
+                    .iter()
+                    .filter(|(_, candidate)| legacy_masters.contains(&candidate.master_record_name))
+                    .map(|(state_id, _)| state_id.clone())
+                    .collect();
+                for state_id in legacy_ids {
+                    let Some(candidate) = candidates_by_id.remove(&state_id) else {
+                        continue;
+                    };
+                    let mut matches = assets_by_master
+                        .remove(&candidate.master_record_name)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|asset| metadata_capture_candidate_matches(asset, &candidate));
+                    let Some(asset) = matches.next() else {
+                        record_metadata_capture_failure(
+                            db.as_ref(),
+                            &candidate.library,
+                            "no current provider child matched durable catalogue evidence",
+                            &mut repair,
+                        )
+                        .await;
+                        continue;
+                    };
+                    if matches.next().is_some() {
+                        record_metadata_capture_failure(
+                            db.as_ref(),
+                            &candidate.library,
+                            "multiple provider children matched durable catalogue evidence",
+                            &mut repair,
+                        )
+                        .await;
+                        continue;
+                    }
+                    match db
+                        .claim_legacy_master_state_owner(
+                            &candidate.library,
+                            &candidate.master_record_name,
+                            asset.asset_record_name(),
+                        )
+                        .await
+                    {
+                        Ok(true) => {
+                            let asset = asset.with_state_record_name(Arc::from(state_id));
+                            refresh_metadata_capture_candidate(
+                                db.as_ref(),
+                                config,
+                                &candidate,
+                                asset,
+                                &mut repair,
+                            )
+                            .await;
+                        }
+                        Ok(false) => {
+                            record_metadata_capture_failure(
+                                db.as_ref(),
+                                &candidate.library,
+                                "a different provider child owns the legacy catalogue row",
+                                &mut repair,
+                            )
+                            .await;
+                        }
+                        Err(error) => {
+                            let message = error.to_string();
+                            record_metadata_capture_failure(
+                                db.as_ref(),
+                                &candidate.library,
+                                &message,
+                                &mut repair,
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                let message = error.to_string();
+                let unresolved: Vec<String> = candidates_by_id
+                    .iter()
+                    .filter(|(_, candidate)| legacy_masters.contains(&candidate.master_record_name))
+                    .map(|(state_id, _)| state_id.clone())
+                    .collect();
+                for state_id in unresolved {
+                    if let Some(candidate) = candidates_by_id.remove(&state_id) {
+                        record_metadata_capture_failure(
+                            db.as_ref(),
+                            &candidate.library,
+                            &message,
+                            &mut repair,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+
+    if shutdown_token.is_cancelled() {
+        repair.stats.interrupted = true;
+    } else {
+        for (_, candidate) in candidates_by_id {
+            record_metadata_capture_failure(
+                db.as_ref(),
+                &candidate.library,
+                "provider lookup omitted the requested catalogue identity",
+                &mut repair,
+            )
+            .await;
+        }
+    }
+    match db
+        .complete_metadata_capture_revision(library, crate::state::METADATA_CAPTURE_REVISION)
+        .await
+    {
+        Ok(status) => repair.stats.metadata_capture_remaining = status.remaining_assets,
+        Err(error) => {
+            repair.stats.state_write_failures = repair.stats.state_write_failures.saturating_add(1);
+            repair.failures = repair.failures.saturating_add(1);
+            repair.stats.metadata_capture_failures =
+                repair.stats.metadata_capture_failures.saturating_add(1);
+            tracing::warn!(error = %error, library, "Could not finalize metadata-capture repair state");
+        }
+    }
+    if repair.failures > 0 || repair.stats.interrupted {
+        block_sync_token_for_incremental_delta(
+            &mut repair.stats,
+            METADATA_CAPTURE_REPAIR_FAILED_REASON,
+        );
+    }
+    repair
+}
+
 fn set_full_enumeration_reason(result: &mut SyncResult, reason: FullEnumerationReason) {
     if result.full_enumeration_ran && result.stats.full_enumeration_reason.is_none() {
         result.stats.full_enumeration_reason = Some(reason);
@@ -4946,6 +5361,8 @@ pub async fn download_photos_with_sync(
     {
         backfill_asset_master_mappings_from_album_history(db.as_ref()).await;
     }
+    let metadata_capture_repair =
+        run_metadata_capture_repair(passes, &config, controls, &shutdown_token).await;
 
     // Give every non-downloaded asset a fresh start this sync:
     // failed -> pending (with attempts reset), and stale attempt counts on
@@ -5115,7 +5532,7 @@ pub async fn download_photos_with_sync(
         }
     }?;
 
-    let result = append_pending_retry_to_sync_result(
+    let mut result = append_pending_retry_to_sync_result(
         download_client,
         passes,
         &config,
@@ -5124,7 +5541,20 @@ pub async fn download_photos_with_sync(
         total_pending,
         result,
     )
-    .await;
+    .await?;
+
+    result.stats.accumulate(&metadata_capture_repair.stats);
+    if metadata_capture_repair.failures > 0 {
+        result.outcome = merge_download_outcomes(
+            &result.outcome,
+            &DownloadOutcome::PartialFailure {
+                failed_count: metadata_capture_repair.failures,
+            },
+        );
+    }
+    if metadata_capture_repair.stats.sync_token_blocked {
+        result.sync_token = None;
+    }
 
     // Pending is transient — anything still pending after a complete sync either
     // wasn't enumerated or failed silently. Skip on interrupt where pending is expected.
@@ -5145,7 +5575,7 @@ pub async fn download_photos_with_sync(
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Fold per-pass `album.len()` results into a `(counts, error_count)` tuple,
@@ -7369,6 +7799,7 @@ async fn apply_changed_provider_metadata(
             asset.state_id(),
             asset.metadata(),
             mark_for_rewrite,
+            crate::state::METADATA_CAPTURE_REVISION,
         )
         .await;
     match refresh {
@@ -14667,6 +15098,375 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contract_metadata_capture_revision_repair_is_durable() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let stored_records = incremental_photo_records_with_favorite("CAPTURE_REVISION", false);
+        let stored_asset = PhotoAsset::new(stored_records[0].clone(), stored_records[1].clone());
+        let changed_records = incremental_photo_records_with_favorite("CAPTURE_REVISION", true);
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(PendingLookupSession {
+                    records: Arc::new(changed_records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+        let media_path =
+            seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &stored_asset).await;
+        db.upsert_asset_master_mapping("PrimarySync", "asset-CAPTURE_REVISION", "CAPTURE_REVISION")
+            .await
+            .expect("seed durable provider identity");
+        assert!(
+            db.claim_legacy_master_state_owner(
+                "PrimarySync",
+                "CAPTURE_REVISION",
+                "asset-CAPTURE_REVISION",
+            )
+            .await
+            .expect("seed legacy state owner")
+        );
+        db.set_metadata_capture_revision_for_test("PrimarySync", "CAPTURE_REVISION", 0);
+        let before = tokio::fs::read(&media_path)
+            .await
+            .expect("read seeded media");
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            std::slice::from_ref(&pass),
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("normal sync should repair stale capture metadata");
+
+        assert!(
+            matches!(result.outcome, DownloadOutcome::Success),
+            "unexpected outcome: {:?}, stats: {:?}",
+            result.outcome,
+            result.stats
+        );
+        assert_eq!(result.stats.downloaded, 0);
+        assert_eq!(result.stats.metadata_capture_revision, Some(1));
+        assert_eq!(result.stats.metadata_capture_refreshed, 1);
+        assert_eq!(result.stats.metadata_capture_failures, 0);
+        assert_eq!(result.stats.metadata_capture_remaining, 0);
+        assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+        let refreshed = db
+            .get_downloaded_page(0, 1)
+            .await
+            .expect("read refreshed row")
+            .remove(0);
+        assert!(refreshed.metadata.is_favorite);
+        assert_eq!(refreshed.local_path.as_deref(), Some(media_path.as_path()));
+        assert_eq!(
+            tokio::fs::read(&media_path)
+                .await
+                .expect("read repaired media"),
+            before,
+            "catalogue-only repair must not mutate media when outputs are disabled"
+        );
+        let summary = db.get_summary().await.expect("summary");
+        let capture = summary
+            .metadata_capture
+            .iter()
+            .find(|status| status.library == "PrimarySync")
+            .expect("capture status");
+        assert_eq!(capture.active_revision, 1);
+        assert_eq!(capture.pending_revision, None);
+        assert_eq!(capture.remaining_assets, 0);
+    }
+
+    #[tokio::test]
+    async fn current_capture_revision_adds_no_provider_lookup_requests() {
+        #[derive(Clone, Debug)]
+        struct CountingCaptureSession {
+            lookups: Arc<AtomicUsize>,
+            changes: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl PhotosSession for CountingCaptureSession {
+            async fn post(
+                &self,
+                url: &str,
+                _body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                if url.contains("/records/lookup?") {
+                    self.lookups.fetch_add(1, Ordering::SeqCst);
+                    return Ok(json!({"records": []}));
+                }
+                if url.contains("/changes/zone?") {
+                    self.changes.fetch_add(1, Ordering::SeqCst);
+                    return Ok(changes_zone_response(Vec::new(), "zone-token-next"));
+                }
+                Ok(json!({"records": [], "syncToken": "ignored-query-token"}))
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let records = incremental_photo_records("CAPTURE_CURRENT");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let changes = Arc::new(AtomicUsize::new(0));
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(CountingCaptureSession {
+                    lookups: Arc::clone(&lookups),
+                    changes: Arc::clone(&changes),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+        seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &asset).await;
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &[pass],
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("current capture revision should use the normal incremental path");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(lookups.load(Ordering::SeqCst), 0);
+        assert_eq!(changes.load(Ordering::SeqCst), 1);
+        assert_eq!(result.stats.metadata_capture_refreshed, 0);
+        assert_eq!(result.stats.metadata_capture_remaining, 0);
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn normal_sync_writes_configured_xmp_after_capture_revision_repair() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let stored_records = incremental_photo_records_with_favorite("CAPTURE_XMP", false);
+        let stored_asset = PhotoAsset::new(stored_records[0].clone(), stored_records[1].clone());
+        let changed_records = incremental_photo_records_with_favorite("CAPTURE_XMP", true);
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(PendingLookupSession {
+                    records: Arc::new(changed_records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+        let media_path =
+            seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &stored_asset).await;
+        db.upsert_asset_master_mapping("PrimarySync", "asset-CAPTURE_XMP", "CAPTURE_XMP")
+            .await
+            .expect("seed durable provider identity");
+        assert!(
+            db.claim_legacy_master_state_owner("PrimarySync", "CAPTURE_XMP", "asset-CAPTURE_XMP",)
+                .await
+                .expect("seed legacy state owner")
+        );
+        db.set_metadata_capture_revision_for_test("PrimarySync", "CAPTURE_XMP", 0);
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &[pass],
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("normal sync should repair metadata and drain the configured XMP write");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.downloaded, 0);
+        assert_eq!(result.stats.metadata_capture_refreshed, 1);
+        let sidecar_name = format!(
+            "{}.xmp",
+            media_path
+                .file_name()
+                .expect("media path has filename")
+                .to_string_lossy()
+        );
+        assert!(media_path.with_file_name(sidecar_name).exists());
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .expect("read rewrite queue")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_capture_lookup_preserves_incremental_checkpoint_and_retries() {
+        #[derive(Clone, Debug)]
+        struct FailingCaptureLookupSession;
+
+        #[async_trait::async_trait]
+        impl PhotosSession for FailingCaptureLookupSession {
+            async fn post(
+                &self,
+                url: &str,
+                _body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                if url.contains("/records/lookup?") {
+                    anyhow::bail!("temporary lookup failure");
+                }
+                if url.contains("/changes/zone?") {
+                    return Ok(changes_zone_response(Vec::new(), "zone-token-next"));
+                }
+                Ok(json!({"records": [], "syncToken": "ignored-query-token"}))
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let records = incremental_photo_records("CAPTURE_RETRY");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session("PrimarySync", "", Box::new(FailingCaptureLookupSession)),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+        seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &asset).await;
+        db.upsert_asset_master_mapping("PrimarySync", "asset-CAPTURE_RETRY", "CAPTURE_RETRY")
+            .await
+            .unwrap();
+        db.set_metadata_capture_revision_for_test("PrimarySync", "CAPTURE_RETRY", 0);
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            &[pass],
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("lookup failure should remain a reported durable repair");
+
+        assert!(matches!(
+            result.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(result.sync_token, None);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(METADATA_CAPTURE_REPAIR_FAILED_REASON)
+        );
+        assert_eq!(result.stats.metadata_capture_failures, 1);
+        assert_eq!(result.stats.metadata_capture_remaining, 1);
+        assert!(
+            db.has_metadata_capture_work(
+                &["PrimarySync"],
+                crate::state::METADATA_CAPTURE_REVISION,
+            )
+                .await
+                .unwrap(),
+            "failed lookup must leave durable retry work"
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_capture_repair_keeps_unprocessed_rows_pending_without_failure() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let records = incremental_photo_records("CAPTURE_INTERRUPTED");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(PendingLookupSession {
+                    records: Arc::new(records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &asset).await;
+        db.upsert_asset_master_mapping(
+            "PrimarySync",
+            "asset-CAPTURE_INTERRUPTED",
+            "CAPTURE_INTERRUPTED",
+        )
+        .await
+        .expect("seed durable provider identity");
+        db.set_metadata_capture_revision_for_test("PrimarySync", "CAPTURE_INTERRUPTED", 0);
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+
+        let repair = run_metadata_capture_repair(
+            std::slice::from_ref(&pass),
+            &config,
+            DownloadControls::download_hidden(),
+            &shutdown,
+        )
+        .await;
+
+        assert!(repair.stats.interrupted);
+        assert!(repair.stats.sync_token_blocked);
+        assert_eq!(repair.stats.metadata_capture_refreshed, 0);
+        assert_eq!(repair.stats.metadata_capture_failures, 0);
+        assert_eq!(repair.stats.metadata_capture_remaining, 1);
+        let summary = db.get_summary().await.expect("summary");
+        let capture = summary
+            .metadata_capture
+            .iter()
+            .find(|status| status.library == "PrimarySync")
+            .expect("capture status");
+        assert_eq!(capture.pending_revision, Some(1));
+        assert_eq!(capture.failed_assets, 0);
+        assert_eq!(capture.remaining_assets, 1);
+    }
+
+    #[tokio::test]
     async fn incremental_sync_queries_zone_changes_once_per_library() {
         let calls = Arc::new(AtomicUsize::new(0));
         let session = changes_zone_session(
@@ -17927,6 +18727,10 @@ mod tests {
             bytes_downloaded: 1_000,
             disk_bytes_written: 900,
             exif_failures: 1,
+            metadata_capture_revision: Some(1),
+            metadata_capture_refreshed: 2,
+            metadata_capture_failures: 1,
+            metadata_capture_remaining: 5,
             state_write_failures: 2,
             enumeration_errors: 3,
             count_probe_failures: 4,
@@ -17994,6 +18798,10 @@ mod tests {
             bytes_downloaded: 2_500,
             disk_bytes_written: 2_400,
             exif_failures: 4,
+            metadata_capture_revision: Some(1),
+            metadata_capture_refreshed: 3,
+            metadata_capture_failures: 2,
+            metadata_capture_remaining: 7,
             state_write_failures: 5,
             enumeration_errors: 6,
             count_probe_failures: 7,
@@ -18056,6 +18864,10 @@ mod tests {
         assert_eq!(acc.bytes_downloaded, 3_500, "bytes_downloaded must sum");
         assert_eq!(acc.disk_bytes_written, 3_300, "disk_bytes_written must sum");
         assert_eq!(acc.exif_failures, 5, "exif_failures must sum");
+        assert_eq!(acc.metadata_capture_revision, Some(1));
+        assert_eq!(acc.metadata_capture_refreshed, 5);
+        assert_eq!(acc.metadata_capture_failures, 3);
+        assert_eq!(acc.metadata_capture_remaining, 12);
         assert_eq!(acc.state_write_failures, 7, "state_write_failures must sum");
         assert_eq!(acc.enumeration_errors, 9, "enumeration_errors must sum");
         assert_eq!(

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1690,6 +1690,7 @@ where
                                     asset.state_id(),
                                     asset.metadata(),
                                     mark_for_rewrite,
+                                    crate::state::METADATA_CAPTURE_REVISION,
                                 )
                                 .await
                             {
@@ -4694,6 +4695,7 @@ mod tests {
             _: &str,
             _: &crate::state::AssetMetadata,
             _: bool,
+            _: i64,
         ) -> Result<usize, StateError> {
             Ok(0)
         }
@@ -4740,6 +4742,53 @@ mod tests {
         }
 
         async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
+            Ok(false)
+        }
+
+        async fn begin_metadata_capture_revision(
+            &self,
+            library: &str,
+            target_revision: i64,
+        ) -> Result<crate::state::MetadataCaptureStatus, StateError> {
+            Ok(crate::state::MetadataCaptureStatus {
+                library: library.to_owned(),
+                active_revision: target_revision,
+                pending_revision: None,
+                processed_assets: 0,
+                failed_assets: 0,
+                remaining_assets: 0,
+                last_error: None,
+            })
+        }
+
+        async fn get_metadata_capture_candidates(
+            &self,
+            _: &str,
+            _: i64,
+            _: usize,
+        ) -> Result<Vec<crate::state::MetadataCaptureCandidate>, StateError> {
+            Ok(Vec::new())
+        }
+
+        async fn record_metadata_capture_failure(
+            &self,
+            _: &str,
+            _: i64,
+            _: &str,
+        ) -> Result<(), StateError> {
+            Ok(())
+        }
+
+        async fn complete_metadata_capture_revision(
+            &self,
+            library: &str,
+            target_revision: i64,
+        ) -> Result<crate::state::MetadataCaptureStatus, StateError> {
+            self.begin_metadata_capture_revision(library, target_revision)
+                .await
+        }
+
+        async fn has_metadata_capture_work(&self, _: &[&str], _: i64) -> Result<bool, StateError> {
             Ok(false)
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1322,6 +1322,7 @@ mod tests {
             last_inventory_drop_previous_total: None,
             last_inventory_drop_current_total: None,
             last_inventory_drop_library: None,
+            metadata_capture: Vec::new(),
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -4,10 +4,9 @@
 //! (monitoring tools, Home Assistant, webhooks). In watch mode the file is
 //! overwritten every cycle — it's the current cycle's state, not a history log.
 //!
-//! # Schema v2
+//! # Schema v3
 //!
-//! v2 renames run-option fields to match the v0.20 public CLI and removes
-//! old incremental controls.
+//! v3 adds metadata-capture revision and repair progress to `stats`.
 
 use std::path::{Path, PathBuf};
 
@@ -182,7 +181,7 @@ mod tests {
     #[test]
     fn report_serialization_roundtrip() {
         let report = SyncReport {
-            version: "2",
+            version: "3",
             kei_version: "0.7.12",
             timestamp: "2026-04-15T12:00:00Z".to_string(),
             status: "success".to_string(),
@@ -226,6 +225,10 @@ mod tests {
                 },
                 bytes_downloaded: 1_200_000_000,
                 disk_bytes_written: 1_300_000_000,
+                metadata_capture_revision: Some(1),
+                metadata_capture_refreshed: 25,
+                metadata_capture_failures: 2,
+                metadata_capture_remaining: 75,
                 inventory_drop_warnings: 1,
                 inventory_drop_assets: 5,
                 inventory_drop_percent: Some(1.2),
@@ -242,10 +245,14 @@ mod tests {
         let json = serde_json::to_string_pretty(&report).expect("serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
 
-        assert_eq!(parsed["version"], "2");
+        assert_eq!(parsed["version"], "3");
         assert_eq!(parsed["status"], "success");
         assert_eq!(parsed["stats"]["downloaded"], 50);
         assert_eq!(parsed["stats"]["api_total_at_start"], 405);
+        assert_eq!(parsed["stats"]["metadata_capture_revision"], 1);
+        assert_eq!(parsed["stats"]["metadata_capture_refreshed"], 25);
+        assert_eq!(parsed["stats"]["metadata_capture_failures"], 2);
+        assert_eq!(parsed["stats"]["metadata_capture_remaining"], 75);
         assert_eq!(parsed["stats"]["inventory_drop_warnings"], 1);
         assert_eq!(parsed["stats"]["inventory_drop_previous_total"], 410);
         assert_eq!(parsed["stats"]["inventory_drop_current_total"], 405);
@@ -295,11 +302,11 @@ mod tests {
         assert_eq!(json["threads"], 6);
         assert!(
             json.get("directory").is_none(),
-            "schema v2 must not emit the legacy options.directory key"
+            "schema v3 must not emit the legacy options.directory key"
         );
         assert!(
             json.get("threads_num").is_none(),
-            "schema v2 must not emit the legacy options.threads_num key"
+            "schema v3 must not emit the legacy options.threads_num key"
         );
     }
 
@@ -351,7 +358,7 @@ mod tests {
         // and is_zero_usize on failed_assets_truncated must keep clean-run
         // reports free of both fields.
         let report = SyncReport {
-            version: "2",
+            version: "3",
             kei_version: "test",
             timestamp: "2026-04-15T12:00:00Z".to_string(),
             status: "success".to_string(),
@@ -404,7 +411,7 @@ mod tests {
             error_message: Some("HTTP 429".to_string()),
         };
         let report = SyncReport {
-            version: "2",
+            version: "3",
             kei_version: "test",
             timestamp: "2026-04-15T12:00:00Z".to_string(),
             status: "partial_failure".to_string(),
@@ -452,7 +459,7 @@ mod tests {
     #[test]
     fn failed_assets_truncated_emitted_when_nonzero() {
         let report = SyncReport {
-            version: "2",
+            version: "3",
             kei_version: "test",
             timestamp: "2026-04-15T12:00:00Z".to_string(),
             status: "partial_failure".to_string(),
@@ -501,7 +508,7 @@ mod tests {
         let path = dir.path().join("report.json");
 
         let report = SyncReport {
-            version: "2",
+            version: "3",
             kei_version: "0.7.12",
             timestamp: "2026-04-15T12:00:00Z".to_string(),
             status: "success".to_string(),
@@ -540,7 +547,7 @@ mod tests {
 
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
-        assert_eq!(parsed["version"], "2");
+        assert_eq!(parsed["version"], "3");
         assert_eq!(parsed["options"]["username"], "test@example.com");
     }
 }

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -11,7 +11,9 @@ use rusqlite::{Connection, OptionalExtension, Transaction};
 use super::error::StateError;
 use super::schema;
 use super::types::{
-    AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, SyncSummary, VersionSizeKey,
+    AssetMetadata, AssetRecord, AssetStatus, METADATA_CAPTURE_REVISION, MediaType,
+    MetadataCaptureCandidate, MetadataCaptureStatus, MetadataCaptureVersionEvidence, SyncRunStats,
+    SyncSummary, VersionSizeKey,
 };
 
 /// Fallback source identifier when `AssetMetadata::source` is unset.
@@ -630,6 +632,7 @@ pub trait MetadataRewriteStore: Send + Sync {
         asset_id: &str,
         metadata: &AssetMetadata,
         mark_for_rewrite: bool,
+        capture_revision: i64,
     ) -> Result<usize, StateError>;
     async fn get_downloaded_metadata_hashes(
         &self,
@@ -660,6 +663,58 @@ pub trait MetadataRewriteStore: Send + Sync {
         pre_rewrite_checksum: Option<&str>,
     ) -> Result<(), StateError>;
     async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError>;
+    async fn begin_metadata_capture_revision(
+        &self,
+        _library: &str,
+        _target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        Err(StateError::Invariant {
+            operation: "begin_metadata_capture_revision",
+            detail: "metadata-capture revision state is not implemented by this store".into(),
+        })
+    }
+    async fn get_metadata_capture_candidates(
+        &self,
+        _library: &str,
+        _target_revision: i64,
+        _limit: usize,
+    ) -> Result<Vec<MetadataCaptureCandidate>, StateError> {
+        Err(StateError::Invariant {
+            operation: "get_metadata_capture_candidates",
+            detail: "metadata-capture candidate reads are not implemented by this store".into(),
+        })
+    }
+    async fn record_metadata_capture_failure(
+        &self,
+        _library: &str,
+        _target_revision: i64,
+        _error: &str,
+    ) -> Result<(), StateError> {
+        Err(StateError::Invariant {
+            operation: "record_metadata_capture_failure",
+            detail: "metadata-capture failure state is not implemented by this store".into(),
+        })
+    }
+    async fn complete_metadata_capture_revision(
+        &self,
+        _library: &str,
+        _target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        Err(StateError::Invariant {
+            operation: "complete_metadata_capture_revision",
+            detail: "metadata-capture completion is not implemented by this store".into(),
+        })
+    }
+    async fn has_metadata_capture_work(
+        &self,
+        _libraries: &[&str],
+        _target_revision: i64,
+    ) -> Result<bool, StateError> {
+        Err(StateError::Invariant {
+            operation: "has_metadata_capture_work",
+            detail: "metadata-capture work checks are not implemented by this store".into(),
+        })
+    }
 }
 
 pub struct SqliteStateDb {
@@ -1008,6 +1063,36 @@ fn upsert_asset_row(
     Ok(())
 }
 
+fn record_metadata_capture_revision(
+    conn: &Connection,
+    library: &str,
+    asset_id: &str,
+    revision: i64,
+    updated_at: i64,
+) -> Result<(), StateError> {
+    let changed = conn
+        .execute(
+            "INSERT INTO asset_metadata_capture_revisions \
+                (library, asset_id, revision, updated_at) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(library, asset_id) DO UPDATE SET \
+                revision = excluded.revision, updated_at = excluded.updated_at \
+             WHERE asset_metadata_capture_revisions.revision < excluded.revision",
+            rusqlite::params![library, asset_id, revision, updated_at],
+        )
+        .map_err(|e| StateError::query("record_metadata_capture_revision", e))?;
+    if changed > 0 {
+        conn.execute(
+            "UPDATE metadata_capture_state SET \
+                processed_assets = processed_assets + 1, updated_at = ?1 \
+             WHERE library = ?2 AND pending_revision = ?3",
+            rusqlite::params![updated_at, library, revision],
+        )
+        .map_err(|e| StateError::query("record_metadata_capture_revision::progress", e))?;
+    }
+    Ok(())
+}
+
 /// Execute the `mark_downloaded` UPDATE on `conn`. Returns rows affected;
 /// callers decide what zero rows means in their context.
 fn update_status_to_downloaded(
@@ -1219,6 +1304,14 @@ impl SqliteStateDb {
                 });
             }
 
+            record_metadata_capture_revision(
+                conn,
+                &library,
+                &id,
+                METADATA_CAPTURE_REVISION,
+                downloaded_at,
+            )?;
+
             Ok(())
         })
         .await
@@ -1257,6 +1350,13 @@ impl SqliteStateDb {
                 rows, 1,
                 "import_adopt UPDATE missed the row inserted by UPSERT in the same tx — SQL bug"
             );
+            record_metadata_capture_revision(
+                &tx,
+                &record.library,
+                &record.id,
+                METADATA_CAPTURE_REVISION,
+                now,
+            )?;
 
             // Snapshot on-disk size + mtime so the next import-existing run
             // can short-circuit the SHA-256 re-read when the file is
@@ -1724,6 +1824,30 @@ impl SqliteStateDb {
                 }
             }
 
+            let mut capture_stmt = conn
+                .prepare(
+                    "SELECT library FROM metadata_capture_state \
+                     UNION SELECT DISTINCT library FROM assets \
+                     ORDER BY library",
+                )
+                .map_err(|e| StateError::query("get_summary::metadata_capture", e))?;
+            let capture_libraries = capture_stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| StateError::query("get_summary::metadata_capture", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| StateError::query("get_summary::metadata_capture", e))?;
+            let mut metadata_capture = Vec::with_capacity(capture_libraries.len());
+            for library in capture_libraries {
+                let remaining =
+                    metadata_capture_remaining(conn, &library, METADATA_CAPTURE_REVISION)?;
+                metadata_capture.push(metadata_capture_status(
+                    conn,
+                    &library,
+                    METADATA_CAPTURE_REVISION,
+                    remaining,
+                )?);
+            }
+
             Ok(SyncSummary {
                 total_assets,
                 downloaded,
@@ -1751,6 +1875,7 @@ impl SqliteStateDb {
                 last_inventory_drop_previous_total,
                 last_inventory_drop_current_total,
                 last_inventory_drop_library,
+                metadata_capture,
             })
         })
         .await
@@ -3634,6 +3759,7 @@ impl SqliteStateDb {
         asset_id: &str,
         metadata: &AssetMetadata,
         mark_for_rewrite: bool,
+        capture_revision: i64,
     ) -> Result<usize, StateError> {
         let library = library.to_owned();
         let asset_id = asset_id.to_owned();
@@ -3706,24 +3832,35 @@ impl SqliteStateDb {
                     ],
                 )
                 .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
-            if updated > 0 {
-                return Ok(updated);
+            let durable = if updated > 0 {
+                updated
+            } else {
+                // A row can leave `downloaded` mid-cycle when the provider
+                // publishes new media for the same asset, which stores the
+                // incoming metadata as it resets the row for re-download. The
+                // metadata is durable, so report the match rather than a lost
+                // write. A missing or still-stale row stays a failure.
+                let durable: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM assets \
+                         WHERE library = ?1 AND id = ?2 AND is_deleted = 0 \
+                           AND metadata_hash IS NOT NULL AND metadata_hash = ?3",
+                        rusqlite::params![library, asset_id, metadata.metadata_hash.as_deref()],
+                        |row| row.get(0),
+                    )
+                    .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
+                usize::try_from(durable).unwrap_or(0)
+            };
+            if durable > 0 {
+                record_metadata_capture_revision(
+                    conn,
+                    &library,
+                    &asset_id,
+                    capture_revision,
+                    rewrite_at,
+                )?;
             }
-            // A row can leave `downloaded` mid-cycle when the provider
-            // publishes new media for the same asset, which stores the
-            // incoming metadata as it resets the row for re-download. The
-            // metadata is durable, so report the match rather than a lost
-            // write. A missing or still-stale row stays a failure.
-            let durable: i64 = conn
-                .query_row(
-                    "SELECT COUNT(*) FROM assets \
-                     WHERE library = ?1 AND id = ?2 AND is_deleted = 0 \
-                       AND metadata_hash IS NOT NULL AND metadata_hash = ?3",
-                    rusqlite::params![library, asset_id, metadata.metadata_hash.as_deref()],
-                    |row| row.get(0),
-                )
-                .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
-            Ok(usize::try_from(durable).unwrap_or(0))
+            Ok(durable)
         })
         .await
     }
@@ -3949,6 +4086,319 @@ impl SqliteStateDb {
         })
         .await
     }
+
+    pub(crate) async fn begin_metadata_capture_revision(
+        &self,
+        library: &str,
+        target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        let library = library.to_owned();
+        self.with_conn_mut("begin_metadata_capture_revision", move |conn| {
+            let tx = conn.transaction().map_err(|e| {
+                StateError::query("begin_metadata_capture_revision::transaction", e)
+            })?;
+            let remaining = metadata_capture_remaining(&tx, &library, target_revision)?;
+            let existing = tx
+                .query_row(
+                    "SELECT active_revision, pending_revision, processed_assets, \
+                            failed_assets, last_error \
+                     FROM metadata_capture_state WHERE library = ?1",
+                    [&library],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, Option<i64>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, Option<String>>(4)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|e| StateError::query("begin_metadata_capture_revision::read", e))?;
+            let (mut active, previous_pending, mut processed, mut failed, mut last_error) =
+                existing.unwrap_or((0, None, 0, 0, None));
+            let pending = if remaining == 0 {
+                active = active.max(target_revision);
+                None
+            } else {
+                if previous_pending != Some(target_revision) {
+                    processed = 0;
+                    failed = 0;
+                    last_error = None;
+                }
+                Some(target_revision)
+            };
+            let now = Utc::now().timestamp();
+            tx.execute(
+                "INSERT INTO metadata_capture_state \
+                    (library, active_revision, pending_revision, processed_assets, \
+                     failed_assets, last_error, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+                 ON CONFLICT(library) DO UPDATE SET \
+                    active_revision = excluded.active_revision, \
+                    pending_revision = excluded.pending_revision, \
+                    processed_assets = excluded.processed_assets, \
+                    failed_assets = excluded.failed_assets, \
+                    last_error = excluded.last_error, updated_at = excluded.updated_at",
+                rusqlite::params![library, active, pending, processed, failed, last_error, now],
+            )
+            .map_err(|e| StateError::query("begin_metadata_capture_revision::write", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("begin_metadata_capture_revision::commit", e))?;
+            Ok(MetadataCaptureStatus {
+                library,
+                active_revision: active,
+                pending_revision: pending,
+                processed_assets: u64::try_from(processed).unwrap_or(0),
+                failed_assets: u64::try_from(failed).unwrap_or(0),
+                remaining_assets: remaining,
+                last_error,
+            })
+        })
+        .await
+    }
+
+    pub(crate) async fn get_metadata_capture_candidates(
+        &self,
+        library: &str,
+        target_revision: i64,
+        limit: usize,
+    ) -> Result<Vec<MetadataCaptureCandidate>, StateError> {
+        let library = library.to_owned();
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        self.with_conn("get_metadata_capture_candidates", move |conn| {
+            let mut stmt = conn
+                .prepare_cached(
+                    r"
+                    WITH stale_assets AS (
+                        SELECT assets.library, assets.id
+                        FROM assets
+                        LEFT JOIN asset_metadata_capture_revisions AS revisions
+                          ON revisions.library = assets.library
+                         AND revisions.asset_id = assets.id
+                        WHERE assets.library = ?1
+                          AND assets.status = 'downloaded'
+                          AND assets.is_deleted = 0
+                          AND (revisions.revision IS NULL OR revisions.revision < ?2)
+                        GROUP BY assets.library, assets.id
+                        ORDER BY assets.id
+                        LIMIT ?3
+                    )
+                    SELECT stale_assets.library, stale_assets.id,
+                           COALESCE(mapping.master_record_name,
+                                    owner.master_record_name,
+                                    stale_assets.id),
+                           COALESCE(mapping.asset_record_name,
+                                    owner.asset_record_name),
+                           assets.version_size, assets.checksum, assets.size_bytes
+                    FROM stale_assets
+                    JOIN assets
+                      ON assets.library = stale_assets.library
+                     AND assets.id = stale_assets.id
+                     AND assets.status = 'downloaded'
+                     AND assets.is_deleted = 0
+                    LEFT JOIN asset_master_mappings AS mapping
+                      ON mapping.library = stale_assets.library
+                     AND mapping.asset_record_name = stale_assets.id
+                    LEFT JOIN legacy_master_state_owners AS owner
+                      ON owner.library = stale_assets.library
+                     AND owner.master_record_name = stale_assets.id
+                    ORDER BY stale_assets.id, assets.version_size
+                    ",
+                )
+                .map_err(|e| StateError::query("get_metadata_capture_candidates::prepare", e))?;
+            let rows = stmt
+                .query_map(rusqlite::params![library, target_revision, limit], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, i64>(6)?,
+                    ))
+                })
+                .map_err(|e| StateError::query("get_metadata_capture_candidates::query", e))?;
+            let mut candidates = Vec::<MetadataCaptureCandidate>::new();
+            for row in rows {
+                let (library, asset_id, master, asset, version, checksum, size) =
+                    row.map_err(|e| StateError::query("get_metadata_capture_candidates::row", e))?;
+                let version_size =
+                    VersionSizeKey::from_str(&version).ok_or_else(|| StateError::Invariant {
+                        operation: "get_metadata_capture_candidates",
+                        detail: format!("unknown durable version_size {version:?}"),
+                    })?;
+                let evidence = MetadataCaptureVersionEvidence {
+                    version_size,
+                    checksum,
+                    size_bytes: u64::try_from(size).unwrap_or(0),
+                };
+                if let Some(candidate) = candidates.last_mut()
+                    && candidate.asset_id == asset_id
+                {
+                    candidate.versions.push(evidence);
+                } else {
+                    candidates.push(MetadataCaptureCandidate {
+                        library,
+                        asset_id,
+                        master_record_name: master,
+                        asset_record_name: asset,
+                        versions: vec![evidence],
+                    });
+                }
+            }
+            Ok(candidates)
+        })
+        .await
+    }
+
+    pub(crate) async fn record_metadata_capture_failure(
+        &self,
+        library: &str,
+        target_revision: i64,
+        error: &str,
+    ) -> Result<(), StateError> {
+        let library = library.to_owned();
+        let error = error.to_owned();
+        self.with_conn("record_metadata_capture_failure", move |conn| {
+            conn.execute(
+                "UPDATE metadata_capture_state SET failed_assets = failed_assets + 1, \
+                    last_error = ?1, updated_at = ?2 \
+                 WHERE library = ?3 AND pending_revision = ?4",
+                rusqlite::params![error, Utc::now().timestamp(), library, target_revision],
+            )
+            .map_err(|e| StateError::query("record_metadata_capture_failure", e))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn complete_metadata_capture_revision(
+        &self,
+        library: &str,
+        target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        let library = library.to_owned();
+        self.with_conn_mut("complete_metadata_capture_revision", move |conn| {
+            let tx = conn.transaction().map_err(|e| {
+                StateError::query("complete_metadata_capture_revision::transaction", e)
+            })?;
+            let remaining = metadata_capture_remaining(&tx, &library, target_revision)?;
+            if remaining == 0 {
+                tx.execute(
+                    "UPDATE metadata_capture_state SET active_revision = MAX(active_revision, ?1), \
+                        pending_revision = NULL, failed_assets = 0, last_error = NULL, \
+                        updated_at = ?2 \
+                     WHERE library = ?3",
+                    rusqlite::params![target_revision, Utc::now().timestamp(), library],
+                )
+                .map_err(|e| StateError::query("complete_metadata_capture_revision::write", e))?;
+            }
+            let status = metadata_capture_status(&tx, &library, target_revision, remaining)?;
+            tx.commit()
+                .map_err(|e| StateError::query("complete_metadata_capture_revision::commit", e))?;
+            Ok(status)
+        })
+        .await
+    }
+
+    pub(crate) async fn has_metadata_capture_work(
+        &self,
+        libraries: &[&str],
+        target_revision: i64,
+    ) -> Result<bool, StateError> {
+        if libraries.is_empty() {
+            return Ok(false);
+        }
+        let libraries = unique_sorted_strings(libraries);
+        self.with_conn("has_metadata_capture_work", move |conn| {
+            for library in libraries {
+                if metadata_capture_remaining(conn, &library, target_revision)? > 0 {
+                    return Ok(true);
+                }
+                let pending: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM metadata_capture_state \
+                         WHERE library = ?1 AND pending_revision = ?2)",
+                        rusqlite::params![library, target_revision],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map(|value| value != 0)
+                    .map_err(|e| StateError::query("has_metadata_capture_work", e))?;
+                if pending {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        })
+        .await
+    }
+}
+
+fn metadata_capture_remaining(
+    conn: &Connection,
+    library: &str,
+    target_revision: i64,
+) -> Result<u64, StateError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM ( \
+             SELECT assets.id FROM assets \
+             LEFT JOIN asset_metadata_capture_revisions AS revisions \
+               ON revisions.library = assets.library AND revisions.asset_id = assets.id \
+             WHERE assets.library = ?1 AND assets.status = 'downloaded' \
+               AND assets.is_deleted = 0 \
+               AND (revisions.revision IS NULL OR revisions.revision < ?2) \
+             GROUP BY assets.id \
+         )",
+        rusqlite::params![library, target_revision],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| u64::try_from(count).unwrap_or(0))
+    .map_err(|e| StateError::query("metadata_capture_remaining", e))
+}
+
+fn metadata_capture_status(
+    conn: &Connection,
+    library: &str,
+    target_revision: i64,
+    remaining_assets: u64,
+) -> Result<MetadataCaptureStatus, StateError> {
+    let row = conn
+        .query_row(
+            "SELECT active_revision, pending_revision, processed_assets, \
+                    failed_assets, last_error \
+             FROM metadata_capture_state WHERE library = ?1",
+            [library],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|e| StateError::query("metadata_capture_status", e))?;
+    let (active_revision, pending_revision, processed, failed, last_error) = row.unwrap_or({
+        if remaining_assets > 0 {
+            (0, Some(target_revision), 0, 0, None)
+        } else {
+            (target_revision, None, 0, 0, None)
+        }
+    });
+    Ok(MetadataCaptureStatus {
+        library: library.to_owned(),
+        active_revision,
+        pending_revision,
+        processed_assets: u64::try_from(processed).unwrap_or(0),
+        failed_assets: u64::try_from(failed).unwrap_or(0),
+        remaining_assets,
+        last_error,
+    })
 }
 
 #[async_trait]
@@ -4574,6 +5024,7 @@ impl MetadataRewriteStore for SqliteStateDb {
         asset_id: &str,
         metadata: &AssetMetadata,
         mark_for_rewrite: bool,
+        capture_revision: i64,
     ) -> Result<usize, StateError> {
         SqliteStateDb::refresh_downloaded_asset_metadata(
             self,
@@ -4581,6 +5032,7 @@ impl MetadataRewriteStore for SqliteStateDb {
             asset_id,
             metadata,
             mark_for_rewrite,
+            capture_revision,
         )
         .await
     }
@@ -4636,6 +5088,48 @@ impl MetadataRewriteStore for SqliteStateDb {
 
     async fn has_downloaded_without_metadata_hash(&self) -> Result<bool, StateError> {
         SqliteStateDb::has_downloaded_without_metadata_hash(self).await
+    }
+
+    async fn begin_metadata_capture_revision(
+        &self,
+        library: &str,
+        target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        SqliteStateDb::begin_metadata_capture_revision(self, library, target_revision).await
+    }
+
+    async fn get_metadata_capture_candidates(
+        &self,
+        library: &str,
+        target_revision: i64,
+        limit: usize,
+    ) -> Result<Vec<MetadataCaptureCandidate>, StateError> {
+        SqliteStateDb::get_metadata_capture_candidates(self, library, target_revision, limit).await
+    }
+
+    async fn record_metadata_capture_failure(
+        &self,
+        library: &str,
+        target_revision: i64,
+        error: &str,
+    ) -> Result<(), StateError> {
+        SqliteStateDb::record_metadata_capture_failure(self, library, target_revision, error).await
+    }
+
+    async fn complete_metadata_capture_revision(
+        &self,
+        library: &str,
+        target_revision: i64,
+    ) -> Result<MetadataCaptureStatus, StateError> {
+        SqliteStateDb::complete_metadata_capture_revision(self, library, target_revision).await
+    }
+
+    async fn has_metadata_capture_work(
+        &self,
+        libraries: &[&str],
+        target_revision: i64,
+    ) -> Result<bool, StateError> {
+        SqliteStateDb::has_metadata_capture_work(self, libraries, target_revision).await
     }
 }
 
@@ -4726,6 +5220,24 @@ impl SqliteStateDb {
             "UPDATE assets SET metadata_hash = NULL \
              WHERE library = ?1 AND id = ?2 AND version_size = ?3",
             rusqlite::params![library, asset_id, version_size],
+        )
+        .unwrap();
+    }
+
+    pub(crate) fn set_metadata_capture_revision_for_test(
+        &self,
+        library: &str,
+        asset_id: &str,
+        revision: i64,
+    ) {
+        let conn = self
+            .acquire_lock("test_set_metadata_capture_revision")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO asset_metadata_capture_revisions \
+                (library, asset_id, revision, updated_at) VALUES (?1, ?2, ?3, 0) \
+             ON CONFLICT(library, asset_id) DO UPDATE SET revision = excluded.revision",
+            rusqlite::params![library, asset_id, revision],
         )
         .unwrap();
     }
@@ -9462,7 +9974,13 @@ mod tests {
         db.upsert_seen(&republished).await.unwrap();
 
         let matched = db
-            .refresh_downloaded_asset_metadata("PrimarySync", "MOVED_ON", &edited, true)
+            .refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "MOVED_ON",
+                &edited,
+                true,
+                METADATA_CAPTURE_REVISION,
+            )
             .await
             .unwrap();
         assert!(
@@ -9471,7 +9989,13 @@ mod tests {
         );
 
         let stale = db
-            .refresh_downloaded_asset_metadata("PrimarySync", "ABSENT", &edited, true)
+            .refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "ABSENT",
+                &edited,
+                true,
+                METADATA_CAPTURE_REVISION,
+            )
             .await
             .unwrap();
         assert_eq!(stale, 0, "a missing row is still a lost write");
@@ -9628,7 +10152,13 @@ mod tests {
         };
         let expected_hash = metadata.compute_hash();
         let updated = db
-            .refresh_downloaded_asset_metadata("PrimarySync", "PHOTO", &metadata, true)
+            .refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "PHOTO",
+                &metadata,
+                true,
+                METADATA_CAPTURE_REVISION,
+            )
             .await
             .unwrap();
         assert_eq!(updated, 2);
@@ -9660,6 +10190,167 @@ mod tests {
             assert_eq!(record.checksum.as_ref(), "checksum123");
             assert_eq!(record.metadata.rating, Some(4));
         }
+    }
+
+    #[tokio::test]
+    async fn metadata_capture_revision_repair_is_resumable_and_preserves_file_state() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("ASSET_CHILD")
+            .checksum("provider-checksum")
+            .filename("photo.jpg")
+            .size(2048)
+            .metadata(AssetMetadata {
+                metadata_hash: Some("revision-zero".to_string()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "ASSET_CHILD",
+            "original",
+            Path::new("/photos/photo.jpg"),
+            "local-checksum",
+            Some("provider-checksum"),
+        )
+        .await
+        .unwrap();
+        db.upsert_asset_master_mapping("PrimarySync", "ASSET_CHILD", "MASTER")
+            .await
+            .unwrap();
+        {
+            let conn = db.acquire_lock("test_metadata_capture_revision").unwrap();
+            conn.execute(
+                "UPDATE asset_metadata_capture_revisions SET revision = 0 \
+                 WHERE library = 'PrimarySync' AND asset_id = 'ASSET_CHILD'",
+                [],
+            )
+            .unwrap();
+        }
+
+        let started = db
+            .begin_metadata_capture_revision("PrimarySync", METADATA_CAPTURE_REVISION)
+            .await
+            .unwrap();
+        assert_eq!(started.active_revision, 0);
+        assert_eq!(started.pending_revision, Some(METADATA_CAPTURE_REVISION));
+        assert_eq!(started.remaining_assets, 1);
+
+        let candidates = db
+            .get_metadata_capture_candidates("PrimarySync", METADATA_CAPTURE_REVISION, 10)
+            .await
+            .unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].asset_id, "ASSET_CHILD");
+        assert_eq!(candidates[0].master_record_name, "MASTER");
+        assert_eq!(
+            candidates[0].asset_record_name.as_deref(),
+            Some("ASSET_CHILD")
+        );
+        assert_eq!(candidates[0].versions.len(), 1);
+        assert_eq!(candidates[0].versions[0].size_bytes, 2048);
+
+        db.record_metadata_capture_failure(
+            "PrimarySync",
+            METADATA_CAPTURE_REVISION,
+            "temporary provider failure",
+        )
+        .await
+        .unwrap();
+        let still_pending = db
+            .complete_metadata_capture_revision("PrimarySync", METADATA_CAPTURE_REVISION)
+            .await
+            .unwrap();
+        assert_eq!(still_pending.remaining_assets, 1);
+        assert_eq!(still_pending.failed_assets, 1);
+
+        let metadata = AssetMetadata {
+            rating: Some(5),
+            ..AssetMetadata::default()
+        };
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            "ASSET_CHILD",
+            &metadata,
+            true,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap();
+        let completed = db
+            .complete_metadata_capture_revision("PrimarySync", METADATA_CAPTURE_REVISION)
+            .await
+            .unwrap();
+        assert_eq!(completed.active_revision, METADATA_CAPTURE_REVISION);
+        assert_eq!(completed.pending_revision, None);
+        assert_eq!(completed.remaining_assets, 0);
+        assert_eq!(completed.processed_assets, 1);
+        assert_eq!(completed.failed_assets, 0);
+
+        let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 1);
+        assert_eq!(
+            downloaded[0].local_path.as_deref(),
+            Some(Path::new("/photos/photo.jpg"))
+        );
+        assert_eq!(
+            downloaded[0].local_checksum.as_deref(),
+            Some("local-checksum")
+        );
+        assert_eq!(
+            downloaded[0].download_checksum.as_deref(),
+            Some("provider-checksum")
+        );
+        assert_eq!(downloaded[0].metadata.rating, Some(5));
+        assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn metadata_capture_candidates_are_bounded_and_library_scoped() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for (library, id) in [
+            ("PrimarySync", "A"),
+            ("PrimarySync", "B"),
+            ("PrimarySync", "C"),
+            ("SharedSync-AAAA", "D"),
+        ] {
+            let mut record = TestAssetRecord::new(id).build();
+            record.library = Arc::from(library);
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_downloaded(
+                library,
+                id,
+                "original",
+                Path::new("/photos/photo.jpg"),
+                "local-checksum",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let conn = db.acquire_lock("test_metadata_capture_scope").unwrap();
+            conn.execute("DELETE FROM asset_metadata_capture_revisions", [])
+                .unwrap();
+        }
+
+        assert!(
+            db.has_metadata_capture_work(&["PrimarySync"], METADATA_CAPTURE_REVISION)
+                .await
+                .unwrap()
+        );
+        let primary = db
+            .get_metadata_capture_candidates("PrimarySync", METADATA_CAPTURE_REVISION, 2)
+            .await
+            .unwrap();
+        assert_eq!(primary.len(), 2);
+        assert!(primary.iter().all(|row| row.library == "PrimarySync"));
+        let shared = db
+            .get_metadata_capture_candidates("SharedSync-AAAA", METADATA_CAPTURE_REVISION, 2)
+            .await
+            .unwrap();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].asset_id, "D");
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -22,4 +22,7 @@ pub use db::{
     DownloadStateStore, ImportStateStore, MembershipStore, MetadataRewriteStore, ReportStateStore,
     SqliteStateDb, SyncTokenStore,
 };
+#[cfg(test)]
+pub(crate) use types::MetadataCaptureStatus;
 pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};
+pub(crate) use types::{METADATA_CAPTURE_REVISION, MetadataCaptureCandidate};

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 17;
+pub(crate) const SCHEMA_VERSION: i32 = 18;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -479,6 +479,34 @@ CREATE TABLE IF NOT EXISTS legacy_master_state_owners (
 );
 ";
 
+/// V18 metadata-capture revisions and per-library repair state.
+///
+/// Existing assets intentionally receive no row in
+/// `asset_metadata_capture_revisions`; absence is durable evidence that the
+/// catalogue metadata predates the current capture semantics.
+const SCHEMA_V18: &str = r"
+CREATE TABLE IF NOT EXISTS asset_metadata_capture_revisions (
+    library TEXT NOT NULL,
+    asset_id TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (library, asset_id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_capture_state (
+    library TEXT PRIMARY KEY NOT NULL,
+    active_revision INTEGER NOT NULL DEFAULT 0,
+    pending_revision INTEGER,
+    processed_assets INTEGER NOT NULL DEFAULT 0,
+    failed_assets INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_metadata_capture_revision
+    ON asset_metadata_capture_revisions (library, revision);
+";
+
 /// Apply migration for a specific version.
 ///
 /// `start_version` is the schema version the DB carried when `migrate()`
@@ -633,6 +661,7 @@ fn migrate_to_version(
         15 => conn.execute_batch(SCHEMA_V15)?,
         16 => conn.execute_batch(SCHEMA_V16)?,
         17 => conn.execute_batch(SCHEMA_V17)?,
+        18 => conn.execute_batch(SCHEMA_V18)?,
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -1901,6 +1930,47 @@ mod tests {
             assert!(column_exists(&conn, "legacy_master_state_owners", column).unwrap());
         }
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn test_v18_creates_metadata_capture_revision_state_without_backfill() {
+        let conn = Connection::open_in_memory().unwrap();
+        for version in 1..=17 {
+            migrate_to_version(&conn, 0, version).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO assets (library, id, version_size, checksum, filename, \
+                created_at, size_bytes, media_type, status, last_seen_at) \
+             VALUES ('PrimarySync', 'legacy', 'original', 'checksum', 'legacy.jpg', \
+                1, 10, 'photo', 'downloaded', 1)",
+            [],
+        )
+        .unwrap();
+        set_schema_version(&conn, 17).unwrap();
+
+        migrate(&conn).unwrap();
+
+        for table in ["asset_metadata_capture_revisions", "metadata_capture_state"] {
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(exists, 1, "missing {table}");
+        }
+        let revisions: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM asset_metadata_capture_revisions",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            revisions, 0,
+            "pre-v18 catalogue rows must remain visibly stale"
+        );
     }
 
     #[test]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -7,6 +7,11 @@ use chrono::{DateTime, FixedOffset, Local, Utc};
 
 use crate::types::AssetVersionSize;
 
+/// Revision of the catalogue metadata semantics produced by the current
+/// binary. Bump this when decoder or capture behavior changes in a way that
+/// requires existing catalogue rows to be hydrated again.
+pub(crate) const METADATA_CAPTURE_REVISION: i64 = 1;
+
 /// Version size key for state tracking.
 ///
 /// This is a 1-byte enum representing the version size, saving ~23 bytes
@@ -502,6 +507,39 @@ pub struct SyncRunStats {
     pub inventory_drop_library: Option<String>,
 }
 
+/// One provider version used to identify the correct child of a legacy
+/// master-keyed catalogue row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MetadataCaptureVersionEvidence {
+    pub(crate) version_size: VersionSizeKey,
+    pub(crate) checksum: String,
+    pub(crate) size_bytes: u64,
+}
+
+/// One stale catalogue identity selected for bounded provider hydration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MetadataCaptureCandidate {
+    pub(crate) library: String,
+    pub(crate) asset_id: String,
+    pub(crate) master_record_name: String,
+    pub(crate) asset_record_name: Option<String>,
+    pub(crate) versions: Vec<MetadataCaptureVersionEvidence>,
+}
+
+/// Durable metadata-capture state for one provider library.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MetadataCaptureStatus {
+    pub library: String,
+    pub active_revision: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_revision: Option<i64>,
+    pub processed_assets: u64,
+    pub failed_assets: u64,
+    pub remaining_assets: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
 /// Summary of the current state database.
 #[derive(Debug, Clone)]
 pub struct SyncSummary {
@@ -559,6 +597,8 @@ pub struct SyncSummary {
     pub last_inventory_drop_current_total: Option<u64>,
     /// Library where the latest inventory warning was observed.
     pub last_inventory_drop_library: Option<String>,
+    /// Per-library metadata-capture revision and repair progress.
+    pub metadata_capture: Vec<MetadataCaptureStatus>,
 }
 
 #[cfg(test)]

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -126,6 +126,28 @@ impl WatchPrecheck {
             } => true,
         }
     }
+
+    fn include_local_work_zones(&mut self, zones: rustc_hash::FxHashSet<String>) {
+        if zones.is_empty() {
+            return;
+        }
+        match self {
+            Self::SkipAll => {
+                *self = Self::Proceed {
+                    changed_zones: Some(zones),
+                    db_sync_token_after_success: None,
+                };
+            }
+            Self::Proceed {
+                changed_zones: Some(changed_zones),
+                ..
+            } => changed_zones.extend(zones),
+            Self::Proceed {
+                changed_zones: None,
+                ..
+            } => {}
+        }
+    }
 }
 
 /// State-DB metadata key for the first-sync shared-library notice. Bumping
@@ -1193,6 +1215,47 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     "Local drift probe found missing or damaged files; forcing this cycle to retry them"
                 );
                 watch_precheck = WatchPrecheck::proceed_all();
+            }
+        }
+
+        if is_watch_mode
+            && !config.runtime.dry_run
+            && !config.runtime.only_print_filenames
+            && let Some(db) = state_db.as_deref()
+        {
+            let mut local_work_zones = rustc_hash::FxHashSet::default();
+            for library in &library_states {
+                let zone = library.zone_name.as_str();
+                let capture_pending = match db
+                    .has_metadata_capture_work(&[zone], state::METADATA_CAPTURE_REVISION)
+                    .await
+                {
+                    Ok(pending) => pending,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "Could not inspect metadata-capture work before watch pre-check");
+                        true
+                    }
+                };
+                let rewrite_pending = match db
+                    .get_pending_metadata_rewrites_page(Some(&[zone]), 0, 1)
+                    .await
+                {
+                    Ok(rows) => !rows.is_empty(),
+                    Err(error) => {
+                        tracing::warn!(error = %error, "Could not inspect metadata-rewrite work before watch pre-check");
+                        true
+                    }
+                };
+                if capture_pending || rewrite_pending {
+                    local_work_zones.insert(library.zone_name.clone());
+                }
+            }
+            if !local_work_zones.is_empty() {
+                tracing::debug!(
+                    libraries = local_work_zones.len(),
+                    "Pending metadata work bypassed the watch no-change shortcut"
+                );
+                watch_precheck.include_local_work_zones(local_work_zones);
             }
         }
 
@@ -2431,6 +2494,40 @@ mod tests {
         );
         assert!(precheck.should_sync_zone("PrimarySync"));
         assert!(!precheck.should_sync_zone("SharedSync-123"));
+    }
+
+    #[test]
+    fn pending_metadata_work_bypasses_skip_for_only_affected_zone() {
+        let mut precheck = WatchPrecheck::SkipAll;
+        let mut local_zones = rustc_hash::FxHashSet::default();
+        local_zones.insert("SharedSync-123".to_string());
+
+        precheck.include_local_work_zones(local_zones);
+
+        assert!(!precheck.should_sync_zone("PrimarySync"));
+        assert!(precheck.should_sync_zone("SharedSync-123"));
+        assert!(precheck.db_sync_token_after_success().is_none());
+    }
+
+    #[test]
+    fn pending_metadata_work_joins_provider_changed_zones_without_losing_db_token() {
+        let mut changed_zones = rustc_hash::FxHashSet::default();
+        changed_zones.insert("PrimarySync".to_string());
+        let mut precheck = WatchPrecheck::Proceed {
+            changed_zones: Some(changed_zones),
+            db_sync_token_after_success: Some("db-token-after-cycle".to_string()),
+        };
+        let mut local_zones = rustc_hash::FxHashSet::default();
+        local_zones.insert("SharedSync-123".to_string());
+
+        precheck.include_local_work_zones(local_zones);
+
+        assert!(precheck.should_sync_zone("PrimarySync"));
+        assert!(precheck.should_sync_zone("SharedSync-123"));
+        assert_eq!(
+            precheck.db_sync_token_after_success(),
+            Some("db-token-after-cycle")
+        );
     }
 
     #[tokio::test]
@@ -4593,7 +4690,13 @@ mod tests {
             }
             if let Some(newer) = &self.refresh_on_mark_downloaded {
                 self.inner
-                    .refresh_downloaded_asset_metadata(library, id, newer, true)
+                    .refresh_downloaded_asset_metadata(
+                        library,
+                        id,
+                        newer,
+                        true,
+                        state::METADATA_CAPTURE_REVISION,
+                    )
                     .await?;
             }
             self.inner
@@ -5158,6 +5261,7 @@ mod tests {
             asset_id: &str,
             metadata: &state::AssetMetadata,
             mark_for_rewrite: bool,
+            capture_revision: i64,
         ) -> Result<usize, state::error::StateError> {
             if self.fail_refresh_downloaded_metadata {
                 return Err(state::error::StateError::LockPoisoned(
@@ -5165,7 +5269,13 @@ mod tests {
                 ));
             }
             self.inner
-                .refresh_downloaded_asset_metadata(library, asset_id, metadata, mark_for_rewrite)
+                .refresh_downloaded_asset_metadata(
+                    library,
+                    asset_id,
+                    metadata,
+                    mark_for_rewrite,
+                    capture_revision,
+                )
                 .await
         }
 
@@ -5237,6 +5347,58 @@ mod tests {
             &self,
         ) -> Result<bool, state::error::StateError> {
             self.inner.has_downloaded_without_metadata_hash().await
+        }
+
+        async fn begin_metadata_capture_revision(
+            &self,
+            library: &str,
+            target_revision: i64,
+        ) -> Result<state::MetadataCaptureStatus, state::error::StateError> {
+            self.inner
+                .begin_metadata_capture_revision(library, target_revision)
+                .await
+        }
+
+        async fn get_metadata_capture_candidates(
+            &self,
+            library: &str,
+            target_revision: i64,
+            limit: usize,
+        ) -> Result<Vec<state::MetadataCaptureCandidate>, state::error::StateError> {
+            self.inner
+                .get_metadata_capture_candidates(library, target_revision, limit)
+                .await
+        }
+
+        async fn record_metadata_capture_failure(
+            &self,
+            library: &str,
+            target_revision: i64,
+            error: &str,
+        ) -> Result<(), state::error::StateError> {
+            self.inner
+                .record_metadata_capture_failure(library, target_revision, error)
+                .await
+        }
+
+        async fn complete_metadata_capture_revision(
+            &self,
+            library: &str,
+            target_revision: i64,
+        ) -> Result<state::MetadataCaptureStatus, state::error::StateError> {
+            self.inner
+                .complete_metadata_capture_revision(library, target_revision)
+                .await
+        }
+
+        async fn has_metadata_capture_work(
+            &self,
+            libraries: &[&str],
+            target_revision: i64,
+        ) -> Result<bool, state::error::StateError> {
+            self.inner
+                .has_metadata_capture_work(libraries, target_revision)
+                .await
         }
     }
 
@@ -6556,6 +6718,132 @@ mod tests {
                 .as_deref(),
             Some("zone-tok-new"),
             "durable provider state must allow the zone checkpoint to advance"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cycle_capture_revision_repair_advances_checkpoint_after_durable_metadata() {
+        #[derive(Clone, Debug)]
+        struct CaptureRevisionSession {
+            records: Arc<Vec<serde_json::Value>>,
+        }
+
+        #[async_trait::async_trait]
+        impl crate::icloud::photos::PhotosSession for CaptureRevisionSession {
+            async fn post(
+                &self,
+                url: &str,
+                _body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<serde_json::Value> {
+                if url.contains("/records/lookup?") {
+                    return Ok(serde_json::json!({"records": self.records.as_ref()}));
+                }
+                if url.contains("/changes/zone?") {
+                    return Ok(serde_json::json!({
+                        "zones": [{
+                            "zoneID": {
+                                "zoneName": "PrimarySync",
+                                "ownerRecordName": "_defaultOwner"
+                            },
+                            "syncToken": "zone-tok-new",
+                            "moreComing": false,
+                            "records": []
+                        }]
+                    }));
+                }
+                Ok(serde_json::json!({"records": []}))
+            }
+
+            fn clone_box(&self) -> Box<dyn crate::icloud::photos::PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        let config = make_run_cycle_config();
+        let inner = Arc::new(state::SqliteStateDb::open_in_memory().expect("state db"));
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let db = Arc::clone(&inner) as Arc<dyn download::DownloadStore>;
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        seed_run_cycle_metadata_drift_asset(&db, download_dir.path()).await;
+        inner
+            .upsert_asset_master_mapping(
+                "PrimarySync",
+                "asset-master-PrimarySync",
+                "master-PrimarySync",
+            )
+            .await
+            .expect("seed durable provider identity");
+        assert!(
+            inner
+                .claim_legacy_master_state_owner(
+                    "PrimarySync",
+                    "master-PrimarySync",
+                    "asset-master-PrimarySync",
+                )
+                .await
+                .expect("seed legacy state owner")
+        );
+        inner.set_metadata_capture_revision_for_test("PrimarySync", "master-PrimarySync", 0);
+
+        let page = run_cycle_favourited_asset_page();
+        let records = page["records"]
+            .as_array()
+            .expect("provider page records")
+            .clone();
+        let album = make_full_album_with_boxed_session(
+            "PrimarySync",
+            Box::new(CaptureRevisionSession {
+                records: Arc::new(records),
+            }),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                media: media_without_photo_downloads(),
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.stats.downloaded, 0);
+        assert_eq!(result.stats.metadata_capture_refreshed, 1);
+        assert_eq!(result.stats.metadata_capture_remaining, 0);
+        assert!(
+            inner.get_downloaded_page(0, 1).await.unwrap()[0]
+                .metadata
+                .is_favorite,
+            "automatic repair must durably store the provider metadata"
+        );
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-new"),
+            "durable capture repair must allow the zone checkpoint to advance"
         );
     }
 

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -82,7 +82,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 17;
+const HELPER_SCHEMA_VERSION: i32 = 18;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -265,6 +265,27 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
             PRIMARY KEY (library, master_record_name)
         );
 
+        CREATE TABLE IF NOT EXISTS asset_metadata_capture_revisions (
+            library TEXT NOT NULL,
+            asset_id TEXT NOT NULL,
+            revision INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (library, asset_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS metadata_capture_state (
+            library TEXT PRIMARY KEY NOT NULL,
+            active_revision INTEGER NOT NULL DEFAULT 0,
+            pending_revision INTEGER,
+            processed_assets INTEGER NOT NULL DEFAULT 0,
+            failed_assets INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            updated_at INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_asset_metadata_capture_revision
+            ON asset_metadata_capture_revisions (library, revision);
+
         CREATE TABLE IF NOT EXISTS scoped_db_sync_tokens (
             provider TEXT NOT NULL,
             account TEXT NOT NULL,
@@ -310,7 +331,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 17). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 18). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -328,7 +349,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 17;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 18;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \
@@ -398,7 +419,7 @@ friendly = false
 
     let body = std::fs::read_to_string(&report_path).expect("sync_report.json");
     let json: serde_json::Value = serde_json::from_str(&body).expect("valid report JSON");
-    assert_eq!(json["version"], "2", "schema version");
+    assert_eq!(json["version"], "3", "schema version");
     assert!(json["kei_version"].as_str().is_some_and(|v| !v.is_empty()));
     assert!(
         json["timestamp"]
@@ -1661,6 +1682,13 @@ fn status_shows_safe_backup_summary_after_clean_sync() {
         None,
         None,
     );
+    conn.execute(
+        "INSERT INTO asset_metadata_capture_revisions \
+            (library, asset_id, revision, updated_at) \
+         VALUES ('PrimarySync', 'a1', 1, ?1)",
+        [1_700_000_000_i64],
+    )
+    .unwrap();
     conn.execute(
         "INSERT INTO sync_runs (
             started_at, completed_at, status, assets_seen, assets_downloaded,
@@ -3771,6 +3799,18 @@ fn behavioral_helper_carries_every_migrated_column() {
         has_legacy_master_state_owners,
         "v17 table legacy_master_state_owners must exist in the behavioral helper's DDL"
     );
+
+    for table in ["asset_metadata_capture_revisions", "metadata_capture_state"] {
+        let exists: bool = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?1")
+            .unwrap()
+            .exists([table])
+            .unwrap();
+        assert!(
+            exists,
+            "v18 table {table} must exist in the behavioral helper's DDL"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1768,7 +1768,7 @@ fn sync_report_json_writes_valid_schema() {
 
         let body = std::fs::read_to_string(&report_path).expect("report file");
         let json: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
-        assert_eq!(json["version"], "2", "schema version");
+        assert_eq!(json["version"], "3", "schema version");
         assert!(json["kei_version"].is_string(), "kei_version present");
         assert!(json["timestamp"].is_string(), "timestamp present");
         let status = json["status"].as_str().expect("status string");


### PR DESCRIPTION
## Summary
- Track metadata-capture revisions per asset and repair progress per library.
- Repair stale downloaded catalogue rows with bounded provider lookups without downloading media again.
- Queue configured metadata rewrites, preserve checkpoints on failures, and bypass watch-mode shortcuts while work remains.
- Report repair progress through sync reports and `kei status`.

## Tests
- `just gate` => passed

Closes #687
