### PR TITLE
Reject different-byte destination races

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,6 +257,12 @@ exchanges the verified `.part` file with that exact fingerprint. A changed
 target is restored or retained and the state row stays failed. All other
 downloads keep no-overwrite publication.
 
+When no-overwrite publication finds an existing destination, the file owner
+compares it with the verified `.part` file. Identical bytes are deduplicated.
+Different or unverifiable bytes return a typed collision and retain the
+`.part` file. The pipeline records the task as failed before it can write a
+sidecar or finalize downloaded state.
+
 A file may be safe on disk while its state write is still a cycle failure. Do
 not weaken deferred state-write handling or infer that a visible final file
 means the database transition succeeded.
@@ -433,7 +439,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 
 | Contract | Owner | Required behavior |
 |----------|-------|-------------------|
-| `FILE_PUBLISH_NO_OVERWRITE` | `src/download/file.rs` | Publishing a completed `.part` file never replaces an existing final file unless `--repair-truncated` carries exact durable path and fingerprint authorization. |
+| `FILE_PUBLISH_NO_OVERWRITE` | `src/download/file.rs`, `src/download/pipeline.rs` | Publishing a completed `.part` file never replaces an existing final file unless `--repair-truncated` carries exact durable path and fingerprint authorization. A no-replace collision succeeds only when the verified `.part` and destination bytes are identical. Different or unverifiable bytes retain retry evidence and cannot reach metadata writes or downloaded finalization. |
 | `TEMP_FILE_DELETE_REQUIRES_DURABLE_OWNERSHIP` | `src/download/mod.rs`, `src/download/pipeline.rs`, `src/fs_util.rs`, `src/state/db.rs` | Orphan cleanup deletes only an exact stale path claimed in durable state. It retains verified filesystem handles through removal and never follows a directory or file symlink. Normal completion and graceful interruption retire the claim. |
 | `SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE` | `src/sync_cycle.rs` | The database pre-check token advances only after a successful non-dry-run cycle with a current pass plan. |
 | `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY` | `src/sync_cycle.rs`, `src/download/mod.rs` | A zone checkpoint advances only with complete token evidence and durable recovery for unfinished work. |

--- a/scripts/test-scenarios/path-family.sh
+++ b/scripts/test-scenarios/path-family.sh
@@ -5,6 +5,9 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "$script_dir/lib.sh"
 
 run_scenario_test lib identity_collision
+run_scenario_test lib contract_file_publish_no_overwrite_destination_already_exists
+run_scenario_test lib contract_file_publish_different_destination_returns_typed_collision
+run_scenario_test lib different_byte_destination_race_keeps_loser_failed_without_metadata_write
 run_scenario_test lib live_photo_motion_with_size_suffixed_primary_stem_is_on_disk_skipped
 run_scenario_test lib live_photo_motion_with_identity_suffixed_primary_stem_is_on_disk_skipped
 run_scenario_test lib live_photo_motion_with_sanitized_identity_suffix_is_on_disk_skipped

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -143,6 +143,15 @@ pub(super) enum ConditionalPublishTargetChanged {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[error(
+    "Refusing to deduplicate {part_path} with {final_path} because their verified bytes differ"
+)]
+pub(super) struct FinalPathCollision {
+    part_path: PathBuf,
+    final_path: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
 #[error("Conditional publication must retain paths: {paths:?}")]
 struct ConditionalPublishMustRetainPaths {
     paths: Vec<PathBuf>,
@@ -586,8 +595,7 @@ async fn attempt_download_with_publication<C: DownloadClient>(
 }
 
 /// Rename a `.part` file to its final destination, handling the case where
-/// a concurrent download already placed the final file. If the destination
-/// exists, the redundant `.part` file is removed instead of overwriting.
+/// a concurrent download already placed identical bytes at the final path.
 #[cfg(test)]
 pub(super) async fn rename_part_to_final(
     part_path: &Path,
@@ -619,18 +627,30 @@ pub(super) async fn publish_part_to_final(
         }
         Ok(PublishResult::DestinationExists) => {
             // CONTRACT: FILE_PUBLISH_NO_OVERWRITE
-            // Another task won the race — clean up our .part file.
+            let part_fingerprint = fingerprint_regular_file(part_path)
+                .await
+                .with_context(|| format!("Could not verify {}", part_path.display()))?;
+            let final_fingerprint = fingerprint_regular_file(final_path)
+                .await
+                .with_context(|| format!("Could not verify {}", final_path.display()))?;
+            if part_fingerprint != final_fingerprint {
+                return Err(FinalPathCollision {
+                    part_path: part_path.to_path_buf(),
+                    final_path: final_path.to_path_buf(),
+                }
+                .into());
+            }
+
             tracing::debug!(
                 path = %final_path.display(),
-                "Destination already exists, removing redundant .part file"
+                "Destination has identical bytes, removing redundant .part file"
             );
-            if let Err(rm_err) = fs::remove_file(part_path).await {
-                tracing::warn!(
-                    path = %part_path.display(),
-                    error = %rm_err,
-                    "Failed to remove redundant .part file"
-                );
-            }
+            fs::remove_file(part_path).await.with_context(|| {
+                format!(
+                    "Could not remove redundant completed download {}",
+                    part_path.display()
+                )
+            })?;
             Ok(())
         }
         Err(e) => Err(e).with_context(|| {
@@ -4312,7 +4332,7 @@ mod tests {
         let part = dir.path().join("photo.part");
         let final_path = dir.path().join("photo.jpg");
         tokio::fs::write(&final_path, b"existing").await.unwrap();
-        tokio::fs::write(&part, b"duplicate").await.unwrap();
+        tokio::fs::write(&part, b"existing").await.unwrap();
 
         // Should succeed without replacing the existing final file. On Linux,
         // plain rename(old, new) would overwrite `photo.jpg`; the publish path
@@ -4326,6 +4346,23 @@ mod tests {
             b"existing",
             "existing final file must not be replaced by duplicate .part bytes"
         );
+    }
+
+    #[tokio::test]
+    async fn contract_file_publish_different_destination_returns_typed_collision() {
+        let dir = TempDir::new().unwrap();
+        let part = dir.path().join("photo.part");
+        let final_path = dir.path().join("photo.jpg");
+        tokio::fs::write(&final_path, b"winner").await.unwrap();
+        tokio::fs::write(&part, b"loser").await.unwrap();
+
+        let error = rename_part_to_final(&part, &final_path)
+            .await
+            .expect_err("different bytes must collide");
+
+        assert!(error.downcast_ref::<FinalPathCollision>().is_some());
+        assert_eq!(tokio::fs::read(&final_path).await.unwrap(), b"winner");
+        assert_eq!(tokio::fs::read(&part).await.unwrap(), b"loser");
     }
 
     #[tokio::test]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -5276,6 +5276,164 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn different_byte_destination_race_keeps_loser_failed_without_metadata_write() {
+        use crate::state::{MediaType, SqliteStateDb};
+        use base64::Engine as _;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let winner_body = MINIMAL_JPEG.to_vec();
+        let mut loser_body = MINIMAL_JPEG.to_vec();
+        *loser_body
+            .get_mut(17)
+            .expect("minimal JPEG must contain a Y-density value") = 2;
+        let server = crate::start_wiremock_or_skip!();
+        Mock::given(method("GET"))
+            .and(path("/WINNER.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(winner_body.clone())
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/LOSER.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(loser_body.clone())
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let download_path = dir.path().join("shared.jpg");
+        let winner_db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let loser_db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let retry = RetryConfig {
+            max_retries: 0,
+            base_delay_secs: 0,
+            max_delay_secs: 0,
+        };
+        let metadata = MetadataFlags::from(&crate::config::MetadataConfig {
+            xmp_sidecar: true,
+            ..crate::config::MetadataConfig::default()
+        });
+        let make_task = |asset_id: &str, checksum_byte: u8, rating: u8| DownloadTask {
+            url: format!("{}/{asset_id}.jpg", server.uri()).into(),
+            download_path: download_path.clone(),
+            publication: crate::download::file::FinalPublication::NoReplace,
+            checksum: base64::engine::general_purpose::STANDARD
+                .encode([checksum_byte; 32])
+                .into(),
+            asset_id: asset_id.into(),
+            asset_record_name: asset_id.into(),
+            library: "PrimarySync".into(),
+            metadata: Arc::new(MetadataPayload {
+                rating: Some(rating),
+                ..MetadataPayload::default()
+            }),
+            size: winner_body.len() as u64,
+            created_local: chrono::Local::now().fixed_offset(),
+            version_size: VersionSizeKey::Original,
+            media_type: MediaType::Photo,
+        };
+        let winner_task = make_task("WINNER", 0x41, 1);
+        let loser_task = make_task("LOSER", 0x42, 5);
+        let loser_part_path = super::super::file::temp_download_path(
+            &download_path,
+            &loser_task.checksum,
+            ".kei-tmp",
+        )
+        .expect("valid temporary path");
+
+        for (db, task) in [(&winner_db, &winner_task), (&loser_db, &loser_task)] {
+            db.upsert_seen(&AssetRecord::new_pending(
+                Arc::from("PrimarySync"),
+                task.asset_id.to_string(),
+                task.version_size,
+                task.checksum.to_string(),
+                "shared.jpg".to_string(),
+                chrono::Utc::now(),
+                None,
+                task.size,
+                MediaType::Photo,
+            ))
+            .await
+            .unwrap();
+        }
+
+        let client = Client::new();
+        let winner_store: Arc<dyn DownloadStore> = winner_db.clone();
+        let winner_result = run_download_pass(
+            PassConfig {
+                client: &client,
+                retry_config: &retry,
+                metadata,
+                mark_capture_repair_after_download: false,
+                concurrency: 1,
+                reporting: DownloadReporting::hidden(),
+                temp_suffix: Arc::from(".kei-tmp"),
+                shutdown_token: CancellationToken::new(),
+                state_db: Some(winner_store),
+                rate_limit_counter: Arc::new(AtomicUsize::new(0)),
+                bandwidth_limiter: None,
+                library: Arc::from("PrimarySync"),
+            },
+            vec![winner_task],
+        )
+        .await;
+        assert_eq!(winner_result.downloaded, 1);
+        assert!(winner_result.failed.is_empty());
+
+        let sidecar_path = sidecar_path_for(&download_path);
+        let winner_sidecar = fs::read(&sidecar_path).expect("winner sidecar must be written");
+        let loser_store: Arc<dyn DownloadStore> = loser_db.clone();
+        let loser_result = run_download_pass(
+            PassConfig {
+                client: &client,
+                retry_config: &retry,
+                metadata,
+                mark_capture_repair_after_download: false,
+                concurrency: 1,
+                reporting: DownloadReporting::hidden(),
+                temp_suffix: Arc::from(".kei-tmp"),
+                shutdown_token: CancellationToken::new(),
+                state_db: Some(loser_store),
+                rate_limit_counter: Arc::new(AtomicUsize::new(0)),
+                bandwidth_limiter: None,
+                library: Arc::from("PrimarySync"),
+            },
+            vec![loser_task],
+        )
+        .await;
+
+        assert_eq!(loser_result.downloaded, 0);
+        assert_eq!(loser_result.failed.len(), 1);
+        assert_eq!(fs::read(&download_path).unwrap(), winner_body);
+        assert_eq!(fs::read(&sidecar_path).unwrap(), winner_sidecar);
+        assert_eq!(fs::read(&loser_part_path).unwrap(), loser_body);
+        assert!(
+            loser_db
+                .get_downloaded_page(0, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let failed = loser_db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert!(
+            failed[0]
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("verified bytes differ")),
+            "collision must remain durable failed work"
+        );
+    }
+
     #[tokio::test]
     async fn temporary_ownership_retires_after_publish_and_interruption() {
         use base64::Engine as _;


### PR DESCRIPTION
## Summary
- Compare a verified `.part` file with an existing destination after a no-replace publication race.
- Deduplicate only identical bytes. Return a typed collision for different bytes and retain the `.part` file.
- Keep the losing asset failed and retryable before sidecar writes or downloaded-state finalization.
- Add the collision regressions to the `path-family` scenario and document the updated publication invariant.

Fixes #758

## Tests
- `just test scenario path-family`
- `cargo test --no-default-features contract_file_publish -- --nocapture`
- `just gate`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Risk
- A destination race now reads both files to compare their size and SHA-256. This adds I/O only when no-replace publication finds an existing destination.
- No schema, configuration, or public CLI changes.
