### PR TITLE
Add exact review scope and validation provenance

### DIFF
--- a/.agents/skills/kei-pr-ready/SKILL.md
+++ b/.agents/skills/kei-pr-ready/SKILL.md
@@ -53,9 +53,10 @@ gate or a passing unit test as proof that all consumers were traced.
 6. Investigate every failure. Use bounded output and
    `just agent-failure-summary` when a retained full-test log is relevant.
 
-Treat gate, CI, and full-test results as proof only when their recorded head
-matches the reviewed head. Label results from the same branch at another head
-as `STALE` and results from another branch as `OTHER BRANCH`.
+Treat gate, CI, and full-test results as proof only when the record shows that
+the run stayed on one head and that head matches the reviewed head. Label
+results from the same branch at another head as `STALE` and results from
+another branch as `OTHER BRANCH`.
 
 Do not run live tests unless the changed behavior requires them. Follow
 `tests/README.md`, run live suites single-threaded, and preserve rate-limit and

--- a/.agents/skills/kei-pr-ready/SKILL.md
+++ b/.agents/skills/kei-pr-ready/SKILL.md
@@ -14,11 +14,15 @@ or change GitHub state.
 1. Read repository-root `AGENTS.md`, then the relevant sections of
    `CONTRIBUTING.md`, `docs/architecture.md`, and `tests/README.md`.
 2. Run `just agent-status`.
-3. Confirm the current branch, upstream, working-tree state, and comparison
-   base. Prefer the remote default branch; fall back to `origin/main` when the
-   default cannot be resolved.
-4. Inspect committed, staged, and unstaged changes. Return a not-ready verdict
-   if unrelated work prevents an attributable review.
+3. Resolve the remote default branch, falling back to `origin/main`, then run
+   `just review-scope BASE=<resolved-base>`.
+4. Record the exact base, merge base, and head. Inspect committed, staged,
+   unstaged, and untracked changes. Return a not-ready verdict if unrelated
+   work prevents an attributable review.
+5. Create a coverage ledger for every changed `(status, path)` entry, including
+   tests, docs, workflows, deletions, and renames. Mark each entry `reviewed` or
+   `skipped` with a concrete reason. Keep unchanged callers and invariant owners
+   in a separate context list. Never silently omit a changed entry.
 
 ## Classify impact
 
@@ -49,6 +53,10 @@ gate or a passing unit test as proof that all consumers were traced.
 6. Investigate every failure. Use bounded output and
    `just agent-failure-summary` when a retained full-test log is relevant.
 
+Treat gate, CI, and full-test results as proof only when their recorded head
+matches the reviewed head. Label results from the same branch at another head
+as `STALE` and results from another branch as `OTHER BRANCH`.
+
 Do not run live tests unless the changed behavior requires them. Follow
 `tests/README.md`, run live suites single-threaded, and preserve rate-limit and
 shared-session constraints.
@@ -62,10 +70,13 @@ documentation.
 Report:
 
 - base, head, and reviewed diff scope
+- merge base and validation provenance
+- changed-file coverage ledger and separate context-file list
 - impact classification, owners, safety contracts, and scenario slices
 - exact validation commands and results
 - unresolved failures, skipped checks, risks, and missing evidence
 - final verdict: ready or not ready
 
 Never report ready when a required check failed, was skipped without a
-documented reason, or could not be attributed to the reviewed diff.
+documented reason, could not be attributed to the reviewed head, or any changed
+file is unaccounted for.

--- a/justfile
+++ b/justfile
@@ -147,8 +147,14 @@ agent-status:
         echo "(no run records found)"
     fi
     echo
+    scripts/just/review-scope.sh --validation-only
+    echo
     echo "recent full-test history:"
     scripts/full-test/history.sh 3 2>/dev/null || true
+
+# Exact branch review input plus workspace and validation provenance.
+review-scope BASE="origin/main":
+    scripts/just/review-scope.sh "{{BASE}}"
 
 # Summarize the latest full-test phase log, or pass LOG=/path/to/log.
 agent-failure-summary LOG="":

--- a/scripts/full-test/begin_run.sh
+++ b/scripts/full-test/begin_run.sh
@@ -17,6 +17,7 @@ mkdir -p "$runs_dir"
 current="$runs_dir/.current.jsonl"
 marker="$runs_dir/.run-marker"
 start_file="$runs_dir/.run-started-at"
+start_head_file="$runs_dir/.run-start-head"
 rate_flag="$runs_dir/.rate-limited"
 skip_flag="$runs_dir/.live-skipped"
 lockfile="$runs_dir/.lock"
@@ -61,6 +62,7 @@ run_id=$(date +%Y%m%dT%H%M%S)
     # runs record the actual start time, not finalization time.
     date -u +%s >"$marker"
     date +%Y-%m-%dT%H:%M:%S >"$start_file"
+    git rev-parse HEAD >"$start_head_file"
 ) 9>"$lockfile"
 
 echo "$run_id"

--- a/scripts/full-test/begin_run.sh
+++ b/scripts/full-test/begin_run.sh
@@ -18,6 +18,7 @@ current="$runs_dir/.current.jsonl"
 marker="$runs_dir/.run-marker"
 start_file="$runs_dir/.run-started-at"
 start_head_file="$runs_dir/.run-start-head"
+start_worktree_file="$runs_dir/.run-start-worktree-clean"
 rate_flag="$runs_dir/.rate-limited"
 skip_flag="$runs_dir/.live-skipped"
 lockfile="$runs_dir/.lock"
@@ -63,6 +64,11 @@ run_id=$(date +%Y%m%dT%H%M%S)
     date -u +%s >"$marker"
     date +%Y-%m-%dT%H:%M:%S >"$start_file"
     git rev-parse HEAD >"$start_head_file"
+    if [[ -z "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+        echo true >"$start_worktree_file"
+    else
+        echo false >"$start_worktree_file"
+    fi
 ) 9>"$lockfile"
 
 echo "$run_id"

--- a/scripts/full-test/finalize_run.sh
+++ b/scripts/full-test/finalize_run.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 runs_dir="${KEI_FULL_TEST_RUNS_DIR:-/tmp/codex/kei/full-test/test-runs}"
 current="$runs_dir/.current.jsonl"
 start_file="$runs_dir/.run-started-at"
+start_head_file="$runs_dir/.run-start-head"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 if [[ ! -s "$current" ]]; then
@@ -21,7 +22,12 @@ ts=$(date +%Y%m%dT%H%M%S)
 out="$runs_dir/$ts.json"
 
 branch=$(git branch --show-current 2>/dev/null || echo "(detached)")
-head=$(git rev-parse --short HEAD 2>/dev/null || echo "(no rev)")
+if [[ ! -s "$start_head_file" ]]; then
+    echo "missing full-test start head: $start_head_file" >&2
+    exit 1
+fi
+head=$(head -n 1 "$start_head_file")
+end_head=$(git rev-parse HEAD 2>/dev/null || echo "(no rev)")
 rustc=$(rustc -V 2>/dev/null || echo "(no rustc)")
 if [[ -s "$start_file" ]]; then
     started_at=$(head -n 1 "$start_file")
@@ -33,9 +39,9 @@ fi
 # a partial record over a missing one.
 metrics_json=$("$script_dir/collect_metrics.py" 2>/dev/null || echo "{}")
 
-python3 - "$current" "$out" "$branch" "$head" "$rustc" "$started_at" "$metrics_json" <<'PY'
+python3 - "$current" "$out" "$branch" "$head" "$end_head" "$rustc" "$started_at" "$metrics_json" <<'PY'
 import json, sys
-src, dst, branch, head, rustc, started_at, metrics_json = sys.argv[1:8]
+src, dst, branch, head, end_head, rustc, started_at, metrics_json = sys.argv[1:9]
 phases = {}
 with open(src) as f:
     for line in f:
@@ -49,6 +55,7 @@ record = {
     "started_at": started_at,
     "branch": branch,
     "head": head,
+    "end_head": end_head,
     "rustc": rustc,
     "phases": phases,
     "metrics": json.loads(metrics_json or "{}"),
@@ -58,5 +65,5 @@ with open(dst, "w") as f:
 PY
 
 # Clear staging + run marker (lets the next /full-test start cleanly).
-rm -f "$current" "$runs_dir/.run-marker" "$start_file"
+rm -f "$current" "$runs_dir/.run-marker" "$start_file" "$start_head_file"
 echo "$out"

--- a/scripts/full-test/finalize_run.sh
+++ b/scripts/full-test/finalize_run.sh
@@ -11,6 +11,7 @@ runs_dir="${KEI_FULL_TEST_RUNS_DIR:-/tmp/codex/kei/full-test/test-runs}"
 current="$runs_dir/.current.jsonl"
 start_file="$runs_dir/.run-started-at"
 start_head_file="$runs_dir/.run-start-head"
+start_worktree_file="$runs_dir/.run-start-worktree-clean"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 if [[ ! -s "$current" ]]; then
@@ -28,6 +29,16 @@ if [[ ! -s "$start_head_file" ]]; then
 fi
 head=$(head -n 1 "$start_head_file")
 end_head=$(git rev-parse HEAD 2>/dev/null || echo "(no rev)")
+if [[ ! -s "$start_worktree_file" ]]; then
+    echo "missing full-test start worktree state: $start_worktree_file" >&2
+    exit 1
+fi
+start_worktree_clean=$(head -n 1 "$start_worktree_file")
+if [[ -z "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+    end_worktree_clean=true
+else
+    end_worktree_clean=false
+fi
 rustc=$(rustc -V 2>/dev/null || echo "(no rustc)")
 if [[ -s "$start_file" ]]; then
     started_at=$(head -n 1 "$start_file")
@@ -39,9 +50,9 @@ fi
 # a partial record over a missing one.
 metrics_json=$("$script_dir/collect_metrics.py" 2>/dev/null || echo "{}")
 
-python3 - "$current" "$out" "$branch" "$head" "$end_head" "$rustc" "$started_at" "$metrics_json" <<'PY'
+python3 - "$current" "$out" "$branch" "$head" "$end_head" "$start_worktree_clean" "$end_worktree_clean" "$rustc" "$started_at" "$metrics_json" <<'PY'
 import json, sys
-src, dst, branch, head, end_head, rustc, started_at, metrics_json = sys.argv[1:9]
+src, dst, branch, head, end_head, start_clean, end_clean, rustc, started_at, metrics_json = sys.argv[1:11]
 phases = {}
 with open(src) as f:
     for line in f:
@@ -56,6 +67,8 @@ record = {
     "branch": branch,
     "head": head,
     "end_head": end_head,
+    "start_worktree_clean": start_clean == "true",
+    "end_worktree_clean": end_clean == "true",
     "rustc": rustc,
     "phases": phases,
     "metrics": json.loads(metrics_json or "{}"),
@@ -65,5 +78,5 @@ with open(dst, "w") as f:
 PY
 
 # Clear staging + run marker (lets the next /full-test start cleanly).
-rm -f "$current" "$runs_dir/.run-marker" "$start_file" "$start_head_file"
+rm -f "$current" "$runs_dir/.run-marker" "$start_file" "$start_head_file" "$start_worktree_file"
 echo "$out"

--- a/scripts/just/review-scope.sh
+++ b/scripts/just/review-scope.sh
@@ -42,15 +42,19 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 print(data.get("branch", ""))
 print(data.get("head", ""))
 print(data.get("end_head", ""))
+print("true" if data.get("start_worktree_clean") is True else "false")
+print("true" if data.get("end_worktree_clean") is True else "false")
 PY
     )
-    local record_branch record_head record_end_head resolved_head resolved_end_head validation_status
+    local record_branch record_head record_end_head record_start_clean record_end_clean resolved_head resolved_end_head validation_status
     record_branch=$(sed -n '1p' <<<"$record")
     record_head=$(sed -n '2p' <<<"$record")
     record_end_head=$(sed -n '3p' <<<"$record")
+    record_start_clean=$(sed -n '4p' <<<"$record")
+    record_end_clean=$(sed -n '5p' <<<"$record")
     resolved_head=$(git rev-parse --verify "${record_head}^{commit}" 2>/dev/null || true)
     resolved_end_head=$(git rev-parse --verify "${record_end_head}^{commit}" 2>/dev/null || true)
-    if [[ -n "$resolved_head" && "$resolved_head" == "$current_head" && "$resolved_end_head" == "$current_head" ]]; then
+    if [[ -n "$resolved_head" && "$resolved_head" == "$current_head" && "$resolved_end_head" == "$current_head" && "$record_start_clean" == true && "$record_end_clean" == true ]]; then
         validation_status=CURRENT
     elif [[ -n "$record_branch" && "$record_branch" == "$current_branch" ]]; then
         validation_status=STALE
@@ -62,6 +66,8 @@ PY
     echo "validation_branch: ${record_branch:-(unknown)}"
     echo "validation_head: ${record_head:-(unknown)}"
     echo "validation_end_head: ${record_end_head:-(unknown)}"
+    echo "validation_start_worktree_clean: $record_start_clean"
+    echo "validation_end_worktree_clean: $record_end_clean"
     echo "validation_status: $validation_status"
 }
 

--- a/scripts/just/review-scope.sh
+++ b/scripts/just/review-scope.sh
@@ -32,7 +32,8 @@ print_validation_provenance() {
         return
     fi
 
-    record=$(python3 - "$latest" <<'PY'
+    record=$(
+        python3 - "$latest" <<'PY'
 import json
 import sys
 
@@ -41,11 +42,11 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 print(data.get("branch", ""))
 print(data.get("head", ""))
 PY
-)
+    )
     local record_branch record_head validation_status
     record_branch=$(sed -n '1p' <<<"$record")
     record_head=$(sed -n '2p' <<<"$record")
-    if [[ -n "$record_head" && ( "$current_head" == "$record_head"* || "$record_head" == "$current_head"* ) ]]; then
+    if [[ -n "$record_head" && ("$current_head" == "$record_head"* || "$record_head" == "$current_head"*) ]]; then
         validation_status=CURRENT
     elif [[ -n "$record_branch" && "$record_branch" == "$current_branch" ]]; then
         validation_status=STALE

--- a/scripts/just/review-scope.sh
+++ b/scripts/just/review-scope.sh
@@ -41,12 +41,16 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     data = json.load(handle)
 print(data.get("branch", ""))
 print(data.get("head", ""))
+print(data.get("end_head", ""))
 PY
     )
-    local record_branch record_head validation_status
+    local record_branch record_head record_end_head resolved_head resolved_end_head validation_status
     record_branch=$(sed -n '1p' <<<"$record")
     record_head=$(sed -n '2p' <<<"$record")
-    if [[ -n "$record_head" && ("$current_head" == "$record_head"* || "$record_head" == "$current_head"*) ]]; then
+    record_end_head=$(sed -n '3p' <<<"$record")
+    resolved_head=$(git rev-parse --verify "${record_head}^{commit}" 2>/dev/null || true)
+    resolved_end_head=$(git rev-parse --verify "${record_end_head}^{commit}" 2>/dev/null || true)
+    if [[ -n "$resolved_head" && "$resolved_head" == "$current_head" && "$resolved_end_head" == "$current_head" ]]; then
         validation_status=CURRENT
     elif [[ -n "$record_branch" && "$record_branch" == "$current_branch" ]]; then
         validation_status=STALE
@@ -57,6 +61,7 @@ PY
     echo "latest_full_test: $latest"
     echo "validation_branch: ${record_branch:-(unknown)}"
     echo "validation_head: ${record_head:-(unknown)}"
+    echo "validation_end_head: ${record_end_head:-(unknown)}"
     echo "validation_status: $validation_status"
 }
 

--- a/scripts/just/review-scope.sh
+++ b/scripts/just/review-scope.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode=scope
+base_ref=origin/main
+if [[ "${1:-}" == "--validation-only" ]]; then
+    mode=validation
+elif [[ -n "${1:-}" ]]; then
+    base_ref=$1
+fi
+base_ref="${base_ref#BASE=}"
+
+latest_full_test() {
+    local runs_dir latest
+    runs_dir="${KEI_FULL_TEST_RUNS_DIR:-/tmp/codex/kei/full-test/test-runs}"
+    latest=$(find "$runs_dir" -maxdepth 1 -name '*.json' -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2- || true)
+    printf '%s' "$latest"
+}
+
+print_validation_provenance() {
+    local current_branch current_head latest record
+    current_branch=$(git branch --show-current 2>/dev/null || true)
+    current_head=$(git rev-parse HEAD)
+    latest=$(latest_full_test)
+
+    echo "validation provenance:"
+    echo "current_branch: ${current_branch:-(detached)}"
+    echo "current_head: $current_head"
+    if [[ -z "$latest" ]]; then
+        echo "latest_full_test: (none)"
+        echo "validation_status: NONE"
+        return
+    fi
+
+    record=$(python3 - "$latest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+print(data.get("branch", ""))
+print(data.get("head", ""))
+PY
+)
+    local record_branch record_head validation_status
+    record_branch=$(sed -n '1p' <<<"$record")
+    record_head=$(sed -n '2p' <<<"$record")
+    if [[ -n "$record_head" && ( "$current_head" == "$record_head"* || "$record_head" == "$current_head"* ) ]]; then
+        validation_status=CURRENT
+    elif [[ -n "$record_branch" && "$record_branch" == "$current_branch" ]]; then
+        validation_status=STALE
+    else
+        validation_status="OTHER BRANCH"
+    fi
+
+    echo "latest_full_test: $latest"
+    echo "validation_branch: ${record_branch:-(unknown)}"
+    echo "validation_head: ${record_head:-(unknown)}"
+    echo "validation_status: $validation_status"
+}
+
+if [[ "$mode" == validation ]]; then
+    print_validation_provenance
+    exit 0
+fi
+
+base_sha=$(git rev-parse --verify "${base_ref}^{commit}")
+head_sha=$(git rev-parse HEAD)
+merge_base=$(git merge-base "$base_sha" "$head_sha")
+commit_count=$(git rev-list --count "${merge_base}..${head_sha}")
+
+echo "review target:"
+echo "base_ref: $base_ref"
+echo "base: $base_sha"
+echo "merge_base: $merge_base"
+echo "head: $head_sha"
+echo "commits: $commit_count"
+echo
+echo "changed files:"
+changed_files=$(git diff --name-status --find-renames "${merge_base}...${head_sha}")
+if [[ -n "$changed_files" ]]; then
+    printf '%s\n' "$changed_files"
+else
+    echo "(none)"
+fi
+echo
+echo "changed lines:"
+changed_lines=$(git diff --numstat --find-renames "${merge_base}...${head_sha}")
+if [[ -n "$changed_lines" ]]; then
+    printf '%s\n' "$changed_lines"
+else
+    echo "(none)"
+fi
+echo
+echo "summary:"
+summary=$(git diff --shortstat "${merge_base}...${head_sha}")
+if [[ -n "$summary" ]]; then
+    printf '%s\n' "$summary"
+else
+    echo "(none)"
+fi
+echo
+echo "workspace:"
+workspace=$(git status --short --untracked-files=all)
+if [[ -n "$workspace" ]]; then
+    printf '%s\n' "$workspace"
+else
+    echo "(clean)"
+fi
+echo
+print_validation_provenance

--- a/scripts/test-scenarios/fulltest-harness.sh
+++ b/scripts/test-scenarios/fulltest-harness.sh
@@ -5,5 +5,6 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "$script_dir/lib.sh"
 
 run_scenario_test test:branch_static full_test
+run_scenario_test test:branch_static review_scope_reports_exact_diff_workspace_and_validation_provenance
 run_scenario_test test:branch_static scenario_fulltest_harness_rejects_unreferenced_helpers
 run_scenario_test test:branch_static scenario_runner_rejects_filters_that_match_no_tests

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -46,6 +46,22 @@ fn command_text(output: &Output) -> String {
 }
 
 #[cfg(target_os = "linux")]
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {}: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    command_text(&output).trim().to_owned()
+}
+
+#[cfg(target_os = "linux")]
 fn assert_text_order(output: &str, names: &[&str]) {
     let mut previous = None;
     for name in names {
@@ -1100,6 +1116,11 @@ fn repo_pr_ready_skill_uses_current_validation_workflow() {
         "name: kei-pr-ready",
         "without publishing or changing it",
         "just agent-status",
+        "just review-scope BASE=<resolved-base>",
+        "coverage ledger",
+        "validation provenance",
+        "STALE",
+        "OTHER BRANCH",
         "docs/architecture.md",
         "tests/README.md",
         "just test scenario NAME",
@@ -1116,6 +1137,93 @@ fn repo_pr_ready_skill_uses_current_validation_workflow() {
     assert!(
         metadata.contains("Use $kei-pr-ready"),
         "skill metadata must keep its default invocation aligned with SKILL.md"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
+    let temp = tempfile::tempdir().expect("review scope tempdir");
+    let repo = temp.path().join("repo");
+    let runs = temp.path().join("runs");
+    std::fs::create_dir_all(&repo).expect("create fixture repo");
+    std::fs::create_dir_all(&runs).expect("create fixture runs directory");
+
+    run_git(&repo, &["init", "-b", "main"]);
+    run_git(&repo, &["config", "user.name", "Kei Test"]);
+    run_git(&repo, &["config", "user.email", "kei-test@example.invalid"]);
+    std::fs::write(repo.join("tracked.txt"), "base\n").expect("write base file");
+    run_git(&repo, &["add", "tracked.txt"]);
+    run_git(&repo, &["commit", "-m", "base"]);
+    let base = run_git(&repo, &["rev-parse", "HEAD"]);
+
+    run_git(&repo, &["checkout", "-b", "feature"]);
+    std::fs::write(repo.join("tracked.txt"), "feature\n").expect("write feature file");
+    std::fs::write(repo.join("added.txt"), "added\n").expect("write added file");
+    run_git(&repo, &["add", "tracked.txt", "added.txt"]);
+    run_git(&repo, &["commit", "-m", "feature"]);
+    let head = run_git(&repo, &["rev-parse", "HEAD"]);
+    std::fs::write(repo.join("tracked.txt"), "workspace\n").expect("write workspace file");
+    std::fs::write(repo.join("untracked.txt"), "untracked\n").expect("write untracked file");
+
+    let record = runs.join("latest.json");
+    let abbreviated_head = head
+        .get(..7)
+        .expect("git SHA has at least seven ASCII bytes");
+    write_json(
+        &record,
+        &serde_json::json!({"branch": "feature", "head": abbreviated_head}),
+    );
+    let run_scope = || {
+        Command::new(repo_path("scripts/just/review-scope.sh"))
+            .arg("BASE=main")
+            .current_dir(&repo)
+            .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+            .output()
+            .expect("run review scope helper")
+    };
+
+    let current = run_scope();
+    assert!(
+        current.status.success(),
+        "review scope failed: {}",
+        String::from_utf8_lossy(&current.stderr)
+    );
+    let current = command_text(&current);
+    for expected in [
+        "base_ref: main",
+        &format!("base: {base}"),
+        &format!("merge_base: {base}"),
+        &format!("head: {head}"),
+        "commits: 1",
+        "A\tadded.txt",
+        "M\ttracked.txt",
+        " M tracked.txt",
+        "?? untracked.txt",
+        "validation_status: CURRENT",
+    ] {
+        assert!(
+            current.contains(expected),
+            "review scope output missing {expected}:\n{current}"
+        );
+    }
+
+    write_json(
+        &record,
+        &serde_json::json!({"branch": "feature", "head": base}),
+    );
+    assert!(
+        command_text(&run_scope()).contains("validation_status: STALE"),
+        "same-branch result at another head must be stale"
+    );
+
+    write_json(
+        &record,
+        &serde_json::json!({"branch": "other", "head": base}),
+    );
+    assert!(
+        command_text(&run_scope()).contains("validation_status: OTHER BRANCH"),
+        "result from another branch must not prove the current head"
     );
 }
 

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -389,12 +389,14 @@ fn full_test_run_start_metadata_is_stable_until_finalize() {
     for expected in [
         "start_file=\"$runs_dir/.run-started-at\"",
         "start_head_file=\"$runs_dir/.run-start-head\"",
+        "start_worktree_file=\"$runs_dir/.run-start-worktree-clean\"",
         "lockfile=\"$runs_dir/.lock\"",
         "flock 9",
         "if [[ $marker_age -lt 3600 ]]; then",
         "staging: $current (no records yet)",
         "date +%Y-%m-%dT%H:%M:%S >\"$start_file\"",
         "git rev-parse HEAD >\"$start_head_file\"",
+        "git status --porcelain=v1 --untracked-files=all",
     ] {
         assert!(
             begin.contains(expected),
@@ -405,12 +407,17 @@ fn full_test_run_start_metadata_is_stable_until_finalize() {
     for expected in [
         "start_file=\"$runs_dir/.run-started-at\"",
         "start_head_file=\"$runs_dir/.run-start-head\"",
+        "start_worktree_file=\"$runs_dir/.run-start-worktree-clean\"",
         "if [[ -s \"$start_file\" ]]; then",
         "started_at=$(head -n 1 \"$start_file\")",
         "head=$(head -n 1 \"$start_head_file\")",
         "end_head=$(git rev-parse HEAD",
+        "start_worktree_clean=$(head -n 1 \"$start_worktree_file\")",
+        "end_worktree_clean=true",
         "\"end_head\": end_head",
-        "rm -f \"$current\" \"$runs_dir/.run-marker\" \"$start_file\" \"$start_head_file\"",
+        "\"start_worktree_clean\": start_clean == \"true\"",
+        "\"end_worktree_clean\": end_clean == \"true\"",
+        "rm -f \"$current\" \"$runs_dir/.run-marker\" \"$start_file\" \"$start_head_file\" \"$start_worktree_file\"",
     ] {
         assert!(
             finalize.contains(expected),
@@ -639,10 +646,21 @@ fn full_test_reporting_executes_grouped_and_legacy_fixtures() {
 #[test]
 fn full_test_finalize_emits_metrics_and_cleans_staging() {
     let temp = tempfile::tempdir().expect("finalize fixture tempdir");
+    let repo = temp.path().join("repo");
     let runs = temp.path().join("runs");
     let bin = temp.path().join("bin");
+    std::fs::create_dir(&repo).expect("create fixture repo");
     std::fs::create_dir(&runs).expect("create finalize runs dir");
     std::fs::create_dir(&bin).expect("create stub bin dir");
+
+    run_git(&repo, &["init", "-b", "fixture"]);
+    run_git(&repo, &["config", "user.name", "Kei Test"]);
+    run_git(&repo, &["config", "user.email", "kei-test@example.invalid"]);
+    std::fs::write(repo.join("tracked.txt"), "fixture\n").expect("write fixture file");
+    std::fs::write(repo.join("Cargo.lock"), "name = \"fixture\"\n")
+        .expect("write fixture lockfile");
+    run_git(&repo, &["add", "tracked.txt", "Cargo.lock"]);
+    run_git(&repo, &["commit", "-m", "fixture"]);
 
     std::fs::write(
         runs.join(".current.jsonl"),
@@ -651,9 +669,11 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
     .expect("write phase fixture");
     std::fs::write(runs.join(".run-started-at"), "2026-07-17T12:34:56\n")
         .expect("write start fixture");
-    let head = run_git(&repo_path(""), &["rev-parse", "HEAD"]);
+    let head = run_git(&repo, &["rev-parse", "HEAD"]);
     std::fs::write(runs.join(".run-start-head"), format!("{head}\n"))
         .expect("write start head fixture");
+    std::fs::write(runs.join(".run-start-worktree-clean"), "true\n")
+        .expect("write start worktree fixture");
     std::fs::write(runs.join(".run-marker"), "fixture\n").expect("write marker fixture");
 
     write_executable(&bin.join("cargo"), "#!/usr/bin/env bash\nexit 0\n");
@@ -666,6 +686,7 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
 
     let output = Command::new("bash")
         .arg(repo_path("scripts/full-test/finalize_run.sh"))
+        .current_dir(&repo)
         .env("KEI_FULL_TEST_RUNS_DIR", &runs)
         .env("PATH", path)
         .output()
@@ -685,6 +706,8 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
     assert_eq!(record["started_at"], "2026-07-17T12:34:56");
     assert_eq!(record["head"], head);
     assert_eq!(record["end_head"], head);
+    assert_eq!(record["start_worktree_clean"], true);
+    assert_eq!(record["end_worktree_clean"], true);
     assert_eq!(record["phases"]["static_checks"]["status"], "pass");
     assert_eq!(record["phases"]["static_checks"]["tests"], 3);
     assert!(record["metrics"].is_object());
@@ -693,6 +716,7 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
         ".current.jsonl",
         ".run-started-at",
         ".run-start-head",
+        ".run-start-worktree-clean",
         ".run-marker",
     ] {
         assert!(
@@ -769,6 +793,8 @@ fn full_test_head_change_is_not_current_validation() {
     .expect("parse head change record");
     assert_eq!(record["head"], start_head);
     assert_eq!(record["end_head"], end_head);
+    assert_eq!(record["start_worktree_clean"], true);
+    assert_eq!(record["end_worktree_clean"], true);
 
     let scope = Command::new(repo_path("scripts/just/review-scope.sh"))
         .arg("--validation-only")
@@ -783,6 +809,90 @@ fn full_test_head_change_is_not_current_validation() {
     assert!(
         scope.contains("validation_status: STALE"),
         "a run that changed heads must not be current:\n{scope}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn full_test_dirty_start_is_not_current_validation() {
+    let temp = tempfile::tempdir().expect("dirty start fixture tempdir");
+    let repo = temp.path().join("repo");
+    let runs = temp.path().join("runs");
+    let bin = temp.path().join("bin");
+    std::fs::create_dir_all(&repo).expect("create fixture repo");
+    std::fs::create_dir_all(&runs).expect("create fixture runs directory");
+    std::fs::create_dir_all(&bin).expect("create stub bin directory");
+
+    run_git(&repo, &["init", "-b", "feature"]);
+    run_git(&repo, &["config", "user.name", "Kei Test"]);
+    run_git(&repo, &["config", "user.email", "kei-test@example.invalid"]);
+    std::fs::write(repo.join("tracked.txt"), "committed\n").expect("write committed file");
+    run_git(&repo, &["add", "tracked.txt"]);
+    run_git(&repo, &["commit", "-m", "base"]);
+    let head = run_git(&repo, &["rev-parse", "HEAD"]);
+    std::fs::write(repo.join("tracked.txt"), "validated dirty bytes\n")
+        .expect("write dirty fixture");
+
+    let begin = Command::new(repo_path("scripts/full-test/begin_run.sh"))
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .output()
+        .expect("begin dirty fixture run");
+    assert!(
+        begin.status.success(),
+        "begin fixture failed: {}",
+        String::from_utf8_lossy(&begin.stderr)
+    );
+    std::fs::write(
+        runs.join(".current.jsonl"),
+        "{\"phase\":\"static_checks\",\"status\":\"pass\",\"wall_s\":1.0}\n",
+    )
+    .expect("write phase fixture");
+    std::fs::write(repo.join("tracked.txt"), "committed\n").expect("restore committed file");
+
+    write_executable(&bin.join("cargo"), "#!/usr/bin/env bash\nexit 0\n");
+    write_executable(&bin.join("docker"), "#!/usr/bin/env bash\nexit 1\n");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").expect("PATH must be set")
+    );
+    let finalize = Command::new(repo_path("scripts/full-test/finalize_run.sh"))
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .env("PATH", path)
+        .output()
+        .expect("finalize dirty fixture run");
+    assert!(
+        finalize.status.success(),
+        "finalize fixture failed: {}",
+        String::from_utf8_lossy(&finalize.stderr)
+    );
+
+    let record_path = PathBuf::from(command_text(&finalize).trim());
+    let record: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&record_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", record_path.display())),
+    )
+    .expect("parse dirty-start record");
+    assert_eq!(record["head"], head);
+    assert_eq!(record["end_head"], head);
+    assert_eq!(record["start_worktree_clean"], false);
+    assert_eq!(record["end_worktree_clean"], true);
+
+    let scope = Command::new(repo_path("scripts/just/review-scope.sh"))
+        .arg("--validation-only")
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .output()
+        .expect("check dirty-start validation provenance");
+    assert!(scope.status.success());
+    let scope = command_text(&scope);
+    assert!(scope.contains("validation_start_worktree_clean: false"));
+    assert!(scope.contains("validation_end_worktree_clean: true"));
+    assert!(
+        scope.contains("validation_status: STALE"),
+        "a run that started dirty must not be current:\n{scope}"
     );
 }
 
@@ -1275,7 +1385,9 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
         &serde_json::json!({
             "branch": "feature",
             "head": abbreviated_head,
-            "end_head": head
+            "end_head": head,
+            "start_worktree_clean": true,
+            "end_worktree_clean": true
         }),
     );
     let run_scope = || {
@@ -1304,6 +1416,8 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
         "M\ttracked.txt",
         " M tracked.txt",
         "?? untracked.txt",
+        "validation_start_worktree_clean: true",
+        "validation_end_worktree_clean: true",
         "validation_status: CURRENT",
     ] {
         assert!(
@@ -1314,7 +1428,22 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
 
     write_json(
         &record,
-        &serde_json::json!({"branch": "feature", "head": base, "end_head": base}),
+        &serde_json::json!({"branch": "feature", "head": head, "end_head": head}),
+    );
+    assert!(
+        command_text(&run_scope()).contains("validation_status: STALE"),
+        "legacy records without worktree evidence must not be current"
+    );
+
+    write_json(
+        &record,
+        &serde_json::json!({
+            "branch": "feature",
+            "head": base,
+            "end_head": base,
+            "start_worktree_clean": true,
+            "end_worktree_clean": true
+        }),
     );
     assert!(
         command_text(&run_scope()).contains("validation_status: STALE"),
@@ -1323,7 +1452,13 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
 
     write_json(
         &record,
-        &serde_json::json!({"branch": "other", "head": base, "end_head": base}),
+        &serde_json::json!({
+            "branch": "other",
+            "head": base,
+            "end_head": base,
+            "start_worktree_clean": true,
+            "end_worktree_clean": true
+        }),
     );
     assert!(
         command_text(&run_scope()).contains("validation_status: OTHER BRANCH"),

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -388,11 +388,13 @@ fn full_test_run_start_metadata_is_stable_until_finalize() {
 
     for expected in [
         "start_file=\"$runs_dir/.run-started-at\"",
+        "start_head_file=\"$runs_dir/.run-start-head\"",
         "lockfile=\"$runs_dir/.lock\"",
         "flock 9",
         "if [[ $marker_age -lt 3600 ]]; then",
         "staging: $current (no records yet)",
         "date +%Y-%m-%dT%H:%M:%S >\"$start_file\"",
+        "git rev-parse HEAD >\"$start_head_file\"",
     ] {
         assert!(
             begin.contains(expected),
@@ -402,9 +404,13 @@ fn full_test_run_start_metadata_is_stable_until_finalize() {
 
     for expected in [
         "start_file=\"$runs_dir/.run-started-at\"",
+        "start_head_file=\"$runs_dir/.run-start-head\"",
         "if [[ -s \"$start_file\" ]]; then",
         "started_at=$(head -n 1 \"$start_file\")",
-        "rm -f \"$current\" \"$runs_dir/.run-marker\" \"$start_file\"",
+        "head=$(head -n 1 \"$start_head_file\")",
+        "end_head=$(git rev-parse HEAD",
+        "\"end_head\": end_head",
+        "rm -f \"$current\" \"$runs_dir/.run-marker\" \"$start_file\" \"$start_head_file\"",
     ] {
         assert!(
             finalize.contains(expected),
@@ -645,6 +651,9 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
     .expect("write phase fixture");
     std::fs::write(runs.join(".run-started-at"), "2026-07-17T12:34:56\n")
         .expect("write start fixture");
+    let head = run_git(&repo_path(""), &["rev-parse", "HEAD"]);
+    std::fs::write(runs.join(".run-start-head"), format!("{head}\n"))
+        .expect("write start head fixture");
     std::fs::write(runs.join(".run-marker"), "fixture\n").expect("write marker fixture");
 
     write_executable(&bin.join("cargo"), "#!/usr/bin/env bash\nexit 0\n");
@@ -674,16 +683,107 @@ fn full_test_finalize_emits_metrics_and_cleans_staging() {
     )
     .expect("parse finalized record");
     assert_eq!(record["started_at"], "2026-07-17T12:34:56");
+    assert_eq!(record["head"], head);
+    assert_eq!(record["end_head"], head);
     assert_eq!(record["phases"]["static_checks"]["status"], "pass");
     assert_eq!(record["phases"]["static_checks"]["tests"], 3);
     assert!(record["metrics"].is_object());
     assert!(record["metrics"]["deps_count"].is_number());
-    for staging in [".current.jsonl", ".run-started-at", ".run-marker"] {
+    for staging in [
+        ".current.jsonl",
+        ".run-started-at",
+        ".run-start-head",
+        ".run-marker",
+    ] {
         assert!(
             !runs.join(staging).exists(),
             "finalize must remove {staging}"
         );
     }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn full_test_head_change_is_not_current_validation() {
+    let temp = tempfile::tempdir().expect("head change fixture tempdir");
+    let repo = temp.path().join("repo");
+    let runs = temp.path().join("runs");
+    let bin = temp.path().join("bin");
+    std::fs::create_dir_all(&repo).expect("create fixture repo");
+    std::fs::create_dir_all(&runs).expect("create fixture runs directory");
+    std::fs::create_dir_all(&bin).expect("create stub bin directory");
+
+    run_git(&repo, &["init", "-b", "feature"]);
+    run_git(&repo, &["config", "user.name", "Kei Test"]);
+    run_git(&repo, &["config", "user.email", "kei-test@example.invalid"]);
+    std::fs::write(repo.join("tracked.txt"), "start\n").expect("write starting file");
+    run_git(&repo, &["add", "tracked.txt"]);
+    run_git(&repo, &["commit", "-m", "start"]);
+    let start_head = run_git(&repo, &["rev-parse", "HEAD"]);
+
+    let begin = Command::new(repo_path("scripts/full-test/begin_run.sh"))
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .output()
+        .expect("begin full-test fixture run");
+    assert!(
+        begin.status.success(),
+        "begin fixture failed: {}",
+        String::from_utf8_lossy(&begin.stderr)
+    );
+    std::fs::write(
+        runs.join(".current.jsonl"),
+        "{\"phase\":\"static_checks\",\"status\":\"pass\",\"wall_s\":1.0}\n",
+    )
+    .expect("write phase fixture");
+
+    std::fs::write(repo.join("tracked.txt"), "end\n").expect("write ending file");
+    run_git(&repo, &["add", "tracked.txt"]);
+    run_git(&repo, &["commit", "-m", "end"]);
+    let end_head = run_git(&repo, &["rev-parse", "HEAD"]);
+
+    write_executable(&bin.join("cargo"), "#!/usr/bin/env bash\nexit 0\n");
+    write_executable(&bin.join("docker"), "#!/usr/bin/env bash\nexit 1\n");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").expect("PATH must be set")
+    );
+    let finalize = Command::new(repo_path("scripts/full-test/finalize_run.sh"))
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .env("PATH", path)
+        .output()
+        .expect("finalize full-test fixture run");
+    assert!(
+        finalize.status.success(),
+        "finalize fixture failed: {}",
+        String::from_utf8_lossy(&finalize.stderr)
+    );
+
+    let record_path = PathBuf::from(command_text(&finalize).trim());
+    let record: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&record_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", record_path.display())),
+    )
+    .expect("parse head change record");
+    assert_eq!(record["head"], start_head);
+    assert_eq!(record["end_head"], end_head);
+
+    let scope = Command::new(repo_path("scripts/just/review-scope.sh"))
+        .arg("--validation-only")
+        .current_dir(&repo)
+        .env("KEI_FULL_TEST_RUNS_DIR", &runs)
+        .output()
+        .expect("check changed-head validation provenance");
+    assert!(scope.status.success());
+    let scope = command_text(&scope);
+    assert!(scope.contains(&format!("validation_head: {start_head}")));
+    assert!(scope.contains(&format!("validation_end_head: {end_head}")));
+    assert!(
+        scope.contains("validation_status: STALE"),
+        "a run that changed heads must not be current:\n{scope}"
+    );
 }
 
 #[test]
@@ -1172,7 +1272,11 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
         .expect("git SHA has at least seven ASCII bytes");
     write_json(
         &record,
-        &serde_json::json!({"branch": "feature", "head": abbreviated_head}),
+        &serde_json::json!({
+            "branch": "feature",
+            "head": abbreviated_head,
+            "end_head": head
+        }),
     );
     let run_scope = || {
         Command::new(repo_path("scripts/just/review-scope.sh"))
@@ -1210,7 +1314,7 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
 
     write_json(
         &record,
-        &serde_json::json!({"branch": "feature", "head": base}),
+        &serde_json::json!({"branch": "feature", "head": base, "end_head": base}),
     );
     assert!(
         command_text(&run_scope()).contains("validation_status: STALE"),
@@ -1219,7 +1323,7 @@ fn review_scope_reports_exact_diff_workspace_and_validation_provenance() {
 
     write_json(
         &record,
-        &serde_json::json!({"branch": "other", "head": base}),
+        &serde_json::json!({"branch": "other", "head": base, "end_head": base}),
     );
     assert!(
         command_text(&run_scope()).contains("validation_status: OTHER BRANCH"),


### PR DESCRIPTION
## Summary

- Add `just review-scope` to report the exact base, merge base, head, committed branch diff, workspace state, and validation provenance.
- Mark retained full-test evidence as `CURRENT`, `STALE`, `OTHER BRANCH`, or `NONE`, and show the result in `just agent-status`.
- Require exact-head evidence and a complete changed-file coverage ledger in the repository PR-readiness skill.
- Test the helper against a real temporary Git repository and include the regression in the `fulltest-harness` scenario.

## Contract and risk

Acceptance criteria:

- A clean worktree does not hide committed branch changes from review scope.
- Validation from another head or branch is not presented as proof for the reviewed head.
- Both `just review-scope` and `just review-scope BASE=<ref>` resolve the requested comparison base.

Safety-contract IDs: None.

Risk is limited to developer and agent review tooling. This does not change kei runtime behavior, state, provider access, or filesystem publication. Independent/adversarial review: None.

## Test plan

- `cargo check` passed.
- `cargo test --test branch_static review_scope -- --nocapture` passed.
- `just test scenario fulltest-harness` passed.
- `just review-scope BASE=origin/main` reported the committed five-file branch diff and clean workspace.
- `just review-scope BASE=HEAD` reported an empty committed diff without hiding workspace changes.
- `just gate` passed on commit `44c3ede5757e230ce8a2d00a52712a5ef2812a16`. Optional local actionlint, ShellCheck, shfmt, and Ruff checks were skipped because those tools are not installed.

## Regression proof

`review_scope_reports_exact_diff_workspace_and_validation_provenance` creates a real temporary Git repository and proves committed diff discovery, workspace discovery, abbreviated-head matching, and `CURRENT`/`STALE`/`OTHER BRANCH` classification. Before this change, `just agent-status` could report a clean worktree while omitting committed branch changes and could display retained full-test output from another branch without an explicit provenance warning.

## Checklist

- [x] `just gate` passes, or the unchecked item is explained in the test plan
- [x] Behavior changes include focused tests
- [x] CLI, docs, workflow, Docker, systemd, or Homebrew surface changes were checked against their matching files
