### PR TITLE
Add debug-only Photos request and response dumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ download pipeline does not parse CloudKit records.
 - Keep trust-boundary validation and data-loss guards intact.
 - Never log passwords, cookies, bearer tokens, Apple IDs, or unredacted
   provider identifiers. Preserve secret wrappers and redaction.
+- Exception: with debug assertions and `KEI_REQUEST_DUMP_DIR` explicitly enabled, unredacted Photos request/response bodies may be dumped to that private local directory; headers, URLs, normal logs, and builds without debug assertions are excluded.
 - Keep `unsafe` local. Document each block with a concrete `SAFETY` invariant
   and update `UNSAFE.md` when unsafe code changes.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,15 @@ provider checkpoints while local catalog paths are reconciled.
 
 ### Full and incremental enumeration
 
+Debug builds can set `KEI_REQUEST_DUMP_DIR` to capture Photos session
+bodies as `000001.req.<epoch-ms>.json` and `000001.res.<epoch-ms>.json`.
+The counter pairs requests and responses; timestamps are captured separately.
+Bodies are unredacted and private; request URLs and headers are not captured.
+HTTP error bodies retain the existing size bound and may contain non-JSON text.
+Successful responses are serialized from parsed JSON without pretty-printing.
+Writes are best-effort, with no run subfolder or cleanup.
+Release builds without debug assertions do not include this diagnostic code.
+
 Full enumeration streams records/query results and gathers a provider token
 from every active pass. Natural stream completion and usable, unanimous pass
 tokens are the authoritative proof. Count probes and pagination differences

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -9,6 +9,23 @@ use crate::retry::{self, RetryAction, RetryConfig, parse_retry_after_header};
 /// pathological server value can't stall the retry loop.
 const RETRY_AFTER_MAX: Duration = Duration::from_secs(120);
 
+#[cfg(debug_assertions)]
+async fn dump_body(dir: &std::path::Path, id: usize, kind: &str, body: &str) {
+    let timestamp = chrono::Utc::now().timestamp_millis();
+    let result: std::io::Result<()> = async {
+        let mut directory = tokio::fs::DirBuilder::new();
+        directory.recursive(true);
+        #[cfg(unix)]
+        directory.mode(0o700);
+        directory.create(dir).await?;
+        tokio::fs::write(dir.join(format!("{id:06}.{kind}.{timestamp}.json")), body).await
+    }
+    .await;
+    if result.is_err() {
+        tracing::warn!(id, kind, "Could not dump Photos body");
+    }
+}
+
 /// Async HTTP session trait for the photos service.
 ///
 /// Abstracted as a trait so album/library code can be tested with stubs
@@ -36,6 +53,20 @@ impl PhotosSession for reqwest::Client {
         body: String,
         headers: &[(&str, &str)],
     ) -> anyhow::Result<Value> {
+        #[cfg(debug_assertions)]
+        let dump = std::env::var_os("KEI_REQUEST_DUMP_DIR")
+            .filter(|dir| !dir.is_empty())
+            .map(|dir| {
+                static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+                (
+                    std::path::PathBuf::from(dir),
+                    NEXT_ID.fetch_add(1, Ordering::Relaxed),
+                )
+            });
+        #[cfg(debug_assertions)]
+        if let Some((dir, id)) = &dump {
+            dump_body(dir, *id, "req", &body).await;
+        }
         let mut builder = self.post(url).body(body);
         for &(k, v) in headers {
             builder = builder.header(k, v);
@@ -47,6 +78,10 @@ impl PhotosSession for reqwest::Client {
             let url = resp.url().to_string();
             let retry_after = parse_retry_after_header(resp.headers(), RETRY_AFTER_MAX);
             let resp_body = read_bounded_error_body(resp, &url).await;
+            #[cfg(debug_assertions)]
+            if let Some((dir, id)) = &dump {
+                dump_body(dir, *id, "res", &resp_body).await;
+            }
             if !resp_body.is_empty() {
                 // 421 bodies are the most diagnostic signal for distinguishing
                 // ADP-class from session-class misdirected requests (e.g. the
@@ -83,6 +118,10 @@ impl PhotosSession for reqwest::Client {
         }
 
         let json: Value = resp.json().await?;
+        #[cfg(debug_assertions)]
+        if let Some((dir, id)) = &dump {
+            dump_body(dir, *id, "res", &json.to_string()).await;
+        }
         Ok(json)
     }
 

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -11,6 +11,8 @@ const RETRY_AFTER_MAX: Duration = Duration::from_secs(120);
 
 #[cfg(debug_assertions)]
 async fn dump_body(dir: &std::path::Path, id: usize, kind: &str, body: &str) {
+    use tokio::io::AsyncWriteExt;
+
     let timestamp = chrono::Utc::now().timestamp_millis();
     let result: std::io::Result<()> = async {
         let mut directory = tokio::fs::DirBuilder::new();
@@ -18,7 +20,15 @@ async fn dump_body(dir: &std::path::Path, id: usize, kind: &str, body: &str) {
         #[cfg(unix)]
         directory.mode(0o700);
         directory.create(dir).await?;
-        tokio::fs::write(dir.join(format!("{id:06}.{kind}.{timestamp}.json")), body).await
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options
+            .open(dir.join(format!("{id:06}.{kind}.{timestamp}.json")))
+            .await?;
+        file.write_all(body.as_bytes()).await?;
+        file.flush().await
     }
     .await;
     if result.is_err() {
@@ -1166,6 +1176,62 @@ mod tests {
 
     use wiremock::matchers::method as wm_method;
     use wiremock::{Mock, ResponseTemplate};
+
+    #[cfg(all(unix, debug_assertions))]
+    #[test]
+    fn dump_files_are_private_in_existing_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if std::env::var_os("KEI_DUMP_PERMISSION_CHILD").is_some() {
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let server = wiremock::MockServer::start().await;
+                Mock::given(wm_method("POST"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_json(serde_json::json!({"records": []})),
+                    )
+                    .mount(&server)
+                    .await;
+                let response =
+                    PhotosSession::post(&reqwest::Client::new(), &server.uri(), "{}".into(), &[])
+                        .await
+                        .unwrap();
+                assert_eq!(response, serde_json::json!({"records": []}));
+            });
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Isolate process-wide umask and environment changes from parallel tests.
+        let output = std::process::Command::new("sh")
+            .args(["-c", "umask 022; exec \"$@\"", "sh"])
+            .arg(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "icloud::photos::session::tests::dump_files_are_private_in_existing_directory",
+                "--nocapture",
+            ])
+            .env("KEI_DUMP_PERMISSION_CHILD", "1")
+            .env("KEI_REQUEST_DUMP_DIR", dir.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(files.len(), 2);
+        for file in files {
+            assert_eq!(file.metadata().unwrap().permissions().mode() & 0o777, 0o600);
+            let expected = if file.file_name().to_str().unwrap().contains(".req.") {
+                "{}"
+            } else {
+                "{\"records\":[]}"
+            };
+            assert_eq!(std::fs::read_to_string(file.path()).unwrap(), expected);
+        }
+    }
 
     /// The FIDO failure mode from issue #221: CloudKit returns 401 with
     /// `"no auth method found"` in the JSON body. A real reqwest client


### PR DESCRIPTION
## Summary
Supersedes #798 with a smaller, debug-only implementation: 39 Rust lines plus 10 documentation/instruction lines.

Set `KEI_REQUEST_DUMP_DIR` to capture Photos API bodies as `000001.req.<epoch-ms>.json` and `000001.res.<epoch-ms>.json`. A process-local counter pairs requests and responses; each file has its own timestamp. Writes are asynchronous and best-effort. No new dependency, CLI flag, run subfolder, or cleanup.

Bodies are private and unredacted. Request URLs, headers, authentication traffic, and media downloads are excluded. Normal release builds compile out the dump code. Successful responses are serialized parsed JSON; HTTP errors retain the existing bounded body. Transport failures or malformed successful JSON can leave an unmatched request. Existing directories retain their permissions, and timestamped files generally accumulate across runs.

## Validation
- `just static-checks` passed on commit `08e5b5d` using CI-pinned Rust 1.94.1 and explicitly selected installed lint tools: formatting, clippy with all/no-default features, rustdoc, locked fetch, cargo audit, workflow/script lint, contracts, typos, and round-trip guard.
- Offline behavior tests and `just gate` deliberately not run at the author request; no new tests added.
- Live smoke passed on Hippoxmox photos CT108 after completing authentication: one bounded `list --library primary albums` command exited 0 and produced 2 requests, 2 responses, and 2 complete pairs. All four files parsed as JSON objects; counters and epoch-millisecond filenames paired correctly, with no duplicates or unmatched files. Total captured size: 19,371 bytes.
- The smoke used a side-by-side Rust 1.98.0 debug binary built from the same source tree subsequently committed as `08e5b5d`; its transferred SHA-256 matched the local binary. Installed binary and services were untouched, with no media downloads. Fresh scratch/dump directories were 0700 and files were 0600 under the smoke process umask. Raw bodies remained private on the guest.
- Newer Rust 1.98.0 all-target clippy reports a pre-existing `chunks_exact_to_as_chunks` warning in `src/sync_loop.rs:8955`; no unrelated lint cleanup included.

## Review Scope
Reviewed all three changed files: the session transport hook, architecture behavior notes, and narrowly scoped AGENTS exception. No CLI, schema, catalog, media publication, or provider checkpoint changes. Live smoke covers successful metadata request/response capture, not every error path or release exclusion.

No separate matching issue was found; #798 is the existing matching request-capture PR.