### PR TITLE
Preserve unreadable and concurrently changed XMP sidecars

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -302,7 +302,9 @@ planned from, so it records a marker on failure but never retires one.
 XMP sidecars record the exact properties that kei writes in the kei namespace.
 A later rewrite deletes a cleared property only when that marker proves kei
 owned the prior value. Unmarked standard properties and unrelated third-party
-namespaces remain unchanged.
+namespaces remain unchanged. An existing sidecar must be readable and parseable,
+and its bytes must still match the writer's initial read at publication. A
+failed check preserves the sidecar and its durable rewrite marker.
 
 A drain only rewrites a file whose bytes still match the checksum on its row,
 because the alternative is embedding into damage and then vouching for it. A
@@ -352,6 +354,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 | `UNKNOWN_PROVIDER_IDENTITY_REMAINS_PENDING` | `src/download/retry.rs` | Inconclusive provider identity retains the pending row and records verification evidence. |
 | `POLICY_EXCLUDED_REQUIRES_EXPLICIT_SOURCE_DELETION` | `src/download/retry.rs`, `src/state/db.rs` | Policy-excluded rows become source-deleted only after targeted provider deletion evidence. Present or inconclusive responses retain them outside actionable pending work. |
 | `METADATA_WRITES_REQUIRE_OPT_IN` | `src/download/metadata_rewrite.rs` | Media and sidecar metadata writes run only for explicitly enabled metadata flags. |
+| `XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs` | An existing XMP sidecar is replaced only when it parses and its bytes still match the writer's initial read. Failure preserves the sidecar and durable rewrite marker. |
 | `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE` | `src/download/mod.rs`, `src/state/db.rs` | Revision repair updates catalogue metadata and configured rewrite evidence before promotion, stays library-scoped, and preserves the provider checkpoint on unresolved work. |
 
 ## Change-impact checklist

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,7 +304,9 @@ A later rewrite deletes a cleared property only when that marker proves kei
 owned the prior value. Unmarked standard properties and unrelated third-party
 namespaces remain unchanged. An existing sidecar must be readable and parseable,
 and its bytes must still match the writer's initial read at publication. A
-failed check preserves the sidecar and its durable rewrite marker.
+failed check preserves the sidecar and its durable rewrite marker. Each attempt
+uses a new temporary path so retained ambiguous bytes cannot block a later
+retry.
 
 A drain only rewrites a file whose bytes still match the checksum on its row,
 because the alternative is embedding into damage and then vouching for it. A

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -551,7 +551,7 @@ pub(super) async fn publish_part_to_final(
     publication: FinalPublication,
 ) -> anyhow::Result<()> {
     if let FinalPublication::ReplaceTruncated(expected) = publication {
-        return replace_truncated_file(part_path, final_path, expected).await;
+        return replace_file_if_unchanged(part_path, final_path, expected).await;
     }
 
     match publish_part_no_replace(part_path, final_path).await {
@@ -591,7 +591,39 @@ pub(super) async fn publish_part_to_final(
     }
 }
 
-async fn replace_truncated_file(
+/// Publish a prepared file only while the destination still matches the
+/// caller's initial observation. `None` means the destination did not exist;
+/// `Some` authorizes replacement of exactly those bytes and no others.
+#[cfg(feature = "xmp")]
+pub(super) async fn publish_file_if_unchanged(
+    part_path: &Path,
+    final_path: &Path,
+    expected: Option<ExistingFileFingerprint>,
+) -> anyhow::Result<()> {
+    if let Some(expected) = expected {
+        return replace_file_if_unchanged(part_path, final_path, expected).await;
+    }
+
+    match publish_part_no_replace(part_path, final_path).await {
+        Ok(PublishResult::Published) => {
+            crate::fs_util::fsync_parent_dir_async_best_effort(final_path).await;
+            Ok(())
+        }
+        Ok(PublishResult::DestinationExists) => anyhow::bail!(
+            "Refusing to publish {} because it appeared after write planning",
+            final_path.display()
+        ),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Could not publish prepared file {} -> {}",
+                part_path.display(),
+                final_path.display()
+            )
+        }),
+    }
+}
+
+async fn replace_file_if_unchanged(
     part_path: &Path,
     final_path: &Path,
     expected: ExistingFileFingerprint,
@@ -600,13 +632,13 @@ async fn replace_truncated_file(
         .await
         .with_context(|| {
             format!(
-                "Could not verify truncated repair target {}",
+                "Could not verify replacement target {}",
                 final_path.display()
             )
         })?;
     anyhow::ensure!(
         current == expected,
-        "Refusing to replace {} because its bytes changed after repair planning",
+        "Refusing to replace {} because its bytes changed after write planning",
         final_path.display()
     );
 
@@ -647,23 +679,27 @@ async fn replace_truncated_file(
         }
     };
     if displaced != expected {
-        let restored =
-            restore_repair_target_if_unchanged(part_path, final_path, &displaced_path, replacement)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Could not restore {} after its bytes changed during repair publication",
-                        final_path.display()
-                    )
-                })?;
+        let restored = restore_repair_target_if_unchanged(
+            part_path,
+            final_path,
+            &displaced_path,
+            replacement,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Could not restore {} after its bytes changed during conditional publication",
+                final_path.display()
+            )
+        })?;
         if restored {
             anyhow::bail!(
-                "Refusing to replace {} because its bytes changed during repair publication; the original target was restored",
+                "Refusing to replace {} because its bytes changed during conditional publication; the original target was restored",
                 final_path.display()
             );
         }
         anyhow::bail!(
-            "Refusing to replace {} because its bytes changed during repair publication; the displaced bytes remain at {}",
+            "Refusing to replace {} because its bytes changed during conditional publication; the displaced bytes remain at {}",
             final_path.display(),
             displaced_path.display()
         );
@@ -673,7 +709,7 @@ async fn replace_truncated_file(
         tracing::warn!(
             path = %displaced_path.display(),
             %error,
-            "Failed to remove displaced truncated file after verified replacement"
+            "Failed to remove displaced file after verified replacement"
         );
     }
     crate::fs_util::fsync_parent_dir_async_best_effort(final_path).await;
@@ -1211,25 +1247,25 @@ pub(super) async fn fingerprint_file(path: &Path) -> anyhow::Result<ExistingFile
     .await?
 }
 
-/// Fingerprint a repair entry and reject links or special files.
+/// Fingerprint a replacement entry and reject links or special files.
 pub(super) async fn fingerprint_regular_file(
     path: &Path,
 ) -> anyhow::Result<ExistingFileFingerprint> {
     let before = fs::symlink_metadata(path)
         .await
-        .with_context(|| format!("Could not inspect repair file {}", path.display()))?;
+        .with_context(|| format!("Could not inspect replacement file {}", path.display()))?;
     anyhow::ensure!(
         before.file_type().is_file(),
-        "Repair path is not a regular file: {}",
+        "Replacement path is not a regular file: {}",
         path.display()
     );
     let fingerprint = fingerprint_file(path).await?;
     let after = fs::symlink_metadata(path)
         .await
-        .with_context(|| format!("Could not recheck repair file {}", path.display()))?;
+        .with_context(|| format!("Could not recheck replacement file {}", path.display()))?;
     anyhow::ensure!(
         after.file_type().is_file(),
-        "Repair path changed away from a regular file: {}",
+        "Replacement path changed away from a regular file: {}",
         path.display()
     );
     Ok(fingerprint)

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -27,7 +27,9 @@ use little_exif::metadata::Metadata;
 #[cfg(not(feature = "xmp"))]
 use little_exif::rational::uR64;
 #[cfg(feature = "xmp")]
-use xmp_toolkit::{OpenFileOptions, XmpFile, XmpMeta, XmpValue, xmp_ns};
+use xmp_toolkit::{
+    FromStrOptions, OpenFileOptions, XmpErrorType, XmpFile, XmpMeta, XmpValue, xmp_ns,
+};
 
 #[cfg(feature = "xmp")]
 use super::heif;
@@ -551,20 +553,65 @@ fn temp_path_for(path: &Path, temp_suffix: &str) -> PathBuf {
 ///
 /// If a sidecar already exists (e.g., from Darktable / Lightroom / digiKam),
 /// its existing XMP properties are read and kei's fields are layered on top
-/// rather than overwriting the whole packet. A malformed existing sidecar
-/// falls back to a fresh packet — kei's enriched view wins over a file we
-/// can't parse.
+/// rather than overwriting the whole packet. Existing bytes must remain
+/// readable, parseable, and unchanged through publication. Otherwise the
+/// write fails without replacing them.
 #[cfg(feature = "xmp")]
-pub(crate) fn write_sidecar(
+pub(crate) async fn write_sidecar(
     media_path: &Path,
     write: &MetadataWrite,
     temp_suffix: &str,
 ) -> Result<()> {
+    let media_path = media_path.to_path_buf();
+    let write = write.clone();
+    let temp_suffix = temp_suffix.to_owned();
+    let prepared = tokio::task::spawn_blocking(move || {
+        prepare_sidecar_write(&media_path, &write, &temp_suffix)
+    })
+    .await
+    .context("XMP sidecar preparation task panicked")??;
+    let Some(prepared) = prepared else {
+        return Ok(());
+    };
+
+    // CONTRACT: XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT
+    super::file::publish_file_if_unchanged(
+        &prepared.tmp_path,
+        &prepared.sidecar_path,
+        prepared.expected,
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "Could not install XMP sidecar {} -> {}",
+            prepared.tmp_path.display(),
+            prepared.sidecar_path.display()
+        )
+    })?;
+    tracing::debug!(path = %prepared.sidecar_path.display(), "Wrote XMP sidecar");
+    Ok(())
+}
+
+#[cfg(feature = "xmp")]
+struct PreparedSidecar {
+    tmp_path: PathBuf,
+    sidecar_path: PathBuf,
+    expected: Option<super::file::ExistingFileFingerprint>,
+}
+
+#[cfg(feature = "xmp")]
+fn prepare_sidecar_write(
+    media_path: &Path,
+    write: &MetadataWrite,
+    temp_suffix: &str,
+) -> Result<Option<PreparedSidecar>> {
+    use sha2::{Digest, Sha256};
+
     ensure_initialized();
 
     let Some(name) = media_path.file_name() else {
         if write.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         anyhow::bail!(
             "Cannot write an XMP sidecar because the media path has no filename: {}",
@@ -578,22 +625,30 @@ pub(crate) fn write_sidecar(
 
     // Seed the packet with any existing sidecar content so user-authored
     // ratings / keywords / develop settings from another tool survive.
-    let mut meta = match std::fs::read(&sidecar_path) {
-        Ok(existing_bytes) => match std::str::from_utf8(&existing_bytes)
-            .ok()
-            .and_then(|s| s.parse::<XmpMeta>().ok())
-        {
-            Some(parsed) => parsed,
-            None => {
-                tracing::warn!(
-                    path = %sidecar_path.display(),
-                    "Existing XMP sidecar could not be parsed; overwriting with a fresh packet"
-                );
-                XmpMeta::new().context("creating XmpMeta")?
-            }
-        },
+    let (mut meta, expected) = match std::fs::read(&sidecar_path) {
+        Ok(existing_bytes) => {
+            let existing = std::str::from_utf8(&existing_bytes).with_context(|| {
+                format!(
+                    "Existing XMP sidecar is not valid UTF-8: {}",
+                    sidecar_path.display()
+                )
+            })?;
+            let parsed = parse_existing_sidecar(existing).with_context(|| {
+                format!(
+                    "Could not parse existing XMP sidecar {}",
+                    sidecar_path.display()
+                )
+            })?;
+            let size = u64::try_from(existing_bytes.len())
+                .context("Existing XMP sidecar is too large to fingerprint")?;
+            let fingerprint = super::file::ExistingFileFingerprint {
+                size,
+                sha256: Sha256::digest(&existing_bytes).into(),
+            };
+            (parsed, Some(fingerprint))
+        }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            XmpMeta::new().context("creating XmpMeta")?
+            (XmpMeta::new().context("creating XmpMeta")?, None)
         }
         Err(e) => {
             return Err(e).with_context(|| {
@@ -605,26 +660,59 @@ pub(crate) fn write_sidecar(
         }
     };
     if write.is_empty() && !meta.contains_property(KEI_XMP_NS, KEI_MANAGED_FIELDS) {
-        return Ok(());
+        return Ok(None);
     }
     apply_to_owned_sidecar(&mut meta, write)?;
     let bytes = meta.to_string().into_bytes();
 
-    std::fs::write(&tmp_path, &bytes).with_context(|| {
+    let mut temp = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)
+        .with_context(|| {
+            format!(
+                "Could not create temporary XMP sidecar {}",
+                tmp_path.display()
+            )
+        })?;
+    let guard = TmpGuard::new(&tmp_path);
+    std::io::Write::write_all(&mut temp, &bytes).with_context(|| {
         format!(
             "Could not write temporary XMP sidecar {}",
             tmp_path.display()
         )
     })?;
-    atomic_install(&tmp_path, &sidecar_path).with_context(|| {
+    temp.sync_all().with_context(|| {
         format!(
-            "Could not install XMP sidecar {} -> {}",
-            tmp_path.display(),
-            sidecar_path.display()
+            "Could not sync temporary XMP sidecar {}",
+            tmp_path.display()
         )
     })?;
-    tracing::debug!(path = %sidecar_path.display(), "Wrote XMP sidecar");
-    Ok(())
+    guard.disarm();
+    Ok(Some(PreparedSidecar {
+        tmp_path,
+        sidecar_path,
+        expected,
+    }))
+}
+
+#[cfg(feature = "xmp")]
+fn parse_existing_sidecar(existing: &str) -> Result<XmpMeta> {
+    match XmpMeta::from_str_with_options(existing, FromStrOptions::default().require_xmp_meta()) {
+        Ok(parsed) => Ok(parsed),
+        Err(error) if error.error_type == XmpErrorType::XmpMetaElementMissing => {
+            let parsed = existing.parse::<XmpMeta>()?;
+            anyhow::ensure!(
+                parsed
+                    .iter(xmp_toolkit::IterOptions::default())
+                    .next()
+                    .is_some(),
+                "sidecar has no recognizable XMP properties"
+            );
+            Ok(parsed)
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Apply a complete sidecar snapshot without deleting metadata that kei cannot
@@ -1150,7 +1238,10 @@ mod tests {
         path: &std::path::Path,
         write: &super::MetadataWrite,
     ) -> super::Result<()> {
-        super::write_sidecar(path, write, ".meta-tmp")
+        static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+        RUNTIME
+            .get_or_init(|| tokio::runtime::Runtime::new().expect("sidecar test runtime"))
+            .block_on(super::write_sidecar(path, write, ".meta-tmp"))
     }
 
     use super::*;
@@ -2451,6 +2542,124 @@ mod tests {
         fs::remove_file(&media_path).ok();
     }
 
+    #[tokio::test]
+    async fn write_sidecar_refuses_existing_file_changed_after_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("changed.jpg");
+        let sidecar_path = dir.path().join("changed.jpg.xmp");
+        std::fs::write(&media_path, b"placeholder").unwrap();
+
+        ensure_initialized();
+        let mut original = XmpMeta::new().unwrap();
+        original
+            .set_property(
+                xmp_ns::DC,
+                "creator",
+                &XmpValue::new("Initial author".to_string()),
+            )
+            .unwrap();
+        std::fs::write(&sidecar_path, original.to_string().into_bytes()).unwrap();
+
+        let prepared = prepare_sidecar_write(
+            &media_path,
+            &MetadataWrite {
+                rating: Some(4),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+        )
+        .unwrap()
+        .expect("sidecar update should be prepared");
+        let temp_path = prepared.tmp_path.clone();
+
+        let external = b"external replacement after initial read";
+        std::fs::write(&sidecar_path, external).unwrap();
+        let error = crate::download::file::publish_file_if_unchanged(
+            &prepared.tmp_path,
+            &prepared.sidecar_path,
+            prepared.expected,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("bytes changed"), "{error:#}");
+        assert_eq!(
+            std::fs::read(&sidecar_path).unwrap(),
+            external,
+            "an external change after the initial read must not be replaced"
+        );
+        assert!(
+            temp_path.exists(),
+            "refused publication retains the prepared file because an exchange failure could have displaced user bytes there"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_sidecar_refuses_file_created_after_missing_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("appeared.jpg");
+        let sidecar_path = dir.path().join("appeared.jpg.xmp");
+        std::fs::write(&media_path, b"placeholder").unwrap();
+
+        let prepared = prepare_sidecar_write(
+            &media_path,
+            &MetadataWrite {
+                rating: Some(4),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+        )
+        .unwrap()
+        .expect("new sidecar should be prepared");
+        let temp_path = prepared.tmp_path.clone();
+
+        let external = b"sidecar created by another application";
+        std::fs::write(&sidecar_path, external).unwrap();
+        let error = crate::download::file::publish_file_if_unchanged(
+            &prepared.tmp_path,
+            &prepared.sidecar_path,
+            prepared.expected,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("appeared"), "{error:#}");
+        assert_eq!(std::fs::read(&sidecar_path).unwrap(), external);
+        assert!(
+            temp_path.exists(),
+            "refused publication retains the prepared file for operator inspection"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_sidecar_preserves_preexisting_temp_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("temp-conflict.jpg");
+        let sidecar_path = dir.path().join("temp-conflict.jpg.xmp");
+        let temp_path = dir.path().join("temp-conflict.jpg.xmp.meta-tmp");
+        std::fs::write(&media_path, b"placeholder").unwrap();
+        let existing_temp = b"unowned or displaced bytes";
+        std::fs::write(&temp_path, existing_temp).unwrap();
+
+        let error = super::write_sidecar(
+            &media_path,
+            &MetadataWrite {
+                rating: Some(4),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("Could not create temporary XMP sidecar"),
+            "{error:#}"
+        );
+        assert_eq!(std::fs::read(&temp_path).unwrap(), existing_temp);
+        assert!(!sidecar_path.exists());
+    }
+
     #[test]
     fn write_sidecar_clears_only_fields_previously_owned_by_kei() {
         let dir = test_tmp_dir("sidecar_tests");
@@ -2711,27 +2920,48 @@ mod tests {
     }
 
     #[test]
-    fn write_sidecar_recovers_from_unparsable_existing() {
-        // A garbage existing sidecar should not block kei's write; we log
-        // and fall back to a fresh packet rather than erroring.
+    fn write_sidecar_preserves_unparsable_existing() {
         let dir = test_tmp_dir("sidecar_tests");
         std::fs::create_dir_all(&dir).unwrap();
         let media_path = dir.join("garbage.jpg");
         let sidecar_path = dir.join("garbage.jpg.xmp");
         std::fs::write(&media_path, b"placeholder").unwrap();
-        std::fs::write(&sidecar_path, b"<<< this is not XMP >>>").unwrap();
+        let original = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF";
+        std::fs::write(&sidecar_path, original).unwrap();
 
         let write = MetadataWrite {
             title: Some("Clean".into()),
             ..MetadataWrite::default()
         };
-        write_sidecar_with_default_suffix(&media_path, &write).expect("fallback to fresh packet");
+        let error = write_sidecar_with_default_suffix(&media_path, &write).unwrap_err();
 
-        let out = fs::read_to_string(&sidecar_path).unwrap();
-        assert!(out.contains("Clean"), "fallback write must land: {out}");
+        assert!(
+            format!("{error:#}").contains("Could not parse existing XMP sidecar"),
+            "{error:#}"
+        );
+        assert_eq!(
+            fs::read(&sidecar_path).unwrap(),
+            original,
+            "unparsable third-party bytes must remain unchanged"
+        );
 
         fs::remove_file(&sidecar_path).ok();
         fs::remove_file(&media_path).ok();
+    }
+
+    #[test]
+    fn parse_existing_sidecar_accepts_bare_rdf_with_properties() {
+        let bare_rdf = r#"<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:format>image/jpeg</dc:format>
+</rdf:Description>
+</rdf:RDF>"#;
+
+        let parsed = parse_existing_sidecar(bare_rdf).unwrap();
+        assert_eq!(
+            parsed.property(xmp_ns::DC, "format").unwrap().value,
+            "image/jpeg"
+        );
     }
 
     #[test]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -51,6 +51,9 @@ const EXIF_EX_XMP_PREFIX: &str = "exifEX";
 const KEI_MANAGED_FIELDS: &str = "managedFields";
 
 #[cfg(feature = "xmp")]
+static SIDECAR_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(feature = "xmp")]
 #[derive(Clone, Copy)]
 enum ManagedXmpField {
     CreateDate,
@@ -621,8 +624,6 @@ fn prepare_sidecar_write(
     let mut sidecar_name = name.to_os_string();
     sidecar_name.push(".xmp");
     let sidecar_path = media_path.with_file_name(&sidecar_name);
-    let tmp_path = temp_path_for(&sidecar_path, temp_suffix);
-
     // Seed the packet with any existing sidecar content so user-authored
     // ratings / keywords / develop settings from another tool survive.
     let (mut meta, expected) = match std::fs::read(&sidecar_path) {
@@ -665,16 +666,7 @@ fn prepare_sidecar_write(
     apply_to_owned_sidecar(&mut meta, write)?;
     let bytes = meta.to_string().into_bytes();
 
-    let mut temp = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&tmp_path)
-        .with_context(|| {
-            format!(
-                "Could not create temporary XMP sidecar {}",
-                tmp_path.display()
-            )
-        })?;
+    let (mut temp, tmp_path) = create_unique_sidecar_temp(&sidecar_path, temp_suffix)?;
     let guard = TmpGuard::new(&tmp_path);
     std::io::Write::write_all(&mut temp, &bytes).with_context(|| {
         format!(
@@ -694,6 +686,45 @@ fn prepare_sidecar_write(
         sidecar_path,
         expected,
     }))
+}
+
+#[cfg(feature = "xmp")]
+fn sidecar_temp_path(sidecar_path: &Path, temp_suffix: &str, sequence: u64) -> PathBuf {
+    let parent = sidecar_path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".kei-xmp-{}-{sequence}{temp_suffix}",
+        std::process::id()
+    ))
+}
+
+#[cfg(feature = "xmp")]
+fn create_unique_sidecar_temp(
+    sidecar_path: &Path,
+    temp_suffix: &str,
+) -> Result<(std::fs::File, PathBuf)> {
+    loop {
+        let candidate = sidecar_temp_path(
+            sidecar_path,
+            temp_suffix,
+            SIDECAR_TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        );
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => return Ok((file, candidate)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Could not create temporary XMP sidecar {}",
+                        candidate.display()
+                    )
+                });
+            }
+        }
+    }
 }
 
 #[cfg(feature = "xmp")]
@@ -2510,9 +2541,8 @@ mod tests {
 
     #[test]
     fn write_sidecar_is_atomic_rewrite() {
-        let dir = test_tmp_dir("sidecar_tests");
-        std::fs::create_dir_all(&dir).unwrap();
-        let media_path = dir.join("rewrite.jpg");
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("rewrite.jpg");
         std::fs::write(&media_path, b"placeholder").unwrap();
 
         let first = MetadataWrite {
@@ -2527,7 +2557,7 @@ mod tests {
         };
         write_sidecar_with_default_suffix(&media_path, &second).unwrap();
 
-        let sidecar = dir.join("rewrite.jpg.xmp");
+        let sidecar = dir.path().join("rewrite.jpg.xmp");
         let s = fs::read_to_string(&sidecar).unwrap();
         assert!(s.contains("After"), "second write should replace first");
         assert!(
@@ -2535,11 +2565,15 @@ mod tests {
             "previous title must not leak through"
         );
 
-        let tmp = dir.join("rewrite.jpg.xmp.meta-tmp");
-        assert!(!tmp.exists(), "temp sidecar file must be cleaned up");
-
-        fs::remove_file(&sidecar).ok();
-        fs::remove_file(&media_path).ok();
+        let retained_temps: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with(".kei-xmp-"))
+            .collect();
+        assert!(
+            retained_temps.is_empty(),
+            "successful writes must remove their unique temp files: {retained_temps:?}"
+        );
     }
 
     #[tokio::test]
@@ -2632,16 +2666,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_sidecar_preserves_preexisting_temp_path() {
+    async fn write_sidecar_retries_after_retained_conflict_temp() {
         let dir = tempfile::tempdir().unwrap();
         let media_path = dir.path().join("temp-conflict.jpg");
         let sidecar_path = dir.path().join("temp-conflict.jpg.xmp");
-        let temp_path = dir.path().join("temp-conflict.jpg.xmp.meta-tmp");
         std::fs::write(&media_path, b"placeholder").unwrap();
-        let existing_temp = b"unowned or displaced bytes";
-        std::fs::write(&temp_path, existing_temp).unwrap();
 
-        let error = super::write_sidecar(
+        let prepared = prepare_sidecar_write(
+            &media_path,
+            &MetadataWrite {
+                rating: Some(4),
+                ..MetadataWrite::default()
+            },
+            ".meta-tmp",
+        )
+        .unwrap()
+        .expect("initial sidecar should be prepared");
+        let retained_path = prepared.tmp_path.clone();
+        let retained_bytes = std::fs::read(&retained_path).unwrap();
+
+        ensure_initialized();
+        let mut external = XmpMeta::new().unwrap();
+        external
+            .set_property(
+                xmp_ns::DC,
+                "creator",
+                &XmpValue::new("External author".to_string()),
+            )
+            .unwrap();
+        std::fs::write(&sidecar_path, external.to_string().into_bytes()).unwrap();
+        crate::download::file::publish_file_if_unchanged(
+            &prepared.tmp_path,
+            &prepared.sidecar_path,
+            prepared.expected,
+        )
+        .await
+        .unwrap_err();
+
+        super::write_sidecar(
             &media_path,
             &MetadataWrite {
                 rating: Some(4),
@@ -2650,14 +2712,16 @@ mod tests {
             ".meta-tmp",
         )
         .await
-        .unwrap_err();
+        .expect("a retained conflict file must not block a later attempt");
 
-        assert!(
-            format!("{error:#}").contains("Could not create temporary XMP sidecar"),
-            "{error:#}"
+        assert_eq!(
+            std::fs::read(&retained_path).unwrap(),
+            retained_bytes,
+            "the later attempt must not overwrite or delete ambiguous retained bytes"
         );
-        assert_eq!(std::fs::read(&temp_path).unwrap(), existing_temp);
-        assert!(!sidecar_path.exists());
+        let written = std::fs::read_to_string(&sidecar_path).unwrap();
+        assert!(written.contains("External author"), "{written}");
+        assert!(written.contains("Rating"), "{written}");
     }
 
     #[test]

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -200,26 +200,14 @@ async fn write_sidecar_metadata(
     created_local: DateTime<FixedOffset>,
     temp_suffix: &str,
 ) -> bool {
-    let sidecar_path = path.to_path_buf();
-    let sidecar_temp_suffix = temp_suffix.to_string();
-    match tokio::task::spawn_blocking(move || {
-        let write = plan_sidecar_write(&payload, &created_local);
-        if write.is_empty() {
-            return true;
-        }
-        match super::metadata::write_sidecar(&sidecar_path, &write, &sidecar_temp_suffix) {
-            Err(e) => {
-                tracing::warn!(path = %sidecar_path.display(), error = %e, "Failed to write XMP sidecar");
-                false
-            }
-            Ok(()) => true,
-        }
-    })
-    .await
-    {
-        Ok(ok) => ok,
+    let write = plan_sidecar_write(&payload, &created_local);
+    if write.is_empty() {
+        return true;
+    }
+    match super::metadata::write_sidecar(path, &write, temp_suffix).await {
+        Ok(()) => true,
         Err(e) => {
-            tracing::warn!(error = %e, "XMP sidecar task panicked");
+            tracing::warn!(path = %path.display(), error = %e, "Failed to write XMP sidecar");
             false
         }
     }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -7364,6 +7364,84 @@ mod tests {
         );
     }
 
+    /// #741: the normal pending-rewrite owner must treat an unparsable
+    /// third-party sidecar as visible retryable work, not successful output.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_sidecar_rewrite_requires_stable_input() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let dir = TempDir::new().unwrap();
+        let db = Arc::new(
+            SqliteStateDb::open(&dir.path().join("state.db"))
+                .await
+                .unwrap(),
+        );
+        let download_dir = dir.path().join("downloads");
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(download_dir.as_path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let stored = jpeg_asset("UNPARSABLE_SIDECAR", "unparsable.jpg", true);
+        let derived = seed_downloaded_jpeg_asset(&db, &config, &stored).await;
+        db.record_metadata_write_failure(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+        )
+        .await
+        .unwrap();
+        let sidecar_path = sidecar_path_for(&derived.path);
+        let original = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF";
+        fs::write(&sidecar_path, original).unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::empty::<Result<PhotoAsset, anyhow::Error>>(),
+            &config,
+            DownloadControls::download_hidden(),
+            0,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.exif_failures, 1);
+        assert_eq!(fs::read(&sidecar_path).unwrap(), original);
+        assert_eq!(
+            db.get_pending_metadata_rewrites(10).await.unwrap().len(),
+            1,
+            "failed sidecar rewrite must keep its durable marker"
+        );
+
+        let (outcome, stats) = build_download_outcome(
+            &reqwest::Client::new(),
+            &[],
+            &config,
+            DownloadControls::download_hidden(),
+            result,
+            Instant::now(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(outcome, DownloadOutcome::PartialFailure { .. }));
+        assert_eq!(stats.exif_failures, 1);
+        assert_eq!(
+            serde_json::to_value(&stats).unwrap()["exif_failures"],
+            1,
+            "sync report statistics must expose the sidecar failure"
+        );
+    }
+
     /// Data-sacred regression for the trust-state fast-skip removal.
     ///
     /// When the state DB says an asset is `downloaded` and the config_hash

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -7442,6 +7442,73 @@ mod tests {
         );
     }
 
+    /// #752: ambiguous bytes retained from a refused sidecar publication must
+    /// not block the durable marker from succeeding on a later drain.
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn retained_sidecar_temp_does_not_block_pending_rewrite_retry() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        let dir = TempDir::new().unwrap();
+        let db = Arc::new(
+            SqliteStateDb::open(&dir.path().join("state.db"))
+                .await
+                .unwrap(),
+        );
+        let download_dir = dir.path().join("downloads");
+        let mut config = DownloadConfig::test_default();
+        config.directory = Arc::from(download_dir.as_path());
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        let stored = jpeg_asset("RETAINED_SIDECAR_TEMP", "retained.jpg", true);
+        let derived = seed_downloaded_jpeg_asset(&db, &config, &stored).await;
+        db.record_metadata_write_failure(
+            "PrimarySync",
+            stored.state_id(),
+            derived.version_size.as_str(),
+        )
+        .await
+        .unwrap();
+
+        let retained_path = derived.path.parent().unwrap().join(format!(
+            ".kei-xmp-{}-{}.kei-tmp",
+            std::process::id(),
+            u64::MAX
+        ));
+        let retained_bytes = b"ambiguous bytes from an earlier publication";
+        fs::write(&retained_path, retained_bytes).unwrap();
+
+        let result = stream_and_download_from_stream(
+            &reqwest::Client::new(),
+            stream::empty::<Result<PhotoAsset, anyhow::Error>>(),
+            &config,
+            DownloadControls::download_hidden(),
+            0,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.exif_failures, 0);
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(fs::read(&retained_path).unwrap(), retained_bytes);
+        let sidecar = fs::read_to_string(sidecar_path_for(&derived.path)).unwrap();
+        assert!(sidecar.contains("<xmp:Rating>5</xmp:Rating>"), "{sidecar}");
+    }
+
     /// Data-sacred regression for the trust-state fast-skip removal.
     ///
     /// When the state DB says an asset is `downloaded` and the config_hash


### PR DESCRIPTION
## Summary
- Preserve existing XMP sidecars when they cannot be read or parsed.
- Publish sidecar updates only when the destination still matches the initial read.
- Keep failed rewrite markers durable and report the failure through cycle statistics.
- Document `XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT`.

Fixes #741

## Tests
- `cargo test --all-features write_sidecar_ --no-fail-fast`
- `cargo test --all-features parse_existing_sidecar_accepts_bare_rdf_with_properties`
- `cargo test --all-features contract_xmp_sidecar_rewrite_requires_stable_input`
- `just gate`

## Risk
- A refused concurrent publication retains its prepared temporary file. This avoids deleting bytes that an interrupted exchange may have displaced.
- Bare RDF with recognized properties remains supported. Unrecognized input fails closed.
