### PR TITLE
Update chacha20 to non-yanked release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary
- Update the locked `chacha20` release from 0.10.0 to 0.10.2 so `cargo audit --deny warnings` no longer reports a yanked dependency.
- Keep `rand` at 0.10.1 and leave every other locked dependency unchanged.

## Tests
- `cargo audit --deny warnings` => passed; scanned 411 dependencies with no denied warnings
- `just gate` => passed

## Risk
- Low. This is a patch-level lockfile update on the existing `rand` dependency path. It does not change public interfaces, configuration, state, or filesystem contracts.
