### PR TITLE
Recover from stale Apple authentication state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `kei reset session` discards the local iCloud session, including the cookie jar, persisted session, response cache, and trust tokens, so the next `kei login`
+  runs a clean password and two-factor authentication flow. The stored password and state database are kept, and a running kei instance blocks the reset through
+  the per-account session lock. Without `--yes`, it prompts on a TTY and errors under non-interactive use, matching `reset sync-token`. ([#717], fixes [#716])
 - Added `kei sync --refresh-metadata --repair-capture-timestamps`, an explicit repair for embedded timestamps written before capture-local resolution. It replaces an existing timestamp only for a state-recorded downloaded file with a usable Apple offset, writes the capture-local timestamp and offset together, and keeps ordinary metadata refreshes non-destructive. The command requires `metadata.set_exif_datetime = true` and can overwrite camera-supplied metadata. ([#726])
 - XMP sidecars carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error from the media's own EXIF alongside the CloudKit
   location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` and `exif:GPSHPositioningError` properties. HEIF files with
@@ -35,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#698]: https://github.com/rhoopr/kei/issues/698
 [#703]: https://github.com/rhoopr/kei/issues/703
+[#716]: https://github.com/rhoopr/kei/issues/716
+[#717]: https://github.com/rhoopr/kei/pull/717
 [#726]: https://github.com/rhoopr/kei/issues/726
 
 ## [0.23.1] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `kei reset session` discards the local iCloud session, including the cookie jar, persisted session, response cache, and trust tokens, so the next `kei login`
-  runs a clean password and two-factor authentication flow. The stored password and state database are kept, and a running kei instance blocks the reset through
-  the per-account session lock. Without `--yes`, it prompts on a TTY and errors under non-interactive use, matching `reset sync-token`. ([#717], fixes [#716])
+  runs a clean password and two-factor authentication flow. The stored password and state database are kept. An active process holding the account lock blocks the
+  reset; a sleeping watch process detects the reset generation and stops before reusing its in-memory session. Without `--yes`, the command prompts on a TTY and
+  errors under non-interactive use, matching `reset sync-token`. ([#717], fixes [#716])
 - Added `kei sync --refresh-metadata --repair-capture-timestamps`, an explicit repair for embedded timestamps written before capture-local resolution. It replaces an existing timestamp only for a state-recorded downloaded file with a usable Apple offset, writes the capture-local timestamp and offset together, and keeps ordinary metadata refreshes non-destructive. The command requires `metadata.set_exif_datetime = true` and can overwrite camera-supplied metadata. ([#726])
 - XMP sidecars carry the source photo's GPS fix time, speed, speed reference, and horizontal positioning error from the media's own EXIF alongside the CloudKit
   location. This includes DNG and other TIFF-based RAW content, and uses the standard `exif:GPSTimeStamp` and `exif:GPSHPositioningError` properties. HEIF files with
@@ -27,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Authentication now retries verification-code delivery once from clean local state when Apple rejects a persisted cookie or session with HTTP 403. The retry
+  removes only the affected account's cookie jar, session, and validation cache while holding the account lock; password material and the state database remain
+  unchanged. `kei reset session` provides the same cleanup explicitly. ([#716])
 - Headless foreground login and one-shot sync now exit immediately with auth code 3 when 2FA needs operator action. The error prints the `kei login get-code` and `kei login submit-code <CODE>` flow. Watch and service processes keep their durable wait-and-resume behavior. `kei password set` now accepts password-file and password-command sources, and fails before prompting when stdin is not a terminal. ([#698])
 - Embedded XMP writes for HEIC, HEIF, and AVIF files now use a byte-preserving item-map writer. Multi-image files such as HDR and portrait captures carry an XMP packet per image, so kei writes the one describing the primary image and leaves gain map, depth, and matte metadata untouched. A new primary-image packet also describes a tone map when the existing `dimg` and Exif `cdsc` relationships prove that exact scope and no XMP already owns the tone map; ambiguous relationships and external item data fail without replacing the media file. Rewritten files retain their existing permissions. ([#558])
 - A filtered sibling can no longer displace the child that owns a legacy master-keyed state row on the next sync. kei records the owner before planning downloads and reuses it during full sync, incremental sync, and pending retry. ([#721], fixes [#691])

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,19 @@ classifier, which reports auth exit code 3 and the `login get-code` and
 into a durable wait, and only when the resolved configuration is in watch or
 service mode.
 
+Interactive login and `login get-code` may retry once from clean local auth
+state when Apple rejects verification-code delivery with HTTP 403 and the
+attempt loaded a persisted cookie jar or session. The failed session removes
+only its cookie jar, session, and validation cache while it still holds the
+per-account lock, then the shared auth owner creates one clean replacement
+session. Password material and SQLite state remain unchanged. `reset session`
+exposes the same locked cleanup explicitly. Cleanup advances a generation in
+the existing lock file. A watch process that released its lock for idle sleep
+detects a changed generation when it wakes and stops before its old in-memory
+session can recreate reset credentials. Reauthentication handoffs carry their
+pre-release generation into replacement-session creation, so a reset in that
+gap also wins.
+
 ### Sync and provider checkpoints
 
 ```text

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -66,6 +66,11 @@ pub enum AuthError {
     #[error("Another kei process is using the iCloud session: {0}")]
     LockContention(String),
 
+    #[error(
+        "The local iCloud session was reset while this process was idle. Restart kei to load fresh authentication state."
+    )]
+    SessionReset,
+
     #[error(transparent)]
     Http(Box<reqwest::Error>),
 
@@ -105,6 +110,10 @@ impl AuthError {
     /// Check if this error indicates lock contention with another kei instance.
     pub const fn is_lock_contention(&self) -> bool {
         matches!(self, Self::LockContention(_))
+    }
+
+    pub(crate) const fn is_session_reset(&self) -> bool {
+        matches!(self, Self::SessionReset)
     }
 
     /// True when Apple returned a terminal authentication state that should

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -11,6 +11,7 @@ pub mod srp;
 pub mod twofa;
 
 use crate::retry::RetryConfig;
+use std::future::Future;
 
 /// Retry budget for Apple's auth endpoints (SRP init/complete, 2FA push,
 /// 2FA submit). The flow is user-blocking, so we keep this short: three
@@ -79,6 +80,76 @@ enum AuthFlowErrorClass {
     Other,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("Apple rejected persisted authentication state")]
+struct RetryWithCleanAuth {
+    removed_files: usize,
+    generation: session::SessionGeneration,
+}
+
+#[derive(Debug)]
+struct TwoFactorGeneration {
+    generation: session::SessionGeneration,
+}
+
+impl std::fmt::Display for TwoFactorGeneration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        AuthError::TwoFactorRequired.fmt(f)
+    }
+}
+
+pub(crate) fn two_factor_generation(error: &anyhow::Error) -> Option<session::SessionGeneration> {
+    error
+        .downcast_ref::<TwoFactorGeneration>()
+        .map(|error| error.generation)
+}
+
+fn is_forbidden(error: &anyhow::Error) -> bool {
+    matches!(
+        error.downcast_ref::<AuthError>(),
+        Some(AuthError::ApiError { code: 403, .. })
+    )
+}
+
+async fn map_push_error(session: &Session, error: anyhow::Error) -> Result<anyhow::Error> {
+    if session.loaded_persisted_auth() && is_forbidden(&error) {
+        let removed_files = session
+            .discard_persisted_auth()
+            .await
+            .map_err(|error| error.context("Could not discard stale iCloud authentication state"))?
+            .len();
+        return Ok(RetryWithCleanAuth {
+            removed_files,
+            generation: session.generation(),
+        }
+        .into());
+    }
+    Ok(error)
+}
+
+async fn retry_once_after_stale_auth<T, F, Fut>(
+    initial_generation: Option<session::SessionGeneration>,
+    mut attempt: F,
+) -> Result<T>
+where
+    F: FnMut(Option<session::SessionGeneration>) -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    match attempt(initial_generation).await {
+        Err(error) => {
+            let Some(retry) = error.downcast_ref::<RetryWithCleanAuth>() else {
+                return Err(error);
+            };
+            tracing::warn!(
+                removed_files = retry.removed_files,
+                "Apple rejected persisted authentication state; retrying once from clean state"
+            );
+            attempt(Some(retry.generation)).await
+        }
+        result => result,
+    }
+}
+
 /// Classify errors that change auth orchestration behavior.
 ///
 /// `anyhow::Error` remains the return type so the original error chain is
@@ -131,6 +202,7 @@ pub async fn authenticate(
         code,
         crate::personality::Mode::Off,
         crate::InputMode::detect(),
+        None,
     )
     .await
 }
@@ -156,6 +228,7 @@ pub(crate) async fn authenticate_in_input_mode(
         code,
         crate::personality::Mode::Off,
         input_mode,
+        None,
     )
     .await
 }
@@ -191,6 +264,7 @@ pub async fn authenticate_with_mode(
         code,
         mode,
         crate::InputMode::detect(),
+        None,
     )
     .await
 }
@@ -210,6 +284,7 @@ pub(crate) async fn authenticate_with_modes(
     code: Option<&str>,
     mode: crate::personality::Mode,
     input_mode: crate::InputMode,
+    expected_generation: Option<session::SessionGeneration>,
 ) -> Result<AuthResult> {
     #[cfg(debug_assertions)]
     if std::env::var("KEI_UNSTABLE_FAKE_TWO_FACTOR_REQUIRED_FOR_TESTS").as_deref() == Ok("1") {
@@ -218,18 +293,37 @@ pub(crate) async fn authenticate_with_modes(
     }
 
     let endpoints = Endpoints::for_domain(domain)?;
-    let session = Session::new(cookie_dir, apple_id, endpoints.home, timeout_secs).await?;
-    authenticate_inner(
-        session,
-        &endpoints,
-        apple_id,
-        password_provider,
-        domain,
-        client_id,
-        code,
-        mode,
-        input_mode,
-    )
+    retry_once_after_stale_auth(expected_generation, |generation| {
+        let client_id = client_id.clone();
+        let endpoints = &endpoints;
+        async move {
+            let session = match generation {
+                Some(generation) => {
+                    Session::new_after_release(
+                        cookie_dir,
+                        apple_id,
+                        endpoints.home,
+                        timeout_secs,
+                        generation,
+                    )
+                    .await?
+                }
+                None => Session::new(cookie_dir, apple_id, endpoints.home, timeout_secs).await?,
+            };
+            authenticate_inner(
+                session,
+                endpoints,
+                apple_id,
+                password_provider,
+                domain,
+                client_id,
+                code,
+                mode,
+                input_mode,
+            )
+            .await
+        }
+    })
     .await
 }
 
@@ -425,7 +519,11 @@ async fn authenticate_inner(
         // Headless with no code: bail without any Apple API calls.
         // The user triggers the push manually via `get-code`.
         if code.is_none() && !input_mode.can_prompt() {
-            return Err(AuthError::TwoFactorRequired.into());
+            return Err(anyhow::Error::new(AuthError::TwoFactorRequired).context(
+                TwoFactorGeneration {
+                    generation: session.generation(),
+                },
+            ));
         }
 
         let verified = if let Some(c) = code {
@@ -438,10 +536,14 @@ async fn authenticate_inner(
             // a code for some accounts but not all — the explicit push
             // ensures every account gets one. Apple deduplicates, so
             // accounts that already got a code from SRP won't see a second.
-            if let Err(e) =
+            if let Err(error) =
                 twofa::trigger_push_notification(&mut session, endpoints, &client_id, domain).await
             {
-                tracing::warn!(error = %e, "Failed to trigger push notification");
+                let error = map_push_error(&session, error).await?;
+                if error.downcast_ref::<RetryWithCleanAuth>().is_some() || is_forbidden(&error) {
+                    return Err(error);
+                }
+                tracing::warn!(error = %error, "Failed to trigger push notification");
             }
 
             const MAX_WRONG_CODES: u32 = 3;
@@ -521,7 +623,17 @@ pub async fn send_2fa_push(
     domain: &str,
 ) -> Result<()> {
     let endpoints = Endpoints::for_domain(domain)?;
-    send_2fa_push_inner(cookie_dir, apple_id, password_provider, domain, &endpoints).await
+    retry_once_after_stale_auth(None, |generation| {
+        send_2fa_push_inner(
+            cookie_dir,
+            apple_id,
+            password_provider,
+            domain,
+            &endpoints,
+            generation,
+        )
+    })
+    .await
 }
 
 async fn send_2fa_push_inner(
@@ -530,8 +642,15 @@ async fn send_2fa_push_inner(
     password_provider: &crate::password::PasswordProvider,
     domain: &str,
     endpoints: &Endpoints,
+    expected_generation: Option<session::SessionGeneration>,
 ) -> Result<()> {
-    let mut session = Session::new(cookie_dir, apple_id, endpoints.home, None).await?;
+    let mut session = match expected_generation {
+        Some(generation) => {
+            Session::new_after_release(cookie_dir, apple_id, endpoints.home, None, generation)
+                .await?
+        }
+        None => Session::new(cookie_dir, apple_id, endpoints.home, None).await?,
+    };
 
     let client_id = session
         .client_id()
@@ -646,7 +765,10 @@ async fn send_2fa_push_inner(
         return already_authenticated();
     }
 
-    twofa::trigger_push_notification(&mut session, endpoints, &client_id, domain).await
+    match twofa::trigger_push_notification(&mut session, endpoints, &client_id, domain).await {
+        Ok(()) => Ok(()),
+        Err(error) => Err(map_push_error(&session, error).await?),
+    }
 }
 
 fn already_authenticated() -> Result<()> {
@@ -734,7 +856,7 @@ mod tests {
     use secrecy::SecretString;
     use std::sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     };
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
@@ -822,6 +944,201 @@ mod tests {
             classify_auth_flow_error(&transient),
             AuthFlowErrorClass::TransientAppleFailure
         );
+    }
+
+    #[tokio::test]
+    async fn two_factor_required_carries_session_generation() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(
+            cookies.path(),
+            "generation@example.com",
+            "https://example.com",
+            None,
+        )
+        .await
+        .expect("session");
+        let generation = session.generation();
+        let error = anyhow::Error::new(AuthError::TwoFactorRequired)
+            .context(TwoFactorGeneration { generation });
+
+        assert_eq!(two_factor_generation(&error), Some(generation));
+        assert!(
+            error
+                .downcast_ref::<AuthError>()
+                .is_some_and(AuthError::is_two_factor_required)
+        );
+        assert_eq!(
+            classify_auth_flow_error(&error),
+            AuthFlowErrorClass::Other,
+            "the generation wrapper is only classified by sync owners"
+        );
+        assert!(error.to_string().contains("Two-factor authentication"));
+    }
+
+    #[tokio::test]
+    async fn map_push_error_only_cleans_persisted_403() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let apple_id = "persisted@example.com";
+        let files = session::persisted_auth_files(cookies.path(), apple_id);
+        tokio::fs::write(&files[1], b"stale")
+            .await
+            .expect("session file");
+        let persisted = Session::new(cookies.path(), apple_id, "https://example.com", None)
+            .await
+            .expect("persisted session");
+
+        let retry = map_push_error(
+            &persisted,
+            AuthError::ApiError {
+                code: 403,
+                message: "forbidden".into(),
+            }
+            .into(),
+        )
+        .await
+        .expect("map persisted 403");
+
+        assert!(retry.downcast_ref::<RetryWithCleanAuth>().is_some());
+        assert!(files.iter().all(|path| !path.exists()));
+        drop(persisted);
+
+        let clean = Session::new(cookies.path(), apple_id, "https://example.com", None)
+            .await
+            .expect("clean session");
+        let forbidden = map_push_error(
+            &clean,
+            AuthError::ApiError {
+                code: 403,
+                message: "forbidden".into(),
+            }
+            .into(),
+        )
+        .await
+        .expect("map clean 403");
+        assert!(is_forbidden(&forbidden));
+
+        let unavailable = map_push_error(
+            &clean,
+            AuthError::ApiError {
+                code: 503,
+                message: "unavailable".into(),
+            }
+            .into(),
+        )
+        .await
+        .expect("map non-403");
+        assert!(unavailable.downcast_ref::<RetryWithCleanAuth>().is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_auth_retry_runs_once_more() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(
+            cookies.path(),
+            "generation@example.com",
+            "https://example.com",
+            None,
+        )
+        .await
+        .expect("session");
+        let generation = session.generation();
+        drop(session);
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let result = retry_once_after_stale_auth(None, |expected_generation| {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                match attempts.fetch_add(1, Ordering::SeqCst) {
+                    0 => {
+                        assert_eq!(expected_generation, None);
+                        Err(RetryWithCleanAuth {
+                            removed_files: 3,
+                            generation,
+                        }
+                        .into())
+                    }
+                    1 => {
+                        assert_eq!(expected_generation, Some(generation));
+                        Ok(42)
+                    }
+                    attempt => panic!("unexpected attempt {attempt}"),
+                }
+            }
+        })
+        .await
+        .expect("clean retry");
+
+        assert_eq!(result, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn ordinary_auth_failure_does_not_retry() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let err = retry_once_after_stale_auth(None, |expected_generation| {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(expected_generation, None);
+                Err::<(), _>(
+                    AuthError::ApiError {
+                        code: 403,
+                        message: "forbidden".into(),
+                    }
+                    .into(),
+                )
+            }
+        })
+        .await
+        .expect_err("clean failure");
+
+        assert!(is_forbidden(&err));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_auth_retry_surfaces_second_failure() {
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(
+            cookies.path(),
+            "generation@example.com",
+            "https://example.com",
+            None,
+        )
+        .await
+        .expect("session");
+        let generation = session.generation();
+        drop(session);
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let err = retry_once_after_stale_auth(None, |expected_generation| {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    assert_eq!(expected_generation, None);
+                    Err::<(), anyhow::Error>(
+                        RetryWithCleanAuth {
+                            removed_files: 1,
+                            generation,
+                        }
+                        .into(),
+                    )
+                } else {
+                    assert_eq!(expected_generation, Some(generation));
+                    Err(AuthError::ApiError {
+                        code: 403,
+                        message: "still forbidden".into(),
+                    }
+                    .into())
+                }
+            }
+        })
+        .await
+        .expect_err("second failure");
+
+        assert!(is_forbidden(&err));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 
     #[test]
@@ -990,7 +1307,7 @@ mod tests {
             Some(SecretString::from("should-not-be-read"))
         });
 
-        let err = send_2fa_push_inner(cookies.path(), apple_id, &provider, "com", &endpoints)
+        let err = send_2fa_push_inner(cookies.path(), apple_id, &provider, "com", &endpoints, None)
             .await
             .expect_err("validated session should not need a 2FA push");
 
@@ -1033,7 +1350,7 @@ mod tests {
             Some(SecretString::from("should-not-be-read"))
         });
 
-        let err = send_2fa_push_inner(cookies.path(), apple_id, &provider, "com", &endpoints)
+        let err = send_2fa_push_inner(cookies.path(), apple_id, &provider, "com", &endpoints, None)
             .await
             .expect_err("validated session should not need a 2FA push");
 
@@ -1057,6 +1374,88 @@ mod tests {
             check_requires_2fa(&cached),
             "regression guard must cover HSA flags that would otherwise demand 2FA"
         );
+    }
+
+    async fn mount_persisted_two_factor_push_forbidden(server: &wiremock::MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/setup/ws/1/validate"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/setup/ws/1/accountLogin"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(make_response(2, true, false, true)),
+            )
+            .expect(1)
+            .mount(server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(403))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn get_code_maps_persisted_push_403_to_clean_retry() {
+        let server = crate::start_wiremock_or_skip!();
+        mount_persisted_two_factor_push_forbidden(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let apple_id = "get-code-retry@example.com";
+        tokio::fs::write(
+            session_file_path(cookies.path(), apple_id),
+            r#"{"session_token":"stale-token"}"#,
+        )
+        .await
+        .expect("session file");
+        let provider: crate::password::PasswordProvider =
+            Arc::new(|| Some(SecretString::from("unused")));
+
+        let err = send_2fa_push_inner(cookies.path(), apple_id, &provider, "com", &endpoints, None)
+            .await
+            .expect_err("persisted push 403");
+
+        assert!(err.downcast_ref::<RetryWithCleanAuth>().is_some());
+    }
+
+    #[tokio::test]
+    async fn interactive_login_maps_persisted_push_403_to_clean_retry() {
+        let server = crate::start_wiremock_or_skip!();
+        mount_persisted_two_factor_push_forbidden(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let cookies = tempfile::tempdir().expect("tempdir");
+        let apple_id = "interactive-retry@example.com";
+        tokio::fs::write(
+            session_file_path(cookies.path(), apple_id),
+            r#"{"session_token":"stale-token"}"#,
+        )
+        .await
+        .expect("session file");
+        let session = Session::new(cookies.path(), apple_id, &server.uri(), Some(5))
+            .await
+            .expect("session");
+        let provider: crate::password::PasswordProvider =
+            Arc::new(|| Some(SecretString::from("unused")));
+
+        let err = authenticate_inner(
+            session,
+            &endpoints,
+            apple_id,
+            &provider,
+            "com",
+            None,
+            None,
+            crate::personality::Mode::Off,
+            crate::InputMode::Interactive,
+        )
+        .await
+        .expect_err("persisted push 403");
+
+        assert!(err.downcast_ref::<RetryWithCleanAuth>().is_some());
     }
 
     #[tokio::test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -77,6 +77,12 @@ impl std::fmt::Debug for AuthResult {
 enum AuthFlowErrorClass {
     TransientAppleFailure,
     MisdirectedRequest,
+    TwoFactorAtGeneration(session::SessionGeneration),
+    PushForbidden,
+    RetryWithCleanAuth {
+        removed_files: usize,
+        generation: session::SessionGeneration,
+    },
     Other,
 }
 
@@ -99,16 +105,14 @@ impl std::fmt::Display for TwoFactorGeneration {
 }
 
 pub(crate) fn two_factor_generation(error: &anyhow::Error) -> Option<session::SessionGeneration> {
-    error
-        .downcast_ref::<TwoFactorGeneration>()
-        .map(|error| error.generation)
+    match classify_auth_flow_error(error) {
+        AuthFlowErrorClass::TwoFactorAtGeneration(generation) => Some(generation),
+        _ => None,
+    }
 }
 
 fn is_forbidden(error: &anyhow::Error) -> bool {
-    matches!(
-        error.downcast_ref::<AuthError>(),
-        Some(AuthError::ApiError { code: 403, .. })
-    )
+    classify_auth_flow_error(error) == AuthFlowErrorClass::PushForbidden
 }
 
 async fn map_push_error(session: &Session, error: anyhow::Error) -> Result<anyhow::Error> {
@@ -136,16 +140,19 @@ where
     Fut: Future<Output = Result<T>>,
 {
     match attempt(initial_generation).await {
-        Err(error) => {
-            let Some(retry) = error.downcast_ref::<RetryWithCleanAuth>() else {
-                return Err(error);
-            };
-            tracing::warn!(
-                removed_files = retry.removed_files,
-                "Apple rejected persisted authentication state; retrying once from clean state"
-            );
-            attempt(Some(retry.generation)).await
-        }
+        Err(error) => match classify_auth_flow_error(&error) {
+            AuthFlowErrorClass::RetryWithCleanAuth {
+                removed_files,
+                generation,
+            } => {
+                tracing::warn!(
+                    removed_files,
+                    "Apple rejected persisted authentication state; retrying once from clean state"
+                );
+                attempt(Some(generation)).await
+            }
+            _ => Err(error),
+        },
         result => result,
     }
 }
@@ -156,6 +163,15 @@ where
 /// preserved. This helper only owns local branch decisions for transient auth
 /// guidance and bounded 421 HTTP-pool recovery.
 fn classify_auth_flow_error(err: &anyhow::Error) -> AuthFlowErrorClass {
+    if let Some(error) = err.downcast_ref::<TwoFactorGeneration>() {
+        return AuthFlowErrorClass::TwoFactorAtGeneration(error.generation);
+    }
+    if let Some(error) = err.downcast_ref::<RetryWithCleanAuth>() {
+        return AuthFlowErrorClass::RetryWithCleanAuth {
+            removed_files: error.removed_files,
+            generation: error.generation,
+        };
+    }
     let Some(auth_err) = err.downcast_ref::<AuthError>() else {
         return AuthFlowErrorClass::Other;
     };
@@ -163,6 +179,8 @@ fn classify_auth_flow_error(err: &anyhow::Error) -> AuthFlowErrorClass {
         AuthFlowErrorClass::TransientAppleFailure
     } else if auth_err.is_misdirected_request() {
         AuthFlowErrorClass::MisdirectedRequest
+    } else if matches!(auth_err, AuthError::ApiError { code: 403, .. }) {
+        AuthFlowErrorClass::PushForbidden
     } else {
         AuthFlowErrorClass::Other
     }
@@ -407,7 +425,7 @@ async fn authenticate_inner(
                     session.reset_http_clients()?;
                     pool_reset = true;
                 }
-                AuthFlowErrorClass::Other => {
+                _ => {
                     tracing::debug!(
                         error = %e,
                         "Invalid authentication token, will log in from scratch"
@@ -453,7 +471,7 @@ async fn authenticate_inner(
                         session.reset_http_clients()?;
                     }
                 }
-                AuthFlowErrorClass::Other => {
+                _ => {
                     tracing::debug!(
                         error = %e,
                         "accountLogin failed, falling back to SRP"
@@ -540,7 +558,11 @@ async fn authenticate_inner(
                 twofa::trigger_push_notification(&mut session, endpoints, &client_id, domain).await
             {
                 let error = map_push_error(&session, error).await?;
-                if error.downcast_ref::<RetryWithCleanAuth>().is_some() || is_forbidden(&error) {
+                if matches!(
+                    classify_auth_flow_error(&error),
+                    AuthFlowErrorClass::RetryWithCleanAuth { .. }
+                        | AuthFlowErrorClass::PushForbidden
+                ) {
                     return Err(error);
                 }
                 tracing::warn!(error = %error, "Failed to trigger push notification");
@@ -694,7 +716,7 @@ async fn send_2fa_push_inner(
                     session.reset_http_clients()?;
                     pool_reset = true;
                 }
-                AuthFlowErrorClass::Other => {}
+                _ => {}
             },
         }
     }
@@ -969,8 +991,7 @@ mod tests {
         );
         assert_eq!(
             classify_auth_flow_error(&error),
-            AuthFlowErrorClass::Other,
-            "the generation wrapper is only classified by sync owners"
+            AuthFlowErrorClass::TwoFactorAtGeneration(generation)
         );
         assert!(error.to_string().contains("Two-factor authentication"));
     }

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -66,6 +67,195 @@ pub fn sanitize_username(username: &str) -> String {
             .last()
             .map_or(prefix_len, |(i, c)| i + c.len_utf8());
         format!("{}_{:016x}", &sanitized[..prefix_end], hash)
+    }
+}
+
+pub(crate) fn persisted_auth_files(cookie_dir: &Path, username: &str) -> [PathBuf; 3] {
+    let sanitized = sanitize_username(username);
+    [
+        cookie_dir.join(&sanitized),
+        cookie_dir.join(format!("{sanitized}.session")),
+        cookie_dir.join(format!("{sanitized}.cache")),
+    ]
+}
+
+/// Per-account lock plus a generation that invalidates sessions released for watch sleep.
+#[derive(Debug)]
+pub(crate) struct SessionStateGuard {
+    cookie_dir: PathBuf,
+    sanitized_username: String,
+    lock_file: std::fs::File,
+    generation: AtomicU64,
+    locked: AtomicBool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SessionGeneration(u64);
+
+fn read_lock_generation(file: &std::fs::File) -> Result<u64> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = file.try_clone()?;
+    file.seek(SeekFrom::Start(0))?;
+    let mut value = String::new();
+    file.read_to_string(&mut value)?;
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(0)
+    } else {
+        value
+            .parse()
+            .context("Session lock file contains an invalid generation")
+    }
+}
+
+fn write_lock_generation(file: &std::fs::File, generation: u64) -> Result<()> {
+    use std::io::{Seek, SeekFrom, Write};
+
+    let mut file = file.try_clone()?;
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    write!(file, "{generation}")?;
+    file.sync_all()?;
+    Ok(())
+}
+
+impl SessionStateGuard {
+    pub(crate) async fn acquire(cookie_dir: &Path, username: &str) -> Result<Self> {
+        Self::acquire_with_generation(cookie_dir, username, None).await
+    }
+
+    async fn acquire_with_generation(
+        cookie_dir: &Path,
+        username: &str,
+        expected_generation: Option<SessionGeneration>,
+    ) -> Result<Self> {
+        let cookie_dir = cookie_dir.to_path_buf();
+        fs::create_dir_all(&cookie_dir).await.with_context(|| {
+            format!("Could not create cookie directory {}", cookie_dir.display())
+        })?;
+        let sanitized_username = sanitize_username(username);
+        let lock_path = cookie_dir.join(format!("{sanitized_username}.lock"));
+        let (lock_file, generation) = tokio::task::spawn_blocking(move || {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&lock_path)
+                .with_context(|| {
+                    format!("Could not create session lock file {}", lock_path.display())
+                })?;
+            let acquired = file.try_lock_exclusive().with_context(|| {
+                format!("Could not acquire session lock {}", lock_path.display())
+            })?;
+            if !acquired {
+                return Err(crate::auth::error::AuthError::LockContention(format!(
+                    "Another kei instance is running for this account (lock: {}). If running in Docker, check for orphaned containers with `docker ps` and stop them with `docker stop <name>`.",
+                    lock_path.display()
+                ))
+                .into());
+            }
+            let generation = read_lock_generation(&file)?;
+            Ok::<_, anyhow::Error>((file, generation))
+        })
+        .await??;
+        if expected_generation.is_some_and(|expected| expected.0 != generation) {
+            return Err(crate::auth::error::AuthError::SessionReset.into());
+        }
+        Ok(Self {
+            cookie_dir,
+            sanitized_username,
+            lock_file,
+            generation: AtomicU64::new(generation),
+            locked: AtomicBool::new(true),
+        })
+    }
+
+    pub(crate) fn files(&self) -> [PathBuf; 3] {
+        persisted_auth_files(&self.cookie_dir, &self.sanitized_username)
+    }
+
+    fn has_replayable_auth(&self) -> bool {
+        self.files()[..2].iter().any(|path| path.exists())
+    }
+
+    fn generation(&self) -> SessionGeneration {
+        SessionGeneration(self.generation.load(Ordering::Acquire))
+    }
+
+    pub(crate) async fn discard(&self) -> Result<Vec<PathBuf>> {
+        anyhow::ensure!(
+            self.locked.load(Ordering::Acquire),
+            "Cannot discard iCloud authentication state without the account lock"
+        );
+        let generation = self
+            .generation
+            .load(Ordering::Acquire)
+            .checked_add(1)
+            .context("Session lock generation overflow")?;
+        let lock_file = self.lock_file.try_clone()?;
+        tokio::task::spawn_blocking(move || write_lock_generation(&lock_file, generation))
+            .await??;
+        self.generation.store(generation, Ordering::Release);
+
+        let mut removed = Vec::new();
+        let mut first_error = None;
+        for path in self.files() {
+            match fs::remove_file(&path).await {
+                Ok(()) => removed.push(path),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if first_error.is_none() => {
+                    first_error = Some(
+                        anyhow::Error::new(e)
+                            .context(format!("Could not remove {}", path.display())),
+                    );
+                }
+                Err(_) => {}
+            }
+        }
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(removed),
+        }
+    }
+
+    fn release(&self) -> Result<()> {
+        if !self.locked.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        FileExt::unlock(&self.lock_file).context("Could not release the session lock file")?;
+        self.locked.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn reacquire(&self) -> Result<()> {
+        if self.locked.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let acquired = self
+            .lock_file
+            .try_lock_exclusive()
+            .context("Could not reacquire the session lock")?;
+        if !acquired {
+            return Err(crate::auth::error::AuthError::LockContention(
+                "Another kei instance acquired the session lock while it was released.".into(),
+            )
+            .into());
+        }
+        let generation = match read_lock_generation(&self.lock_file) {
+            Ok(generation) => generation,
+            Err(error) => {
+                let _ = FileExt::unlock(&self.lock_file);
+                return Err(error);
+            }
+        };
+        if generation != self.generation.load(Ordering::Acquire) {
+            FileExt::unlock(&self.lock_file)?;
+            return Err(crate::auth::error::AuthError::SessionReset.into());
+        }
+        self.locked.store(true, Ordering::Release);
+        Ok(())
     }
 }
 
@@ -161,7 +351,7 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
 ///
 /// Deletes the file if it is corrupt or unreadable (falling back to the old
 /// delete-everything behaviour).
-pub(crate) async fn strip_session_routing_state(session_file: &Path) {
+async fn strip_session_routing_state_file(session_file: &Path) {
     let contents = match fs::read_to_string(session_file).await {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
@@ -210,6 +400,19 @@ pub(crate) async fn strip_session_routing_state(session_file: &Path) {
     // Invalidate validation cache since session is being reset
     let cache_file = session_file.with_extension("cache");
     crate::fs_util::log_remove_async(&cache_file).await;
+}
+
+pub(crate) async fn strip_session_routing_state(
+    cookie_dir: &Path,
+    username: &str,
+    expected_generation: Option<SessionGeneration>,
+) -> Result<()> {
+    let guard =
+        SessionStateGuard::acquire_with_generation(cookie_dir, username, expected_generation)
+            .await?;
+    let session_file = guard.files()[1].clone();
+    strip_session_routing_state_file(&session_file).await;
+    Ok(())
 }
 
 /// Build the API and download HTTP clients for a session.
@@ -263,10 +466,8 @@ pub struct Session {
     home_endpoint: String,
     /// API client timeout (preserved for `reset_http_clients`).
     api_timeout: Duration,
-    /// Exclusive file lock preventing concurrent instances for the same account.
-    /// The advisory lock is held for the lifetime of the Session via the open
-    /// file descriptor; released automatically when the File is dropped.
-    lock_file: std::fs::File,
+    state_guard: SessionStateGuard,
+    loaded_persisted_auth: bool,
 }
 
 impl std::fmt::Debug for Session {
@@ -288,43 +489,48 @@ impl Session {
         home_endpoint: &str,
         timeout_secs: Option<u64>,
     ) -> Result<Self> {
+        Self::new_with_generation(cookie_dir, username, home_endpoint, timeout_secs, None).await
+    }
+
+    pub(crate) async fn new_after_release(
+        cookie_dir: &Path,
+        username: &str,
+        home_endpoint: &str,
+        timeout_secs: Option<u64>,
+        generation: SessionGeneration,
+    ) -> Result<Self> {
+        Self::new_with_generation(
+            cookie_dir,
+            username,
+            home_endpoint,
+            timeout_secs,
+            Some(generation),
+        )
+        .await
+    }
+
+    async fn new_with_generation(
+        cookie_dir: &Path,
+        username: &str,
+        home_endpoint: &str,
+        timeout_secs: Option<u64>,
+        expected_generation: Option<SessionGeneration>,
+    ) -> Result<Self> {
         let sanitized = sanitize_username(username);
         let cookie_dir = cookie_dir.to_path_buf();
 
-        fs::create_dir_all(&cookie_dir).await.with_context(|| {
-            format!("Could not create cookie directory {}", cookie_dir.display())
-        })?;
-
-        // Acquire an exclusive file lock to prevent concurrent instances for
-        // the same account from corrupting session/cookie state.
-        let lock_path = cookie_dir.join(format!("{sanitized}.lock"));
-        let lock_file = tokio::task::spawn_blocking({
-            let lock_path = lock_path.clone();
-            move || {
-                let file = std::fs::File::create(&lock_path).with_context(|| {
-                    format!("Could not create session lock file {}", lock_path.display())
-                })?;
-                let acquired = file
-                    .try_lock_exclusive()
-                    .with_context(|| format!("Could not acquire session lock {}", lock_path.display()))?;
-                if !acquired {
-                    return Err(crate::auth::error::AuthError::LockContention(format!(
-                        "Another kei instance is running for this account (lock: {}). If running in Docker, check for orphaned containers with `docker ps` and stop them with `docker stop <name>`.",
-                        lock_path.display()
-                    ))
-                    .into());
-                }
-                Ok::<std::fs::File, anyhow::Error>(file)
-            }
-        })
-        .await??;
+        let state_guard =
+            SessionStateGuard::acquire_with_generation(&cookie_dir, username, expected_generation)
+                .await?;
+        let loaded_persisted_auth = state_guard.has_replayable_auth();
 
         Self::build(
             cookie_dir,
             &sanitized,
             home_endpoint,
             timeout_secs,
-            lock_file,
+            state_guard,
+            loaded_persisted_auth,
         )
         .await
     }
@@ -336,7 +542,8 @@ impl Session {
         sanitized: &str,
         home_endpoint: &str,
         timeout_secs: Option<u64>,
-        lock_file: std::fs::File,
+        state_guard: SessionStateGuard,
+        loaded_persisted_auth: bool,
     ) -> Result<Self> {
         let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
         let cookie_jar = Arc::new(reqwest::cookie::Jar::default());
@@ -449,7 +656,8 @@ impl Session {
             sanitized_username: sanitized.to_owned(),
             home_endpoint: home_endpoint.to_string(),
             api_timeout: timeout,
-            lock_file,
+            state_guard,
+            loaded_persisted_auth,
         })
     }
 
@@ -524,7 +732,7 @@ impl Session {
     /// Release the exclusive file lock without dropping the Session.
     /// This allows a new Session to acquire the lock (e.g. during re-authentication).
     pub(crate) fn release_lock(&self) -> Result<()> {
-        FileExt::unlock(&self.lock_file).context("Could not release the session lock file")
+        self.state_guard.release()
     }
 
     /// Re-acquire the exclusive file lock after a prior `release_lock()`.
@@ -532,17 +740,19 @@ impl Session {
     /// Returns `Err(AuthError::LockContention)` if another process acquired
     /// the lock in the interim (e.g. a concurrent `get-code` or `submit-code`).
     pub(crate) fn reacquire_lock(&self) -> Result<()> {
-        let acquired = self
-            .lock_file
-            .try_lock_exclusive()
-            .context("Could not reacquire the session lock")?;
-        if !acquired {
-            return Err(crate::auth::error::AuthError::LockContention(
-                "Another kei instance acquired the session lock while it was released.".into(),
-            )
-            .into());
-        }
-        Ok(())
+        self.state_guard.reacquire()
+    }
+
+    pub(crate) fn loaded_persisted_auth(&self) -> bool {
+        self.loaded_persisted_auth
+    }
+
+    pub(crate) fn generation(&self) -> SessionGeneration {
+        self.state_guard.generation()
+    }
+
+    pub(crate) async fn discard_persisted_auth(&self) -> Result<Vec<PathBuf>> {
+        self.state_guard.discard().await
     }
 
     pub fn client_id(&self) -> Option<&str> {
@@ -837,6 +1047,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_reset_invalidates_a_released_session() {
+        let (_td, dir) = test_dir("reset_while_released");
+        let username = "user@test.com";
+        let files = persisted_auth_files(&dir, username);
+        for path in &files {
+            std::fs::write(path, b"stale").unwrap();
+        }
+        let session = Session::new(&dir, username, "https://example.com", None)
+            .await
+            .unwrap();
+        session.release_lock().unwrap();
+
+        let reset = SessionStateGuard::acquire(&dir, username).await.unwrap();
+        reset.discard().await.unwrap();
+        drop(reset);
+
+        let err = session
+            .reacquire_lock()
+            .expect_err("released session must observe the reset");
+        assert!(matches!(
+            err.downcast_ref::<crate::auth::error::AuthError>(),
+            Some(crate::auth::error::AuthError::SessionReset)
+        ));
+        let _replacement = Session::new(&dir, username, "https://example.com", None)
+            .await
+            .expect("reset generation should allow a fresh session");
+    }
+
+    #[tokio::test]
+    async fn session_reset_invalidates_a_replacement_session() {
+        let (_td, dir) = test_dir("reset_during_replacement");
+        let username = "user@test.com";
+        let session = Session::new(&dir, username, "https://example.com", None)
+            .await
+            .unwrap();
+        let generation = session.generation();
+        session.release_lock().unwrap();
+        drop(session);
+
+        let reset = SessionStateGuard::acquire(&dir, username).await.unwrap();
+        reset.discard().await.unwrap();
+        drop(reset);
+
+        let err =
+            Session::new_after_release(&dir, username, "https://example.com", None, generation)
+                .await
+                .expect_err("replacement must not adopt a reset generation");
+        assert!(matches!(
+            err.downcast_ref::<crate::auth::error::AuthError>(),
+            Some(crate::auth::error::AuthError::SessionReset)
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_reset_still_invalidates_a_released_session() {
+        let (_td, dir) = test_dir("failed_reset_while_released");
+        let username = "user@test.com";
+        let files = persisted_auth_files(&dir, username);
+        std::fs::create_dir(&files[0]).unwrap();
+        std::fs::write(&files[1], b"stale").unwrap();
+        let session = Session::new(&dir, username, "https://example.com", None)
+            .await
+            .unwrap();
+        session.release_lock().unwrap();
+
+        let reset = SessionStateGuard::acquire(&dir, username).await.unwrap();
+        reset
+            .discard()
+            .await
+            .expect_err("directory cannot be removed as an auth file");
+        assert!(
+            !files[1].exists(),
+            "later auth files must still be removed after an earlier failure"
+        );
+        drop(reset);
+
+        let err = session
+            .reacquire_lock()
+            .expect_err("failed reset must still invalidate released sessions");
+        assert!(matches!(
+            err.downcast_ref::<crate::auth::error::AuthError>(),
+            Some(crate::auth::error::AuthError::SessionReset)
+        ));
+    }
+
+    #[tokio::test]
+    async fn generation_overflow_preserves_auth_files() {
+        let (_td, dir) = test_dir("generation_overflow");
+        let username = "user@test.com";
+        let files = persisted_auth_files(&dir, username);
+        std::fs::write(&files[0], b"cookie").unwrap();
+        let lock_path = dir.join(format!("{}.lock", sanitize_username(username)));
+        std::fs::write(&lock_path, u64::MAX.to_string()).unwrap();
+        let guard = SessionStateGuard::acquire(&dir, username).await.unwrap();
+
+        guard.discard().await.expect_err("generation must not wrap");
+
+        assert!(files[0].exists());
+    }
+
+    #[tokio::test]
     async fn session_reacquire_lock_contention_error_is_actionable() {
         let (_td, dir) = test_dir("lock_reacquire_contention");
         let s1 = Session::new(&dir, "user@test.com", "https://example.com", None)
@@ -1039,6 +1350,87 @@ mod tests {
         assert_eq!(sanitize_username("@.+-!"), "");
     }
 
+    #[test]
+    fn persisted_auth_files_cover_only_session_artifacts() {
+        let dir = Path::new("/data");
+        let files = persisted_auth_files(dir, "user@test.com");
+        let names: Vec<String> = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        let sanitized = sanitize_username("user@test.com");
+        assert_eq!(
+            names,
+            vec![
+                sanitized.clone(),
+                format!("{sanitized}.session"),
+                format!("{sanitized}.cache"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_cache_alone_is_not_replayable_auth_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = persisted_auth_files(dir.path(), "user@test.com");
+        std::fs::write(&files[2], b"cache").unwrap();
+
+        let guard = SessionStateGuard::acquire(dir.path(), "user@test.com")
+            .await
+            .unwrap();
+        assert!(!guard.has_replayable_auth());
+    }
+
+    #[tokio::test]
+    async fn discard_persisted_auth_removes_only_session_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let username = "user@test.com";
+        let files = persisted_auth_files(dir.path(), username);
+        for path in &files {
+            std::fs::write(path, b"auth").unwrap();
+        }
+        let credential = dir
+            .path()
+            .join(format!("{}.credential", sanitize_username(username)));
+        let db = dir
+            .path()
+            .join(format!("{}.db", sanitize_username(username)));
+        std::fs::write(&credential, b"credential").unwrap();
+        std::fs::write(&db, b"database").unwrap();
+
+        let guard = SessionStateGuard::acquire(dir.path(), username)
+            .await
+            .unwrap();
+        let removed = guard.discard().await.unwrap();
+
+        assert_eq!(removed, files);
+        assert!(files.iter().all(|path| !path.exists()));
+        assert!(credential.exists());
+        assert!(db.exists());
+    }
+
+    #[tokio::test]
+    async fn discard_persisted_auth_refuses_lock_contention() {
+        let dir = tempfile::tempdir().unwrap();
+        let username = "user@test.com";
+        let session = Session::new(dir.path(), username, "https://example.com", None)
+            .await
+            .unwrap();
+        let files = persisted_auth_files(dir.path(), username);
+        std::fs::write(&files[0], b"cookie").unwrap();
+
+        let err = SessionStateGuard::acquire(dir.path(), username)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.downcast_ref::<crate::auth::error::AuthError>()
+                .is_some_and(crate::auth::error::AuthError::is_lock_contention)
+        );
+        assert!(files[0].exists());
+        drop(session);
+    }
+
     #[tokio::test]
     async fn test_persist_jar_cookies_saves_and_reloads() {
         let (_td, dir) = test_dir("persist_jar");
@@ -1236,7 +1628,7 @@ mod tests {
         });
         std::fs::write(&path, data.to_string()).unwrap();
 
-        strip_session_routing_state(&path).await;
+        strip_session_routing_state_file(&path).await;
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let map: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
@@ -1254,7 +1646,7 @@ mod tests {
         let path = dir.path().join("corrupt.session");
         std::fs::write(&path, "not valid json {{{").unwrap();
 
-        strip_session_routing_state(&path).await;
+        strip_session_routing_state_file(&path).await;
 
         assert!(!path.exists());
     }
@@ -1264,7 +1656,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent.session");
 
-        strip_session_routing_state(&path).await;
+        strip_session_routing_state_file(&path).await;
 
         assert!(!path.exists());
     }
@@ -1280,7 +1672,7 @@ mod tests {
         std::fs::write(&path, data.to_string()).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        strip_session_routing_state(&path).await;
+        strip_session_routing_state_file(&path).await;
 
         // restore so tempdir cleanup doesn't fail
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
@@ -1300,7 +1692,7 @@ mod tests {
         });
         std::fs::write(&path, data.to_string()).unwrap();
 
-        strip_session_routing_state(&path).await;
+        strip_session_routing_state_file(&path).await;
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let map: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
@@ -1459,7 +1851,7 @@ mod tests {
         std::fs::write(&cache_path, r#"{"validated_at":1,"account_data":{}}"#).unwrap();
         assert!(cache_path.exists());
 
-        strip_session_routing_state(&session_path).await;
+        strip_session_routing_state_file(&session_path).await;
 
         assert!(
             !cache_path.exists(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -488,6 +488,19 @@ pub enum ResetCommand {
         #[arg(long, short = 'y')]
         yes: bool,
     },
+    /// Discard the local iCloud session, including trust tokens.
+    ///
+    /// Removes the cookie jar, persisted session, and response cache for the
+    /// configured account, so the next `kei login` runs the full password +
+    /// 2FA flow again. The stored password (`kei password`) and the state
+    /// database are kept. Useful when Apple rejects 2FA pushes for a stale
+    /// session. Without `--yes`, prompts for confirmation on a TTY and
+    /// errors out under non-interactive use, matching `reset sync-token`.
+    Session {
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
 }
 
 /// Config management actions.
@@ -629,7 +642,7 @@ pub enum Command {
         action: PasswordAction,
     },
 
-    /// Reset state database or sync tokens
+    /// Reset state database, sync tokens, or the local session
     #[command(after_help = "Documentation: https://github.com/rhoopr/kei/wiki/Reset")]
     Reset {
         #[command(subcommand)]
@@ -1398,6 +1411,39 @@ mod tests {
             cli.command,
             Command::Reset {
                 what: ResetCommand::SyncToken { yes: true },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: false },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session_with_yes() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: true },
+            }
+        ));
+    }
+
+    #[test]
+    fn test_reset_session_with_short_y() {
+        let cli = Cli::try_parse_from(["kei", "reset", "session", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Reset {
+                what: ResetCommand::Session { yes: true },
             }
         ));
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use login::run_login;
 pub(crate) use manifest::run_manifest;
 pub(crate) use password::run_password;
 pub(crate) use reconcile::run_reconcile;
-pub(crate) use reset::{run_reset_state, run_reset_sync_token};
+pub(crate) use reset::{run_reset_session, run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
     AlbumPass, AlbumPlan, CollectionContext, MAX_REAUTH_ATTEMPTS, PassKind, PassScope,
     attempt_reauth, build_collection_context, collection_libraries, init_photos_service,

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -3,11 +3,6 @@
     reason = "CLI subcommand whose primary purpose is to print reset status to stdout"
 )]
 
-use std::path::{Path, PathBuf};
-
-use anyhow::Context;
-use fs4::fs_std::FileExt;
-
 use crate::auth;
 use crate::cli;
 use crate::config;
@@ -112,59 +107,6 @@ pub(crate) async fn run_reset_sync_token(
     Ok(())
 }
 
-/// Session artifacts for `username` inside `cookie_directory`, in removal
-/// order: the cookie jar, the persisted session, and the response cache.
-///
-/// The password store (`<user>.credential`) and the state database are
-/// deliberately excluded: `reset session` discards Apple session state
-/// (including trust tokens) only, so `kei login` can mint a clean session
-/// afterwards.
-fn session_files(cookie_directory: &Path, username: &str) -> Vec<PathBuf> {
-    let slug = auth::session::sanitize_username(username);
-    vec![
-        cookie_directory.join(&slug),
-        cookie_directory.join(format!("{slug}.session")),
-        cookie_directory.join(format!("{slug}.cache")),
-    ]
-}
-
-/// Acquire the per-account advisory session lock, failing on contention.
-///
-/// Mirrors the lock acquisition in `auth::session::Session::new`: a held lock
-/// means another kei instance (sync, service, or login) is active for this
-/// account, and `reset session` must not remove session files from under it.
-fn acquire_session_lock(cookie_directory: &Path, slug: &str) -> anyhow::Result<std::fs::File> {
-    let lock_path = cookie_directory.join(format!("{slug}.lock"));
-    let file = std::fs::File::create(&lock_path)
-        .with_context(|| format!("Could not create session lock file {}", lock_path.display()))?;
-    let acquired = file
-        .try_lock_exclusive()
-        .with_context(|| format!("Could not acquire session lock {}", lock_path.display()))?;
-    anyhow::ensure!(
-        acquired,
-        "Another kei instance is running for this account (lock: {}). \
-         Stop it before resetting the session. If running in Docker, check \
-         for containers with `docker ps` and stop them with `docker stop <name>`.",
-        lock_path.display()
-    );
-    Ok(file)
-}
-
-/// Remove every file in `files` that exists, returning the paths removed.
-async fn discard(files: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
-    let mut removed = Vec::new();
-    for path in files {
-        match tokio::fs::remove_file(path).await {
-            Ok(()) => removed.push(path.clone()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                return Err(e).with_context(|| format!("Could not remove {}", path.display()));
-            }
-        }
-    }
-    Ok(removed)
-}
-
 /// Run the reset-session command: discard the local session so the next
 /// `kei login` starts from a clean slate.
 ///
@@ -187,8 +129,10 @@ pub(crate) async fn run_reset_session(
         anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username.");
     }
 
-    let files = session_files(&cookie_directory, &username);
-    let existing: Vec<&PathBuf> = files.iter().filter(|p| p.exists()).collect();
+    let state_guard =
+        auth::session::SessionStateGuard::acquire(&cookie_directory, &username).await?;
+    let files = state_guard.files();
+    let existing: Vec<_> = files.iter().filter(|p| p.exists()).collect();
 
     // Nothing to remove: report and exit before the lock and the `--yes`
     // guard, mirroring the no-DB early return of the other reset subcommands.
@@ -199,16 +143,6 @@ pub(crate) async fn run_reset_session(
         );
         return Ok(());
     }
-
-    // Hold the same advisory lock the sync service takes — acquired before
-    // the prompt, so no instance can start mid-confirmation and we never
-    // yank session files out from under a running one.
-    let slug = auth::session::sanitize_username(&username);
-    let _lock_file = tokio::task::spawn_blocking({
-        let cookie_directory = cookie_directory.clone();
-        move || acquire_session_lock(&cookie_directory, &slug)
-    })
-    .await??;
 
     if !yes {
         use std::io::IsTerminal;
@@ -235,82 +169,11 @@ pub(crate) async fn run_reset_session(
         }
     }
 
-    let removed = discard(&files).await?;
+    let removed = state_guard.discard().await?;
     for path in &removed {
         println!("Removed {}", path.display());
     }
     println!("Session reset. Run `kei login` to authenticate again.");
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn session_files_cover_jar_session_and_cache_only() {
-        let dir = Path::new("/data");
-        let files = session_files(dir, "user@test.com");
-        let names: Vec<String> = files
-            .iter()
-            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
-            .collect();
-        let slug = auth::session::sanitize_username("user@test.com");
-        assert_eq!(
-            names,
-            vec![
-                slug.clone(),
-                format!("{slug}.session"),
-                format!("{slug}.cache")
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn reset_session_removes_nothing_while_the_session_lock_is_held() {
-        let dir = tempfile::tempdir().unwrap();
-        let slug = auth::session::sanitize_username("user@test.com");
-        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
-        std::fs::write(dir.path().join(format!("{slug}.session")), b"session").unwrap();
-
-        // Simulate a running instance holding the advisory lock.
-        let held = acquire_session_lock(dir.path(), &slug).unwrap();
-
-        // The reset's lock step must fail on contention, so discard never runs.
-        let err = acquire_session_lock(dir.path(), &slug).unwrap_err();
-        assert!(
-            err.to_string().contains("Another kei instance is running"),
-            "unexpected error: {err}"
-        );
-        assert!(dir.path().join(&slug).exists());
-        assert!(dir.path().join(format!("{slug}.session")).exists());
-
-        // Once the running instance goes away, the lock is acquirable again.
-        drop(held);
-        let _reacquired = acquire_session_lock(dir.path(), &slug).unwrap();
-    }
-
-    #[tokio::test]
-    async fn discard_removes_only_listed_files_and_tolerates_missing() {
-        let dir = tempfile::tempdir().unwrap();
-        let slug = auth::session::sanitize_username("user@test.com");
-        let files = session_files(dir.path(), "user@test.com");
-
-        // Present: jar + cache. Missing: .session. Bystanders: credential + db.
-        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
-        std::fs::write(dir.path().join(format!("{slug}.cache")), b"cache").unwrap();
-        let credential = dir.path().join(format!("{slug}.credential"));
-        let db = dir.path().join(format!("{slug}.db"));
-        std::fs::write(&credential, b"cred").unwrap();
-        std::fs::write(&db, b"db").unwrap();
-
-        let removed = discard(&files).await.unwrap();
-
-        assert_eq!(removed.len(), 2);
-        assert!(!dir.path().join(&slug).exists());
-        assert!(!dir.path().join(format!("{slug}.cache")).exists());
-        assert!(credential.exists(), "password store must survive the reset");
-        assert!(db.exists(), "state database must survive the reset");
-    }
 }

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -3,6 +3,13 @@
     reason = "CLI subcommand whose primary purpose is to print reset status to stdout"
 )]
 
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use fs4::fs_std::FileExt;
+
+use crate::auth;
+use crate::cli;
 use crate::config;
 use crate::state;
 
@@ -103,4 +110,207 @@ pub(crate) async fn run_reset_sync_token(
     );
 
     Ok(())
+}
+
+/// Session artifacts for `username` inside `cookie_directory`, in removal
+/// order: the cookie jar, the persisted session, and the response cache.
+///
+/// The password store (`<user>.credential`) and the state database are
+/// deliberately excluded: `reset session` discards Apple session state
+/// (including trust tokens) only, so `kei login` can mint a clean session
+/// afterwards.
+fn session_files(cookie_directory: &Path, username: &str) -> Vec<PathBuf> {
+    let slug = auth::session::sanitize_username(username);
+    vec![
+        cookie_directory.join(&slug),
+        cookie_directory.join(format!("{slug}.session")),
+        cookie_directory.join(format!("{slug}.cache")),
+    ]
+}
+
+/// Acquire the per-account advisory session lock, failing on contention.
+///
+/// Mirrors the lock acquisition in `auth::session::Session::new`: a held lock
+/// means another kei instance (sync, service, or login) is active for this
+/// account, and `reset session` must not remove session files from under it.
+fn acquire_session_lock(cookie_directory: &Path, slug: &str) -> anyhow::Result<std::fs::File> {
+    let lock_path = cookie_directory.join(format!("{slug}.lock"));
+    let file = std::fs::File::create(&lock_path)
+        .with_context(|| format!("Could not create session lock file {}", lock_path.display()))?;
+    let acquired = file
+        .try_lock_exclusive()
+        .with_context(|| format!("Could not acquire session lock {}", lock_path.display()))?;
+    anyhow::ensure!(
+        acquired,
+        "Another kei instance is running for this account (lock: {}). \
+         Stop it before resetting the session. If running in Docker, check \
+         for containers with `docker ps` and stop them with `docker stop <name>`.",
+        lock_path.display()
+    );
+    Ok(file)
+}
+
+/// Remove every file in `files` that exists, returning the paths removed.
+async fn discard(files: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+    for path in files {
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => removed.push(path.clone()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| format!("Could not remove {}", path.display()));
+            }
+        }
+    }
+    Ok(removed)
+}
+
+/// Run the reset-session command: discard the local session so the next
+/// `kei login` starts from a clean slate.
+///
+/// `yes` skips the confirmation prompt. Without it, prompts on a TTY and
+/// errors under non-interactive use, mirroring `reset sync-token`.
+/// Discarding the session (including trust tokens) forces the next
+/// `kei login` to run the full password + 2FA flow; the stored password
+/// and the state database are kept.
+pub(crate) async fn run_reset_session(
+    yes: bool,
+    globals: &config::GlobalArgs,
+    toml: Option<&config::TomlConfig>,
+) -> anyhow::Result<()> {
+    // Reset never authenticates; resolve_auth only reads the password from
+    // CLI/env args, so empty PasswordArgs are fine here.
+    let password_args = cli::PasswordArgs::default();
+    let (username, _, _, cookie_directory) = config::resolve_auth(globals, &password_args, toml);
+
+    if username.is_empty() {
+        anyhow::bail!("Set your iCloud username with ICLOUD_USERNAME or [auth].username.");
+    }
+
+    let files = session_files(&cookie_directory, &username);
+    let existing: Vec<&PathBuf> = files.iter().filter(|p| p.exists()).collect();
+
+    // Nothing to remove: report and exit before the lock and the `--yes`
+    // guard, mirroring the no-DB early return of the other reset subcommands.
+    if existing.is_empty() {
+        println!(
+            "No local session found in {} — nothing to reset.",
+            cookie_directory.display()
+        );
+        return Ok(());
+    }
+
+    // Hold the same advisory lock the sync service takes — acquired before
+    // the prompt, so no instance can start mid-confirmation and we never
+    // yank session files out from under a running one.
+    let slug = auth::session::sanitize_username(&username);
+    let _lock_file = tokio::task::spawn_blocking({
+        let cookie_directory = cookie_directory.clone();
+        move || acquire_session_lock(&cookie_directory, &slug)
+    })
+    .await??;
+
+    if !yes {
+        use std::io::IsTerminal;
+        use std::io::Write;
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "`kei reset session` needs `--yes` when stdin is not a terminal. This discards the local session and trust tokens, and the next `kei login` will run the full password + 2FA flow again."
+            );
+        }
+        println!("This will discard the local iCloud session (including trust tokens):");
+        for path in &existing {
+            println!("  {}", path.display());
+        }
+        println!();
+        println!("The stored password and the state database are kept.");
+        print!("Are you sure? [y/N] ");
+        std::io::stdout().flush()?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let removed = discard(&files).await?;
+    for path in &removed {
+        println!("Removed {}", path.display());
+    }
+    println!("Session reset. Run `kei login` to authenticate again.");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_files_cover_jar_session_and_cache_only() {
+        let dir = Path::new("/data");
+        let files = session_files(dir, "user@test.com");
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        let slug = auth::session::sanitize_username("user@test.com");
+        assert_eq!(
+            names,
+            vec![
+                slug.clone(),
+                format!("{slug}.session"),
+                format!("{slug}.cache")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_session_removes_nothing_while_the_session_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let slug = auth::session::sanitize_username("user@test.com");
+        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
+        std::fs::write(dir.path().join(format!("{slug}.session")), b"session").unwrap();
+
+        // Simulate a running instance holding the advisory lock.
+        let held = acquire_session_lock(dir.path(), &slug).unwrap();
+
+        // The reset's lock step must fail on contention, so discard never runs.
+        let err = acquire_session_lock(dir.path(), &slug).unwrap_err();
+        assert!(
+            err.to_string().contains("Another kei instance is running"),
+            "unexpected error: {err}"
+        );
+        assert!(dir.path().join(&slug).exists());
+        assert!(dir.path().join(format!("{slug}.session")).exists());
+
+        // Once the running instance goes away, the lock is acquirable again.
+        drop(held);
+        let _reacquired = acquire_session_lock(dir.path(), &slug).unwrap();
+    }
+
+    #[tokio::test]
+    async fn discard_removes_only_listed_files_and_tolerates_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let slug = auth::session::sanitize_username("user@test.com");
+        let files = session_files(dir.path(), "user@test.com");
+
+        // Present: jar + cache. Missing: .session. Bystanders: credential + db.
+        std::fs::write(dir.path().join(&slug), b"jar").unwrap();
+        std::fs::write(dir.path().join(format!("{slug}.cache")), b"cache").unwrap();
+        let credential = dir.path().join(format!("{slug}.credential"));
+        let db = dir.path().join(format!("{slug}.db"));
+        std::fs::write(&credential, b"cred").unwrap();
+        std::fs::write(&db, b"db").unwrap();
+
+        let removed = discard(&files).await.unwrap();
+
+        assert_eq!(removed.len(), 2);
+        assert!(!dir.path().join(&slug).exists());
+        assert!(!dir.path().join(format!("{slug}.cache")).exists());
+        assert!(credential.exists(), "password store must survive the reset");
+        assert!(db.exists(), "state database must survive the reset");
+    }
 }

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -163,6 +163,7 @@ pub(crate) async fn attempt_reauth(
     input_mode: crate::InputMode,
 ) -> anyhow::Result<()> {
     let mut session = shared_session.write().await;
+    session.reacquire_lock()?;
 
     // Try validation first — timeout prevents a hung HTTP request from
     // holding the write lock indefinitely and starving download tasks.
@@ -178,10 +179,11 @@ pub(crate) async fn attempt_reauth(
     }
 
     tracing::info!("Session invalid, performing full re-authentication...");
+    let generation = session.generation();
     session.release_lock()?;
     drop(session);
 
-    let new_auth = auth::authenticate_in_input_mode(
+    let new_auth = auth::authenticate_with_modes(
         cookie_directory,
         username,
         password_provider,
@@ -189,7 +191,9 @@ pub(crate) async fn attempt_reauth(
         None,
         None,
         None, // no code — interactive prompt or TwoFactorRequired
+        crate::personality::Mode::Off,
         input_mode,
+        Some(generation),
     )
     .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,8 @@ fn make_provider_from_auth(
 
 use commands::{
     run_config_show, run_doctor, run_import_existing, run_list, run_login, run_manifest,
-    run_password, run_reconcile, run_reset_state, run_reset_sync_token, run_status, run_verify,
+    run_password, run_reconcile, run_reset_session, run_reset_state, run_reset_sync_token,
+    run_status, run_verify,
 };
 
 /// Get the database path for a given auth config, merging with TOML defaults.
@@ -874,6 +875,9 @@ async fn run(env_password: Option<String>, input_mode: InputMode) -> anyhow::Res
             }
             cli::ResetCommand::SyncToken { yes } => {
                 return run_reset_sync_token(yes, &globals, toml_config.as_ref(), input_mode).await;
+            }
+            cli::ResetCommand::Session { yes } => {
+                return run_reset_session(yes, &globals, toml_config.as_ref()).await;
             }
         },
         Command::Verify(args) => {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -61,6 +61,7 @@ enum WatchPrecheck {
 enum SyncAuthErrorClass {
     TwoFactorRequired,
     LockContention,
+    SessionReset,
     Other,
 }
 
@@ -77,6 +78,8 @@ fn classify_sync_auth_error(err: &anyhow::Error) -> SyncAuthErrorClass {
         SyncAuthErrorClass::TwoFactorRequired
     } else if auth_err.is_lock_contention() {
         SyncAuthErrorClass::LockContention
+    } else if auth_err.is_session_reset() {
+        SyncAuthErrorClass::SessionReset
     } else {
         SyncAuthErrorClass::Other
     }
@@ -798,11 +801,13 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         None,
         config.ui.personality_mode,
         input_mode,
+        None,
     )
     .await
     {
         Ok(result) => result,
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
+            let expected_generation = auth::two_factor_generation(&e);
             if !should_wait_for_2fa(is_watch_mode, &e) {
                 return Err(e);
             }
@@ -827,6 +832,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     None,
                     config.ui.personality_mode,
                     input_mode,
+                    expected_generation,
                 )
             })
             .await?
@@ -883,6 +889,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     let mut retried_after_session_error = false;
     let (shared_session, mut photos_service, libraries) = loop {
         let this_auth = take_pending_auth(&mut pending_auth)?;
+        let released_generation = this_auth.session.generation();
         let init_result =
             init_photos_service(this_auth, api_retry_config, config.ui.personality_mode).await;
         let (ss, mut ps) = match init_result {
@@ -899,6 +906,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                         &password_provider,
                         &notifier,
                         None,
+                        Some(released_generation),
                         is_watch_mode,
                         input_mode,
                     )
@@ -922,6 +930,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                         &password_provider,
                         &notifier,
                         Some((ss, ps)),
+                        None,
                         is_watch_mode,
                         input_mode,
                     )
@@ -1721,29 +1730,58 @@ async fn reauth_after_session_error(
     password_provider: &crate::password::PasswordProvider,
     notifier: &Notifier,
     live: Option<(auth::SharedSession, crate::icloud::photos::PhotosService)>,
+    released_generation: Option<auth::session::SessionGeneration>,
     is_watch_mode: bool,
     input_mode: crate::InputMode,
 ) -> anyhow::Result<auth::AuthResult> {
-    if let Some((ss, ps)) = live {
-        ss.read().await.release_lock()?;
+    let expected_generation = if let Some((ss, ps)) = live {
+        let session = ss.read().await;
+        let generation = session.generation();
+        session.release_lock()?;
+        drop(session);
         drop(ps);
         drop(ss);
-    }
+        Some(generation)
+    } else {
+        released_generation
+    };
 
     clear_validation_cache_for_reauth(&config.auth.cookie_directory, &config.auth.username).await;
-    match authenticate_sync_session(config, password_provider, input_mode).await {
+    match authenticate_sync_session(config, password_provider, input_mode, expected_generation)
+        .await
+    {
         Ok(result) => return Ok(result),
+        Err(e)
+            if matches!(
+                classify_sync_auth_error(&e),
+                SyncAuthErrorClass::SessionReset | SyncAuthErrorClass::LockContention
+            ) =>
+        {
+            return Err(e);
+        }
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
-            if let Some(result) =
-                retry_persisted_session_after_two_factor(config, password_provider, input_mode)
-                    .await
+            let expected_generation = auth::two_factor_generation(&e).or(expected_generation);
+            if let Some(result) = retry_persisted_session_after_two_factor(
+                config,
+                password_provider,
+                input_mode,
+                expected_generation,
+            )
+            .await?
             {
                 return Ok(result);
             }
             if !should_wait_for_2fa(is_watch_mode, &e) {
                 return Err(e);
             }
-            return notify_and_wait_for_2fa(config, password_provider, notifier, input_mode).await;
+            return notify_and_wait_for_2fa(
+                config,
+                password_provider,
+                notifier,
+                input_mode,
+                expected_generation,
+            )
+            .await;
         }
         Err(e) => {
             tracing::warn!(
@@ -1753,23 +1791,41 @@ async fn reauth_after_session_error(
         }
     }
 
-    let session_file =
-        auth::session_file_path(&config.auth.cookie_directory, &config.auth.username);
-    auth::strip_session_routing_state(&session_file).await;
+    auth::strip_session_routing_state(
+        &config.auth.cookie_directory,
+        &config.auth.username,
+        expected_generation,
+    )
+    .await?;
 
-    match authenticate_sync_session(config, password_provider, input_mode).await {
+    match authenticate_sync_session(config, password_provider, input_mode, expected_generation)
+        .await
+    {
         Ok(result) => Ok(result),
+        Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::SessionReset => Err(e),
         Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::TwoFactorRequired => {
-            if let Some(result) =
-                retry_persisted_session_after_two_factor(config, password_provider, input_mode)
-                    .await
+            let expected_generation = auth::two_factor_generation(&e).or(expected_generation);
+            if let Some(result) = retry_persisted_session_after_two_factor(
+                config,
+                password_provider,
+                input_mode,
+                expected_generation,
+            )
+            .await?
             {
                 return Ok(result);
             }
             if !should_wait_for_2fa(is_watch_mode, &e) {
                 return Err(e);
             }
-            notify_and_wait_for_2fa(config, password_provider, notifier, input_mode).await
+            notify_and_wait_for_2fa(
+                config,
+                password_provider,
+                notifier,
+                input_mode,
+                expected_generation,
+            )
+            .await
         }
         Err(e) => Err(e),
     }
@@ -1794,6 +1850,7 @@ async fn authenticate_sync_session(
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
     input_mode: crate::InputMode,
+    expected_generation: Option<auth::session::SessionGeneration>,
 ) -> anyhow::Result<auth::AuthResult> {
     auth::authenticate_with_modes(
         &config.auth.cookie_directory,
@@ -1805,6 +1862,7 @@ async fn authenticate_sync_session(
         None,
         config.ui.personality_mode,
         input_mode,
+        expected_generation,
     )
     .await
 }
@@ -1813,19 +1871,23 @@ async fn retry_persisted_session_after_two_factor(
     config: &config::Config,
     password_provider: &crate::password::PasswordProvider,
     input_mode: crate::InputMode,
-) -> Option<auth::AuthResult> {
+    expected_generation: Option<auth::session::SessionGeneration>,
+) -> anyhow::Result<Option<auth::AuthResult>> {
     tracing::debug!(
         "2FA-required auth wrote session state; retrying persisted-session auth once before waiting"
     );
     clear_validation_cache_for_reauth(&config.auth.cookie_directory, &config.auth.username).await;
-    match authenticate_sync_session(config, password_provider, input_mode).await {
-        Ok(result) => Some(result),
+    match authenticate_sync_session(config, password_provider, input_mode, expected_generation)
+        .await
+    {
+        Ok(result) => Ok(Some(result)),
+        Err(e) if classify_sync_auth_error(&e) == SyncAuthErrorClass::SessionReset => Err(e),
         Err(e) => {
             tracing::debug!(
                 error = %e,
                 "Persisted-session retry after 2FA-required auth did not recover"
             );
-            None
+            Ok(None)
         }
     }
 }
@@ -1835,6 +1897,7 @@ async fn notify_and_wait_for_2fa(
     password_provider: &crate::password::PasswordProvider,
     notifier: &Notifier,
     input_mode: crate::InputMode,
+    expected_generation: Option<auth::session::SessionGeneration>,
 ) -> anyhow::Result<auth::AuthResult> {
     let msg = two_factor_recovery_message(&config.auth.username);
     tracing::warn!(message = %msg, "2FA required");
@@ -1846,7 +1909,7 @@ async fn notify_and_wait_for_2fa(
         None,
     );
     wait_and_retry_2fa(&config.auth.cookie_directory, &config.auth.username, || {
-        authenticate_sync_session(config, password_provider, input_mode)
+        authenticate_sync_session(config, password_provider, input_mode, expected_generation)
     })
     .await
 }
@@ -3247,6 +3310,14 @@ mod tests {
                 "session.lock".into()
             )),
             SyncAuthErrorClass::LockContention
+        );
+    }
+
+    #[test]
+    fn classify_sync_auth_error_detects_session_reset() {
+        assert_eq!(
+            classify_sync_auth_error_for(auth::error::AuthError::SessionReset),
+            SyncAuthErrorClass::SessionReset
         );
     }
 
@@ -4888,7 +4959,7 @@ mod tests {
             .find("clear_validation_cache_for_reauth")
             .expect("session-error reauth must clear cache before retrying auth");
         let lenient_auth = body
-            .find("authenticate_sync_session(config, password_provider, input_mode)")
+            .find("match authenticate_sync_session(")
             .expect("session-error reauth must try persisted-session auth");
         let strip = body
             .find("auth::strip_session_routing_state")

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2427,6 +2427,105 @@ fn reset_sync_token_with_yes_clears_under_non_tty() {
     );
 }
 
+#[test]
+fn reset_session_no_session() {
+    // With no session files at all, `reset session` reports and exits 0
+    // before the confirmation/`--yes` guard fires, mirroring the no-DB
+    // early return of `reset state` / `reset sync-token`.
+    let dir = tempfile::tempdir().unwrap();
+    clean_cmd()
+        .env("ICLOUD_USERNAME", "test@example.com")
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No local session found"));
+}
+
+#[test]
+fn reset_session_removes_session_files_and_keeps_bystanders() {
+    // assert_cmd pipes stdin, so this also covers `--yes` under non-TTY:
+    // the guard only fires on the missing-flag path, not in scripted use.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let slug = sanitize_username(username);
+
+    let jar = dir.path().join(&slug);
+    let session = dir.path().join(format!("{slug}.session"));
+    let cache = dir.path().join(format!("{slug}.cache"));
+    let credential = dir.path().join(format!("{slug}.credential"));
+    let db = dir.path().join(format!("{slug}.db"));
+    for (path, contents) in [
+        (&jar, "jar"),
+        (&session, "session"),
+        (&cache, "cache"),
+        (&credential, "cred"),
+        (&db, "db"),
+    ] {
+        std::fs::write(path, contents).unwrap();
+    }
+
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session", "--yes"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Removed"),
+        "stdout should report removed files: {stdout}"
+    );
+    assert!(
+        stdout.contains("kei login"),
+        "stdout should point at `kei login`: {stdout}"
+    );
+
+    assert!(!jar.exists(), "cookie jar must be removed");
+    assert!(!session.exists(), "persisted session must be removed");
+    assert!(!cache.exists(), "response cache must be removed");
+    assert!(credential.exists(), "password store must survive the reset");
+    assert!(db.exists(), "state database must survive the reset");
+}
+
+#[test]
+fn reset_session_without_yes_on_non_tty_errors() {
+    // `kei reset session` ships the same non-interactive guard as
+    // `reset sync-token`. Under non-TTY use (CI, scripts, docker exec
+    // without -t), running without `--yes` errors out instead of silently
+    // doing nothing — or worse, discarding trust tokens by accident.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let slug = sanitize_username(username);
+
+    let jar = dir.path().join(&slug);
+    let session = dir.path().join(format!("{slug}.session"));
+    std::fs::write(&jar, "jar").unwrap();
+    std::fs::write(&session, "session").unwrap();
+
+    let out = clean_cmd()
+        .env("ICLOUD_USERNAME", username)
+        .env("KEI_DATA_DIR", dir.path())
+        .args(["reset", "session"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--yes"),
+        "non-tty error must mention --yes; stderr: {stderr}"
+    );
+
+    assert!(jar.exists(), "cookie jar must not be removed without --yes");
+    assert!(
+        session.exists(),
+        "persisted session must not be removed without --yes"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Password source behavior
 // ═══════════════════════════════════════════════════════════════════════

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -524,6 +524,34 @@ fn reset_sync_token_short_y_flag_parses() {
         .success();
 }
 
+#[test]
+fn reset_session_help_advertises_yes_flag() {
+    // `kei reset session` ships with `--yes` to skip the confirmation
+    // prompt, matching the other reset subcommands. Help text must surface
+    // it so users discover the safe non-interactive form.
+    common::cmd()
+        .args(["reset", "session", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--yes"));
+}
+
+#[test]
+fn reset_session_yes_flag_parses() {
+    common::cmd()
+        .args(["reset", "session", "--yes", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn reset_session_short_y_flag_parses() {
+    common::cmd()
+        .args(["reset", "session", "-y", "--help"])
+        .assert()
+        .success();
+}
+
 // ── Enum validation (rejection only — acceptance covered by unit tests) ─
 
 #[test]
@@ -1276,7 +1304,8 @@ fn reset_help_succeeds() {
         .assert()
         .success()
         .stdout(predicate::str::contains("state"))
-        .stdout(predicate::str::contains("sync-token"));
+        .stdout(predicate::str::contains("sync-token"))
+        .stdout(predicate::str::contains("session"));
 }
 
 #[test]
@@ -1292,6 +1321,14 @@ fn reset_state_new_help_succeeds() {
 fn reset_sync_token_help_succeeds() {
     common::cmd()
         .args(["reset", "sync-token", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn reset_session_help_succeeds() {
+    common::cmd()
+        .args(["reset", "session", "--help"])
         .assert()
         .success();
 }


### PR DESCRIPTION
## Summary

- preserve Ilya Barbashov's `kei reset session` implementation from #717;
- automatically retry verification-code delivery once from clean local state
  when Apple rejects replayed cookie/session state with HTTP 403;
- fence reset, idle watch, and reauthentication handoffs with a generation in
  the existing per-account lock file.

Fixes #716. Supersedes #717 while retaining and crediting its original authored
commit.

## Behaviour

`kei reset session` removes only the configured account's cookie jar,
`.session`, and `.cache`. It preserves password material, the state database,
media, metadata, and unrelated files.

Interactive `kei login` and `kei login get-code` keep the existing
persisted-session path first. If code delivery returns HTTP 403 after that
attempt loaded a cookie jar or session, kei invalidates old sessions, performs
the exact cleanup under the account lock, and retries once from clean state.
Clean-start failures, non-403 failures, and the second attempt are never
retried.

The lock file now stores a generation. A sleeping watch process or a
replacement-session handoff rejects a changed generation, so `reset session`
cannot be undone by stale in-memory credentials or an in-flight reauthentication
path.

## Proof

A controlled live comparison used the same `kei 0.23.2-dev` binary, account,
host, password source, network path, and Apple endpoint:

- stale persisted auth: HTTP 403 and no code;
- clean auth: successful request and immediate code delivery.

The candidate then recovered from the stale state automatically, delivered and
accepted a code, and reused the resulting cache for a read-only
`kei list libraries` request.

## Tests

- `cargo test 'auth::'`
- `cargo test reset`
- `cargo test classify_sync_auth_error`
- `cargo test --no-default-features 'auth::'`
- `cargo test --no-default-features reset`
- `just test scenario auth-session`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::unnecessary-sort-by`
- `cargo clippy --all-targets --no-default-features -- -D warnings -A clippy::unnecessary-sort-by`

The targeted suites and both clippy feature matrices pass. `just gate` reaches
the unchanged `clippy::unnecessary-sort-by` warning at
`src/icloud/photos/queries.rs:242` on current `main`; the commands above suppress
only that existing lint to validate this branch.

## Risk

- Local auth cleanup is restricted to three exact account-scoped paths.
- The account lock is held while cleanup runs.
- The generation is persisted before deletion, so interruption and partial
  failure still invalidate released sessions.
- No dependency, configuration key, database schema, media path, Apple route,
  SMS flow, or bridge protocol was added.
