### PR TITLE
Avoid false reconciliation failures for new renditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Path reconciliation no longer reports newly selected adjusted renditions as failed moves before the download pass creates them. Expanding media or rendition
+  settings now exits successfully when the new files download and state writes complete. ([#795])
 - Changing only `skip_created_before` or `skip_created_after` no longer copies
   every existing selected file to an ID-suffixed path. Date bounds now change
   inventory eligibility without inventing local path drift, and upgraded
@@ -50,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#716]: https://github.com/rhoopr/kei/issues/716
 [#717]: https://github.com/rhoopr/kei/pull/717
 [#726]: https://github.com/rhoopr/kei/issues/726
+[#795]: https://github.com/rhoopr/kei/issues/795
 
 ## [0.23.1] - 2026-08-16
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -3612,8 +3612,10 @@ pub(crate) async fn reconcile_catalog_paths(
     for task in tasks {
         let target = PendingRetryTarget::from_task(&task);
         let Some(record) = records_by_target.get(&target) else {
-            stats.failed += 1;
-            tracing::warn!(asset_id = %task.asset_id, "Path reconciliation task had no catalog row");
+            tracing::debug!(
+                version_size = task.version_size.as_str(),
+                "Path reconciliation left newly selected version to normal download"
+            );
             continue;
         };
         let Some(source_path) = record.local_path.as_deref() else {
@@ -14149,8 +14151,14 @@ mod tests {
             .await
             .unwrap();
 
-        let records =
+        let mut records =
             mock_photo_records_for_zone_with_filename("RECONCILE", "PrimarySync", "reconcile.jpg");
+        records[1]["fields"]["resJPEGFullRes"] = json!({"value": {
+            "downloadURL": "https://p01.icloud-content.com/reconcile-adjusted.jpg",
+            "size": 512,
+            "fileChecksum": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
+        }});
+        records[1]["fields"]["resJPEGFullFileType"] = json!({"value": "public.jpeg"});
         let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
         let passes = vec![AlbumPass {
             kind: PassKind::Unfiled,
@@ -14166,9 +14174,16 @@ mod tests {
         let mut config = test_config();
         config.directory = Arc::from(new_dir.path());
         config.state_db = Some(db.clone());
-        let expected_path = filter::expected_paths_for(&asset, &config)
+        config.edited = true;
+        let expected_paths = filter::expected_paths_for(&asset, &config);
+        let expected_path = expected_paths
             .into_iter()
-            .next()
+            .find(|path| path.version_size == VersionSizeKey::Original)
+            .unwrap()
+            .path;
+        let adjusted_path = filter::expected_paths_for(&asset, &config)
+            .into_iter()
+            .find(|path| path.version_size == VersionSizeKey::Adjusted)
             .unwrap()
             .path;
 
@@ -14178,12 +14193,15 @@ mod tests {
 
         assert!(result.complete);
         assert_eq!(result.stats.downloaded, 1);
+        assert_eq!(result.stats.failed, 0);
         assert_eq!(tokio::fs::read(&old_path).await.unwrap(), b"catalog bytes");
         assert_eq!(
             tokio::fs::read(&expected_path).await.unwrap(),
             b"catalog bytes"
         );
+        assert!(!adjusted_path.exists());
         let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(downloaded.len(), 1);
         assert_eq!(
             downloaded[0].local_path.as_deref(),
             Some(expected_path.as_path())
@@ -14196,6 +14214,7 @@ mod tests {
                 let mut config = test_config();
                 config.directory = Arc::from(new_dir.path());
                 config.state_db = Some(db.clone());
+                config.edited = true;
                 config
             }),
             CancellationToken::new(),


### PR DESCRIPTION
## Summary

- leave newly selected versions to the normal download pass when path
  reconciliation has no existing catalogue row for them
- preserve the existing failures and durable deferrals for media that does have
  a downloaded catalogue row
- extend the existing path-reconciliation regression with an adjusted rendition

## Problem

Enabling adjusted renditions on an existing library made path reconciliation
treat each new rendition as a failed move because it had no previous catalogue
row.  The normal download pass then saved those files successfully, but the
command still exited non-zero with a contradictory summary showing zero failed
downloads.

## Safety

- the skipped reconciliation branch performs no file or state mutation
- normal download still owns pending state, transfer, verification, metadata,
  and downloaded finalisation for the new rendition
- existing-row reconciliation retains missing-file deferral, no-overwrite copy,
  conflicting-byte failure, state-write failure, interruption, and provider
  evidence gates
- no schema, CLI, configuration, serialisation, or dependency change

## Validation

- `cargo test --lib path_reconciliation_copies_catalog_file_without_provider_inventory`
- `just test scenario config-reconciliation`
- `just gate`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

An isolated one-day validation of the #794 and #795 merge result started with
113 original media files, enabled only `edited = true`, and downloaded one
adjusted rendition with zero failures.  Every baseline hash remained unchanged,
the new config hash was promoted, pending reconciliation cleared, and the
unchanged third cycle finished with 114 state rows matching 114 media files,
with no missing files, untracked files, or missing sidecars.

## Relationship

Follow-up to #794.  #794 prevents date-bound changes from inventing local path
drift; this pull request prevents newly selected renditions from being counted
as failed path moves during that reconciliation flow.

Fixes #795
