### PR TITLE
Preserve XMP altitude precision

### DIFF
--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -2372,16 +2372,10 @@ fn encode_gps(decimal: f64, pos: char, neg: char) -> String {
     format!("{deg_u32},{min:.4}{hemisphere}")
 }
 
-/// XMP `exif:GPSAltitude` is a rational; we use `meters/1` (scale of 1).
+/// Preserve the provider's altitude precision using Rust's shortest round-trip decimal.
 #[cfg(feature = "xmp")]
 fn encode_altitude(meters: f64) -> String {
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        reason = "abs() is non-negative; altitudes in millimeters never approach u64::MAX"
-    )]
-    let scaled = (meters.abs() * 1000.0).round() as u64;
-    format!("{scaled}/1000")
+    meters.abs().to_string()
 }
 
 #[cfg(all(test, feature = "xmp"))]

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -21,7 +21,6 @@ use little_exif::filetype::FileExtension;
 #[cfg(not(feature = "xmp"))]
 use little_exif::ifd::ExifTagGroup;
 use little_exif::metadata::Metadata;
-#[cfg(any(not(feature = "xmp"), test))]
 use little_exif::rational::uR64;
 #[cfg(feature = "xmp")]
 use xmp_toolkit::{
@@ -2372,10 +2371,11 @@ fn encode_gps(decimal: f64, pos: char, neg: char) -> String {
     format!("{deg_u32},{min:.4}{hemisphere}")
 }
 
-/// Preserve the provider's altitude precision using Rust's shortest round-trip decimal.
+/// Preserve provider altitude precision in the rational form required by EXIF reconciliation.
 #[cfg(feature = "xmp")]
 fn encode_altitude(meters: f64) -> String {
-    meters.abs().to_string()
+    let rational = uR64::from(meters.abs());
+    format!("{}/{}", rational.nominator, rational.denominator)
 }
 
 #[cfg(all(test, feature = "xmp"))]
@@ -3144,6 +3144,9 @@ mod tests {
 
     #[test]
     fn apply_metadata_gps_roundtrips() {
+        const ALTITUDE: f64 = 9.250_123_456_789;
+        const ALTITUDE_RATIONAL: &str = "2032686204/219746927";
+
         let dir = test_tmp_dir("meta_tests");
         let path = fresh_jpeg(&dir, "gps.jpg");
         apply_metadata_with_default_suffix(
@@ -3152,7 +3155,7 @@ mod tests {
                 gps: Some(GpsCoords {
                     latitude: 37.7749,
                     longitude: -122.4194,
-                    altitude: Some(17.0),
+                    altitude: Some(ALTITUDE),
                 }),
                 ..MetadataWrite::default()
             },
@@ -3165,6 +3168,20 @@ mod tests {
         assert!(lat.contains('N'), "lat should end with N: {lat}");
         let lng = meta.property(xmp_ns::EXIF, "GPSLongitude").unwrap().value;
         assert!(lng.contains('W'), "lng should end with W: {lng}");
+        assert_eq!(
+            meta.property(xmp_ns::EXIF, "GPSAltitude").unwrap().value,
+            ALTITUDE_RATIONAL
+        );
+
+        let native = Metadata::new_from_path(&path).unwrap();
+        let native_altitude = native
+            .get_tag(&ExifTag::GPSAltitude(Vec::new()))
+            .next()
+            .and_then(|tag| match tag {
+                ExifTag::GPSAltitude(values) => values.first(),
+                _ => None,
+            });
+        assert_eq!(native_altitude, Some(&ur64(2_032_686_204, 219_746_927)));
         fs::remove_file(&path).ok();
     }
 

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -1257,6 +1257,8 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     const CLOUDKIT_ALTITUDE: f64 = 9.250_123_456_789;
+    #[cfg(feature = "xmp")]
+    const CLOUDKIT_ALTITUDE_XMP: &str = "2032686204/219746927";
 
     #[cfg(feature = "xmp")]
     fn assert_cloudkit_authority_with_source_gps(meta: &XmpMeta) {
@@ -1275,7 +1277,7 @@ mod tests {
         let coordinate = |name: &str| meta.property(xmp_ns::EXIF, name).expect(name).value;
         assert_eq!(coordinate("GPSLatitude"), "12,20.7360N");
         assert_eq!(coordinate("GPSLongitude"), "78,54.0720W");
-        assert_eq!(coordinate("GPSAltitude"), CLOUDKIT_ALTITUDE.to_string());
+        assert_eq!(coordinate("GPSAltitude"), CLOUDKIT_ALTITUDE_XMP);
         crate::test_helpers::assert_source_gps_in_xmp(meta);
         assert_ne!(
             meta.property(xmp_ns::EXIF, "GPSTimeStamp")
@@ -2948,7 +2950,7 @@ mod tests {
         assert_eq!(value(xmp_ns::XMP, "Rating"), "4");
         assert_eq!(value(xmp_ns::EXIF, "GPSLatitude"), "12,20.7360N");
         assert_eq!(value(xmp_ns::EXIF, "GPSLongitude"), "78,54.0720W");
-        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "9.25");
+        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "37/4");
         assert_eq!(
             std::fs::read(&media_path).expect("read source DNG after sidecar"),
             source_bytes,

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -1256,6 +1256,9 @@ mod tests {
     }
 
     #[cfg(feature = "xmp")]
+    const CLOUDKIT_ALTITUDE: f64 = 9.250_123_456_789;
+
+    #[cfg(feature = "xmp")]
     fn assert_cloudkit_authority_with_source_gps(meta: &XmpMeta) {
         const CAPTURE: &str = "2019-03-04T05:06:07+11:00";
         for (namespace, property) in [
@@ -1272,7 +1275,7 @@ mod tests {
         let coordinate = |name: &str| meta.property(xmp_ns::EXIF, name).expect(name).value;
         assert_eq!(coordinate("GPSLatitude"), "12,20.7360N");
         assert_eq!(coordinate("GPSLongitude"), "78,54.0720W");
-        assert_eq!(coordinate("GPSAltitude"), "9250/1000");
+        assert_eq!(coordinate("GPSAltitude"), CLOUDKIT_ALTITUDE.to_string());
         crate::test_helpers::assert_source_gps_in_xmp(meta);
         assert_ne!(
             meta.property(xmp_ns::EXIF, "GPSTimeStamp")
@@ -2825,7 +2828,7 @@ mod tests {
             timezone_offset: Some(39_600),
             latitude: Some(12.3456),
             longitude: Some(-78.9012),
-            altitude: Some(9.25),
+            altitude: Some(CLOUDKIT_ALTITUDE),
             ..MetadataPayload::default()
         };
         let cloudkit_created = authority_cloudkit_time();
@@ -2878,7 +2881,7 @@ mod tests {
                 timezone_offset: Some(39_600),
                 latitude: Some(12.3456),
                 longitude: Some(-78.9012),
-                altitude: Some(9.25),
+                altitude: Some(CLOUDKIT_ALTITUDE),
                 metadata_hash: Some("gps-retry-hash".into()),
                 ..AssetMetadata::default()
             },
@@ -2945,7 +2948,7 @@ mod tests {
         assert_eq!(value(xmp_ns::XMP, "Rating"), "4");
         assert_eq!(value(xmp_ns::EXIF, "GPSLatitude"), "12,20.7360N");
         assert_eq!(value(xmp_ns::EXIF, "GPSLongitude"), "78,54.0720W");
-        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "9250/1000");
+        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "9.25");
         assert_eq!(
             std::fs::read(&media_path).expect("read source DNG after sidecar"),
             source_bytes,


### PR DESCRIPTION
## Summary

- preserve provider altitude precision in XMP instead of rounding to integer millimetres
- exercise high-precision altitude through initial and retry sidecar writes

## Safety

The change only alters the lexical encoding of opt-in XMP altitude metadata.  It does not change media transfer, publication, state, checkpoints, or overwrite policy.

## Evidence

- `cargo test --all-features sidecar_write_ --quiet`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::unnecessary-sort-by` (`queries.rs` is handled separately)
- installed the exact release binary in LXC 108 and ran a fresh one-day sync
- 63/63 parsed XMP altitude values matched the icloudpd reference, with 0 mismatches
