### PR TITLE
Preserve provider checkpoints when album grouping writes fail

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,9 @@ different gates:
 
 - A zone checkpoint may advance after a transfer failure when the exact retry
   work is durable and enumeration/token proof is complete.
+- An exhausted album grouping write preserves the zone checkpoint. Replay
+  retries the relationship before it skips media that is already downloaded,
+  and the relationship insert is idempotent.
 - The broader database pre-check token advances only after a clean aggregate
   cycle for the exact account, selection, filter, config, and selected-zone
   scope.

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -8380,6 +8380,7 @@ async fn download_photos_incremental_collecting_inner(
                     .await
                 && let Some(album_name) = effective_config.album_name.as_deref()
             {
+                planning_state_write_failures = planning_state_write_failures.saturating_add(1);
                 tracing::warn!(
                     asset_id = %asset.id(),
                     album = %album_name,
@@ -15981,6 +15982,102 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "changes/zone is zone-scoped; querying once per pass repeats the same delta"
+        );
+    }
+
+    #[tokio::test]
+    async fn collecting_album_membership_failure_replays_without_redownloading() {
+        let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
+        let dir = TempDir::new().expect("temp dir");
+        let records = incremental_photo_records("COLLECTED_GROUPING");
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        seed_complete_album_snapshot(
+            db.as_ref(),
+            "container-vacation",
+            "Vacation",
+            &[("asset-COLLECTED_GROUPING", "COLLECTED_GROUPING")],
+        )
+        .await;
+        let change_calls = Arc::new(AtomicUsize::new(0));
+        let pass = AlbumPass {
+            kind: PassKind::Album,
+            album: changes_album_with_container(
+                "Vacation",
+                Some("container-vacation"),
+                changes_zone_session(Arc::clone(&change_calls), records),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.recent = Some(10);
+        config.state_db = Some(Arc::clone(&db) as Arc<dyn DownloadStore>);
+        let media_path = seed_downloaded_metadata_asset(db.as_ref(), &config, &pass, &asset).await;
+        let config = Arc::new(config);
+        let media_before = tokio::fs::read(&media_path)
+            .await
+            .expect("read seeded media");
+
+        db.fail_asset_album_writes_for_test();
+        let failed = download_photos_incremental(
+            &Client::new(),
+            std::slice::from_ref(&pass),
+            &config,
+            "zone-token-prev",
+            DownloadControls::download_hidden(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("membership failure should return a partial result");
+
+        assert!(matches!(
+            failed.outcome,
+            DownloadOutcome::PartialFailure { failed_count: 1 }
+        ));
+        assert_eq!(failed.stats.state_write_failures, 1);
+        assert_eq!(failed.stats.downloaded, 0);
+        assert!(
+            db.get_all_asset_albums("PrimarySync")
+                .await
+                .expect("read missing album membership")
+                .is_empty(),
+            "the injected failure must leave the compatibility relationship absent"
+        );
+
+        db.allow_asset_album_writes_for_test();
+        for cycle in 2..=3 {
+            let recovered = download_photos_incremental(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                &config,
+                "zone-token-prev",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("grouping replay cycle {cycle} failed: {error}"));
+
+            assert!(matches!(recovered.outcome, DownloadOutcome::Success));
+            assert_eq!(recovered.stats.state_write_failures, 0);
+            assert_eq!(
+                recovered.stats.downloaded, 0,
+                "cycle {cycle} must not redownload landed media"
+            );
+            assert_eq!(
+                db.get_all_asset_albums("PrimarySync")
+                    .await
+                    .expect("read recovered album membership"),
+                vec![("COLLECTED_GROUPING".to_string(), "Vacation".to_string())],
+                "cycle {cycle} must leave one idempotent relationship"
+            );
+        }
+        assert_eq!(change_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            tokio::fs::read(&media_path)
+                .await
+                .expect("read stable media"),
+            media_before,
+            "grouping replay must not change landed media"
         );
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1869,6 +1869,8 @@ where
                                 .await
                                     && let Some(album) = config.album_name.as_deref()
                                 {
+                                    state_write_failures_producer
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                     tracing::warn!(
                                         asset_id = %asset.id(),
                                         album = %album,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -5931,6 +5931,22 @@ impl MetadataRewriteStore for SqliteStateDb {
 
 #[cfg(test)]
 impl SqliteStateDb {
+    pub(crate) fn fail_asset_album_writes_for_test(&self) {
+        let conn = self.acquire_lock("test_fail_asset_album_writes").unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TRIGGER fail_asset_album_writes \
+             BEFORE INSERT ON asset_albums \
+             BEGIN SELECT RAISE(FAIL, 'simulated asset album write failure'); END;",
+        )
+        .unwrap();
+    }
+
+    pub(crate) fn allow_asset_album_writes_for_test(&self) {
+        let conn = self.acquire_lock("test_allow_asset_album_writes").unwrap();
+        conn.execute_batch("DROP TRIGGER fail_asset_album_writes")
+            .unwrap();
+    }
+
     pub(crate) fn fail_provider_metadata_refresh_for_test(&self) {
         let conn = self
             .acquire_lock("test_fail_provider_metadata_refresh")

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -7973,6 +7973,167 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_cycle_album_membership_failure_preserves_and_replays_checkpoint() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = crate::start_wiremock_or_skip!();
+        let body = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(body));
+        Mock::given(method("GET"))
+            .and(path("/photo.jpg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body)
+                    .insert_header("content-type", "image/jpeg"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = make_run_cycle_config();
+        let inner = Arc::new(state::SqliteStateDb::open_in_memory().expect("state db"));
+        inner
+            .set_metadata("sync_token:PrimarySync", "zone-tok-prev")
+            .await
+            .expect("seed zone token");
+        let db: Arc<dyn download::DownloadStore> = inner.clone();
+        let download_dir = tempfile::tempdir().expect("download tempdir");
+        let media_path = download_dir.path().join("TestAlbum/cGhvdG8uanBn.JPG");
+        let page = full_album_page_with_download(
+            "PrimarySync",
+            "master-PrimarySync",
+            "zone-tok-new",
+            &format!("{}/photo.jpg", server.uri()),
+            body.len() as u64,
+            &checksum,
+        );
+        let album = make_full_album_with_session(
+            "PrimarySync",
+            crate::test_helpers::MockPhotosSession::new()
+                .ok(album_count_response(1))
+                .ok(page.clone())
+                .ok(album_count_response(1))
+                .ok(page.clone())
+                .ok(album_count_response(1))
+                .ok(page),
+        );
+        let lib_state = make_run_cycle_library_state_with_passes(
+            "PrimarySync",
+            "sync_token:PrimarySync",
+            vec![crate::commands::AlbumPass {
+                kind: crate::commands::PassKind::Album,
+                album,
+                exclude_ids: Arc::new(rustc_hash::FxHashSet::default()),
+            }],
+        );
+        let states = vec![&lib_state];
+        let build_download_config = make_run_cycle_download_config_builder_with_options(
+            download_dir.path(),
+            Arc::clone(&db),
+            RunCycleDownloadConfigOptions {
+                per_pass_paths: true,
+                ..RunCycleDownloadConfigOptions::default()
+            },
+        );
+        let (_session_dir, shared_session) = make_shared_session_for_run_cycle().await;
+
+        inner.fail_asset_album_writes_for_test();
+        let failed = run_cycle(
+            &states,
+            &config,
+            Some(db.as_ref()),
+            false,
+            &build_download_config,
+            download::DownloadControls::download_hidden(),
+            &shared_session,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("run failed grouping cycle");
+
+        assert_eq!(failed.failed_count, 1, "cycle stats: {:?}", failed.stats);
+        assert_eq!(
+            failed.stats.state_write_failures, 1,
+            "cycle stats: {:?}",
+            failed.stats
+        );
+        assert_eq!(failed.stats.downloaded, 1);
+        assert_eq!(
+            std::fs::read(&media_path).expect("read landed media"),
+            body,
+            "the media must land even though grouping state is not durable"
+        );
+        assert!(!failed.db_sync_token_advance_safe);
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read preserved zone token")
+                .as_deref(),
+            Some("zone-tok-prev"),
+            "a missing grouping relationship must preserve the replay checkpoint"
+        );
+        assert!(
+            inner
+                .get_all_asset_albums("PrimarySync")
+                .await
+                .expect("read missing grouping relationship")
+                .is_empty()
+        );
+
+        inner.allow_asset_album_writes_for_test();
+        for cycle in 2..=3 {
+            let recovered = run_cycle(
+                &states,
+                &config,
+                Some(db.as_ref()),
+                false,
+                &build_download_config,
+                download::DownloadControls::download_hidden(),
+                &shared_session,
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("grouping replay cycle {cycle} failed: {error}"));
+
+            assert_eq!(recovered.failed_count, 0);
+            assert_eq!(recovered.stats.state_write_failures, 0);
+            assert_eq!(
+                recovered.stats.downloaded, 0,
+                "cycle {cycle} must not redownload landed media"
+            );
+            assert_eq!(
+                inner
+                    .get_all_asset_albums("PrimarySync")
+                    .await
+                    .expect("read recovered grouping relationship"),
+                vec![(
+                    "asset-master-PrimarySync".to_string(),
+                    "TestAlbum".to_string()
+                )],
+                "cycle {cycle} must leave one idempotent relationship"
+            );
+        }
+        assert_eq!(
+            inner
+                .get_metadata("sync_token:PrimarySync")
+                .await
+                .expect("read recovered zone token")
+                .as_deref(),
+            Some("zone-tok-new"),
+            "the checkpoint may advance after the grouping relationship is durable"
+        );
+        assert_eq!(
+            std::fs::read(&media_path).expect("read stable media"),
+            body,
+            "grouping replay must not change landed media"
+        );
+    }
+
+    #[tokio::test]
     async fn run_cycle_durable_expired_url_failure_advances_zone_checkpoint() {
         use base64::Engine as _;
         use sha2::{Digest, Sha256};


### PR DESCRIPTION
## Summary
- Report exhausted album grouping writes as state-write failures in streaming and collected incremental routes.
- Preserve the previous provider checkpoint until replay stores the missing relationship.
- Add SQLite fault-injection coverage for media publication, replay without re-download, and idempotent recovery.

Fixes #759

Safety contract: `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY`

## Tests
- `cargo test --all-features album_membership_failure_ -- --nocapture`
- `cargo test --no-default-features album_membership_failure_ -- --nocapture`
- `just test scenario identity-deltas`
- `just gate`

## Risk
Low. The change makes checkpoint advancement more conservative after a failed grouping write. It does not change the schema or media publication path.
