### PR TITLE
Bound metadata capture repair cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Automatic metadata-capture repair in watch and service mode now schedules another cycle after at most 60 seconds when a 500-asset batch makes clean progress and more work remains. Stalled or failed batches use the configured watch interval, and one-shot sync stays capped at one batch. `kei status` and `sync_report.json` continue to report remaining work. A synthetic database with one million distinct assets grew by 87.363 MiB, or 17.51 percent, for revision state. Repairing one million stale assets in one library needs 2,000 successful batches, which adds about 33 hours of follow-up waits plus provider and cycle processing time. ([#742])
 - State databases now use schema version 17 to record which iCloud asset owns an adopted legacy master row. Older kei versions reject a version 17 database instead of opening it. To downgrade, restore a state DB backup made before the upgrade; downloaded media files are unchanged. ([#721])
 
 ### Fixed
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#720]: https://github.com/rhoopr/kei/pull/720
 [#721]: https://github.com/rhoopr/kei/pull/721
 [#725]: https://github.com/rhoopr/kei/issues/725
+[#742]: https://github.com/rhoopr/kei/issues/742
 [#691]: https://github.com/rhoopr/kei/issues/691
 [@mmenanno]: https://github.com/mmenanno
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -275,6 +275,17 @@ Only an identity that cannot be resolved from durable asset/master evidence
 uses the bounded legacy hydration path. Unselected libraries keep separate
 pending state and do not force work in selected libraries.
 
+Automatic repair processes at most 500 stale assets per library in one sync
+cycle. When a clean batch makes progress and work remains, watch and service
+mode wait at most 60 seconds before the next cycle. A stalled or failed batch
+uses the configured watch interval so persistent provider failures do not cause
+rapid retries. A one-shot sync processes one batch. `kei status` reads durable
+remaining counts, and `sync_report.json` reports the current cycle's refreshed,
+failed, and remaining counts. Revision storage uses one row per distinct asset.
+A synthetic one-million-asset database grew by 87.363 MiB, or 17.51 percent.
+One library with one million stale assets needs 2,000 successful batches, which
+adds about 33 hours of follow-up waits plus provider and cycle processing time.
+
 The watch pre-check includes only libraries with pending capture work or
 serviceable rewrite work, even when iCloud reports no provider changes. A
 rewrite marker is serviceable only when a metadata writer is enabled. A capture

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -420,7 +420,24 @@ pub struct SyncStats {
     pub recap: recap::RunRecap,
 }
 
+const RATE_LIMIT_PRESSURE_PERCENT: u64 = 10;
+const RATE_LIMIT_PERCENT_SCALE: u64 = 100;
+
 impl SyncStats {
+    /// Whether observed HTTP 429/503 retries crossed the operator-warning threshold.
+    #[must_use]
+    pub(crate) fn has_rate_limit_pressure(&self) -> bool {
+        if self.rate_limited == 0 {
+            return false;
+        }
+        if self.assets_seen == 0 {
+            return true;
+        }
+        let observations = u64::try_from(self.rate_limited).unwrap_or(u64::MAX);
+        observations.saturating_mul(RATE_LIMIT_PERCENT_SCALE) / self.assets_seen
+            >= RATE_LIMIT_PRESSURE_PERCENT
+    }
+
     /// Add `other` into `self`, field by field. Used by the per-cycle loop in
     /// `sync_loop::run_cycle` to fold each library's stats into a cycle-wide
     /// total.
@@ -4334,6 +4351,10 @@ async fn run_metadata_capture_repair(
         })
         .collect();
     let resolutions = provider_pass.album.resolve_records(&requests).await;
+    repair.stats.rate_limited = repair
+        .stats
+        .rate_limited
+        .saturating_add(resolutions.rate_limit_observations);
     let mut legacy_masters = FxHashSet::default();
     for (state_id, resolution) in resolutions.results {
         if shutdown_token.is_cancelled() {
@@ -10012,6 +10033,22 @@ mod tests {
         container_id: Option<&str>,
         session: Box<dyn PhotosSession>,
     ) -> PhotoAlbum {
+        album_with_session_and_retry_config(
+            zone,
+            name,
+            container_id,
+            RetryConfig::default(),
+            session,
+        )
+    }
+
+    fn album_with_session_and_retry_config(
+        zone: &str,
+        name: &str,
+        container_id: Option<&str>,
+        retry_config: RetryConfig,
+        session: Box<dyn PhotosSession>,
+    ) -> PhotoAlbum {
         PhotoAlbum::new(
             PhotoAlbumConfig {
                 params: Arc::new(HashMap::new()),
@@ -10022,7 +10059,7 @@ mod tests {
                 query_filter: None,
                 page_size: 100,
                 zone_id: Arc::new(json!({"zoneName": zone})),
-                retry_config: RetryConfig::default(),
+                retry_config,
                 container_id: container_id.map(Arc::from),
                 cross_zone_sources: Vec::new(),
             },
@@ -15335,6 +15372,7 @@ mod tests {
         #[derive(Clone, Debug)]
         struct CaptureScaleSession {
             records: Arc<HashMap<String, Value>>,
+            rate_limited_once: Arc<AtomicBool>,
         }
 
         #[async_trait::async_trait]
@@ -15351,6 +15389,15 @@ mod tests {
                     } else {
                         json!({"records": [], "syncToken": "ignored-query-token"})
                     });
+                }
+                if !self.rate_limited_once.swap(true, Ordering::SeqCst) {
+                    return Err(crate::icloud::photos::session::HttpStatusError {
+                        status: 429,
+                        url: url.to_owned(),
+                        retry_after: None,
+                        body: None,
+                    }
+                    .into());
                 }
                 let request: Value = serde_json::from_str(&body)?;
                 let records = request["records"]
@@ -15411,11 +15458,18 @@ mod tests {
 
         let pass = AlbumPass {
             kind: PassKind::Unfiled,
-            album: album_with_session(
+            album: album_with_session_and_retry_config(
                 "PrimarySync",
                 "",
+                None,
+                RetryConfig {
+                    max_retries: 1,
+                    base_delay_secs: 0,
+                    max_delay_secs: 0,
+                },
                 Box::new(CaptureScaleSession {
                     records: Arc::new(provider_records),
+                    rate_limited_once: Arc::new(AtomicBool::new(false)),
                 }),
             ),
             exclude_ids: Arc::new(FxHashSet::default()),
@@ -15428,10 +15482,10 @@ mod tests {
             zone_sync_token: "zone-token-prev".to_string(),
         };
 
-        for (cycle, refreshed, remaining, active_revision) in [
-            (1, 500, 701, 0),
-            (2, 500, 201, 0),
-            (3, 201, 0, crate::state::METADATA_CAPTURE_REVISION),
+        for (cycle, refreshed, remaining, active_revision, rate_limited) in [
+            (1, 500, 701, 0, 1),
+            (2, 500, 201, 0, 0),
+            (3, 201, 0, crate::state::METADATA_CAPTURE_REVISION, 0),
         ] {
             let result = download_photos_with_sync(
                 &Client::new(),
@@ -15454,6 +15508,12 @@ mod tests {
             );
             assert_eq!(
                 result.stats.metadata_capture_remaining, remaining,
+                "cycle {cycle}"
+            );
+            assert_eq!(result.stats.rate_limited, rate_limited, "cycle {cycle}");
+            assert_eq!(
+                result.stats.has_rate_limit_pressure(),
+                rate_limited > 0,
                 "cycle {cycle}"
             );
             let summary = db.get_summary().await.expect("capture status");

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -296,6 +296,9 @@ pub struct SyncStats {
     pub metadata_capture_refreshed: usize,
     pub metadata_capture_failures: usize,
     pub metadata_capture_remaining: u64,
+    /// True when this cycle durably reduced metadata-capture work.
+    #[serde(skip)]
+    pub(crate) metadata_capture_progressed: bool,
     pub state_write_failures: usize,
     pub enumeration_errors: usize,
     /// Best-effort count-probe failures observed before full enumeration.
@@ -422,9 +425,8 @@ impl SyncStats {
     /// `sync_loop::run_cycle` to fold each library's stats into a cycle-wide
     /// total.
     ///
-    /// All numeric counters sum; `interrupted` ORs (any library being
-    /// interrupted means the cycle was interrupted); `skipped` delegates to
-    /// [`SkipBreakdown::accumulate`].
+    /// All numeric counters sum; boolean cycle facts OR; `skipped` delegates
+    /// to [`SkipBreakdown::accumulate`].
     ///
     /// Adding a new field to `SyncStats` requires updating this method too --
     /// otherwise the new counter silently zeros out across multi-library
@@ -454,6 +456,7 @@ impl SyncStats {
         self.metadata_capture_refreshed += other.metadata_capture_refreshed;
         self.metadata_capture_failures += other.metadata_capture_failures;
         self.metadata_capture_remaining += other.metadata_capture_remaining;
+        self.metadata_capture_progressed |= other.metadata_capture_progressed;
         self.state_write_failures += other.state_write_failures;
         self.enumeration_errors += other.enumeration_errors;
         self.count_probe_failures += other.count_probe_failures;
@@ -4537,7 +4540,11 @@ async fn run_metadata_capture_repair(
         .complete_metadata_capture_revision(library, crate::state::METADATA_CAPTURE_REVISION)
         .await
     {
-        Ok(status) => repair.stats.metadata_capture_remaining = status.remaining_assets,
+        Ok(status) => {
+            repair.stats.metadata_capture_progressed =
+                status.remaining_assets < initial.remaining_assets;
+            repair.stats.metadata_capture_remaining = status.remaining_assets;
+        }
         Err(error) => {
             repair.stats.state_write_failures = repair.stats.state_write_failures.saturating_add(1);
             repair.failures = repair.failures.saturating_add(1);
@@ -15471,6 +15478,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_capture_source_deletions_count_as_clean_progress() {
+        const DELETED_ASSETS: usize = 500;
+        const STALE_ASSETS: usize = DELETED_ASSETS + 1;
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let mut provider_records = Vec::with_capacity(DELETED_ASSETS * 2);
+        for index in 0..STALE_ASSETS {
+            let master_id = format!("CAPTURE_DELETED_{index:04}");
+            let asset_id = format!("asset-{master_id}");
+            if index < DELETED_ASSETS {
+                let master = incremental_photo_records(&master_id)
+                    .into_iter()
+                    .next()
+                    .expect("master record");
+                provider_records.push(master);
+                provider_records.push(json!({
+                    "recordName": asset_id,
+                    "serverErrorCode": "UNKNOWN_ITEM",
+                    "reason": "record not found"
+                }));
+            }
+
+            let record = TestAssetRecord::new(&asset_id)
+                .filename("metadata-capture-deleted.jpg")
+                .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                .size(1024)
+                .build();
+            db.upsert_seen(&record).await.expect("seed state row");
+            db.mark_downloaded(
+                "PrimarySync",
+                &asset_id,
+                "original",
+                Path::new("/photos/metadata-capture-deleted.jpg"),
+                "seeded-local-sha256",
+                None,
+            )
+            .await
+            .expect("mark state row downloaded");
+            db.upsert_asset_master_mapping("PrimarySync", &asset_id, &master_id)
+                .await
+                .expect("seed provider mapping");
+        }
+        db.acquire_lock("test_metadata_capture_deleted_stale")
+            .expect("state lock")
+            .execute("DELETE FROM asset_metadata_capture_revisions", [])
+            .expect("mark every asset stale");
+
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(PendingLookupSession {
+                    records: Arc::new(provider_records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        let result = download_photos_with_sync(
+            &Client::new(),
+            std::slice::from_ref(&pass),
+            Arc::new(config),
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("source-deleted capture batch");
+
+        assert!(matches!(result.outcome, DownloadOutcome::Success));
+        assert_eq!(result.stats.metadata_capture_refreshed, 0);
+        assert_eq!(result.stats.metadata_capture_failures, 0);
+        assert_eq!(result.stats.metadata_capture_remaining, 1);
+        assert!(result.stats.metadata_capture_progressed);
+        assert_eq!(
+            db.get_summary().await.expect("summary").source_deleted,
+            u64::try_from(DELETED_ASSETS).expect("deleted count fits u64")
+        );
+    }
+
+    #[tokio::test]
     async fn current_capture_revision_adds_no_provider_lookup_requests() {
         #[derive(Clone, Debug)]
         struct CountingCaptureSession {
@@ -19014,6 +19109,7 @@ mod tests {
             metadata_capture_refreshed: 2,
             metadata_capture_failures: 1,
             metadata_capture_remaining: 5,
+            metadata_capture_progressed: false,
             state_write_failures: 2,
             enumeration_errors: 3,
             count_probe_failures: 4,
@@ -19085,6 +19181,7 @@ mod tests {
             metadata_capture_refreshed: 3,
             metadata_capture_failures: 2,
             metadata_capture_remaining: 7,
+            metadata_capture_progressed: true,
             state_write_failures: 5,
             enumeration_errors: 6,
             count_probe_failures: 7,
@@ -19151,6 +19248,7 @@ mod tests {
         assert_eq!(acc.metadata_capture_refreshed, 5);
         assert_eq!(acc.metadata_capture_failures, 3);
         assert_eq!(acc.metadata_capture_remaining, 12);
+        assert!(acc.metadata_capture_progressed);
         assert_eq!(acc.state_write_failures, 7, "state_write_failures must sum");
         assert_eq!(acc.enumeration_errors, 9, "enumeration_errors must sum");
         assert_eq!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -15324,6 +15324,153 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_capture_revision_repair_progresses_across_bounded_cycles() {
+        #[derive(Clone, Debug)]
+        struct CaptureScaleSession {
+            records: Arc<HashMap<String, Value>>,
+        }
+
+        #[async_trait::async_trait]
+        impl PhotosSession for CaptureScaleSession {
+            async fn post(
+                &self,
+                url: &str,
+                body: String,
+                _headers: &[(&str, &str)],
+            ) -> anyhow::Result<Value> {
+                if !url.contains("/records/lookup?") {
+                    return Ok(if url.contains("/changes/zone?") {
+                        changes_zone_response(Vec::new(), "zone-token-next")
+                    } else {
+                        json!({"records": [], "syncToken": "ignored-query-token"})
+                    });
+                }
+                let request: Value = serde_json::from_str(&body)?;
+                let records = request["records"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|record| record["recordName"].as_str())
+                    .filter_map(|record_name| self.records.get(record_name).cloned())
+                    .collect::<Vec<_>>();
+                Ok(json!({"records": records}))
+            }
+
+            fn clone_box(&self) -> Box<dyn PhotosSession> {
+                Box::new(self.clone())
+            }
+        }
+
+        const STALE_ASSETS: usize = 1_201;
+        let stale_assets = u64::try_from(STALE_ASSETS).expect("asset count fits u64");
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let mut provider_records = HashMap::with_capacity(STALE_ASSETS * 2);
+        for index in 0..STALE_ASSETS {
+            let master_id = format!("CAPTURE_SCALE_{index:04}");
+            let asset_id = format!("asset-{master_id}");
+            for record in incremental_photo_records_with_favorite(&master_id, true) {
+                provider_records.insert(
+                    record["recordName"]
+                        .as_str()
+                        .expect("provider record name")
+                        .to_owned(),
+                    record,
+                );
+            }
+            let record = TestAssetRecord::new(&asset_id)
+                .filename("metadata-capture-scale.jpg")
+                .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                .size(1024)
+                .build();
+            db.upsert_seen(&record).await.expect("seed state row");
+            db.mark_downloaded(
+                "PrimarySync",
+                &asset_id,
+                "original",
+                Path::new("/photos/metadata-capture-scale.jpg"),
+                "seeded-local-sha256",
+                None,
+            )
+            .await
+            .expect("mark state row downloaded");
+            db.upsert_asset_master_mapping("PrimarySync", &asset_id, &master_id)
+                .await
+                .expect("seed provider mapping");
+        }
+        db.acquire_lock("test_metadata_capture_scale_stale")
+            .expect("state lock")
+            .execute("DELETE FROM asset_metadata_capture_revisions", [])
+            .expect("mark every asset stale");
+
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: album_with_session(
+                "PrimarySync",
+                "",
+                Box::new(CaptureScaleSession {
+                    records: Arc::new(provider_records),
+                }),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        let dir = TempDir::new().expect("temp dir");
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        config.sync_mode = SyncMode::Incremental {
+            zone_sync_token: "zone-token-prev".to_string(),
+        };
+
+        for (cycle, refreshed, remaining, active_revision) in [
+            (1, 500, 701, 0),
+            (2, 500, 201, 0),
+            (3, 201, 0, crate::state::METADATA_CAPTURE_REVISION),
+        ] {
+            let result = download_photos_with_sync(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                Arc::new(config.clone()),
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("metadata-capture cycle");
+
+            assert!(
+                matches!(result.outcome, DownloadOutcome::Success),
+                "cycle {cycle}: {:?}",
+                result.stats
+            );
+            assert_eq!(
+                result.stats.metadata_capture_refreshed, refreshed,
+                "cycle {cycle}"
+            );
+            assert_eq!(
+                result.stats.metadata_capture_remaining, remaining,
+                "cycle {cycle}"
+            );
+            let summary = db.get_summary().await.expect("capture status");
+            let capture = summary
+                .metadata_capture
+                .iter()
+                .find(|status| status.library == "PrimarySync")
+                .expect("primary capture status");
+            assert_eq!(capture.active_revision, active_revision, "cycle {cycle}");
+            assert_eq!(
+                capture.pending_revision,
+                (remaining > 0).then_some(crate::state::METADATA_CAPTURE_REVISION),
+                "cycle {cycle}"
+            );
+            assert_eq!(
+                capture.processed_assets,
+                stale_assets - remaining,
+                "cycle {cycle}"
+            );
+            assert_eq!(capture.remaining_assets, remaining, "cycle {cycle}");
+        }
+    }
+
+    #[tokio::test]
     async fn current_capture_revision_adds_no_provider_lookup_requests() {
         #[derive(Clone, Debug)]
         struct CountingCaptureSession {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3138,7 +3138,7 @@ pub(super) async fn run_download_pass(
 /// at/above it, the operator should adjust cadence to avoid prolonged
 /// back-off behavior and possible hard lockouts.
 fn maybe_warn_rate_limit_pressure(stats: &super::SyncStats) {
-    if stats.rate_limited == 0 {
+    if !stats.has_rate_limit_pressure() {
         return;
     }
     if stats.assets_seen == 0 {
@@ -3965,19 +3965,14 @@ mod tests {
 
     #[test]
     fn rate_limit_pressure_triggers_at_exactly_10_percent() {
-        // 10/100 = 10% → triggers
         let stats = stats_with_rl(100, 10);
-        let pct = stats.rate_limited as u64 * 100 / stats.assets_seen.max(1);
-        assert_eq!(pct, 10);
-        assert!(pct >= 10);
+        assert!(stats.has_rate_limit_pressure());
     }
 
     #[test]
     fn rate_limit_pressure_below_10_percent_does_not_trigger() {
         let stats = stats_with_rl(100, 9);
-        let pct = stats.rate_limited as u64 * 100 / stats.assets_seen.max(1);
-        assert_eq!(pct, 9);
-        assert!(pct < 10);
+        assert!(!stats.has_rate_limit_pressure());
     }
 
     #[test]
@@ -3986,12 +3981,14 @@ mod tests {
         // would produce a misleading "300%" for 3 observations) and emit a
         // separate no-anchor warn path.
         let stats = stats_with_rl(0, 3);
+        assert!(stats.has_rate_limit_pressure());
         maybe_warn_rate_limit_pressure(&stats);
     }
 
     #[test]
     fn rate_limit_pressure_zero_observations_skips_quickly() {
         let stats = stats_with_rl(100, 0);
+        assert!(!stats.has_rate_limit_pressure());
         maybe_warn_rate_limit_pressure(&stats); // no panic, no denom needed
     }
 

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -154,6 +154,7 @@ pub(crate) enum RecordResolution {
 pub(crate) struct RecordResolutionBatch {
     pub(crate) results: Vec<(ProviderRecordId, RecordResolution)>,
     pub(crate) complete: bool,
+    pub(crate) rate_limit_observations: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -960,6 +961,7 @@ impl PhotoAlbum {
         requests: &[RecordLookupRequest],
     ) -> RecordResolutionBatch {
         let mut results = Vec::with_capacity(requests.len());
+        let mut rate_limit_observations = 0usize;
         let url = format!(
             "{}/records/lookup?{}",
             self.service_endpoint,
@@ -994,7 +996,11 @@ impl PhotoAlbum {
             )
             .await
             {
-                Ok(response) => response,
+                Ok(retried) => {
+                    rate_limit_observations =
+                        rate_limit_observations.saturating_add(retried.rate_limit_observations);
+                    retried.response
+                }
                 Err(error) => {
                     let error = classify_provider_lookup_error(&error);
                     crate::metrics::record_targeted_lookup("transient_failure", batch.len());
@@ -1156,6 +1162,7 @@ impl PhotoAlbum {
         RecordResolutionBatch {
             results: grouped,
             complete,
+            rate_limit_observations,
         }
     }
 

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use serde_json::Value;
@@ -353,6 +354,21 @@ fn classify_api_error(e: &anyhow::Error) -> RetryAction {
     RetryAction::Abort
 }
 
+fn classify_rate_limit_error(e: &anyhow::Error) -> bool {
+    if let Some(http_err) = e.downcast_ref::<HttpStatusError>() {
+        return matches!(http_err.status, 429 | 503);
+    }
+    e.downcast_ref::<reqwest::Error>()
+        .and_then(reqwest::Error::status)
+        .is_some_and(|status| matches!(status.as_u16(), 429 | 503))
+}
+
+#[derive(Debug)]
+pub(crate) struct RetriedPostResponse {
+    pub(crate) response: Value,
+    pub(crate) rate_limit_observations: usize,
+}
+
 /// Retry a `session.post()` call with default exponential backoff.
 ///
 /// Inspects each response for `CloudKit` server errors (`serverErrorCode`)
@@ -388,11 +404,23 @@ pub(crate) async fn retry_post_allowing_record_errors(
     body: &str,
     headers: &[(&str, &str)],
     retry_config: &RetryConfig,
-) -> anyhow::Result<Value> {
-    retry::retry_with_backoff(retry_config, classify_api_error, || async {
-        session.post(url, body.to_owned(), headers).await
+) -> anyhow::Result<RetriedPostResponse> {
+    let rate_limit_observations = AtomicUsize::new(0);
+    let response = retry::retry_with_backoff(
+        retry_config,
+        |error| {
+            if classify_rate_limit_error(error) {
+                rate_limit_observations.fetch_add(1, Ordering::Relaxed);
+            }
+            classify_api_error(error)
+        },
+        || async { session.post(url, body.to_owned(), headers).await },
+    )
+    .await?;
+    Ok(RetriedPostResponse {
+        response,
+        rate_limit_observations: rate_limit_observations.load(Ordering::Relaxed),
     })
-    .await
 }
 
 /// Errors from `changes/zone` when syncToken is invalid.
@@ -896,18 +924,21 @@ mod tests {
     fn test_post_503_is_retryable() {
         let err = reqwest_status_error(503);
         assert_eq!(classify_api_error(&err), RetryAction::Retry);
+        assert!(classify_rate_limit_error(&err));
     }
 
     #[test]
     fn test_post_429_is_retryable() {
         let err = reqwest_status_error(429);
         assert_eq!(classify_api_error(&err), RetryAction::Retry);
+        assert!(classify_rate_limit_error(&err));
     }
 
     #[test]
     fn test_post_421_aborts() {
         let err = reqwest_status_error(421);
         assert_eq!(classify_api_error(&err), RetryAction::Abort);
+        assert!(!classify_rate_limit_error(&err));
     }
 
     // ── Gap: empty records array passes through cleanly ──────────────

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -478,7 +478,7 @@ fn metadata_capture_watch_interval(
     configured_interval.map(|interval| {
         if cycle_failed_count == 0
             && stats.metadata_capture_remaining > 0
-            && stats.metadata_capture_refreshed > 0
+            && stats.metadata_capture_progressed
         {
             interval.min(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
         } else {
@@ -2517,6 +2517,7 @@ mod tests {
         let stats = download::SyncStats {
             metadata_capture_refreshed: 500,
             metadata_capture_remaining: 701,
+            metadata_capture_progressed: true,
             ..download::SyncStats::default()
         };
 
@@ -2529,6 +2530,16 @@ mod tests {
             Some(60)
         );
         assert_eq!(metadata_capture_watch_interval(None, &stats, 0), None);
+
+        let deleted_batch = download::SyncStats {
+            metadata_capture_remaining: 1,
+            metadata_capture_progressed: true,
+            ..download::SyncStats::default()
+        };
+        assert_eq!(
+            metadata_capture_watch_interval(default_interval, &deleted_batch, 0),
+            Some(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
+        );
     }
 
     #[test]
@@ -2546,6 +2557,7 @@ mod tests {
                     metadata_capture_refreshed: 499,
                     metadata_capture_failures: 1,
                     metadata_capture_remaining: 701,
+                    metadata_capture_progressed: true,
                     ..download::SyncStats::default()
                 },
                 1,
@@ -2553,6 +2565,7 @@ mod tests {
             (
                 download::SyncStats {
                     metadata_capture_refreshed: 500,
+                    metadata_capture_progressed: true,
                     ..download::SyncStats::default()
                 },
                 0,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -479,6 +479,7 @@ fn metadata_capture_watch_interval(
         if cycle_failed_count == 0
             && stats.metadata_capture_remaining > 0
             && stats.metadata_capture_progressed
+            && !stats.has_rate_limit_pressure()
         {
             interval.min(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
         } else {
@@ -2531,6 +2532,16 @@ mod tests {
         );
         assert_eq!(metadata_capture_watch_interval(None, &stats, 0), None);
 
+        let absorbed_rate_limit = download::SyncStats {
+            assets_seen: 100,
+            rate_limited: 9,
+            ..stats
+        };
+        assert_eq!(
+            metadata_capture_watch_interval(default_interval, &absorbed_rate_limit, 0),
+            Some(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
+        );
+
         let deleted_batch = download::SyncStats {
             metadata_capture_remaining: 1,
             metadata_capture_progressed: true,
@@ -2576,6 +2587,34 @@ mod tests {
                     Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL),
                     &stats,
                     cycle_failed_count,
+                ),
+                Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL)
+            );
+        }
+    }
+
+    #[test]
+    fn rate_limited_metadata_capture_keeps_the_configured_interval() {
+        for stats in [
+            download::SyncStats {
+                rate_limited: 1,
+                metadata_capture_remaining: 701,
+                metadata_capture_progressed: true,
+                ..download::SyncStats::default()
+            },
+            download::SyncStats {
+                assets_seen: 100,
+                rate_limited: 10,
+                metadata_capture_remaining: 701,
+                metadata_capture_progressed: true,
+                ..download::SyncStats::default()
+            },
+        ] {
+            assert_eq!(
+                metadata_capture_watch_interval(
+                    Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL),
+                    &stats,
+                    0,
                 ),
                 Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL)
             );

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -466,6 +466,27 @@ async fn maybe_notify_shared_libraries(
 /// value set. 24 hours, matching the Docker image's always-on service shape.
 pub(crate) const SERVICE_MODE_DEFAULT_WATCH_INTERVAL: u64 = 86400;
 
+/// Maximum idle delay between clean metadata-capture repair batches.
+const METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS: u64 = 60;
+
+#[must_use]
+fn metadata_capture_watch_interval(
+    configured_interval: Option<u64>,
+    stats: &download::SyncStats,
+    cycle_failed_count: usize,
+) -> Option<u64> {
+    configured_interval.map(|interval| {
+        if cycle_failed_count == 0
+            && stats.metadata_capture_remaining > 0
+            && stats.metadata_capture_refreshed > 0
+        {
+            interval.min(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
+        } else {
+            interval
+        }
+    })
+}
+
 /// Decide whether to apply the service-mode watch-interval fallback.
 ///
 /// Returns `Some(interval)` only when `service_mode` is true AND the
@@ -1232,6 +1253,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             break;
         }
         cycle_index = cycle_index.saturating_add(1);
+        let mut next_watch_interval = config.watch.interval;
 
         // In watch mode with incremental sync, use changes/database as a
         // cheap pre-check before refreshing album plans or running a sync.
@@ -1404,6 +1426,23 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 )
                 .await;
 
+            next_watch_interval = metadata_capture_watch_interval(
+                config.watch.interval,
+                &cycle_result.stats,
+                cycle_result.failed_count,
+            );
+            if let (Some(configured_interval), Some(follow_up_interval)) =
+                (config.watch.interval, next_watch_interval)
+                && follow_up_interval < configured_interval
+            {
+                tracing::info!(
+                    refreshed = cycle_result.stats.metadata_capture_refreshed,
+                    remaining = cycle_result.stats.metadata_capture_remaining,
+                    interval_secs = follow_up_interval,
+                    "Metadata-capture repair scheduled a bounded follow-up cycle"
+                );
+            }
+
             // Handle aggregate outcome across all libraries
             if cycle_result.session_expired {
                 reauth_attempts += 1;
@@ -1510,7 +1549,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             run_periodic_reconcile(db.as_ref() as &dyn state::ReportStateStore, cycle_index).await;
         }
 
-        if let Some(interval) = config.watch.interval {
+        if let Some(interval) = next_watch_interval {
             if shutdown_token.is_cancelled() {
                 tracing::info!("Shutdown requested, exiting...");
                 break;
@@ -2470,6 +2509,64 @@ mod tests {
         // Plain `kei sync` must remain single-shot when no interval is
         // configured. Only the service entry point applies the fallback.
         assert_eq!(service_mode_default_interval(None, false), None);
+    }
+
+    #[test]
+    fn progressing_metadata_capture_shortens_the_watch_interval() {
+        let default_interval = Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL);
+        let stats = download::SyncStats {
+            metadata_capture_refreshed: 500,
+            metadata_capture_remaining: 701,
+            ..download::SyncStats::default()
+        };
+
+        assert_eq!(
+            metadata_capture_watch_interval(default_interval, &stats, 0),
+            Some(METADATA_CAPTURE_FOLLOW_UP_INTERVAL_SECS)
+        );
+        assert_eq!(
+            metadata_capture_watch_interval(Some(60), &stats, 0),
+            Some(60)
+        );
+        assert_eq!(metadata_capture_watch_interval(None, &stats, 0), None);
+    }
+
+    #[test]
+    fn stalled_or_failed_metadata_capture_keeps_the_configured_interval() {
+        for (stats, cycle_failed_count) in [
+            (
+                download::SyncStats {
+                    metadata_capture_remaining: 701,
+                    ..download::SyncStats::default()
+                },
+                0,
+            ),
+            (
+                download::SyncStats {
+                    metadata_capture_refreshed: 499,
+                    metadata_capture_failures: 1,
+                    metadata_capture_remaining: 701,
+                    ..download::SyncStats::default()
+                },
+                1,
+            ),
+            (
+                download::SyncStats {
+                    metadata_capture_refreshed: 500,
+                    ..download::SyncStats::default()
+                },
+                0,
+            ),
+        ] {
+            assert_eq!(
+                metadata_capture_watch_interval(
+                    Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL),
+                    &stats,
+                    cycle_failed_count,
+                ),
+                Some(SERVICE_MODE_DEFAULT_WATCH_INTERVAL)
+            );
+        }
     }
 
     #[test]

--- a/tests/branch_static.rs
+++ b/tests/branch_static.rs
@@ -1584,6 +1584,7 @@ fn typed_error_downcasts_stay_in_named_classifier_boundaries() {
         "classify_exit_error",
         "classify_incremental_error",
         "classify_provider_lookup_error",
+        "classify_rate_limit_error",
         "classify_srp_post_error",
         "classify_sync_auth_error",
         "is_session_error",


### PR DESCRIPTION
## Summary

- Schedule another watch or service cycle after at most 60 seconds when metadata capture makes clean progress and work remains.
- Keep the 500-asset per-library batch limit. Stalled or failed cycles use the configured watch interval.
- Preserve one-shot behavior, durable revision promotion, checkpoint gates, and status/report progress.
- Add a production-path test that repairs 1,201 rows as 500, 500, and 201.
- Document completion behavior and measured database growth.

Fixes #742

## Safety

- Preserves `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE`.
- Does not change the schema, CLI, public API, or media files.

## Tests

- `cargo test --lib metadata_capture_`
- `just test scenario service-health`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just gate`
