### PR TITLE
Block checkpoints on malformed required asset fields

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,13 @@ before routing; an inconclusive lookup preserves the prior zone checkpoint.
 Album snapshots and smart folders may require targeted refresh work before or
 alongside the incremental stream.
 
+Downloadable photo records require non-blank `CPLMaster` and `CPLAsset` record names
+and a usable `assetDate` before they enter filtering or path planning. Full
+enumeration reports a malformed record as incomplete. Incremental enumeration
+marks its zone token unsafe. Both routes preserve the prior checkpoint so an
+unchanged provider record remains retryable, and neither route counts the
+record as a policy, filename, or date skip.
+
 Recent and date-bounded runs may advance only when the producer proves the
 bound did not truncate the stream.
 
@@ -341,6 +348,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 | `TEMP_FILE_DELETE_REQUIRES_DURABLE_OWNERSHIP` | `src/download/mod.rs`, `src/download/pipeline.rs`, `src/fs_util.rs`, `src/state/db.rs` | Orphan cleanup deletes only an exact stale path claimed in durable state. It retains verified filesystem handles through removal and never follows a directory or file symlink. Normal completion and graceful interruption retire the claim. |
 | `SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE` | `src/sync_cycle.rs` | The database pre-check token advances only after a successful non-dry-run cycle with a current pass plan. |
 | `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY` | `src/sync_cycle.rs`, `src/download/mod.rs` | A zone checkpoint advances only with complete token evidence and durable recovery for unfinished work. |
+| `MALFORMED_REQUIRED_ASSET_FIELDS_BLOCK_CHECKPOINT` | `src/icloud/photos/asset.rs`, `src/icloud/photos/album.rs`, `src/download/mod.rs`, `src/sync_cycle.rs` | A live asset with a missing or invalid required identity or capture date blocks its zone checkpoint before filtering or path planning. |
 | `UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING` | `src/download/retry.rs` | Inconclusive provider identity retains the pending row and records verification evidence. |
 | `POLICY_EXCLUDED_REQUIRES_EXPLICIT_SOURCE_DELETION` | `src/download/retry.rs`, `src/state/db.rs` | Policy-excluded rows become source-deleted only after targeted provider deletion evidence. Present or inconclusive responses retain them outside actionable pending work. |
 | `METADATA_WRITES_REQUIRE_OPT_IN` | `src/download/metadata_rewrite.rs` | Media and sidecar metadata writes run only for explicitly enabled metadata flags. |

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -59,7 +59,7 @@ are gitignored.
 | `heif_xmp_probe` | full `probe_exif_heif` pipeline: extract XMP from HEIC bytes, then parse it through xmp_toolkit | `src/download/heif.rs` + `xmp_toolkit` |
 | `toml_config` | `TomlConfig` deserializer + custom field deserializers (`folder_structure`, `RecentLimit`) + `deny_unknown_fields` boundary checks | `src/config.rs` |
 | `auth_responses` | `SrpInitResponse`, `AccountLoginResponse`, `TwoFactorChallenge` (with custom deserializer for `fsa_challenge` + `service_errors`) | `src/auth/responses.rs` |
-| `photo_asset_from_record` | `PhotoAsset::from_records`: drives `decode_filename`, `resolve_item_type`, `extract_versions`, and `metadata::extract` in one go. Splits input on the first NUL into two CloudKit `Record` JSON values | `src/icloud/photos/asset.rs` |
+| `photo_asset_from_record` | Validated `PhotoAsset` record-pair construction: checks required identity and capture-date fields, then drives `decode_filename`, `resolve_item_type`, `extract_versions`, and `metadata::extract`. Splits input on the first NUL into two CloudKit `Record` JSON values | `src/icloud/photos/asset.rs` |
 | `state_enums_from_str` | inherent `from_str` parsers on `VersionSizeKey`, `AssetStatus`, `MediaType` - inputs come from a sqlite state DB on disk that could be replayed, hand-edited, or corrupted | `src/state/types.rs` |
 
 ## Findings

--- a/fuzz/fuzz_targets/photo_asset_from_record.rs
+++ b/fuzz/fuzz_targets/photo_asset_from_record.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-// Drives `PhotoAsset::from_records(master, asset)` - the hot path that
-// turns two CloudKit `Record` JSON values into a typed PhotoAsset.
+// Drives the validated `PhotoAsset` record-pair constructor - the hot path
+// that turns two CloudKit `Record` JSON values into a typed PhotoAsset.
 // The internal extractors (decode_filename, resolve_item_type,
 // extract_versions, metadata::extract) chain through five sibling modules
 // plus crate::state::AssetMetadata, so a panic anywhere in there ends up
@@ -11,7 +11,7 @@
 // iteration. Split the input on the first NUL into (master, asset). If
 // the input doesn't contain a NUL, both halves get the same bytes - still
 // useful, since same-shape pairs exercise the version-dedup logic that
-// from_records does.
+// record construction does.
 
 use libfuzzer_sys::fuzz_target;
 use serde_json::Value;

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -52,7 +52,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-use crate::icloud::photos::asset::ChangeEvent;
+use crate::icloud::photos::asset::{ChangeEvent, MALFORMED_REQUIRED_ASSET_FIELDS_REASON};
 use crate::icloud::photos::{
     PhotoAsset, ProviderRecordId, RecordLookupRequest, RecordResolution, SyncTokenError,
 };
@@ -573,6 +573,7 @@ pub(crate) fn sync_token_blocked_source(reason: &str) -> &'static str {
         | "icloud_blank_sync_token"
         | "icloud_sync_token_mismatch"
         | "icloud_sync_token_missing"
+        | MALFORMED_REQUIRED_ASSET_FIELDS_REASON
         | UNPARSABLE_RELATION_DELTA_REASON
         | UNKNOWN_ALBUM_RELATION_ASSET_REASON
         | UNKNOWN_ALBUM_RELATION_CONTAINER_REASON => "icloud",
@@ -595,6 +596,9 @@ pub(crate) fn sync_token_blocked_explanation(reason: &str) -> &'static str {
             "iCloud returned a blank sync token, which kei treated as unusable"
         }
         "icloud_sync_token_mismatch" => "iCloud returned conflicting sync tokens across passes",
+        MALFORMED_REQUIRED_ASSET_FIELDS_REASON => {
+            "iCloud returned a photo record without a usable required identity or capture date"
+        }
         "kei_internal_token_receiver_dropped" => {
             "an internal token collection channel closed before completion"
         }
@@ -6681,6 +6685,14 @@ async fn download_photos_full_with_token_policy(
         stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(
             ICLOUD_ALBUM_COUNT_ERROR_REASON,
         ));
+    } else if token_attempt_allowed
+        && sync_token.is_none()
+        && let Some(reason) = token_block_reason
+    {
+        stats.sync_token_blocked = true;
+        stats.sync_token_blocked_reason = Some(reason);
+        stats.sync_token_blocked_source = Some(sync_token_blocked_source(reason));
+        stats.sync_token_blocked_explanation = Some(sync_token_blocked_explanation(reason));
     }
 
     // Clear enumeration-in-progress markers when the producer reached the

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -12,7 +12,9 @@ use tokio::task::JoinHandle;
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 
-use super::asset::{ChangeEvent, DeltaRecordBuffer, PhotoAsset, extract_master_ref};
+use super::asset::{
+    ChangeEvent, DeltaRecordBuffer, PhotoAsset, RequiredAssetFields, extract_master_ref,
+};
 use super::cloudkit::ChangesZoneResponse;
 use super::queries::{DESIRED_KEYS_VALUES, build_changes_zone_request, encode_params};
 use super::session::{PhotosSession, check_changes_zone_error};
@@ -292,6 +294,7 @@ enum FetcherRangeRole {
 enum EnumerationFailure {
     FetcherError,
     ConsumerDropped,
+    MalformedRecord,
     UnpairedRecords,
 }
 
@@ -507,6 +510,53 @@ fn should_emit_asset_record(
             owners.insert(record_name.to_owned(), range_start);
             true
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FullAssetStateId {
+    Master,
+    Asset,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FullAssetEmission {
+    Sent,
+    Malformed,
+    ReceiverClosed,
+}
+
+async fn emit_full_asset(
+    tx: &mpsc::Sender<anyhow::Result<PhotoAsset>>,
+    master: super::cloudkit::Record,
+    asset_record: &super::cloudkit::Record,
+    state_id: FullAssetStateId,
+) -> FullAssetEmission {
+    let mut asset =
+        match PhotoAsset::try_from_records(master, asset_record, RequiredAssetFields::Downloadable)
+        {
+            Ok(asset) => asset,
+            Err(error) => {
+                return if tx
+                    .send(Err(anyhow::anyhow!(
+                        "Malformed required CloudKit asset field: {error}"
+                    )))
+                    .await
+                    .is_ok()
+                {
+                    FullAssetEmission::Malformed
+                } else {
+                    FullAssetEmission::ReceiverClosed
+                };
+            }
+        };
+    if state_id == FullAssetStateId::Asset {
+        asset = asset.with_state_record_name(Arc::from(asset_record.record_name.as_str()));
+    }
+    if tx.send(Ok(asset)).await.is_ok() {
+        FullAssetEmission::Sent
+    } else {
+        FullAssetEmission::ReceiverClosed
     }
 }
 
@@ -1026,12 +1076,25 @@ impl PhotoAlbum {
                             if master.record_type == "CPLMaster"
                                 && asset.record_type == "CPLAsset" =>
                         {
-                            let mut photo = PhotoAsset::from_records(master, &asset);
-                            if request.state_id.as_str() != request.master_record_name.as_str() {
-                                photo = photo
-                                    .with_state_record_name(Arc::from(request.state_id.as_str()));
+                            match PhotoAsset::try_from_records(
+                                master,
+                                &asset,
+                                RequiredAssetFields::Downloadable,
+                            ) {
+                                Ok(mut photo) => {
+                                    if request.state_id.as_str()
+                                        != request.master_record_name.as_str()
+                                    {
+                                        photo = photo.with_state_record_name(Arc::from(
+                                            request.state_id.as_str(),
+                                        ));
+                                    }
+                                    RecordResolution::Present(photo)
+                                }
+                                Err(error) => RecordResolution::TransientFailure(
+                                    ProviderLookupError::Malformed(error.to_string()),
+                                ),
                             }
-                            RecordResolution::Present(photo)
                         }
                         (Ok(master), None)
                             if request.asset_record_name.is_none()
@@ -1888,6 +1951,7 @@ impl PhotoAlbum {
             let mut emitted_asset_records: FxHashSet<String> = FxHashSet::default();
             let mut consecutive_empty_pages: u32 = 0;
             let mut enumeration_incomplete = false;
+            let mut malformed_record = false;
             let mut stopped_for_limit = false;
             let url = format!(
                 "{}/records/query?{}",
@@ -2131,17 +2195,22 @@ impl PhotoAlbum {
                                 limit_reached = true;
                                 break;
                             }
-                            let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
-                            if sibling_count > 1 && index > 0 {
-                                asset = asset.with_state_record_name(Arc::from(
-                                    asset_rec.record_name.as_str(),
-                                ));
+                            let state_id = if sibling_count > 1 && index > 0 {
+                                FullAssetStateId::Asset
+                            } else {
+                                FullAssetStateId::Master
+                            };
+                            match emit_full_asset(&tx, master.clone(), &asset_rec, state_id).await {
+                                FullAssetEmission::Sent => {
+                                    total_sent += 1;
+                                    page_emitted += 1;
+                                }
+                                FullAssetEmission::Malformed => {
+                                    enumeration_incomplete = true;
+                                    malformed_record = true;
+                                }
+                                FullAssetEmission::ReceiverClosed => return,
                             }
-                            if tx.send(Ok(asset)).await.is_err() {
-                                return;
-                            }
-                            total_sent += 1;
-                            page_emitted += 1;
                         }
                         paired_masters.insert(master.record_name.clone(), master);
                         prune_paired_master_cache(&mut paired_masters, max_pending_records);
@@ -2183,17 +2252,22 @@ impl PhotoAlbum {
                                 limit_reached = true;
                                 break;
                             }
-                            let mut asset = PhotoAsset::from_records(master.clone(), &asset_rec);
-                            if sibling_count > 1 && index > 0 {
-                                asset = asset.with_state_record_name(Arc::from(
-                                    asset_rec.record_name.as_str(),
-                                ));
+                            let state_id = if sibling_count > 1 && index > 0 {
+                                FullAssetStateId::Asset
+                            } else {
+                                FullAssetStateId::Master
+                            };
+                            match emit_full_asset(&tx, master.clone(), &asset_rec, state_id).await {
+                                FullAssetEmission::Sent => {
+                                    total_sent += 1;
+                                    page_emitted += 1;
+                                }
+                                FullAssetEmission::Malformed => {
+                                    enumeration_incomplete = true;
+                                    malformed_record = true;
+                                }
+                                FullAssetEmission::ReceiverClosed => return,
                             }
-                            if tx.send(Ok(asset)).await.is_err() {
-                                return;
-                            }
-                            total_sent += 1;
-                            page_emitted += 1;
                         }
                         paired_masters.insert(master.record_name.clone(), master);
                         prune_paired_master_cache(&mut paired_masters, max_pending_records);
@@ -2214,13 +2288,24 @@ impl PhotoAlbum {
                                 limit_reached = true;
                                 break;
                             }
-                            let asset = PhotoAsset::from_records(master.clone(), &asset_rec)
-                                .with_state_record_name(Arc::from(asset_rec.record_name.as_str()));
-                            if tx.send(Ok(asset)).await.is_err() {
-                                return;
+                            match emit_full_asset(
+                                &tx,
+                                master.clone(),
+                                &asset_rec,
+                                FullAssetStateId::Asset,
+                            )
+                            .await
+                            {
+                                FullAssetEmission::Sent => {
+                                    total_sent += 1;
+                                    page_emitted += 1;
+                                }
+                                FullAssetEmission::Malformed => {
+                                    enumeration_incomplete = true;
+                                    malformed_record = true;
+                                }
+                                FullAssetEmission::ReceiverClosed => return,
                             }
-                            total_sent += 1;
-                            page_emitted += 1;
                         }
                     } else {
                         pending_assets.entry(master_id).or_default().extend(records);
@@ -2296,7 +2381,9 @@ impl PhotoAlbum {
                     (saw_blank_sync_token && behavior.preserve_blank_sync_tokens_for_diagnostics)
                         .then(String::new)
                 });
-                let completion = if enumeration_incomplete {
+                let completion = if malformed_record {
+                    EnumerationCompletion::Incomplete(EnumerationFailure::MalformedRecord)
+                } else if enumeration_incomplete {
                     EnumerationCompletion::Incomplete(EnumerationFailure::UnpairedRecords)
                 } else if stopped_for_limit {
                     EnumerationCompletion::UserBoundReached

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -28,6 +28,24 @@ pub(crate) struct MalformedResource {
     pub(crate) reason: Box<str>,
 }
 
+pub(crate) const MALFORMED_REQUIRED_ASSET_FIELDS_REASON: &str = "malformed_required_asset_fields";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RequiredAssetFields {
+    Identity,
+    Downloadable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum MalformedRequiredAssetField {
+    #[error("CPLMaster recordName is missing or blank")]
+    MasterRecordName,
+    #[error("CPLAsset recordName is missing or blank")]
+    AssetRecordName,
+    #[error("CPLAsset assetDate is missing or invalid")]
+    AssetDate,
+}
+
 /// A change event from the `changes/zone` delta API.
 #[derive(Debug)]
 pub struct ChangeEvent {
@@ -412,6 +430,32 @@ impl PhotoAsset {
         Self::from_records_in_zone(master, asset, None)
     }
 
+    pub(crate) fn try_from_records(
+        master: super::cloudkit::Record,
+        asset: &super::cloudkit::Record,
+        required: RequiredAssetFields,
+    ) -> Result<Self, MalformedRequiredAssetField> {
+        // CONTRACT: MALFORMED_REQUIRED_ASSET_FIELDS_BLOCK_CHECKPOINT
+        if master.record_name.trim().is_empty() {
+            return Err(MalformedRequiredAssetField::MasterRecordName);
+        }
+        if asset.record_name.trim().is_empty() {
+            return Err(MalformedRequiredAssetField::AssetRecordName);
+        }
+        if required == RequiredAssetFields::Downloadable
+            && asset
+                .fields
+                .get("assetDate")
+                .and_then(|field| field.get("value"))
+                .and_then(Value::as_f64)
+                .and_then(f64_to_millis_datetime)
+                .is_none()
+        {
+            return Err(MalformedRequiredAssetField::AssetDate);
+        }
+        Ok(Self::from_records(master, asset))
+    }
+
     /// Construct from typed `Record` structs and pin the CloudKit source zone.
     pub(crate) fn from_records_in_zone(
         master: super::cloudkit::Record,
@@ -750,6 +794,17 @@ impl DeltaRecordBuffer {
         for record in records {
             let reason = classify_change_reason(&record);
 
+            if record.record_name.trim().is_empty() {
+                let mut event = ChangeEvent::new(
+                    record.record_name.into_boxed_str(),
+                    (!record.record_type.is_empty()).then(|| record.record_type.into_boxed_str()),
+                    reason,
+                );
+                event.token_unsafe_reason = Some(MALFORMED_REQUIRED_ASSET_FIELDS_REASON);
+                events.push(event);
+                continue;
+            }
+
             match reason {
                 ChangeReason::HardDeleted => {
                     if record.record_type == "CPLContainerRelation" {
@@ -903,11 +958,24 @@ impl DeltaRecordBuffer {
         // Box::from(&str) copies only the bytes, without the String's Vec
         // capacity slack that .clone().into_boxed_str() would drag along.
         let master_name: Box<str> = Box::from(master_record.record_name.as_str());
-        let mut asset = PhotoAsset::from_records(master_record, &asset_record);
+        let required = if reason == ChangeReason::Created {
+            RequiredAssetFields::Downloadable
+        } else {
+            RequiredAssetFields::Identity
+        };
+        let mut event = ChangeEvent::new(master_name, Some("CPLMaster".into()), reason);
+        let mut asset = match PhotoAsset::try_from_records(master_record, &asset_record, required) {
+            Ok(asset) => asset,
+            Err(error) => {
+                tracing::warn!(error = %error, "Malformed required CloudKit asset field");
+                event.token_unsafe_reason = Some(MALFORMED_REQUIRED_ASSET_FIELDS_REASON);
+                events.push(event);
+                return;
+            }
+        };
         if use_asset_state_id {
             asset = asset.with_state_record_name(Arc::from(asset_record.record_name.as_str()));
         }
-        let mut event = ChangeEvent::new(master_name, Some("CPLMaster".into()), reason);
         event.asset = Some(asset);
         events.push(event);
     }
@@ -1508,6 +1576,107 @@ mod tests {
         let mut record = make_asset_record(name, master_ref);
         record.fields["isDeleted"] = json!({"value": 1});
         record
+    }
+
+    #[test]
+    fn required_downloadable_fields_reject_blank_identity_and_invalid_capture_date() {
+        let cases = [
+            (
+                make_master_record(""),
+                make_asset_record("A1", ""),
+                MalformedRequiredAssetField::MasterRecordName,
+            ),
+            (
+                make_master_record("M1"),
+                make_asset_record("", "M1"),
+                MalformedRequiredAssetField::AssetRecordName,
+            ),
+            (
+                make_master_record("M1"),
+                {
+                    let mut asset = make_asset_record("A1", "M1");
+                    asset.fields["assetDate"]["value"] = json!("not-a-timestamp");
+                    asset
+                },
+                MalformedRequiredAssetField::AssetDate,
+            ),
+            (
+                make_master_record("M1"),
+                {
+                    let mut asset = make_asset_record("A1", "M1");
+                    asset
+                        .fields
+                        .as_object_mut()
+                        .expect("asset fields object")
+                        .remove("assetDate");
+                    asset
+                },
+                MalformedRequiredAssetField::AssetDate,
+            ),
+            (
+                make_master_record("M1"),
+                {
+                    let mut asset = make_asset_record("A1", "M1");
+                    asset.fields["assetDate"]["value"] = json!(i64::MAX);
+                    asset
+                },
+                MalformedRequiredAssetField::AssetDate,
+            ),
+        ];
+
+        for (master, asset, expected) in cases {
+            assert_eq!(
+                PhotoAsset::try_from_records(master, &asset, RequiredAssetFields::Downloadable,)
+                    .unwrap_err(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn identity_only_records_do_not_require_capture_date() {
+        let master = make_master_record("M_DELETED");
+        let mut asset = make_asset_record("A_DELETED", "M_DELETED");
+        asset
+            .fields
+            .as_object_mut()
+            .expect("asset fields object")
+            .remove("assetDate");
+
+        assert!(
+            PhotoAsset::try_from_records(master, &asset, RequiredAssetFields::Identity).is_ok()
+        );
+    }
+
+    #[test]
+    fn delta_pair_with_invalid_capture_date_is_token_unsafe_not_downloadable() {
+        let mut buffer = DeltaRecordBuffer::new();
+        let master = make_master_record("M_BAD_DATE");
+        let mut asset = make_asset_record("A_BAD_DATE", "M_BAD_DATE");
+        asset.fields["assetDate"]["value"] = Value::Null;
+
+        let events = buffer.process_records(vec![master, asset]);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].asset.is_none());
+        assert_eq!(
+            events[0].token_unsafe_reason,
+            Some(MALFORMED_REQUIRED_ASSET_FIELDS_REASON)
+        );
+    }
+
+    #[test]
+    fn delta_blank_record_identity_is_token_unsafe() {
+        let mut buffer = DeltaRecordBuffer::new();
+
+        let events = buffer.process_records(vec![make_master_record("")]);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].asset.is_none());
+        assert_eq!(
+            events[0].token_unsafe_reason,
+            Some(MALFORMED_REQUIRED_ASSET_FIELDS_REASON)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1736,7 +1736,7 @@ pub mod __fuzz {
     /// `()` on success / discard so the harness doesn't name internal types.
     /// Inputs that don't deserialize as a `Record` are skipped.
     pub fn photo_asset_from_record_json(master: Value, asset: Value) {
-        use crate::icloud::photos::asset::PhotoAsset;
+        use crate::icloud::photos::asset::{PhotoAsset, RequiredAssetFields};
         use crate::icloud::photos::cloudkit::Record;
         let Ok(master) = serde_json::from_value::<Record>(master) else {
             return;
@@ -1744,7 +1744,7 @@ pub mod __fuzz {
         let Ok(asset) = serde_json::from_value::<Record>(asset) else {
             return;
         };
-        let _ = PhotoAsset::from_records(master, &asset);
+        let _ = PhotoAsset::try_from_records(master, &asset, RequiredAssetFields::Downloadable);
     }
 
     /// Run the path-component sanitizers over an arbitrary `&str`. Splits

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4364,6 +4364,125 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contract_malformed_required_asset_fields_block_checkpoint() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        db.set_metadata(ENUM_CONFIG_HASH_KEY, "stale-enum-config")
+            .await
+            .expect("seed stale enum config hash");
+
+        let mut page = full_album_page("PrimarySync", "", "zone-tok-new");
+        page["records"][0]["recordName"] = serde_json::json!("");
+        page["records"][1]["recordName"] = serde_json::json!("");
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(page),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run malformed identity cycle");
+
+        assert!(result.failed_count > 0);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(result.stats.skipped.total(), 0);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "paired blank identities must replay from the prior checkpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_invalid_capture_date_preserves_prior_checkpoint() {
+        let config = make_run_cycle_config();
+        let db = make_state_db();
+        db.set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        db.set_metadata(
+            ENUM_CONFIG_HASH_KEY,
+            &download::compute_config_hash(&config),
+        )
+        .await
+        .expect("seed current enum config hash");
+
+        let mut page = full_album_page("PrimarySync", "bad-date", "zone-tok-new");
+        page["records"][1]["fields"]["assetDate"]["value"] = serde_json::json!("not-a-timestamp");
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new().ok(serde_json::json!({
+                "zones": [{
+                    "zoneID": {"zoneName": "PrimarySync", "ownerRecordName": "_defaultOwner"},
+                    "syncToken": "zone-tok-new",
+                    "moreComing": false,
+                    "records": page["records"].clone()
+                }]
+            })),
+        );
+        let lib_state =
+            make_run_cycle_library_state_with_album("PrimarySync", "sync_token:PrimarySync", album);
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let build_download_config =
+            make_run_cycle_download_config_builder(download_dir.path(), Arc::clone(&db));
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        let result = run_cycle(
+            &[&lib_state],
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run malformed capture-date cycle");
+
+        assert_eq!(result.failed_count, 0);
+        assert!(result.stats.sync_token_blocked);
+        assert_eq!(
+            result.stats.sync_token_blocked_reason,
+            Some(crate::icloud::photos::asset::MALFORMED_REQUIRED_ASSET_FIELDS_REASON)
+        );
+        assert_eq!(result.stats.assets_seen, 0);
+        assert_eq!(result.stats.skipped.total(), 0);
+        assert_eq!(
+            db.get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "invalid capture dates must replay from the prior checkpoint"
+        );
+    }
+
+    #[tokio::test]
     async fn watch_recent_exact_first_cycle_seeds_incremental_token() {
         let mut config = make_run_cycle_config();
         config.filters.recent = Some(20);


### PR DESCRIPTION
## Summary

- Reject downloadable CloudKit record pairs with blank `CPLMaster` or `CPLAsset` names or an unusable `assetDate`.
- Preserve full and incremental zone checkpoints so malformed records remain retryable.
- Add production-call-graph coverage and document the checkpoint safety contract.

Fixes #740

## Tests

- `cargo test contract_malformed_required_asset_fields_block_checkpoint -- --nocapture` (passed)
- `cargo test incremental_invalid_capture_date_preserves_prior_checkpoint -- --nocapture` (passed)
- `just gate` (passed)

Optional `actionlint`, `shellcheck`, `shfmt`, and `ruff` checks were skipped because those tools are unavailable.

## Review notes

Identity-only deletion processing does not require `assetDate`. Downloadable record pairs require it before filtering or path planning.
