### PR TITLE
Honor Cargo target directory in full tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -605,7 +605,7 @@ service-smoke:
     #!/usr/bin/env bash
     set -euxo pipefail
     cargo build --release
-    KEI="$PWD/target/release/kei"
+    KEI="$(scripts/full-test/cargo_target_dir.sh)/release/kei"
     # `kei status` derives its state-DB path from the username; pin a
     # placeholder so the smoke does not depend on the operator's .env
     # or saved config.

--- a/scripts/full-test/cargo_target_dir.sh
+++ b/scripts/full-test/cargo_target_dir.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Print the Cargo target directory for commands that consume build artifacts.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+target_dir="${CARGO_TARGET_DIR:-target}"
+
+if [[ "$target_dir" != /* ]]; then
+  target_dir="$repo_root/$target_dir"
+fi
+
+printf '%s\n' "$target_dir"

--- a/scripts/full-test/collect_metrics.py
+++ b/scripts/full-test/collect_metrics.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Collect repo-level metrics for /full-test runs.
 
-Run from the kei repo root after the build + docker phases have
-completed (so target/release/kei and the kei:dev image both exist). Emits a
-JSON object on stdout that finalize_run.sh embeds in the run record.
+Run from the kei repo root after the build + docker phases have completed.
+The release binary under Cargo's target directory and the kei:dev image must
+both exist. Emits a JSON object on stdout that finalize_run.sh embeds in the
+run record.
 
 Metrics:
 - binary_mb           Release binary size, MB (1dp). Bloat detector.
@@ -40,6 +41,11 @@ def file_size_mb(path: Path) -> float | None:
     if not path.exists():
         return None
     return round(path.stat().st_size / 1048576, 1)
+
+
+def cargo_target_dir(repo: Path) -> Path:
+    target = Path(os.environ.get("CARGO_TARGET_DIR", "target"))
+    return target if target.is_absolute() else repo / target
 
 
 def docker_image_size_mb(tag: str) -> float | None:
@@ -159,7 +165,7 @@ def main() -> int:
     repo = repo_root()
     os.chdir(repo)
     metrics = {
-        "binary_mb": file_size_mb(repo / "target" / "release" / "kei"),
+        "binary_mb": file_size_mb(cargo_target_dir(repo) / "release" / "kei"),
         "docker_image_mb": docker_image_size_mb("kei:dev"),
         "src_unwrap_expect": src_unwrap_expect(repo),
         "src_allow_attrs": src_allow_attrs(repo),

--- a/scripts/full-test/run_live_smokes.sh
+++ b/scripts/full-test/run_live_smokes.sh
@@ -20,7 +20,7 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 PROJECT_DIR="$repo_root"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 time_phase="$script_dir/time_phase.sh"
-binary="$repo_root/target/release/kei"
+binary="$("$script_dir/cargo_target_dir.sh")/release/kei"
 # shellcheck disable=SC1091
 source "$repo_root/tests/shell/lib.sh"
 

--- a/scripts/full-test/run_release_archive_smoke.sh
+++ b/scripts/full-test/run_release_archive_smoke.sh
@@ -18,7 +18,8 @@ cd "$repo_root"
 
 target=$(rustc -vV | awk '/^host:/ { print $2 }')
 version=$(awk -F'"' '/^version = "/ { print $2; exit }' Cargo.toml)
-binary="$repo_root/target/release/kei"
+target_dir=$(scripts/full-test/cargo_target_dir.sh)
+binary="$target_dir/release/kei"
 
 if [[ ! -x "$binary" ]]; then
   echo "run_release_archive_smoke: missing release binary at $binary" >&2
@@ -36,7 +37,7 @@ rm -rf "$work"
 mkdir -p "$work/extract" "$work/data"
 
 archive="$work/kei-$target.tar.gz"
-tar -C "$repo_root/target/release" -czf "$archive" kei
+tar -C "$target_dir/release" -czf "$archive" kei
 sha256sum "$archive" > "$work/SHA256SUMS.txt"
 
 tar -C "$work/extract" -xzf "$archive"

--- a/tests/README.md
+++ b/tests/README.md
@@ -147,6 +147,8 @@ details are baked into test code.
 | `ICLOUD_TEST_COOKIE_DIR` | `./.test-cookies` | Pre-authenticated session dir |
 | `KEI_TEST_ALBUM` | `kei-test` | Test album name |
 | `KEI_DOCKER_IMAGE` | `kei:latest` | Docker image under test |
+| `CARGO_TARGET_DIR` | `./target` | Cargo build directory. Full-test packaging, shell, live, service, and metrics phases use release artifacts from this directory. |
+| `KEI_FULL_TEST_TMPDIR` | `/tmp/codex/kei/full-test/tmp` | Temporary directory for full-test child processes and shell-suite scratch data. |
 | `KEI_TEST_SCRATCH_DIR` | `/tmp/codex/kei/shell-tests-$USER` | Base dir for standalone shell-suite scratch; `just full-test` overrides this to `$KEI_FULL_TEST_TMPDIR/shell` or `/tmp/codex/kei/full-test/tmp/shell` |
 | `KEI_IMPORT_FIXTURE_DIR` | `/tmp/codex/kei/import-fixture` | Where `import_existing_live.rs` caches its `--recent 100` sync fixture across runs |
 | `KEI_FULL_TEST_CROSS_ZONE_ALBUM` | unset | Optional full-test album fixture for cross-zone hydration. The album must include at least one asset from a non-primary source zone. |

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -309,6 +309,59 @@ fn full_test_routes_child_tempdirs_to_tmp_codex() {
     );
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn full_test_release_artifacts_follow_cargo_target_dir() {
+    let repo = repo_path("");
+    let helper = repo_path("scripts/full-test/cargo_target_dir.sh");
+
+    let default = Command::new(&helper)
+        .current_dir("/")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("run cargo target directory helper without override");
+    assert!(default.status.success());
+    assert_eq!(
+        command_text(&default).trim(),
+        repo.join("target").display().to_string()
+    );
+
+    let relative = Command::new(&helper)
+        .current_dir("/")
+        .env("CARGO_TARGET_DIR", "target/full-test")
+        .output()
+        .expect("run cargo target directory helper with relative override");
+    assert!(relative.status.success());
+    assert_eq!(
+        command_text(&relative).trim(),
+        repo.join("target/full-test").display().to_string()
+    );
+
+    let absolute_dir = repo.join("target/full-test-absolute");
+    let absolute = Command::new(&helper)
+        .current_dir("/")
+        .env("CARGO_TARGET_DIR", &absolute_dir)
+        .output()
+        .expect("run cargo target directory helper with absolute override");
+    assert!(absolute.status.success());
+    assert_eq!(
+        command_text(&absolute).trim(),
+        absolute_dir.display().to_string()
+    );
+
+    for consumer in [
+        "scripts/full-test/run_release_archive_smoke.sh",
+        "scripts/full-test/run_live_smokes.sh",
+        "tests/shell/lib.sh",
+        "justfile",
+    ] {
+        assert!(
+            repo_file(consumer).contains("cargo_target_dir.sh"),
+            "{consumer} must resolve release artifacts through cargo_target_dir.sh"
+        );
+    }
+}
+
 #[test]
 fn full_test_run_start_metadata_is_stable_until_finalize() {
     let begin = repo_file("scripts/full-test/begin_run.sh");

--- a/tests/shell/lib.sh
+++ b/tests/shell/lib.sh
@@ -134,7 +134,7 @@ kei_scratch_dir() {
 }
 
 kei_release_bin() {
-    printf '%s/target/release/kei' "$PROJECT_DIR"
+    printf '%s/release/kei' "$("$PROJECT_DIR/scripts/full-test/cargo_target_dir.sh")"
 }
 
 # Build if missing or older than Cargo.toml/Cargo.lock. The stat short-


### PR DESCRIPTION
## Summary

- Resolve release artifacts through `CARGO_TARGET_DIR` in packaging, live, shell, service, and metrics checks.
- Add regression coverage for default, relative, and absolute target directories.
- Document `CARGO_TARGET_DIR` and `KEI_FULL_TEST_TMPDIR`.

## Tests

- `cargo test --test branch_static full_test_release_artifacts_follow_cargo_target_dir -- --exact`
- `just test scenario fulltest-harness`
- `just test packaging`
- `just full-test`: 21/21 phases passed, 6,823 tests, zero skipped or failed.
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Risk

Test tooling only. The default `target` directory is unchanged. This does not change product behavior, public APIs, state, or media files.
