### PR TITLE
Fix current stable Clippy lint in encode_params

### DIFF
--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -239,7 +239,7 @@ pub(crate) fn encode_params(params: &HashMap<String, Value>) -> String {
             (k.as_str(), val)
         })
         .collect();
-    pairs.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+    pairs.sort_unstable_by_key(|(key, _)| *key);
 
     url::form_urlencoded::Serializer::new(String::new())
         .extend_pairs(pairs)


### PR DESCRIPTION
## Summary

- use `sort_unstable_by_key` to express that query parameter ordering depends only on the key
- restore `just gate` compatibility with current stable Clippy without changing encoded output

## Testing

- `cargo test test_encode_params`
- `just gate`
- `cargo +1.94.1 clippy --all-targets --all-features -- -D warnings`

Closes #727