### PR TITLE
Preserve capture timestamp milliseconds without a migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ sweep, cannot use album, smart-folder, media, or date/recent filters, and does
 not run under `kei service run`. It is a manual recovery step; the permanent
 automatic fix is tracked in [#687](https://github.com/rhoopr/kei/issues/687).
 
+Capture and addition dates now retain Apple's milliseconds in the catalogue.
+Run this refresh to recover fractions lost by older versions; enable
+`metadata.xmp_sidecar` to correct sidecar capture dates too. Disable embedded
+metadata outputs if media bytes must remain untouched. This requires no schema
+migration or automatic precision-backfill sweep. Older kei binaries cannot read
+catalogue rows containing the new fractional timestamps; do not downgrade after
+they have been written. Native embedded subsecond writing is unchanged.
+
 Use this command after upgrading from a version that rendered capture times in
 the backup host's timezone. It rewrites XMP sidecars in full. For a timestamp
 already present in a file, it adds the capture offset only where the timestamp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -432,6 +432,13 @@ Provider metadata updates that would invalidate a prepared receipt remain
 retryable until the published bytes are finalised in state. Source-deletion
 transitions follow the same rule so a tombstone cannot hide the only proof of
 published repair bytes.
+Capture-instant changes are guarded across every version of the asset, even
+when the metadata hash is unchanged. Addition-date-only updates preserve the
+prepared receipt. An upsert replacing the receipt's own rendition with a new
+provider checksum may invalidate that receipt; a sibling replacement may not.
+Tasks rejected by the state upsert are not dispatched or marked failed, so the
+existing receipt and catalogue evidence remain intact and the state-write
+failure keeps the checkpoint ineligible.
 Provider-version or non-metadata file replacement invalidates the repair state;
 byte-identical re-adoption preserves it. When replacement or adoption occurs
 during the explicit repair run, downloaded-state finalization creates fresh
@@ -446,6 +453,13 @@ short of its provider size. Capture timestamp repair instead leaves that row
 pending because it cannot prove file provenance.
 
 ### State and serialization
+
+Asset capture and addition dates use fractional Unix seconds in the existing
+non-STRICT SQLite INTEGER columns. Readers accept legacy whole seconds and
+round fractional seconds to milliseconds without scaling the whole timestamp.
+Invalid stored dates fail decoding. Metadata refresh commits these dates with
+the metadata and rewrite markers; operational timestamps remain whole seconds.
+This representation requires no schema migration or historical backfill.
 
 Schema, primary-key, sentinel, durable-key, and serialization changes are
 cross-cutting. Search every reader and writer, migrations, fixtures, reports,

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Once;
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, FixedOffset, NaiveDateTime};
+use chrono::{DateTime, FixedOffset, NaiveDateTime, Timelike};
 use little_exif::exif_tag::ExifTag;
 use little_exif::filetype::FileExtension;
 #[cfg(not(feature = "xmp"))]
@@ -258,11 +258,7 @@ impl ExifProbe {
         let Some(existing) = self.datetime_original.as_deref() else {
             return false;
         };
-        let Some((wall_clock, zone)) = parse_capture_timestamp(existing) else {
-            return false;
-        };
-        wall_clock == created_local.naive_local()
-            && zone.is_none_or(|zone| zone == *created_local.offset())
+        capture_timestamp_matches(existing, created_local)
     }
 
     pub(crate) fn native_heif_capture_time_repair_required(
@@ -293,15 +289,20 @@ impl ExifProbe {
                 datetime_original: Some(datetime),
                 offset_time_original: Some(offset),
             } => {
-                let denotes_capture_time =
-                    parse_capture_timestamp(datetime).is_some_and(|(wall_clock, zone)| {
-                        wall_clock == created_local.naive_local()
-                            && zone.is_none_or(|zone| zone == *created_local.offset())
-                    });
+                let denotes_capture_time = capture_timestamp_matches(datetime, created_local);
                 Ok(Some(!denotes_capture_time || offset != expected_offset))
             }
         }
     }
+}
+
+fn capture_timestamp_matches(value: &str, expected: &DateTime<FixedOffset>) -> bool {
+    parse_capture_timestamp(value).is_some_and(|(wall_clock, zone)| {
+        // Native writers may omit subseconds. Never forgive an incorrect nonzero fraction.
+        (wall_clock == expected.naive_local()
+            || Some(wall_clock) == expected.naive_local().with_nanosecond(0))
+            && zone.is_none_or(|zone| zone == *expected.offset())
+    })
 }
 
 /// Split a capture timestamp into its wall clock and the zone it names, if
@@ -314,9 +315,9 @@ fn parse_capture_timestamp(value: &str) -> Option<(NaiveDateTime, Option<FixedOf
         return Some((zoned.naive_local(), Some(*zoned.offset())));
     }
     [
-        "%Y:%m:%d %H:%M:%S",
-        "%Y-%m-%dT%H:%M:%S",
-        "%Y-%m-%d %H:%M:%S",
+        "%Y:%m:%d %H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S%.f",
     ]
     .into_iter()
     .find_map(|format| NaiveDateTime::parse_from_str(value, format).ok())
@@ -1064,7 +1065,9 @@ pub(crate) struct SourceGpsMetadata {
 /// fields are skipped.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct MetadataWrite {
-    /// `"YYYY:MM:DD HH:MM:SS"` EXIF-style datetime string.
+    /// Unzoned datetime: `YYYY:MM:DD HH:MM:SS` for embedded writes, or
+    /// `YYYY-MM-DDTHH:MM:SS` with optional fractional seconds for sidecars.
+    /// `offset_time_original` supplies the XMP zone separately.
     pub(crate) datetime: Option<String>,
     /// EXIF `OffsetTimeOriginal`, formatted as `+HH:MM` or `-HH:MM`.
     pub(crate) offset_time_original: Option<String>,
@@ -2151,9 +2154,7 @@ fn apply_to_xmp(meta: &mut XmpMeta, write: &MetadataWrite) -> xmp_toolkit::XmpRe
         }
     }
     if let Some(dt) = &write.datetime {
-        // XMP uses ISO 8601; our stored form is EXIF-style "YYYY:MM:DD HH:MM:SS".
-        // Convert for XMP, keep a local EXIF copy so XMP Toolkit's reconciler
-        // writes the native block too on formats that have one.
+        // Embedded plans use EXIF form; sidecar plans already carry unzoned ISO 8601.
         let iso = exif_datetime_to_iso(dt);
         let iso_with_offset = write
             .offset_time_original

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -1436,7 +1436,7 @@ mod tests {
             ..MetadataPayload::default()
         };
         let flags = MetadataFlags::DATETIME;
-        let created_local = now_local();
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
         let host_local = (created_local - chrono::Duration::hours(11))
             .format("%Y:%m:%d %H:%M:%S")
             .to_string();
@@ -1446,14 +1446,21 @@ mod tests {
             "not a timestamp".to_string(),
             String::new(),
             "2024-06-15".to_string(),
+            "2024-06-15T10:00:00.628+11:00".to_string(),
+            "2024-06-15T10:00:00.628".to_string(),
+            "2024-06-15T10:00:01+11:00".to_string(),
             // Capture-local wall clock, but claiming a different zone.
+            "2024-06-15T10:00:00.629+10:00".to_string(),
             created_local.format("%Y-%m-%dT%H:%M:%S+05:00").to_string(),
         ] {
             let probe = crate::download::metadata::ExifProbe {
                 datetime_original: Some(existing.clone()),
-                offset_time_original: None,
-                has_other_datetime_offset: false,
-                has_gps: false,
+                #[cfg(feature = "xmp")]
+                native_heif_capture_time:
+                    crate::download::metadata::HeifNativeCaptureTime::Present {
+                        datetime_original: Some(existing.clone()),
+                        offset_time_original: Some("+11:00".into()),
+                    },
                 ..crate::download::metadata::ExifProbe::default()
             };
             let write = plan_metadata_write(flags, &payload, &created_local, &probe);
@@ -1462,61 +1469,18 @@ mod tests {
                 write.offset_time_original.is_none(),
                 "offset must not join the unverified timestamp {existing:?}"
             );
-        }
-    }
-
-    #[test]
-    fn capture_timestamp_comparison_preserves_fractional_precision() {
-        let created_local = now_local() + chrono::Duration::milliseconds(629);
-        for (existing, matches) in [
-            ("2024-06-15T10:00:00.629+11:00", true),
-            ("2024-06-15T10:00:00.628+11:00", false),
-            ("2024-06-15T10:00:00+11:00", true),
-            ("2024-06-15T10:00:00.000+11:00", true),
-            ("2024-06-15T10:00:00.629", true),
-            ("2024-06-15T10:00:00.628", false),
-            ("2024-06-15T10:00:00.000", true),
-            ("2024:06:15 10:00:00", true),
-            ("2024-06-15T10:00:00", true),
-            ("2024-06-15T10:00:01+11:00", false),
-            ("2024-06-15T10:00:00.629+10:00", false),
-            ("2024-06-15T10:00:00+10:00", false),
-        ] {
-            let probe = crate::download::metadata::ExifProbe {
-                datetime_original: Some(existing.into()),
-                offset_time_original: Some("+11:00".into()),
-                #[cfg(feature = "xmp")]
-                native_heif_capture_time:
-                    crate::download::metadata::HeifNativeCaptureTime::Present {
-                        datetime_original: Some(existing.into()),
-                        offset_time_original: Some("+11:00".into()),
-                    },
-                ..crate::download::metadata::ExifProbe::default()
-            };
+            #[cfg(feature = "xmp")]
             assert_eq!(
-                probe.denotes_capture_time(&created_local),
-                matches,
+                probe.native_heif_capture_time_repair_required(&created_local, "+11:00"),
+                Ok(Some(true)),
                 "{existing}"
             );
-            #[cfg(feature = "xmp")]
-            {
-                assert_eq!(
-                    probe.native_heif_capture_time_repair_required(&created_local, "+11:00"),
-                    Ok(Some(!matches)),
-                    "{existing}"
-                );
-                assert_eq!(
-                    probe.native_heif_capture_time_repair_required(&created_local, "+10:00"),
-                    Ok(Some(true)),
-                    "the native offset must still match"
-                );
-            }
         }
     }
 
     #[test]
     fn capture_timestamp_repair_requires_an_offset_and_replaces_the_pair() {
-        let created_local = now_local();
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
         let probe = crate::download::metadata::ExifProbe {
             datetime_original: Some("2024:06:14 23:00:00".into()),
             offset_time_original: Some("+05:00".into()),
@@ -1578,27 +1542,49 @@ mod tests {
             timezone_offset: Some(39_600),
             ..MetadataPayload::default()
         };
-        let created_local = now_local();
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
 
         for existing in [
             created_local.format("%Y-%m-%dT%H:%M:%S").to_string(),
             created_local.format("%Y-%m-%dT%H:%M:%S+11:00").to_string(),
+            "2024-06-15T10:00:00.629+11:00".to_string(),
+            "2024-06-15T10:00:00.000+11:00".to_string(),
+            "2024-06-15T10:00:00.629".to_string(),
+            "2024-06-15T10:00:00.000".to_string(),
             format!("  {}\0", created_local.format("%Y:%m:%d %H:%M:%S")),
         ] {
             let probe = crate::download::metadata::ExifProbe {
                 datetime_original: Some(existing.clone()),
-                offset_time_original: None,
-                has_other_datetime_offset: false,
-                has_gps: false,
+                #[cfg(feature = "xmp")]
+                native_heif_capture_time:
+                    crate::download::metadata::HeifNativeCaptureTime::Present {
+                        datetime_original: Some(existing.clone()),
+                        offset_time_original: Some("+11:00".into()),
+                    },
                 ..crate::download::metadata::ExifProbe::default()
             };
             let write =
                 plan_metadata_write(MetadataFlags::DATETIME, &payload, &created_local, &probe);
+            assert!(write.datetime.is_none());
             assert_eq!(
                 write.offset_time_original.as_deref(),
                 Some("+11:00"),
                 "capture-local timestamp {existing:?} must accept its offset"
             );
+            #[cfg(feature = "xmp")]
+            assert_eq!(
+                probe.native_heif_capture_time_repair_required(&created_local, "+11:00"),
+                Ok(Some(false)),
+                "{existing}"
+            );
+            #[cfg(feature = "xmp")]
+            if existing == "2024-06-15T10:00:00.629+11:00" {
+                assert_eq!(
+                    probe.native_heif_capture_time_repair_required(&created_local, "+10:00"),
+                    Ok(Some(true)),
+                    "the native offset must still match"
+                );
+            }
         }
     }
 
@@ -1627,10 +1613,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("photo.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
-        let (w, source_error) = plan_sidecar_write(&path, &payload, &now_local());
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
+        let (w, source_error) = plan_sidecar_write(&path, &payload, &created_local);
         assert!(source_error.is_none());
         // Every payload field should land in the sidecar write, no flag gating.
-        assert!(w.datetime.is_some());
+        assert_eq!(w.datetime.as_deref(), Some("2024-06-15T10:00:00.629"));
         assert_eq!(w.offset_time_original.as_deref(), Some("+11:00"));
         assert_eq!(w.rating, Some(4));
         assert!(w.gps.is_some());
@@ -2894,74 +2881,6 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     #[tokio::test]
-    async fn fresh_sidecar_write_preserves_capture_precision() {
-        use crate::state::AssetMetadata;
-
-        for (millis, timezone_offset) in [
-            (629, Some(39_600)),
-            (0, Some(39_600)),
-            (629, None),
-            (0, None),
-        ] {
-            let dir = tempfile::tempdir().unwrap();
-            let media_path = dir.path().join("capture.jpg");
-            let media = minimal_jpeg_bytes();
-            std::fs::write(&media_path, &media).unwrap();
-            let metadata = AssetMetadata {
-                timezone_offset,
-                ..AssetMetadata::default()
-            };
-            let created_at =
-                (now_local() + chrono::Duration::milliseconds(millis)).with_timezone(&chrono::Utc);
-            let created_local = metadata.capture_local(created_at);
-            let expected = format!(
-                "{}{}{}",
-                created_local.format("%Y-%m-%dT%H:%M:%S"),
-                if millis == 0 { "" } else { ".629" },
-                if timezone_offset.is_some() {
-                    "+11:00"
-                } else {
-                    ""
-                }
-            );
-            let outcome = write_download_metadata(MetadataWriteRequest {
-                final_path: &media_path,
-                embed_path: None,
-                expected_embed_fingerprint: None,
-                sidecar_path: Some(&media_path),
-                payload: Arc::new(MetadataPayload::from_metadata(&metadata)),
-                created_local,
-                flags: MetadataFlags::XMP_SIDECAR,
-                capture_timestamp_repair: CaptureTimestampRepair::Preserve,
-                temp_suffix: ".precision-test",
-            })
-            .await;
-            assert!(!outcome.any_failed());
-            let sidecar_path = media_path.with_file_name("capture.jpg.xmp");
-            let xmp = std::fs::read_to_string(&sidecar_path)
-                .unwrap()
-                .parse::<XmpMeta>()
-                .unwrap();
-            for (namespace, property) in [
-                (xmp_ns::XMP, "CreateDate"),
-                (xmp_ns::XMP, "ModifyDate"),
-                (xmp_ns::EXIF, "DateTimeOriginal"),
-                (xmp_ns::PHOTOSHOP, "DateCreated"),
-            ] {
-                assert_eq!(xmp.property(namespace, property).unwrap().value, expected);
-            }
-            assert_eq!(
-                xmp.property("http://cipa.jp/exif/1.0/", "OffsetTimeOriginal")
-                    .map(|value| value.value),
-                timezone_offset.map(|_| "+11:00".to_string())
-            );
-            assert_eq!(std::fs::read(&media_path).unwrap(), media);
-            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
-        }
-    }
-
-    #[cfg(feature = "xmp")]
-    #[tokio::test]
     async fn sidecar_write_carries_source_gps_and_corrected_coordinates() {
         let dir = tempfile::tempdir().expect("metadata temp dir");
         let media_path = dir.path().join("source.jpg");
@@ -3055,54 +2974,69 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn sidecar_write_reads_source_gps_from_dng_content() {
-        let dir = tempfile::tempdir().expect("metadata temp dir");
-        let media_path = dir.path().join("source.DNG");
-        let source_bytes = crate::test_helpers::minimal_tiff_with_source_gps();
-        std::fs::write(&media_path, &source_bytes).expect("write source DNG");
-        let payload = MetadataPayload {
-            rating: Some(4),
-            latitude: Some(12.3456),
-            longitude: Some(-78.9012),
-            altitude: Some(9.25),
-            ..MetadataPayload::default()
-        };
+        for (millis, expected) in [(0, "2024-06-15T10:00:00"), (629, "2024-06-15T10:00:00.629")] {
+            let dir = tempfile::tempdir().expect("metadata temp dir");
+            let media_path = dir.path().join("source.DNG");
+            let source_bytes = crate::test_helpers::minimal_tiff_with_source_gps();
+            std::fs::write(&media_path, &source_bytes).expect("write source DNG");
+            let payload = MetadataPayload {
+                rating: Some(4),
+                latitude: Some(12.3456),
+                longitude: Some(-78.9012),
+                altitude: Some(9.25),
+                ..MetadataPayload::default()
+            };
 
-        let outcome = write_download_metadata(MetadataWriteRequest {
-            final_path: &media_path,
-            embed_path: None,
-            expected_embed_fingerprint: None,
-            sidecar_path: Some(&media_path),
-            payload: Arc::new(payload),
-            created_local: now_local(),
-            flags: MetadataFlags::XMP_SIDECAR,
-            capture_timestamp_repair: CaptureTimestampRepair::Preserve,
-            temp_suffix: ".gps-dng-test",
-        })
-        .await;
+            let outcome = write_download_metadata(MetadataWriteRequest {
+                final_path: &media_path,
+                embed_path: None,
+                expected_embed_fingerprint: None,
+                sidecar_path: Some(&media_path),
+                payload: Arc::new(payload),
+                created_local: now_local() + chrono::Duration::milliseconds(millis),
+                flags: MetadataFlags::XMP_SIDECAR,
+                capture_timestamp_repair: CaptureTimestampRepair::Preserve,
+                temp_suffix: ".gps-dng-test",
+            })
+            .await;
 
-        assert!(!outcome.any_failed());
-        let sidecar_path = media_path.with_file_name("source.DNG.xmp");
-        let xmp = std::fs::read_to_string(&sidecar_path)
-            .expect("read DNG sidecar")
-            .parse::<XmpMeta>()
-            .expect("parse DNG sidecar");
-        crate::test_helpers::assert_source_gps_in_xmp(&xmp);
-        let value = |namespace, name| xmp.property(namespace, name).expect(name).value;
-        assert_eq!(value(xmp_ns::XMP, "Rating"), "4");
-        assert_eq!(value(xmp_ns::EXIF, "GPSLatitude"), "12,20.7360N");
-        assert_eq!(value(xmp_ns::EXIF, "GPSLongitude"), "78,54.0720W");
-        assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "37/4");
-        assert_eq!(
-            std::fs::read(&media_path).expect("read source DNG after sidecar"),
-            source_bytes,
-            "sidecar-only metadata must not alter DNG bytes"
-        );
-        assert!(
-            !media_path
-                .with_file_name("source.DNG.xmp.gps-dng-test")
-                .exists(),
-            "successful sidecar publication must remove its temporary file"
-        );
+            assert!(!outcome.any_failed());
+            let sidecar_path = media_path.with_file_name("source.DNG.xmp");
+            let xmp = std::fs::read_to_string(&sidecar_path)
+                .expect("read DNG sidecar")
+                .parse::<XmpMeta>()
+                .expect("parse DNG sidecar");
+            crate::test_helpers::assert_source_gps_in_xmp(&xmp);
+            let value = |namespace, name| xmp.property(namespace, name).expect(name).value;
+            for (namespace, property) in [
+                (xmp_ns::XMP, "CreateDate"),
+                (xmp_ns::XMP, "ModifyDate"),
+                (xmp_ns::EXIF, "DateTimeOriginal"),
+                (xmp_ns::PHOTOSHOP, "DateCreated"),
+            ] {
+                assert_eq!(value(namespace, property), expected);
+            }
+            assert!(
+                xmp.property("http://cipa.jp/exif/1.0/", "OffsetTimeOriginal")
+                    .is_none()
+            );
+            assert_eq!(value(xmp_ns::XMP, "Rating"), "4");
+            assert_eq!(value(xmp_ns::EXIF, "GPSLatitude"), "12,20.7360N");
+            assert_eq!(value(xmp_ns::EXIF, "GPSLongitude"), "78,54.0720W");
+            assert_eq!(value(xmp_ns::EXIF, "GPSAltitude"), "37/4");
+            assert_eq!(
+                std::fs::read(&media_path).expect("read source DNG after sidecar"),
+                source_bytes,
+                "sidecar-only metadata must not alter DNG bytes"
+            );
+            assert!(
+                !media_path
+                    .with_file_name("source.DNG.xmp.gps-dng-test")
+                    .exists(),
+                "successful sidecar publication must remove its temporary file"
+            );
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+        }
     }
 
     #[cfg(feature = "xmp")]

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -448,7 +448,7 @@ fn plan_sidecar_write(
         Err(error) => (super::metadata::SourceGpsMetadata::default(), Some(error)),
     };
     let mut write = super::metadata::MetadataWrite {
-        datetime: Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string()),
+        datetime: Some(created_local.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
         offset_time_original: offset_time_original(payload),
         gps_datetime: source_gps.datetime,
         gps_speed: source_gps.speed,
@@ -1238,7 +1238,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             &record.library,
             &record.id,
-            &record.metadata,
+            (&record.metadata, record.created_at, record.added_at),
             true,
             true,
             crate::state::METADATA_CAPTURE_REVISION,
@@ -1462,6 +1462,82 @@ mod tests {
                 write.offset_time_original.is_none(),
                 "offset must not join the unverified timestamp {existing:?}"
             );
+        }
+    }
+
+    #[test]
+    fn capture_timestamp_comparison_preserves_fractional_precision() {
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
+        let payload = MetadataPayload {
+            timezone_offset: Some(39_600),
+            ..MetadataPayload::default()
+        };
+        for (existing, matches) in [
+            ("2024-06-15T10:00:00.629+11:00", true),
+            ("2024-06-15T10:00:00.628+11:00", false),
+            ("2024-06-15T10:00:00+11:00", true),
+            ("2024-06-15T10:00:00.000+11:00", true),
+            ("2024-06-15T10:00:00.629", true),
+            ("2024-06-15T10:00:00.628", false),
+            ("2024-06-15T10:00:00.000", true),
+            ("2024:06:15 10:00:00", true),
+            ("2024-06-15T10:00:00", true),
+            ("2024-06-15T10:00:01+11:00", false),
+            ("2024-06-15T10:00:00.629+10:00", false),
+            ("2024-06-15T10:00:00+10:00", false),
+        ] {
+            let probe = crate::download::metadata::ExifProbe {
+                datetime_original: Some(existing.into()),
+                offset_time_original: Some("+11:00".into()),
+                #[cfg(feature = "xmp")]
+                native_heif_capture_time:
+                    crate::download::metadata::HeifNativeCaptureTime::Present {
+                        datetime_original: Some(existing.into()),
+                        offset_time_original: Some("+11:00".into()),
+                    },
+                ..crate::download::metadata::ExifProbe::default()
+            };
+            assert_eq!(
+                probe.denotes_capture_time(&created_local),
+                matches,
+                "{existing}"
+            );
+            #[cfg(feature = "xmp")]
+            {
+                assert_eq!(
+                    probe.native_heif_capture_time_repair_required(&created_local, "+11:00"),
+                    Ok(Some(!matches)),
+                    "{existing}"
+                );
+                assert_eq!(
+                    probe.native_heif_capture_time_repair_required(&created_local, "+10:00"),
+                    Ok(Some(true)),
+                    "the native offset must still match"
+                );
+            }
+            let write = plan_metadata_write_with_repair(
+                MetadataFlags::DATETIME,
+                &payload,
+                &created_local,
+                CaptureTimestampRepair::ReplaceWithCaptureLocal,
+                &probe,
+            );
+            assert_eq!(write.datetime.is_none(), matches, "{existing}");
+            if !matches {
+                assert_eq!(write.datetime.as_deref(), Some("2024:06:15 10:00:00"));
+            }
+            let unzoned_probe = crate::download::metadata::ExifProbe {
+                offset_time_original: None,
+                ..probe
+            };
+            let write = plan_metadata_write(
+                MetadataFlags::DATETIME,
+                &payload,
+                &created_local,
+                &unzoned_probe,
+            );
+            assert!(write.datetime.is_none());
+            assert_eq!(write.offset_time_original.is_some(), matches, "{existing}");
         }
     }
 
@@ -2030,10 +2106,11 @@ mod tests {
             .await
             .unwrap();
 
+        let created_local = now_local() + chrono::Duration::milliseconds(629);
         let record = crate::test_helpers::TestAssetRecord::new("CAPTURE_REPAIR_RECOVERY")
             .filename("capture-repair-recovery.jpg")
             .checksum("provider-checksum")
-            .created_at(now_local().with_timezone(&chrono::Utc))
+            .created_at(created_local.with_timezone(&chrono::Utc))
             .metadata(AssetMetadata {
                 timezone_offset: Some(39_600),
                 ..AssetMetadata::default()
@@ -2082,8 +2159,22 @@ mod tests {
             pending[0].capture_repair_receipt,
             Some(CaptureRepairReceipt::Prepared { .. })
         ));
+        assert_eq!(pending[0].asset.created_at, record.created_at);
+        let published = std::fs::read(&photo_path).unwrap();
+        let fingerprint = crate::download::file::fingerprint_regular_file(&photo_path)
+            .await
+            .unwrap();
+        assert!(receipt_matches_fingerprint(
+            pending[0].capture_repair_receipt.as_ref().unwrap(),
+            fingerprint
+        ));
+        assert_eq!(stored_checksums(&db).await, (Some(checksum.clone()), None));
         let probe = crate::download::metadata::probe_exif(&photo_path).unwrap();
-        assert!(probe.denotes_capture_time(&now_local()));
+        assert!(probe.denotes_capture_time(&created_local));
+        assert_eq!(
+            probe.datetime_original.as_deref(),
+            Some("2024-06-15T10:00:00")
+        );
         assert_eq!(probe.offset_time_original.as_deref(), Some("+11:00"));
         drop(db);
 
@@ -2099,6 +2190,14 @@ mod tests {
         .await;
 
         assert_eq!(second, 0);
+        assert_eq!(std::fs::read(&photo_path).unwrap(), published);
+        assert_eq!(
+            stored_checksums(&reopened).await,
+            (
+                Some(fingerprint_checksum(fingerprint)),
+                Some(checksum.clone())
+            )
+        );
         assert!(
             reopened
                 .get_pending_metadata_rewrites_page_for_queue(
@@ -2138,6 +2237,11 @@ mod tests {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+        assert_eq!(std::fs::read(&photo_path).unwrap(), published);
+        assert_eq!(
+            stored_checksums(&reopened).await,
+            (Some(fingerprint_checksum(fingerprint)), Some(checksum))
         );
     }
 
@@ -2817,6 +2921,112 @@ mod tests {
         let after = crate::download::metadata::probe_exif(&photo_path).unwrap();
         assert!(after.denotes_capture_time(&created_local));
         assert_eq!(after.offset_time_original.as_deref(), Some("+11:00"));
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn sidecar_capture_precision_survives_fresh_write_and_catalogue_drain() {
+        use crate::state::{AssetMetadata, SqliteStateDb};
+
+        for (millis, timezone_offset) in [
+            (629, Some(39_600)),
+            (0, Some(39_600)),
+            (629, None),
+            (0, None),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let media_path = dir.path().join("capture.jpg");
+            let media = minimal_jpeg_bytes();
+            std::fs::write(&media_path, &media).unwrap();
+            let checksum = crate::download::file::compute_sha256(&media_path)
+                .await
+                .unwrap();
+            let metadata = AssetMetadata {
+                timezone_offset,
+                metadata_hash: Some("capture-precision".into()),
+                ..AssetMetadata::default()
+            };
+            let created_at =
+                (now_local() + chrono::Duration::milliseconds(millis)).with_timezone(&chrono::Utc);
+            let created_local = metadata.capture_local(created_at);
+            let expected = format!(
+                "{}{}{}",
+                created_local.format("%Y-%m-%dT%H:%M:%S"),
+                if millis == 0 { "" } else { ".629" },
+                if timezone_offset.is_some() {
+                    "+11:00"
+                } else {
+                    ""
+                }
+            );
+            let outcome = write_download_metadata(MetadataWriteRequest {
+                final_path: &media_path,
+                embed_path: None,
+                expected_embed_fingerprint: None,
+                sidecar_path: Some(&media_path),
+                payload: Arc::new(MetadataPayload::from_metadata(&metadata)),
+                created_local,
+                flags: MetadataFlags::XMP_SIDECAR,
+                capture_timestamp_repair: CaptureTimestampRepair::Preserve,
+                temp_suffix: ".precision-test",
+            })
+            .await;
+            assert!(!outcome.any_failed());
+            let sidecar_path = media_path.with_file_name("capture.jpg.xmp");
+            let fresh = std::fs::read_to_string(&sidecar_path).unwrap();
+            let xmp = fresh.parse::<XmpMeta>().unwrap();
+            for (namespace, property) in [
+                (xmp_ns::XMP, "CreateDate"),
+                (xmp_ns::XMP, "ModifyDate"),
+                (xmp_ns::EXIF, "DateTimeOriginal"),
+                (xmp_ns::PHOTOSHOP, "DateCreated"),
+            ] {
+                assert_eq!(xmp.property(namespace, property).unwrap().value, expected);
+            }
+            assert_eq!(
+                xmp.property("http://cipa.jp/exif/1.0/", "OffsetTimeOriginal")
+                    .map(|value| value.value),
+                timezone_offset.map(|_| "+11:00".to_string())
+            );
+            assert_eq!(std::fs::read(&media_path).unwrap(), media);
+
+            let db = SqliteStateDb::open_in_memory().unwrap();
+            seed_downloaded_marker(
+                &db,
+                "CAPTURE_PRECISION",
+                "capture.jpg",
+                &media_path,
+                &checksum,
+                metadata,
+                Some(created_at),
+            )
+            .await;
+            for expected_work in [1, 0] {
+                let pass = run_pending(
+                    &db,
+                    MetadataFlags::XMP_SIDECAR,
+                    Arc::from(".precision-test"),
+                    &CancellationToken::new(),
+                )
+                .await;
+                assert_eq!(pass.fetched, expected_work);
+                assert_eq!(pass.applied, expected_work);
+                assert_eq!(pass.failed, 0);
+                assert!(
+                    db.get_pending_metadata_rewrites(1)
+                        .await
+                        .unwrap()
+                        .is_empty()
+                );
+                assert_eq!(std::fs::read_to_string(&sidecar_path).unwrap(), fresh);
+                assert_eq!(std::fs::read(&media_path).unwrap(), media);
+                assert_eq!(stored_checksums(&db).await, (Some(checksum.clone()), None));
+                let rows = db.get_downloaded_page(0, 1).await.unwrap();
+                assert_eq!(rows[0].created_at, created_at);
+                assert_eq!(rows[0].local_path.as_deref(), Some(media_path.as_path()));
+            }
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+        }
     }
 
     #[cfg(feature = "xmp")]

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -1468,10 +1468,6 @@ mod tests {
     #[test]
     fn capture_timestamp_comparison_preserves_fractional_precision() {
         let created_local = now_local() + chrono::Duration::milliseconds(629);
-        let payload = MetadataPayload {
-            timezone_offset: Some(39_600),
-            ..MetadataPayload::default()
-        };
         for (existing, matches) in [
             ("2024-06-15T10:00:00.629+11:00", true),
             ("2024-06-15T10:00:00.628+11:00", false),
@@ -1515,29 +1511,6 @@ mod tests {
                     "the native offset must still match"
                 );
             }
-            let write = plan_metadata_write_with_repair(
-                MetadataFlags::DATETIME,
-                &payload,
-                &created_local,
-                CaptureTimestampRepair::ReplaceWithCaptureLocal,
-                &probe,
-            );
-            assert_eq!(write.datetime.is_none(), matches, "{existing}");
-            if !matches {
-                assert_eq!(write.datetime.as_deref(), Some("2024:06:15 10:00:00"));
-            }
-            let unzoned_probe = crate::download::metadata::ExifProbe {
-                offset_time_original: None,
-                ..probe
-            };
-            let write = plan_metadata_write(
-                MetadataFlags::DATETIME,
-                &payload,
-                &created_local,
-                &unzoned_probe,
-            );
-            assert!(write.datetime.is_none());
-            assert_eq!(write.offset_time_original.is_some(), matches, "{existing}");
         }
     }
 
@@ -2171,10 +2144,6 @@ mod tests {
         assert_eq!(stored_checksums(&db).await, (Some(checksum.clone()), None));
         let probe = crate::download::metadata::probe_exif(&photo_path).unwrap();
         assert!(probe.denotes_capture_time(&created_local));
-        assert_eq!(
-            probe.datetime_original.as_deref(),
-            Some("2024-06-15T10:00:00")
-        );
         assert_eq!(probe.offset_time_original.as_deref(), Some("+11:00"));
         drop(db);
 
@@ -2925,8 +2894,8 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     #[tokio::test]
-    async fn sidecar_capture_precision_survives_fresh_write_and_catalogue_drain() {
-        use crate::state::{AssetMetadata, SqliteStateDb};
+    async fn fresh_sidecar_write_preserves_capture_precision() {
+        use crate::state::AssetMetadata;
 
         for (millis, timezone_offset) in [
             (629, Some(39_600)),
@@ -2938,12 +2907,8 @@ mod tests {
             let media_path = dir.path().join("capture.jpg");
             let media = minimal_jpeg_bytes();
             std::fs::write(&media_path, &media).unwrap();
-            let checksum = crate::download::file::compute_sha256(&media_path)
-                .await
-                .unwrap();
             let metadata = AssetMetadata {
                 timezone_offset,
-                metadata_hash: Some("capture-precision".into()),
                 ..AssetMetadata::default()
             };
             let created_at =
@@ -2973,8 +2938,10 @@ mod tests {
             .await;
             assert!(!outcome.any_failed());
             let sidecar_path = media_path.with_file_name("capture.jpg.xmp");
-            let fresh = std::fs::read_to_string(&sidecar_path).unwrap();
-            let xmp = fresh.parse::<XmpMeta>().unwrap();
+            let xmp = std::fs::read_to_string(&sidecar_path)
+                .unwrap()
+                .parse::<XmpMeta>()
+                .unwrap();
             for (namespace, property) in [
                 (xmp_ns::XMP, "CreateDate"),
                 (xmp_ns::XMP, "ModifyDate"),
@@ -2989,42 +2956,6 @@ mod tests {
                 timezone_offset.map(|_| "+11:00".to_string())
             );
             assert_eq!(std::fs::read(&media_path).unwrap(), media);
-
-            let db = SqliteStateDb::open_in_memory().unwrap();
-            seed_downloaded_marker(
-                &db,
-                "CAPTURE_PRECISION",
-                "capture.jpg",
-                &media_path,
-                &checksum,
-                metadata,
-                Some(created_at),
-            )
-            .await;
-            for expected_work in [1, 0] {
-                let pass = run_pending(
-                    &db,
-                    MetadataFlags::XMP_SIDECAR,
-                    Arc::from(".precision-test"),
-                    &CancellationToken::new(),
-                )
-                .await;
-                assert_eq!(pass.fetched, expected_work);
-                assert_eq!(pass.applied, expected_work);
-                assert_eq!(pass.failed, 0);
-                assert!(
-                    db.get_pending_metadata_rewrites(1)
-                        .await
-                        .unwrap()
-                        .is_empty()
-                );
-                assert_eq!(std::fs::read_to_string(&sidecar_path).unwrap(), fresh);
-                assert_eq!(std::fs::read(&media_path).unwrap(), media);
-                assert_eq!(stored_checksums(&db).await, (Some(checksum.clone()), None));
-                let rows = db.get_downloaded_page(0, 1).await.unwrap();
-                assert_eq!(rows[0].created_at, created_at);
-                assert_eq!(rows[0].local_path.as_deref(), Some(media_path.as_path()));
-            }
             assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
         }
     }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -16729,10 +16729,6 @@ mod tests {
             assert_eq!(result.stats.failed, 0);
             assert_eq!(result.stats.state_write_failures, 2);
             assert_eq!(result.stats.skipped.on_disk, 0);
-            assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
-            // Source checkpoint policy rejects this candidate token because
-            // state_write_failures is nonzero, not because enumeration failed.
-            assert!(!result.full_enumeration_ran);
             assert!(matches!(
                 result.outcome,
                 DownloadOutcome::PartialFailure { .. }
@@ -16757,8 +16753,6 @@ mod tests {
                 recovered[0].asset.local_checksum.as_deref(),
                 Some("local-original")
             );
-            assert_eq!(recovered[0].asset.download_attempts, 0);
-            assert_eq!(recovered[0].asset.last_error, None);
             assert_eq!(
                 recovered[0].asset.local_path.as_deref(),
                 Some(path.as_path())
@@ -16858,34 +16852,9 @@ mod tests {
                 })
                 .await;
             assert!(!outcome.any_failed());
-            let sidecar = rendition.path.with_file_name(format!(
-                "{}.xmp",
-                rendition.path.file_name().unwrap().to_str().unwrap()
-            ));
-            let xmp: XmpMeta = tokio::fs::read_to_string(sidecar)
-                .await
-                .unwrap()
-                .parse()
-                .unwrap();
-            assert_eq!(
-                xmp.property(xmp_ns::EXIF, "DateTimeOriginal")
-                    .unwrap()
-                    .value,
-                "2023-11-14T22:13:20+00:00"
-            );
         }
         let before = db.get_downloaded_page(0, 10).await.unwrap();
-        let storage: (String, String) = db
-            .acquire_lock("legacy integer dates")
-            .unwrap()
-            .query_row(
-                "SELECT typeof(created_at), typeof(added_at) FROM assets LIMIT 1",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .unwrap();
-        assert_eq!(storage, ("integer".into(), "integer".into()));
-        let mut sidecars = Vec::new();
+        let mut sidecars = HashMap::new();
         let mut full_query_count = 0;
         for refresh in [true, false] {
             config.refresh_metadata = refresh;
@@ -16919,7 +16888,6 @@ mod tests {
             if refresh {
                 full_query_count = session.records_query_count();
                 assert!(full_query_count > 0);
-                assert_eq!(result.stats.sync_token_receivers_with_token, Some(1));
                 assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 2);
                 // The explicit sync owner drains only after the full producer has finished.
                 assert_eq!(
@@ -16959,30 +16927,22 @@ mod tests {
                         motion
                     }
                 );
-                assert_eq!(
-                    file::compute_sha256(path).await.unwrap(),
-                    row.local_checksum.as_ref().unwrap().as_str()
-                );
                 let sidecar = path.with_file_name(format!(
                     "{}.xmp",
                     path.file_name().unwrap().to_str().unwrap()
                 ));
                 let text = tokio::fs::read_to_string(sidecar).await.unwrap();
-                let xmp: XmpMeta = text.parse().unwrap();
-                for (namespace, property) in [
-                    (xmp_ns::EXIF, "DateTimeOriginal"),
-                    (xmp_ns::XMP, "CreateDate"),
-                    (xmp_ns::PHOTOSHOP, "DateCreated"),
-                ] {
+                if refresh {
+                    let xmp: XmpMeta = text.parse().unwrap();
                     assert_eq!(
-                        xmp.property(namespace, property).unwrap().value,
+                        xmp.property(xmp_ns::EXIF, "DateTimeOriginal")
+                            .unwrap()
+                            .value,
                         "2023-11-14T22:13:20.123+00:00"
                     );
-                }
-                if refresh {
-                    sidecars.push(text);
+                    sidecars.insert(path.clone(), text);
                 } else {
-                    assert!(sidecars.contains(&text));
+                    assert_eq!(sidecars.get(path), Some(&text));
                 }
             }
             assert!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -4303,7 +4303,7 @@ async fn refresh_metadata_capture_candidate(
         .refresh_downloaded_asset_metadata(
             &candidate.library,
             &candidate.asset_id,
-            asset.metadata(),
+            (asset.metadata(), asset.created(), Some(asset.added_date())),
             mark_for_rewrite,
             false,
             crate::state::METADATA_CAPTURE_REVISION,
@@ -7943,7 +7943,7 @@ async fn apply_changed_provider_metadata(
         .refresh_downloaded_asset_metadata(
             library,
             asset.state_id(),
-            asset.metadata(),
+            (asset.metadata(), asset.created(), Some(asset.added_date())),
             mark_for_rewrite,
             false,
             crate::state::METADATA_CAPTURE_REVISION,
@@ -8398,24 +8398,18 @@ async fn download_photos_incremental_collecting_inner(
             }
         }
         skip_breakdown.by_state = skip_breakdown.by_state.saturating_add(state_skipped);
-
-        for task in &plan.tasks {
-            retry_sources.insert(
-                RetryTaskKey::from(task),
-                UrlRetrySource {
-                    asset_record_name: asset.asset_record_name_arc(),
-                    pass_index: *pass_index,
-                },
-            );
+        if plan.tasks.is_empty() && state_skipped == 0 {
+            skip_breakdown.on_disk += 1;
         }
 
         // Upsert state records so mark_downloaded/mark_failed can find them.
         // Without this, the UPDATE in mark_downloaded matches 0 rows and the
         // file ends up on disk but untracked in the state DB.
         if let Some(db) = &config.state_db {
-            for task in &plan.tasks {
+            let planned_tasks = std::mem::take(&mut plan.tasks);
+            for task in planned_tasks {
                 if let Err(e) =
-                    planner::upsert_seen_for_task(db.as_ref(), effective_config, asset, task).await
+                    planner::upsert_seen_for_task(db.as_ref(), effective_config, asset, &task).await
                 {
                     planning_state_write_failures = planning_state_write_failures.saturating_add(1);
                     tracing::warn!(
@@ -8423,7 +8417,9 @@ async fn download_photos_incremental_collecting_inner(
                         error = %e,
                         "Failed to record asset in state DB"
                     );
+                    continue;
                 }
+                plan.tasks.push(task);
             }
             // Record this asset's membership in the current album so
             // consumers (EXIF keywords, XMP sidecars, Immich albums) can
@@ -8444,8 +8440,14 @@ async fn download_photos_incremental_collecting_inner(
             }
         }
 
-        if plan.tasks.is_empty() && state_skipped == 0 {
-            skip_breakdown.on_disk += 1;
+        for task in &plan.tasks {
+            retry_sources.insert(
+                RetryTaskKey::from(task),
+                UrlRetrySource {
+                    asset_record_name: asset.asset_record_name_arc(),
+                    pass_index: *pass_index,
+                },
+            );
         }
         tasks.extend(plan.tasks);
     }
@@ -15403,7 +15405,9 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         let stored_records = incremental_photo_records_with_favorite("CAPTURE_REVISION", false);
         let stored_asset = PhotoAsset::new(stored_records[0].clone(), stored_records[1].clone());
-        let changed_records = incremental_photo_records_with_favorite("CAPTURE_REVISION", true);
+        let mut changed_records = incremental_photo_records_with_favorite("CAPTURE_REVISION", true);
+        changed_records[1]["fields"]["assetDate"]["value"] = json!(1_700_000_000_123_i64);
+        changed_records[1]["fields"]["addedDate"]["value"] = json!(1_700_000_000_789_i64);
         let pass = AlbumPass {
             kind: PassKind::Unfiled,
             album: album_with_session(
@@ -15468,6 +15472,11 @@ mod tests {
             .expect("read refreshed row")
             .remove(0);
         assert!(refreshed.metadata.is_favorite);
+        assert_eq!(refreshed.created_at.timestamp_millis(), 1_700_000_000_123);
+        assert_eq!(
+            refreshed.added_at.unwrap().timestamp_millis(),
+            1_700_000_000_789
+        );
         assert_eq!(refreshed.local_path.as_deref(), Some(media_path.as_path()));
         assert_eq!(
             tokio::fs::read(&media_path)
@@ -16633,6 +16642,361 @@ mod tests {
                 .expect("read rewrite queue")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn rejected_capture_upserts_never_dispatch_streaming_or_collecting_tasks() {
+        let server = crate::start_wiremock_or_skip!();
+        for collecting in [false, true] {
+            let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+            let dir = TempDir::new().unwrap();
+            let mut records = incremental_photo_records_with_url(
+                "REJECTED",
+                "capture.jpg",
+                &format!("{}/capture.jpg", server.uri()),
+                1024,
+            );
+            records[0]["fields"]["resOriginalVidComplRes"] = json!({"value": {
+                "downloadURL": format!("{}/capture.mov", server.uri()),
+                "fileChecksum": "provider-motion", "size": 1024,
+            }});
+            records[0]["fields"]["resOriginalVidComplFileType"] =
+                json!({"value": "com.apple.quicktime-movie"});
+            let old = PhotoAsset::new(records[0].clone(), records[1].clone());
+            let path = dir.path().join("historical.jpg");
+            tokio::fs::write(&path, b"historical media").await.unwrap();
+            let record = TestAssetRecord::new(old.asset_record_name())
+                .created_at(old.created())
+                .added_at(old.added_date())
+                .checksum("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                .metadata(old.metadata().clone())
+                .build();
+            db.import_adopt(&record, &path, "local-original", 16, None)
+                .await
+                .unwrap();
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                &record.id,
+                (&record.metadata, record.created_at, record.added_at),
+                false,
+                true,
+                crate::state::METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .unwrap();
+            let mut pending = db
+                .get_pending_metadata_rewrites_page_for_queue(
+                    crate::state::db::MetadataRewriteQueue::CaptureRepair,
+                    None,
+                    0,
+                    10,
+                )
+                .await
+                .unwrap()
+                .remove(0);
+            pending.capture_repair_receipt = db
+                .record_capture_repair_prepared(&pending, "prepared", 2048)
+                .await
+                .unwrap();
+            records[1]["fields"]["assetDate"]["value"] = json!(1_700_086_400_123_i64);
+            let pass = AlbumPass {
+                kind: PassKind::Unfiled,
+                album: changes_album(
+                    "",
+                    changes_zone_session(Arc::new(AtomicUsize::new(0)), records),
+                ),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            };
+            let mut config = incremental_test_config(&dir);
+            config.state_db = Some(db.clone());
+            config.recent = collecting.then_some(10);
+            let result = download_photos_incremental(
+                &Client::new(),
+                &[pass],
+                &Arc::new(config),
+                "zone-token-prev",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                0,
+                "collecting={collecting}"
+            );
+            assert_eq!(result.stats.downloaded, 0);
+            assert_eq!(result.stats.failed, 0);
+            assert_eq!(result.stats.state_write_failures, 2);
+            assert_eq!(result.stats.skipped.on_disk, 0);
+            assert_eq!(result.sync_token.as_deref(), Some("zone-token-next"));
+            // Source checkpoint policy rejects this candidate token because
+            // state_write_failures is nonzero, not because enumeration failed.
+            assert!(!result.full_enumeration_ran);
+            assert!(matches!(
+                result.outcome,
+                DownloadOutcome::PartialFailure { .. }
+            ));
+            let recovered = db
+                .get_pending_metadata_rewrites_page_for_queue(
+                    crate::state::db::MetadataRewriteQueue::CaptureRepair,
+                    None,
+                    0,
+                    10,
+                )
+                .await
+                .unwrap();
+            assert_eq!(recovered.len(), 1);
+            assert_eq!(
+                recovered[0].capture_repair_receipt,
+                pending.capture_repair_receipt
+            );
+            assert_eq!(recovered[0].asset.created_at, record.created_at);
+            assert_eq!(recovered[0].asset.checksum, record.checksum);
+            assert_eq!(
+                recovered[0].asset.local_checksum.as_deref(),
+                Some("local-original")
+            );
+            assert_eq!(recovered[0].asset.download_attempts, 0);
+            assert_eq!(recovered[0].asset.last_error, None);
+            assert_eq!(
+                recovered[0].asset.local_path.as_deref(),
+                Some(path.as_path())
+            );
+            assert_eq!(tokio::fs::read(&path).await.unwrap(), b"historical media");
+            assert!(db.get_pending().await.unwrap().is_empty());
+            assert!(db.get_failed().await.unwrap().is_empty());
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn explicit_live_photo_refresh_repairs_legacy_dates_and_sidecars_then_stays_incremental()
+    {
+        use xmp_toolkit::{XmpMeta, xmp_ns};
+
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+        let dir = TempDir::new().unwrap();
+        let still = include_bytes!("../../tests/data/sample.heic").as_slice();
+        let motion = b"\0\0\0\x14ftypqt  \0\0\0\0qt  ".as_slice();
+        let mut records = incremental_photo_records_with_url(
+            "LIVE_DATES",
+            "capture.HEIC",
+            "https://p01.icloud-content.com/capture.HEIC",
+            still.len() as u64,
+        );
+        records[0]["fields"]["itemType"] = json!({"value": "public.heic"});
+        records[0]["fields"]["resOriginalFileType"] = json!({"value": "public.heic"});
+        records[0]["fields"]["resOriginalVidComplRes"] = json!({"value": {
+            "downloadURL": "https://p01.icloud-content.com/capture.MOV",
+            "fileChecksum": "provider-motion", "size": motion.len(),
+        }});
+        records[0]["fields"]["resOriginalVidComplFileType"] =
+            json!({"value": "com.apple.quicktime-movie"});
+        records[1]["fields"]["timeZoneOffset"] = json!({"value": 0});
+        let old = PhotoAsset::new(records[0].clone(), records[1].clone());
+        records[1]["fields"]["assetDate"]["value"] = json!(1_700_000_000_123_i64);
+        records[1]["fields"]["addedDate"]["value"] = json!(1_700_000_000_789_i64);
+        let current = PhotoAsset::new(records[0].clone(), records[1].clone());
+        assert_eq!(
+            old.metadata().metadata_hash,
+            current.metadata().metadata_hash
+        );
+        let session = changes_zone_session_with_query_page(
+            Arc::new(AtomicUsize::new(0)),
+            records.clone(),
+            json!({"records": records, "syncToken": "full-token"}),
+            1,
+        );
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album("", session.clone()),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path());
+        config.state_db = Some(db.clone());
+        config.sync_mode = SyncMode::Full;
+        config.refresh_metadata = true;
+        config.metadata.xmp_sidecar = true;
+        let expected = filter::expected_paths_for(&old, &config);
+        assert_eq!(expected.len(), 2);
+        for rendition in &expected {
+            let bytes = if rendition.version_size == VersionSizeKey::Original {
+                still
+            } else {
+                motion
+            };
+            tokio::fs::create_dir_all(rendition.path.parent().unwrap())
+                .await
+                .unwrap();
+            tokio::fs::write(&rendition.path, bytes).await.unwrap();
+            let checksum = file::compute_sha256(&rendition.path).await.unwrap();
+            let record = TestAssetRecord::new(old.asset_record_name())
+                .version_size(rendition.version_size)
+                .filename(rendition.path.file_name().unwrap().to_str().unwrap())
+                .created_at(old.created())
+                .added_at(old.added_date())
+                .checksum(&rendition.checksum)
+                .size(rendition.size)
+                .metadata(old.metadata().clone())
+                .build();
+            db.import_adopt(&record, &rendition.path, &checksum, rendition.size, None)
+                .await
+                .unwrap();
+            let outcome =
+                metadata_rewrite::write_download_metadata(metadata_rewrite::MetadataWriteRequest {
+                    final_path: &rendition.path,
+                    embed_path: None,
+                    expected_embed_fingerprint: None,
+                    sidecar_path: Some(&rendition.path),
+                    payload: Arc::new(filter::MetadataPayload::from_metadata(old.metadata())),
+                    created_local: old.metadata().capture_local(old.created()),
+                    flags: MetadataFlags::XMP_SIDECAR,
+                    capture_timestamp_repair: CaptureTimestampRepair::Preserve,
+                    temp_suffix: ".seed",
+                })
+                .await;
+            assert!(!outcome.any_failed());
+            let sidecar = rendition.path.with_file_name(format!(
+                "{}.xmp",
+                rendition.path.file_name().unwrap().to_str().unwrap()
+            ));
+            let xmp: XmpMeta = tokio::fs::read_to_string(sidecar)
+                .await
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                xmp.property(xmp_ns::EXIF, "DateTimeOriginal")
+                    .unwrap()
+                    .value,
+                "2023-11-14T22:13:20+00:00"
+            );
+        }
+        let before = db.get_downloaded_page(0, 10).await.unwrap();
+        let storage: (String, String) = db
+            .acquire_lock("legacy integer dates")
+            .unwrap()
+            .query_row(
+                "SELECT typeof(created_at), typeof(added_at) FROM assets LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(storage, ("integer".into(), "integer".into()));
+        let mut sidecars = Vec::new();
+        let mut full_query_count = 0;
+        for refresh in [true, false] {
+            config.refresh_metadata = refresh;
+            let result = download_photos_with_sync(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                Arc::new(config.clone()),
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(result.outcome, DownloadOutcome::Success),
+                "{:?}",
+                result.stats
+            );
+            assert_eq!(result.full_enumeration_ran, refresh);
+            assert_eq!(result.stats.downloaded, 0);
+            assert_eq!(result.stats.state_write_failures, 0);
+            assert_eq!(result.stats.exif_failures, 0);
+            assert!(!result.stats.sync_token_blocked);
+            assert_eq!(
+                result.sync_token.as_deref(),
+                Some(if refresh {
+                    "full-token"
+                } else {
+                    "zone-token-next"
+                })
+            );
+            if refresh {
+                full_query_count = session.records_query_count();
+                assert!(full_query_count > 0);
+                assert_eq!(result.stats.sync_token_receivers_with_token, Some(1));
+                assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 2);
+                // The explicit sync owner drains only after the full producer has finished.
+                assert_eq!(
+                    drain_pending_metadata_rewrites(
+                        db.as_ref(),
+                        &config.metadata,
+                        CaptureTimestampRepair::Preserve,
+                        &["PrimarySync"],
+                        config.temp_suffix.clone(),
+                        &CancellationToken::new(),
+                    )
+                    .await,
+                    0
+                );
+            }
+            let rows = db.get_downloaded_page(0, 10).await.unwrap();
+            assert_eq!(rows.len(), 2);
+            for row in &rows {
+                let prior = before
+                    .iter()
+                    .find(|prior| prior.version_size == row.version_size)
+                    .unwrap();
+                assert_eq!(row.created_at, current.created());
+                assert_eq!(row.added_at, Some(current.added_date()));
+                assert_eq!(row.metadata.metadata_hash, prior.metadata.metadata_hash);
+                assert_eq!(row.local_path, prior.local_path);
+                assert_eq!(row.local_checksum, prior.local_checksum);
+                assert_eq!(row.download_checksum, prior.download_checksum);
+                assert_eq!(row.checksum, prior.checksum);
+                assert_eq!(row.downloaded_at, prior.downloaded_at);
+                let path = row.local_path.as_ref().unwrap();
+                assert_eq!(
+                    tokio::fs::read(path).await.unwrap(),
+                    if row.version_size == VersionSizeKey::Original {
+                        still
+                    } else {
+                        motion
+                    }
+                );
+                assert_eq!(
+                    file::compute_sha256(path).await.unwrap(),
+                    row.local_checksum.as_ref().unwrap().as_str()
+                );
+                let sidecar = path.with_file_name(format!(
+                    "{}.xmp",
+                    path.file_name().unwrap().to_str().unwrap()
+                ));
+                let text = tokio::fs::read_to_string(sidecar).await.unwrap();
+                let xmp: XmpMeta = text.parse().unwrap();
+                for (namespace, property) in [
+                    (xmp_ns::EXIF, "DateTimeOriginal"),
+                    (xmp_ns::XMP, "CreateDate"),
+                    (xmp_ns::PHOTOSHOP, "DateCreated"),
+                ] {
+                    assert_eq!(
+                        xmp.property(namespace, property).unwrap().value,
+                        "2023-11-14T22:13:20.123+00:00"
+                    );
+                }
+                if refresh {
+                    sidecars.push(text);
+                } else {
+                    assert!(sidecars.contains(&text));
+                }
+            }
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            assert_eq!(session.records_query_count(), full_query_count);
+            config.sync_mode = SyncMode::Incremental {
+                zone_sync_token: result.sync_token.unwrap(),
+            };
+        }
+        assert_eq!(session.changes_zone_calls.load(Ordering::SeqCst), 1);
     }
 
     #[cfg(feature = "xmp")]

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -6648,6 +6648,7 @@ mod tests {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
         use crate::state::SqliteStateDb;
+        use crate::state::types::AssetMetadata;
         use futures_util::stream;
         use std::sync::Arc;
 
@@ -6690,7 +6691,11 @@ mod tests {
             .checksum("historical-medium")
             .filename("historical-medium.jpg")
             .size(1234)
-            .metadata(existing_asset().metadata().clone())
+            .metadata(AssetMetadata {
+                title: Some("stale".to_string()),
+                metadata_hash: Some("stale-hash".to_string()),
+                ..AssetMetadata::default()
+            })
             .build();
         db.upsert_seen(&record).await.unwrap();
         db.mark_downloaded(
@@ -6726,9 +6731,9 @@ mod tests {
             rewrites[0].version_size,
             crate::state::VersionSizeKey::Medium
         );
-        assert_eq!(
+        assert_ne!(
             rewrites[0].metadata.metadata_hash.as_deref(),
-            existing_asset().metadata().metadata_hash.as_deref()
+            Some("stale-hash")
         );
         assert_eq!(rewrites[0].created_at, existing_asset().created());
         assert_eq!(rewrites[0].added_at, Some(existing_asset().added_date()));
@@ -6747,31 +6752,6 @@ mod tests {
             capture_repairs[0].asset.version_size,
             crate::state::VersionSizeKey::Medium
         );
-        let original_bytes = fs::read(&historical_path).unwrap();
-        let mut retry_config = config.as_ref().clone();
-        retry_config.refresh_metadata = false;
-        retry_config.capture_timestamp_repair = crate::download::CaptureTimestampRepair::Preserve;
-        let retry_config = Arc::new(retry_config);
-        for _ in 0..2 {
-            let result = stream_and_download_from_stream(
-                &reqwest::Client::new(),
-                stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(existing_asset())]),
-                &retry_config,
-                DownloadControls::download_hidden(),
-                1,
-                CancellationToken::new(),
-                StreamRuntime::new(None, None),
-            )
-            .await
-            .unwrap();
-            assert_eq!(result.downloaded, 0);
-            let rows = db.get_downloaded_page(0, 10).await.unwrap();
-            assert_eq!(rows.len(), 1);
-            assert_eq!(rows[0].created_at, existing_asset().created());
-            assert_eq!(rows[0].added_at, Some(existing_asset().added_date()));
-            assert_eq!(fs::read(&historical_path).unwrap(), original_bytes);
-            assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
-        }
     }
 
     /// #707 review: the pre-plan refresh makes embedded rewrites reachable for

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1735,7 +1735,7 @@ where
                                 .refresh_downloaded_asset_metadata(
                                     &library,
                                     asset.state_id(),
-                                    asset.metadata(),
+                                    (asset.metadata(), asset.created(), Some(asset.added_date())),
                                     mark_for_rewrite,
                                     capture_repair_requested(config),
                                     crate::state::METADATA_CAPTURE_REVISION,
@@ -1948,6 +1948,7 @@ where
                                         {
                                             state_write_failures_producer
                                                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                            continue;
                                         }
                                         let size = task.size;
                                         if task_tx.send(task).await.is_err() {
@@ -2037,6 +2038,7 @@ where
                                                         1,
                                                         std::sync::atomic::Ordering::Relaxed,
                                                     );
+                                                    continue;
                                                 }
                                                 let size = task.size;
                                                 if task_tx.send(task).await.is_err() {
@@ -4824,7 +4826,11 @@ mod tests {
             &self,
             _: &str,
             _: &str,
-            _: &crate::state::AssetMetadata,
+            _: (
+                &crate::state::AssetMetadata,
+                chrono::DateTime<chrono::Utc>,
+                Option<chrono::DateTime<chrono::Utc>>,
+            ),
             _: bool,
             _: bool,
             _: i64,
@@ -6642,12 +6648,12 @@ mod tests {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
         use crate::state::SqliteStateDb;
-        use crate::state::types::AssetMetadata;
         use futures_util::stream;
         use std::sync::Arc;
 
         fn existing_asset() -> PhotoAsset {
             TestPhotoAsset::new("REFRESH_FILTERED")
+                .asset_date(1_700_000_000_123.0)
                 .filename("filtered.jpg")
                 .item_type("public.jpeg")
                 .orig_file_type("public.jpeg")
@@ -6684,11 +6690,7 @@ mod tests {
             .checksum("historical-medium")
             .filename("historical-medium.jpg")
             .size(1234)
-            .metadata(AssetMetadata {
-                title: Some("stale".to_string()),
-                metadata_hash: Some("stale-hash".to_string()),
-                ..AssetMetadata::default()
-            })
+            .metadata(existing_asset().metadata().clone())
             .build();
         db.upsert_seen(&record).await.unwrap();
         db.mark_downloaded(
@@ -6724,10 +6726,12 @@ mod tests {
             rewrites[0].version_size,
             crate::state::VersionSizeKey::Medium
         );
-        assert_ne!(
+        assert_eq!(
             rewrites[0].metadata.metadata_hash.as_deref(),
-            Some("stale-hash")
+            existing_asset().metadata().metadata_hash.as_deref()
         );
+        assert_eq!(rewrites[0].created_at, existing_asset().created());
+        assert_eq!(rewrites[0].added_at, Some(existing_asset().added_date()));
         assert_eq!(rewrites[0].metadata.title, None);
         let capture_repairs = db
             .get_pending_metadata_rewrites_page_for_queue(
@@ -6743,6 +6747,31 @@ mod tests {
             capture_repairs[0].asset.version_size,
             crate::state::VersionSizeKey::Medium
         );
+        let original_bytes = fs::read(&historical_path).unwrap();
+        let mut retry_config = config.as_ref().clone();
+        retry_config.refresh_metadata = false;
+        retry_config.capture_timestamp_repair = crate::download::CaptureTimestampRepair::Preserve;
+        let retry_config = Arc::new(retry_config);
+        for _ in 0..2 {
+            let result = stream_and_download_from_stream(
+                &reqwest::Client::new(),
+                stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(existing_asset())]),
+                &retry_config,
+                DownloadControls::download_hidden(),
+                1,
+                CancellationToken::new(),
+                StreamRuntime::new(None, None),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result.downloaded, 0);
+            let rows = db.get_downloaded_page(0, 10).await.unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].created_at, existing_asset().created());
+            assert_eq!(rows[0].added_at, Some(existing_asset().added_date()));
+            assert_eq!(fs::read(&historical_path).unwrap(), original_bytes);
+            assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+        }
     }
 
     /// #707 review: the pre-plan refresh makes embedded rewrites reachable for

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -6804,10 +6804,8 @@ mod tests {
         tempfile::tempdir().unwrap()
     }
 
-    #[tokio::test]
-    async fn asset_dates_preserve_every_millisecond_through_sqlite_and_manifest() {
-        let db = SqliteStateDb::open_in_memory().unwrap();
-        let mut record = TestAssetRecord::new("DATES").build();
+    #[test]
+    fn asset_date_codec_preserves_milliseconds_and_rejects_invalid_values() {
         for seconds in [
             DateTime::<Utc>::MIN_UTC.timestamp(),
             -1,
@@ -6816,97 +6814,24 @@ mod tests {
             DateTime::<Utc>::MAX_UTC.timestamp(),
         ] {
             for millis in 0..1000 {
-                record.created_at = DateTime::from_timestamp(seconds, millis * 1_000_000).unwrap();
-                record.added_at = Some(record.created_at);
-                let conn = db.acquire_lock("date roundtrip").unwrap();
-                upsert_asset_row(&conn, &record, 123).unwrap();
-                let stored = conn
-                    .query_row(
-                        &format!("SELECT {ASSET_COLUMNS} FROM assets"),
-                        [],
-                        row_to_asset_record,
-                    )
-                    .unwrap();
-                assert_eq!(stored.created_at, record.created_at);
-                assert_eq!(stored.added_at, record.added_at);
-                assert_eq!(stored.last_seen_at.timestamp(), 123);
+                let date = DateTime::from_timestamp(seconds, millis * 1_000_000).unwrap();
+                assert_eq!(decode_asset_date(encode_asset_date(date), 4).unwrap(), date);
             }
-            let manifest = db.get_manifest_assets().await.unwrap();
-            assert_eq!(manifest[0].created_at, record.created_at);
-            assert_eq!(manifest[0].added_at, record.added_at);
         }
-        record.added_at = None;
-        db.import_adopt(&record, Path::new("/photos/dates.jpg"), "local", 1024, None)
-            .await
-            .unwrap();
-        let manifest = db.get_manifest_assets().await.unwrap();
-        assert_eq!(manifest[0].created_at, record.created_at);
-        assert_eq!(manifest[0].added_at, None);
-    }
-
-    #[tokio::test]
-    async fn asset_dates_decode_legacy_integers_fractional_seconds_and_reject_invalid() {
-        assert!(decode_asset_date(f64::NAN, 4).is_err());
-        let db = SqliteStateDb::open_in_memory().unwrap();
-        db.upsert_seen(&TestAssetRecord::new("DATES").build())
-            .await
-            .unwrap();
-        for (literal, expected_millis) in [
-            ("1700000000", 1_700_000_000_000),
-            ("1700000000.123", 1_700_000_000_123),
-            ("-0.001", -1),
-            ("-1.999", -1999),
-            ("0.9999999", 1000),
+        for (value, expected_millis) in [(-0.001, -1), (-1.999, -1999), (0.9999999, 1000)] {
+            assert_eq!(
+                decode_asset_date(value, 4).unwrap().timestamp_millis(),
+                expected_millis
+            );
+        }
+        for invalid in [
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            9.223_372_036_854_776e18,
+            -9.223_372_036_854_776e18,
         ] {
-            {
-                let conn = db.acquire_lock("legacy dates").unwrap();
-                conn.execute_batch(&format!(
-                    "UPDATE assets SET created_at = {literal}, added_at = {literal}"
-                ))
-                .unwrap();
-                let stored = conn
-                    .query_row(
-                        &format!("SELECT {ASSET_COLUMNS} FROM assets"),
-                        [],
-                        row_to_asset_record,
-                    )
-                    .unwrap();
-                assert_eq!(stored.created_at.timestamp_millis(), expected_millis);
-                assert_eq!(stored.added_at.unwrap().timestamp_millis(), expected_millis);
-            }
-            let manifest = db.get_manifest_assets().await.unwrap();
-            assert_eq!(manifest[0].created_at.timestamp_millis(), expected_millis);
-        }
-        for column in ["created_at", "added_at"] {
-            for invalid in [
-                "1e999",
-                "-1e999",
-                "9223372036854775807",
-                "-9223372036854775808",
-                "'invalid'",
-            ] {
-                {
-                    let conn = db.acquire_lock("invalid dates").unwrap();
-                    conn.execute_batch(&format!(
-                        "UPDATE assets SET created_at = 0, added_at = NULL;
-                         UPDATE assets SET {column} = {invalid}"
-                    ))
-                    .unwrap();
-                    assert!(
-                        conn.query_row(
-                            &format!("SELECT {ASSET_COLUMNS} FROM assets"),
-                            [],
-                            row_to_asset_record
-                        )
-                        .is_err(),
-                        "{column} = {invalid}"
-                    );
-                }
-                assert!(
-                    db.get_manifest_assets().await.is_err(),
-                    "{column} = {invalid}"
-                );
-            }
+            assert!(decode_asset_date(invalid, 4).is_err(), "{invalid}");
         }
     }
 
@@ -12409,143 +12334,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn prepared_capture_receipt_guards_dates_and_provider_replacement() {
-        let db = SqliteStateDb::open_in_memory().unwrap();
-        let created = DateTime::from_timestamp_millis(1_700_000_000_123).unwrap();
-        let added = DateTime::from_timestamp_millis(1_700_000_000_789).unwrap();
-        let mut record = TestAssetRecord::new("DATE_RECEIPT")
-            .created_at(created)
-            .added_at(added)
-            .build();
-        let path = Path::new("/photos/date.jpg");
-        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
-            record.version_size = version;
-            db.import_adopt(&record, path, "local-v1", 1024, None)
-                .await
-                .unwrap();
-        }
-        db.refresh_downloaded_asset_metadata(
-            "PrimarySync",
-            "DATE_RECEIPT",
-            (&record.metadata, created, Some(added)),
-            true,
-            true,
-            METADATA_CAPTURE_REVISION,
-        )
-        .await
-        .unwrap();
-        let mut pending = db
-            .get_pending_metadata_rewrites_page_for_queue(
-                MetadataRewriteQueue::CaptureRepair,
-                None,
-                0,
-                10,
-            )
-            .await
-            .unwrap()
-            .into_iter()
-            .find(|row| row.asset.version_size == VersionSizeKey::Original)
-            .unwrap();
-        pending.capture_repair_receipt = db
-            .record_capture_repair_prepared(&pending, "prepared", 2048)
-            .await
-            .unwrap();
-
-        let changed = created + chrono::Duration::milliseconds(1);
-        record.created_at = changed;
-        for version in [
-            VersionSizeKey::Original,
-            VersionSizeKey::LiveOriginal,
-            VersionSizeKey::Thumb,
-        ] {
-            record.version_size = version;
-            assert!(
-                db.upsert_seen(&record).await.is_err(),
-                "capture change on {version:?}"
-            );
-        }
-        db.import_adopt(&record, path, "local-v1", 1024, None)
-            .await
-            .unwrap_err();
-        db.refresh_downloaded_asset_metadata(
-            "PrimarySync",
-            "DATE_RECEIPT",
-            (&record.metadata, changed, Some(added)),
-            false,
-            false,
-            METADATA_CAPTURE_REVISION,
-        )
-        .await
-        .unwrap_err();
-        let before = db.get_downloaded_page(0, 10).await.unwrap();
-        assert_eq!(before.len(), 2);
-        assert!(
-            before
-                .iter()
-                .all(|row| row.created_at == created && row.added_at == Some(added))
-        );
-
-        record.created_at = created;
-        record.added_at = Some(added + chrono::Duration::milliseconds(1));
-        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
-            record.version_size = version;
-            db.upsert_seen(&record).await.unwrap();
-        }
-        assert_eq!(
-            db.refresh_downloaded_asset_metadata(
-                "PrimarySync",
-                "DATE_RECEIPT",
-                (&record.metadata, created, None),
-                false,
-                false,
-                METADATA_CAPTURE_REVISION,
-            )
-            .await
-            .unwrap(),
-            2
-        );
-        let recovered = db
-            .get_pending_metadata_rewrites_page_for_queue(
-                MetadataRewriteQueue::CaptureRepair,
-                None,
-                0,
-                10,
-            )
-            .await
-            .unwrap();
-        let original = recovered
-            .iter()
-            .find(|row| row.asset.version_size == VersionSizeKey::Original)
-            .unwrap();
-        assert_eq!(
-            original.capture_repair_receipt,
-            pending.capture_repair_receipt
-        );
-        assert!(
-            recovered
-                .iter()
-                .all(|row| row.asset.created_at == created && row.asset.added_at.is_none())
-        );
-
-        record.created_at = changed;
-        record.checksum = "provider-v2".into();
-        db.upsert_seen(&record)
-            .await
-            .expect_err("a replacement sibling cannot invalidate the original receipt");
-        record.version_size = VersionSizeKey::Original;
-        db.upsert_seen(&record).await.unwrap();
-        let rows = db.get_pending().await.unwrap();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].created_at, record.created_at);
-        assert_eq!(rows[0].checksum, record.checksum);
-        let receipt: (Option<String>, Option<String>, Option<i64>) = db.acquire_lock("replacement receipt").unwrap().query_row(
-            "SELECT capture_repair_metadata_hash, capture_repair_output_checksum, capture_repair_output_size FROM assets WHERE version_size = 'original'",
-            [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        ).unwrap();
-        assert_eq!(receipt, (None, None, None));
-    }
-
     async fn seed_downloaded_capture_asset(
         db: &SqliteStateDb,
         id: &str,
@@ -12878,6 +12666,11 @@ mod tests {
             .await
             .unwrap();
 
+        let mut addition_only = pending.asset.clone();
+        addition_only.added_at = Some(DateTime::from_timestamp_millis(1).unwrap());
+        db.upsert_seen(&addition_only).await.unwrap();
+        let stored = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(stored[0].added_at, addition_only.added_at);
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "REFRESH",
@@ -12901,6 +12694,8 @@ mod tests {
             preserved[0].capture_repair_receipt,
             pending.capture_repair_receipt
         );
+        assert_eq!(preserved[0].asset.created_at, pending.asset.created_at);
+        assert_eq!(preserved[0].asset.added_at, None);
 
         let ordinary = db
             .get_pending_metadata_rewrites_page_for_queue(
@@ -13091,7 +12886,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let pending = db
+        let mut pending = db
             .get_pending_metadata_rewrites_page_for_queue(
                 MetadataRewriteQueue::CaptureRepair,
                 None,
@@ -13103,54 +12898,53 @@ mod tests {
             .into_iter()
             .find(|pending| pending.asset.version_size == VersionSizeKey::Original)
             .unwrap();
-        assert!(
-            db.record_capture_repair_prepared(&pending, "prepared-original", 2048)
-                .await
-                .unwrap()
-                .is_some()
-        );
+        pending.capture_repair_receipt = db
+            .record_capture_repair_prepared(&pending, "prepared-original", 2048)
+            .await
+            .unwrap();
+        assert!(pending.capture_repair_receipt.is_some());
 
         let changed = AssetMetadata {
             metadata_hash: Some("metadata-v2".into()),
             rating: Some(5),
             ..AssetMetadata::default()
         };
-        let changed_medium = TestAssetRecord::new("MULTI_REFRESH")
-            .version_size(VersionSizeKey::Medium)
-            .checksum("provider-medium")
-            .metadata(changed.clone())
-            .build();
-        assert!(matches!(
-            db.upsert_seen(&changed_medium).await,
-            Err(StateError::Invariant {
-                operation: "upsert_seen",
-                ..
-            })
-        ));
-        let new_thumb = TestAssetRecord::new("MULTI_REFRESH")
-            .version_size(VersionSizeKey::Thumb)
-            .checksum("provider-thumb")
-            .metadata(changed.clone())
-            .build();
-        assert!(matches!(
-            db.upsert_seen(&new_thumb).await,
-            Err(StateError::Invariant {
-                operation: "upsert_seen",
-                ..
-            })
-        ));
-        assert!(
-            db.refresh_downloaded_asset_metadata(
-                "PrimarySync",
-                "MULTI_REFRESH",
-                (&changed, DateTime::UNIX_EPOCH, None),
-                false,
-                false,
-                METADATA_CAPTURE_REVISION,
-            )
-            .await
-            .is_err()
-        );
+        let mut incoming = medium;
+        for (metadata, created_at) in [
+            (changed, DateTime::UNIX_EPOCH),
+            (current, DateTime::from_timestamp_millis(1).unwrap()),
+        ] {
+            incoming.metadata = Arc::new(metadata);
+            incoming.created_at = created_at;
+            for (version, checksum) in [
+                (VersionSizeKey::Original, "provider-v1"),
+                (VersionSizeKey::Medium, "provider-medium"),
+                (VersionSizeKey::Thumb, "provider-thumb"),
+                (VersionSizeKey::Medium, "provider-replacement"),
+            ] {
+                incoming.version_size = version;
+                incoming.checksum = checksum.into();
+                assert!(matches!(
+                    db.upsert_seen(&incoming).await,
+                    Err(StateError::Invariant {
+                        operation: "upsert_seen",
+                        ..
+                    })
+                ));
+            }
+            assert!(
+                db.refresh_downloaded_asset_metadata(
+                    "PrimarySync",
+                    "MULTI_REFRESH",
+                    (&incoming.metadata, created_at, None),
+                    false,
+                    false,
+                    METADATA_CAPTURE_REVISION,
+                )
+                .await
+                .is_err()
+            );
+        }
 
         let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
         let versions = downloaded
@@ -13159,10 +12953,29 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(versions.len(), 2);
         assert!(
-            versions
-                .iter()
-                .all(|record| { record.metadata.metadata_hash.as_deref() == Some("metadata-v1") }),
+            versions.iter().all(|record| {
+                record.metadata.metadata_hash.as_deref() == Some("metadata-v1")
+                    && record.created_at == DateTime::UNIX_EPOCH
+                    && record.added_at.is_none()
+            }),
             "a blocked version must prevent partial asset-level metadata refresh"
+        );
+        let preserved = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            preserved
+                .iter()
+                .find(|row| row.asset.version_size == VersionSizeKey::Original)
+                .unwrap()
+                .capture_repair_receipt,
+            pending.capture_repair_receipt
         );
     }
 
@@ -13258,7 +13071,7 @@ mod tests {
     #[tokio::test]
     async fn capture_repair_receipt_fails_closed_and_tracks_installed_bytes() {
         let db = SqliteStateDb::open_in_memory().unwrap();
-        let record = TestAssetRecord::new("ADOPT_CAPTURE")
+        let mut record = TestAssetRecord::new("ADOPT_CAPTURE")
             .checksum("provider-v1")
             .metadata(AssetMetadata {
                 metadata_hash: Some("metadata-v1".into()),
@@ -13300,6 +13113,21 @@ mod tests {
             .await
             .unwrap();
 
+        record.created_at += chrono::Duration::milliseconds(1);
+        db.import_adopt(
+            &record,
+            Path::new("/photos/adopted.jpg"),
+            "local-v1",
+            2048,
+            Some(1),
+        )
+        .await
+        .unwrap_err();
+        record.created_at = pending.asset.created_at;
+        assert_eq!(
+            db.get_downloaded_page(0, 10).await.unwrap()[0].created_at,
+            record.created_at
+        );
         db.import_adopt(
             &record,
             Path::new("/photos/readopted.jpg"),
@@ -13379,14 +13207,31 @@ mod tests {
         )
         .await
         .unwrap();
-        let republished = TestAssetRecord::new("ADOPT_CAPTURE")
-            .checksum("provider-v2")
-            .metadata(AssetMetadata {
-                metadata_hash: Some("metadata-v1".into()),
-                ..AssetMetadata::default()
-            })
-            .build();
-        db.upsert_seen(&republished).await.unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 2);
+        for row in &pending {
+            assert!(
+                db.record_capture_repair_prepared(row, "local-v3", 2048)
+                    .await
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        record.checksum = "provider-v2".into();
+        record.created_at += chrono::Duration::milliseconds(1);
+        db.upsert_seen(&record).await.unwrap();
+        let rows = db.get_pending().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].created_at, record.created_at);
+        assert_eq!(rows[0].checksum, record.checksum);
         let receipt: (Option<String>, Option<String>, Option<i64>) = {
             let conn = db.acquire_lock("read invalidated capture receipt").unwrap();
             conn.query_row(
@@ -13650,7 +13495,8 @@ mod tests {
         });
         let asset_json = json!({
             "fields": {
-                "assetDate": {"value": 1736899200000_f64},
+                "assetDate": {"value": 1736899200123_f64},
+                "addedDate": {"value": 1736985600789_f64},
                 "isFavorite": {"value": 1},
                 "orientation": {"value": 6},
                 "duration": {"value": 12.5},
@@ -13686,6 +13532,14 @@ mod tests {
         let pending = db.get_pending().await.unwrap();
         assert_eq!(pending.len(), 1);
         let got = &pending[0];
+        let created = DateTime::from_timestamp_millis(1_736_899_200_123).unwrap();
+        let added = Some(DateTime::from_timestamp_millis(1_736_985_600_789).unwrap());
+        assert_eq!((got.created_at, got.added_at), (created, added));
+        let manifest = db.get_manifest_assets().await.unwrap();
+        assert_eq!(
+            (manifest[0].created_at, manifest[0].added_at),
+            (created, added)
+        );
         let m = &got.metadata;
         assert_eq!(m.source.as_deref(), Some("icloud"));
         assert!(m.is_favorite);
@@ -13712,6 +13566,38 @@ mod tests {
             .expect("provider_data should be valid JSON");
         assert_eq!(provider["recordChangeTag"], json!("tag42"));
         assert_eq!(provider["assetSubtypeV2"], json!(16));
+
+        let legacy_created = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        for (literal, added) in [
+            ("1700000001", DateTime::from_timestamp(1_700_000_001, 0)),
+            ("NULL", None),
+        ] {
+            db.acquire_lock("legacy dates")
+                .unwrap()
+                .execute_batch(&format!(
+                    "UPDATE assets SET created_at = 1700000000, added_at = {literal}"
+                ))
+                .unwrap();
+            let row = db.get_pending().await.unwrap().pop().unwrap();
+            let manifest = db.get_manifest_assets().await.unwrap().pop().unwrap();
+            for dates in [
+                (row.created_at, row.added_at),
+                (manifest.created_at, manifest.added_at),
+            ] {
+                assert_eq!(dates, (legacy_created, added));
+            }
+        }
+        for column in ["created_at", "added_at"] {
+            db.acquire_lock("invalid dates")
+                .unwrap()
+                .execute_batch(&format!(
+                    "UPDATE assets SET created_at = 0, added_at = NULL;
+                 UPDATE assets SET {column} = 'invalid'"
+                ))
+                .unwrap();
+            assert!(db.get_pending().await.is_err(), "{column}");
+            assert!(db.get_manifest_assets().await.is_err(), "{column}");
+        }
     }
 
     // WAL mid-transaction rollback invariant: a second connection that

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -6441,10 +6441,9 @@ mod tests {
         ] {
             {
                 let conn = db.acquire_lock("legacy dates").unwrap();
-                conn.execute(
-                    &format!("UPDATE assets SET created_at = {literal}, added_at = {literal}"),
-                    [],
-                )
+                conn.execute_batch(&format!(
+                    "UPDATE assets SET created_at = {literal}, added_at = {literal}"
+                ))
                 .unwrap();
                 let stored = conn
                     .query_row(
@@ -6456,12 +6455,8 @@ mod tests {
                 assert_eq!(stored.created_at.timestamp_millis(), expected_millis);
                 assert_eq!(stored.added_at.unwrap().timestamp_millis(), expected_millis);
             }
-            assert_eq!(
-                db.get_manifest_assets().await.unwrap()[0]
-                    .created_at
-                    .timestamp_millis(),
-                expected_millis
-            );
+            let manifest = db.get_manifest_assets().await.unwrap();
+            assert_eq!(manifest[0].created_at.timestamp_millis(), expected_millis);
         }
         for column in ["created_at", "added_at"] {
             for invalid in [
@@ -6473,10 +6468,11 @@ mod tests {
             ] {
                 {
                     let conn = db.acquire_lock("invalid dates").unwrap();
-                    conn.execute("UPDATE assets SET created_at = 0, added_at = NULL", [])
-                        .unwrap();
-                    conn.execute(&format!("UPDATE assets SET {column} = {invalid}"), [])
-                        .unwrap();
+                    conn.execute_batch(&format!(
+                        "UPDATE assets SET created_at = 0, added_at = NULL;
+                         UPDATE assets SET {column} = {invalid}"
+                    ))
+                    .unwrap();
                     assert!(
                         conn.query_row(
                             &format!("SELECT {ASSET_COLUMNS} FROM assets"),
@@ -11292,11 +11288,11 @@ mod tests {
     async fn refresh_downloaded_asset_metadata_updates_every_live_downloaded_version() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
+        for version in [VersionSizeKey::Original, VersionSizeKey::Medium] {
             let record = TestAssetRecord::new("PHOTO")
                 .version_size(version)
                 .metadata(AssetMetadata {
-                    rating: Some(4),
+                    metadata_hash: Some("stale-hash".to_string()),
                     ..AssetMetadata::default()
                 })
                 .build();
@@ -11327,41 +11323,32 @@ mod tests {
                  BEGIN SELECT RAISE(FAIL, 'injected revision failure'); END;",
             ).unwrap();
         }
-        assert!(
-            db.refresh_downloaded_asset_metadata(
-                "PrimarySync",
-                "PHOTO",
-                (&metadata, created, Some(added)),
-                true,
-                true,
-                METADATA_CAPTURE_REVISION,
-            )
-            .await
-            .is_err()
-        );
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            "PHOTO",
+            (&metadata, created, Some(added)),
+            true,
+            true,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap_err();
         let unchanged = db.get_downloaded_page(0, 10).await.unwrap();
-        assert!(
-            unchanged
-                .iter()
-                .all(|row| row.created_at != created && row.added_at.is_none())
-        );
-        assert!(
-            db.get_pending_metadata_rewrites(10)
-                .await
-                .unwrap()
-                .is_empty()
-        );
-        assert!(
-            db.get_pending_metadata_rewrites_page_for_queue(
-                MetadataRewriteQueue::CaptureRepair,
-                None,
-                0,
-                10,
-            )
-            .await
-            .unwrap()
-            .is_empty()
-        );
+        assert!(unchanged.iter().all(|row| row.created_at != created
+            && row.added_at.is_none()
+            && row.metadata.rating.is_none()
+            && row.metadata.metadata_hash.as_deref() == Some("stale-hash")));
+        for queue in [
+            MetadataRewriteQueue::Ordinary,
+            MetadataRewriteQueue::CaptureRepair,
+        ] {
+            assert!(
+                db.get_pending_metadata_rewrites_page_for_queue(queue, None, 0, 10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+        }
         db.acquire_lock("remove refresh failure")
             .unwrap()
             .execute_batch("DROP TRIGGER fail_capture_revision")
@@ -11386,7 +11373,7 @@ mod tests {
             assert_eq!(record.id.as_ref(), "PHOTO");
             assert!(matches!(
                 record.version_size,
-                VersionSizeKey::Original | VersionSizeKey::LiveOriginal
+                VersionSizeKey::Original | VersionSizeKey::Medium
             ));
             assert_eq!(record.created_at, created);
             assert_eq!(record.added_at, Some(added));
@@ -11408,48 +11395,28 @@ mod tests {
             assert_eq!(record.checksum.as_ref(), "checksum123");
             assert_eq!(record.metadata.rating, Some(4));
         }
-        let capture = db
-            .get_pending_metadata_rewrites_page_for_queue(
-                MetadataRewriteQueue::CaptureRepair,
-                None,
-                0,
-                10,
-            )
-            .await
-            .unwrap();
-        assert_eq!(capture.len(), 2);
-        assert!(capture.iter().all(|row| matches!(
-            row.capture_repair_receipt,
-            Some(CaptureRepairReceipt::Pending { .. })
-        )));
     }
 
     #[tokio::test]
-    async fn prepared_capture_receipt_blocks_date_changes_but_allows_addition_and_recovery() {
+    async fn prepared_capture_receipt_guards_dates_and_provider_replacement() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let created = DateTime::from_timestamp_millis(1_700_000_000_123).unwrap();
         let added = DateTime::from_timestamp_millis(1_700_000_000_789).unwrap();
-        let metadata = AssetMetadata::default();
+        let mut record = TestAssetRecord::new("DATE_RECEIPT")
+            .created_at(created)
+            .added_at(added)
+            .build();
+        let path = Path::new("/photos/date.jpg");
         for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
-            let record = TestAssetRecord::new("DATE_RECEIPT")
-                .version_size(version)
-                .created_at(created)
-                .added_at(added)
-                .build();
-            db.import_adopt(
-                &record,
-                Path::new("/photos/date.jpg"),
-                "local-v1",
-                1024,
-                None,
-            )
-            .await
-            .unwrap();
+            record.version_size = version;
+            db.import_adopt(&record, path, "local-v1", 1024, None)
+                .await
+                .unwrap();
         }
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "DATE_RECEIPT",
-            (&metadata, created, Some(added)),
+            (&record.metadata, created, Some(added)),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11474,44 +11441,31 @@ mod tests {
             .unwrap();
 
         let changed = created + chrono::Duration::milliseconds(1);
+        record.created_at = changed;
         for version in [
             VersionSizeKey::Original,
             VersionSizeKey::LiveOriginal,
             VersionSizeKey::Thumb,
         ] {
-            let record = TestAssetRecord::new("DATE_RECEIPT")
-                .version_size(version)
-                .created_at(changed)
-                .added_at(added)
-                .build();
+            record.version_size = version;
             assert!(
                 db.upsert_seen(&record).await.is_err(),
                 "capture change on {version:?}"
             );
-            assert!(
-                db.import_adopt(
-                    &record,
-                    Path::new("/photos/date.jpg"),
-                    "local-v1",
-                    1024,
-                    None
-                )
-                .await
-                .is_err()
-            );
         }
-        assert!(
-            db.refresh_downloaded_asset_metadata(
-                "PrimarySync",
-                "DATE_RECEIPT",
-                (&metadata, changed, Some(added)),
-                false,
-                false,
-                METADATA_CAPTURE_REVISION,
-            )
+        db.import_adopt(&record, path, "local-v1", 1024, None)
             .await
-            .is_err()
-        );
+            .unwrap_err();
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            "DATE_RECEIPT",
+            (&record.metadata, changed, Some(added)),
+            false,
+            false,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap_err();
         let before = db.get_downloaded_page(0, 10).await.unwrap();
         assert_eq!(before.len(), 2);
         assert!(
@@ -11520,20 +11474,17 @@ mod tests {
                 .all(|row| row.created_at == created && row.added_at == Some(added))
         );
 
-        let new_added = added + chrono::Duration::milliseconds(1);
+        record.created_at = created;
+        record.added_at = Some(added + chrono::Duration::milliseconds(1));
         for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
-            let record = TestAssetRecord::new("DATE_RECEIPT")
-                .version_size(version)
-                .created_at(created)
-                .added_at(new_added)
-                .build();
+            record.version_size = version;
             db.upsert_seen(&record).await.unwrap();
         }
         assert_eq!(
             db.refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "DATE_RECEIPT",
-                (&metadata, created, None),
+                (&record.metadata, created, None),
                 false,
                 false,
                 METADATA_CAPTURE_REVISION,
@@ -11559,83 +11510,25 @@ mod tests {
             original.capture_repair_receipt,
             pending.capture_repair_receipt
         );
-        assert_eq!(original.asset.created_at, created);
-        assert_eq!(original.asset.added_at, None);
         assert!(
-            db.finish_metadata_rewrite(
-                original,
-                MetadataRewriteQueue::CaptureRepair,
-                Some("prepared"),
-                Some("local-v1"),
-                MetadataRewriteCompletion::CaptureRepair,
-            )
-            .await
-            .unwrap()
+            recovered
+                .iter()
+                .all(|row| row.asset.created_at == created && row.asset.added_at.is_none())
         );
-        let rows = db.get_downloaded_page(0, 10).await.unwrap();
-        assert!(
-            rows.iter()
-                .all(|row| row.created_at == created && row.added_at.is_none())
-        );
-        assert_eq!(
-            rows.iter()
-                .find(|row| row.version_size == VersionSizeKey::Original)
-                .unwrap()
-                .local_checksum
-                .as_deref(),
-            Some("prepared")
-        );
-    }
 
-    #[tokio::test]
-    async fn prepared_capture_receipt_allows_only_its_own_provider_replacement() {
-        let db = SqliteStateDb::open_in_memory().unwrap();
-        let record = TestAssetRecord::new("REPLACED_CAPTURE")
-            .created_at(DateTime::UNIX_EPOCH)
-            .build();
-        db.import_adopt(&record, Path::new("/photos/old.jpg"), "local", 1024, None)
+        record.created_at = changed;
+        record.checksum = "provider-v2".into();
+        db.upsert_seen(&record)
             .await
-            .unwrap();
-        db.refresh_downloaded_asset_metadata(
-            "PrimarySync",
-            &record.id,
-            (&record.metadata, record.created_at, None),
-            false,
-            true,
-            METADATA_CAPTURE_REVISION,
-        )
-        .await
-        .unwrap();
-        let pending = db
-            .get_pending_metadata_rewrites_page_for_queue(
-                MetadataRewriteQueue::CaptureRepair,
-                None,
-                0,
-                10,
-            )
-            .await
-            .unwrap()
-            .remove(0);
-        db.record_capture_repair_prepared(&pending, "prepared", 2048)
-            .await
-            .unwrap();
-        let mut replacement = record.clone();
-        replacement.created_at += chrono::Duration::milliseconds(1);
-        assert!(db.upsert_seen(&replacement).await.is_err());
-        replacement.checksum = "provider-v2".into();
-        replacement.version_size = VersionSizeKey::LiveOriginal;
-        assert!(
-            db.upsert_seen(&replacement).await.is_err(),
-            "a replacement sibling cannot invalidate the original receipt"
-        );
-        replacement.version_size = VersionSizeKey::Original;
-        db.upsert_seen(&replacement).await.unwrap();
+            .expect_err("a replacement sibling cannot invalidate the original receipt");
+        record.version_size = VersionSizeKey::Original;
+        db.upsert_seen(&record).await.unwrap();
         let rows = db.get_pending().await.unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].created_at, replacement.created_at);
-        assert_eq!(rows[0].checksum, replacement.checksum);
+        assert_eq!(rows[0].created_at, record.created_at);
+        assert_eq!(rows[0].checksum, record.checksum);
         let receipt: (Option<String>, Option<String>, Option<i64>) = db.acquire_lock("replacement receipt").unwrap().query_row(
-            "SELECT capture_repair_metadata_hash, capture_repair_output_checksum, capture_repair_output_size FROM assets",
+            "SELECT capture_repair_metadata_hash, capture_repair_output_checksum, capture_repair_output_size FROM assets WHERE version_size = 'original'",
             [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         ).unwrap();
         assert_eq!(receipt, (None, None, None));

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -797,7 +797,7 @@ pub trait MetadataRewriteStore: Send + Sync {
         &self,
         library: &str,
         asset_id: &str,
-        metadata: &AssetMetadata,
+        metadata: (&AssetMetadata, DateTime<Utc>, Option<DateTime<Utc>>),
         mark_for_rewrite: bool,
         mark_capture_repair: bool,
         capture_revision: i64,
@@ -1149,7 +1149,7 @@ fn upsert_asset_row(
                   AND capture_repair_output_checksum <> '' \
                   AND capture_repair_output_size IS NOT NULL \
                   AND capture_repair_output_size >= 0 \
-                  AND capture_repair_metadata_hash IS NOT ?3 \
+                  AND (created_at IS NOT ?6 OR capture_repair_metadata_hash IS NOT ?3) \
                   AND (version_size <> ?4 OR checksum = ?5) \
             )",
             rusqlite::params![
@@ -1157,7 +1157,8 @@ fn upsert_asset_row(
                 &record.id,
                 metadata_hash,
                 record.version_size.as_str(),
-                &record.checksum
+                &record.checksum,
+                encode_asset_date(record.created_at)
             ],
             |row| row.get(0),
         )
@@ -1286,14 +1287,15 @@ fn upsert_asset_row(
                             ELSE assets.capture_repair_output_size
                         END
                 WHERE NOT (
-                    assets.checksum = excluded.checksum
-                    AND assets.capture_repair_metadata_hash IS NOT NULL
+                    assets.capture_repair_metadata_hash IS NOT NULL
                     AND assets.capture_repair_metadata_hash <> ''
                     AND assets.capture_repair_output_checksum IS NOT NULL
                     AND assets.capture_repair_output_checksum <> ''
                     AND assets.capture_repair_output_size IS NOT NULL
                     AND assets.capture_repair_output_size >= 0
-                    AND assets.capture_repair_metadata_hash IS NOT excluded.metadata_hash
+                    AND assets.checksum = excluded.checksum
+                    AND (assets.created_at IS NOT excluded.created_at
+                         OR assets.capture_repair_metadata_hash IS NOT excluded.metadata_hash)
                 )
                 ",
         )
@@ -1305,8 +1307,8 @@ fn upsert_asset_row(
             record.version_size.as_str(),
             &record.checksum,
             &record.filename,
-            record.created_at.timestamp(),
-            record.added_at.map(|dt| dt.timestamp()),
+            encode_asset_date(record.created_at),
+            record.added_at.map(encode_asset_date),
             i64::try_from(record.size_bytes).unwrap_or(i64::MAX),
             record.media_type.as_str(),
             last_seen_at,
@@ -4353,20 +4355,26 @@ impl SqliteStateDb {
         &self,
         library: &str,
         asset_id: &str,
-        metadata: &AssetMetadata,
+        metadata: (&AssetMetadata, DateTime<Utc>, Option<DateTime<Utc>>),
         mark_for_rewrite: bool,
         mark_capture_repair: bool,
         capture_revision: i64,
     ) -> Result<usize, StateError> {
         let library = library.to_owned();
         let asset_id = asset_id.to_owned();
+        let (metadata, created_at, added_at) = metadata;
+        let created_at = encode_asset_date(created_at);
+        let added_at = added_at.map(encode_asset_date);
         let mut metadata = metadata.clone();
         if metadata.metadata_hash.is_none() {
             metadata.refresh_hash();
         }
         let rewrite_at = Utc::now().timestamp();
-        self.with_conn("refresh_downloaded_asset_metadata", move |conn| {
-            let updated = conn
+        self.with_conn_mut("refresh_downloaded_asset_metadata", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("refresh_downloaded_asset_metadata::begin", e))?;
+            let updated = tx
                 .execute(
                     r"
                     UPDATE assets SET
@@ -4393,6 +4401,8 @@ impl SqliteStateDb {
                         deleted_at = ?21,
                         provider_data = ?22,
                         metadata_hash = ?23,
+                        created_at = ?29,
+                        added_at = ?30,
                         capture_repair_output_checksum =
                             CASE
                                 WHEN capture_repair_metadata_hash <> ''
@@ -4455,7 +4465,8 @@ impl SqliteStateDb {
                             AND blocked.capture_repair_output_checksum <> ''
                             AND blocked.capture_repair_output_size IS NOT NULL
                             AND blocked.capture_repair_output_size >= 0
-                            AND blocked.capture_repair_metadata_hash IS NOT ?23
+                            AND (blocked.capture_repair_metadata_hash IS NOT ?23
+                                 OR blocked.created_at IS NOT ?29)
                       )
                     ",
                     rusqlite::params![
@@ -4487,36 +4498,38 @@ impl SqliteStateDb {
                         rewrite_at,
                         library,
                         asset_id,
+                        created_at,
+                        added_at,
                     ],
                 )
                 .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
             let durable = if updated > 0 {
                 updated
             } else {
+                ensure_asset_has_no_prepared_capture_repair(
+                    &tx,
+                    &library,
+                    &asset_id,
+                    "refresh_downloaded_asset_metadata",
+                )?;
                 // A row can leave `downloaded` mid-cycle when the provider
                 // publishes new media for the same asset, which stores the
                 // incoming metadata as it resets the row for re-download. The
                 // metadata is durable, so report the match rather than a lost
                 // write. A missing or still-stale row stays a failure.
-                let durable: i64 = conn
+                let durable: i64 = tx
                     .query_row(
                         "SELECT COUNT(*) FROM assets \
                          WHERE library = ?1 AND id = ?2 AND is_deleted = 0 \
                            AND metadata_hash IS NOT NULL AND metadata_hash = ?3 \
-                           AND NOT EXISTS ( \
-                               SELECT 1 FROM assets AS blocked \
-                               WHERE blocked.library = ?1 AND blocked.id = ?2 \
-                                 AND blocked.status = 'downloaded' \
-                                 AND blocked.is_deleted = 0 \
-                                 AND blocked.capture_repair_metadata_hash IS NOT NULL \
-                                 AND blocked.capture_repair_metadata_hash <> '' \
-                                 AND blocked.capture_repair_output_checksum IS NOT NULL \
-                                 AND blocked.capture_repair_output_checksum <> '' \
-                                 AND blocked.capture_repair_output_size IS NOT NULL \
-                                 AND blocked.capture_repair_output_size >= 0 \
-                                 AND blocked.capture_repair_metadata_hash IS NOT ?3 \
-                           )",
-                        rusqlite::params![library, asset_id, metadata.metadata_hash.as_deref()],
+                           AND created_at IS ?4 AND added_at IS ?5",
+                        rusqlite::params![
+                            library,
+                            asset_id,
+                            metadata.metadata_hash.as_deref(),
+                            created_at,
+                            added_at
+                        ],
                         |row| row.get(0),
                     )
                     .map_err(|e| StateError::query("refresh_downloaded_asset_metadata", e))?;
@@ -4524,13 +4537,15 @@ impl SqliteStateDb {
             };
             if durable > 0 {
                 record_metadata_capture_revision(
-                    conn,
+                    &tx,
                     &library,
                     &asset_id,
                     capture_revision,
                     rewrite_at,
                 )?;
             }
+            tx.commit()
+                .map_err(|e| StateError::query("refresh_downloaded_asset_metadata::commit", e))?;
             Ok(durable)
         })
         .await
@@ -5798,7 +5813,7 @@ impl MetadataRewriteStore for SqliteStateDb {
         &self,
         library: &str,
         asset_id: &str,
-        metadata: &AssetMetadata,
+        metadata: (&AssetMetadata, DateTime<Utc>, Option<DateTime<Utc>>),
         mark_for_rewrite: bool,
         mark_capture_repair: bool,
         capture_revision: i64,
@@ -6179,8 +6194,11 @@ fn manifest_joined_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Man
     let local_checksum: Option<String> = row.get(6)?;
     let download_checksum: Option<String> = row.get(7)?;
     let size_bytes: i64 = row.get(8)?;
-    let created_at_ts: i64 = row.get(9)?;
-    let added_at_ts: Option<i64> = row.get(10)?;
+    let created_at = decode_asset_date(row.get(9)?, 9)?;
+    let added_at = row
+        .get::<_, Option<f64>>(10)?
+        .map(|value| decode_asset_date(value, 10))
+        .transpose()?;
     let downloaded_at_ts: Option<i64> = row.get(11)?;
     let last_seen_at_ts: i64 = row.get(12)?;
     let media_type: String = row.get(13)?;
@@ -6198,8 +6216,8 @@ fn manifest_joined_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Man
             local_checksum,
             download_checksum,
             size_bytes: u64::try_from(size_bytes).unwrap_or(0),
-            created_at: ts_to_utc(created_at_ts),
-            added_at: optional_ts_to_utc(added_at_ts),
+            created_at,
+            added_at,
             downloaded_at: optional_ts_to_utc(downloaded_at_ts),
             last_seen_at: ts_to_utc(last_seen_at_ts),
             media_type,
@@ -6220,6 +6238,43 @@ fn optional_ts_to_utc(ts: Option<i64>) -> Option<DateTime<Utc>> {
     ts.and_then(|ts| Utc.timestamp_opt(ts, 0).single())
 }
 
+// Chrono's whole seconds fit exactly in f64; splitting before scaling preserves
+// every millisecond even at the supported date limits (unlike timestamp_millis).
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "chrono seconds are within f64's exact integer range"
+)]
+fn encode_asset_date(date: DateTime<Utc>) -> f64 {
+    date.timestamp() as f64 + f64::from(date.timestamp_subsec_millis()) / 1000.0
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "finite chrono-range seconds and rounded 0..=1000 milliseconds are checked before casting"
+)]
+fn decode_asset_date(value: f64, column: usize) -> rusqlite::Result<DateTime<Utc>> {
+    let seconds = value.floor();
+    if value.is_finite()
+        && seconds >= DateTime::<Utc>::MIN_UTC.timestamp() as f64
+        && seconds <= DateTime::<Utc>::MAX_UTC.timestamp() as f64
+    {
+        let millis = ((value - seconds) * 1000.0).round() as u32;
+        if let Some(date) = DateTime::from_timestamp(
+            seconds as i64 + i64::from(millis / 1000),
+            (millis % 1000) * 1_000_000,
+        ) {
+            return Ok(date);
+        }
+    }
+    Err(rusqlite::Error::FromSqlConversionFailure(
+        column,
+        rusqlite::types::Type::Real,
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid asset date").into(),
+    ))
+}
+
 /// Convert a database row to an `AssetRecord`.
 ///
 /// Returns `rusqlite::Error` on column extraction failures instead of silently
@@ -6229,8 +6284,11 @@ fn row_to_asset_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRecord>
     let version_size_str: String = row.get(1)?;
     let checksum: String = row.get(2)?;
     let filename: String = row.get(3)?;
-    let created_at_ts: i64 = row.get(4)?;
-    let added_at_ts: Option<i64> = row.get(5)?;
+    let created_at = decode_asset_date(row.get(4)?, 4)?;
+    let added_at = row
+        .get::<_, Option<f64>>(5)?
+        .map(|value| decode_asset_date(value, 5))
+        .transpose()?;
     let size_bytes: i64 = row.get(6)?;
     let media_type_str: String = row.get(7)?;
     let status_str: String = row.get(8)?;
@@ -6304,8 +6362,8 @@ fn row_to_asset_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRecord>
         local_checksum,
         download_checksum,
         size_bytes: u64::try_from(size_bytes).unwrap_or(0),
-        created_at: ts_to_utc(created_at_ts),
-        added_at: optional_ts_to_utc(added_at_ts),
+        created_at,
+        added_at,
         downloaded_at: optional_ts_to_utc(downloaded_at_ts),
         last_seen_at: ts_to_utc(last_seen_at_ts),
         download_attempts: u32::try_from(download_attempts).unwrap_or(u32::MAX),
@@ -6325,6 +6383,116 @@ mod tests {
 
     fn test_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    #[tokio::test]
+    async fn asset_dates_preserve_every_millisecond_through_sqlite_and_manifest() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let mut record = TestAssetRecord::new("DATES").build();
+        for seconds in [
+            DateTime::<Utc>::MIN_UTC.timestamp(),
+            -1,
+            0,
+            1_700_000_000,
+            DateTime::<Utc>::MAX_UTC.timestamp(),
+        ] {
+            for millis in 0..1000 {
+                record.created_at = DateTime::from_timestamp(seconds, millis * 1_000_000).unwrap();
+                record.added_at = Some(record.created_at);
+                let conn = db.acquire_lock("date roundtrip").unwrap();
+                upsert_asset_row(&conn, &record, 123).unwrap();
+                let stored = conn
+                    .query_row(
+                        &format!("SELECT {ASSET_COLUMNS} FROM assets"),
+                        [],
+                        row_to_asset_record,
+                    )
+                    .unwrap();
+                assert_eq!(stored.created_at, record.created_at);
+                assert_eq!(stored.added_at, record.added_at);
+                assert_eq!(stored.last_seen_at.timestamp(), 123);
+            }
+            let manifest = db.get_manifest_assets().await.unwrap();
+            assert_eq!(manifest[0].created_at, record.created_at);
+            assert_eq!(manifest[0].added_at, record.added_at);
+        }
+        record.added_at = None;
+        db.import_adopt(&record, Path::new("/photos/dates.jpg"), "local", 1024, None)
+            .await
+            .unwrap();
+        let manifest = db.get_manifest_assets().await.unwrap();
+        assert_eq!(manifest[0].created_at, record.created_at);
+        assert_eq!(manifest[0].added_at, None);
+    }
+
+    #[tokio::test]
+    async fn asset_dates_decode_legacy_integers_fractional_seconds_and_reject_invalid() {
+        assert!(decode_asset_date(f64::NAN, 4).is_err());
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        db.upsert_seen(&TestAssetRecord::new("DATES").build())
+            .await
+            .unwrap();
+        for (literal, expected_millis) in [
+            ("1700000000", 1_700_000_000_000),
+            ("1700000000.123", 1_700_000_000_123),
+            ("-0.001", -1),
+            ("-1.999", -1999),
+            ("0.9999999", 1000),
+        ] {
+            {
+                let conn = db.acquire_lock("legacy dates").unwrap();
+                conn.execute(
+                    &format!("UPDATE assets SET created_at = {literal}, added_at = {literal}"),
+                    [],
+                )
+                .unwrap();
+                let stored = conn
+                    .query_row(
+                        &format!("SELECT {ASSET_COLUMNS} FROM assets"),
+                        [],
+                        row_to_asset_record,
+                    )
+                    .unwrap();
+                assert_eq!(stored.created_at.timestamp_millis(), expected_millis);
+                assert_eq!(stored.added_at.unwrap().timestamp_millis(), expected_millis);
+            }
+            assert_eq!(
+                db.get_manifest_assets().await.unwrap()[0]
+                    .created_at
+                    .timestamp_millis(),
+                expected_millis
+            );
+        }
+        for column in ["created_at", "added_at"] {
+            for invalid in [
+                "1e999",
+                "-1e999",
+                "9223372036854775807",
+                "-9223372036854775808",
+                "'invalid'",
+            ] {
+                {
+                    let conn = db.acquire_lock("invalid dates").unwrap();
+                    conn.execute("UPDATE assets SET created_at = 0, added_at = NULL", [])
+                        .unwrap();
+                    conn.execute(&format!("UPDATE assets SET {column} = {invalid}"), [])
+                        .unwrap();
+                    assert!(
+                        conn.query_row(
+                            &format!("SELECT {ASSET_COLUMNS} FROM assets"),
+                            [],
+                            row_to_asset_record
+                        )
+                        .is_err(),
+                        "{column} = {invalid}"
+                    );
+                }
+                assert!(
+                    db.get_manifest_assets().await.is_err(),
+                    "{column} = {invalid}"
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -10952,7 +11120,7 @@ mod tests {
             .refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "MOVED_ON",
-                &edited,
+                (&edited, republished.created_at, republished.added_at),
                 true,
                 false,
                 METADATA_CAPTURE_REVISION,
@@ -10963,12 +11131,34 @@ mod tests {
             matched > 0,
             "metadata already stored by the reset must count as durable"
         );
+        for dates in [
+            (
+                republished.created_at + chrono::Duration::milliseconds(1),
+                republished.added_at,
+            ),
+            (republished.created_at, Some(DateTime::UNIX_EPOCH)),
+        ] {
+            assert_eq!(
+                db.refresh_downloaded_asset_metadata(
+                    "PrimarySync",
+                    "MOVED_ON",
+                    (&edited, dates.0, dates.1),
+                    true,
+                    false,
+                    METADATA_CAPTURE_REVISION,
+                )
+                .await
+                .unwrap(),
+                0,
+                "same hash cannot vouch for stale dates"
+            );
+        }
 
         let stale = db
             .refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "ABSENT",
-                &edited,
+                (&edited, republished.created_at, republished.added_at),
                 true,
                 false,
                 METADATA_CAPTURE_REVISION,
@@ -11102,11 +11292,11 @@ mod tests {
     async fn refresh_downloaded_asset_metadata_updates_every_live_downloaded_version() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        for version in [VersionSizeKey::Original, VersionSizeKey::Medium] {
+        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
             let record = TestAssetRecord::new("PHOTO")
                 .version_size(version)
                 .metadata(AssetMetadata {
-                    metadata_hash: Some("stale-hash".to_string()),
+                    rating: Some(4),
                     ..AssetMetadata::default()
                 })
                 .build();
@@ -11128,13 +11318,61 @@ mod tests {
             ..AssetMetadata::default()
         };
         let expected_hash = metadata.compute_hash();
+        let created = DateTime::from_timestamp_millis(1_700_000_000_123).unwrap();
+        let added = DateTime::from_timestamp_millis(-1).unwrap();
+        {
+            let conn = db.acquire_lock("inject refresh commit failure").unwrap();
+            conn.execute_batch(
+                "CREATE TRIGGER fail_capture_revision BEFORE INSERT ON asset_metadata_capture_revisions
+                 BEGIN SELECT RAISE(FAIL, 'injected revision failure'); END;",
+            ).unwrap();
+        }
+        assert!(
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "PHOTO",
+                (&metadata, created, Some(added)),
+                true,
+                true,
+                METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .is_err()
+        );
+        let unchanged = db.get_downloaded_page(0, 10).await.unwrap();
+        assert!(
+            unchanged
+                .iter()
+                .all(|row| row.created_at != created && row.added_at.is_none())
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            db.get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap()
+            .is_empty()
+        );
+        db.acquire_lock("remove refresh failure")
+            .unwrap()
+            .execute_batch("DROP TRIGGER fail_capture_revision")
+            .unwrap();
         let updated = db
             .refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "PHOTO",
-                &metadata,
+                (&metadata, created, Some(added)),
                 true,
-                false,
+                true,
                 METADATA_CAPTURE_REVISION,
             )
             .await
@@ -11148,8 +11386,10 @@ mod tests {
             assert_eq!(record.id.as_ref(), "PHOTO");
             assert!(matches!(
                 record.version_size,
-                VersionSizeKey::Original | VersionSizeKey::Medium
+                VersionSizeKey::Original | VersionSizeKey::LiveOriginal
             ));
+            assert_eq!(record.created_at, created);
+            assert_eq!(record.added_at, Some(added));
             assert_eq!(record.metadata.rating, Some(4));
             assert_eq!(
                 record.metadata.metadata_hash.as_deref(),
@@ -11168,6 +11408,237 @@ mod tests {
             assert_eq!(record.checksum.as_ref(), "checksum123");
             assert_eq!(record.metadata.rating, Some(4));
         }
+        let capture = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(capture.len(), 2);
+        assert!(capture.iter().all(|row| matches!(
+            row.capture_repair_receipt,
+            Some(CaptureRepairReceipt::Pending { .. })
+        )));
+    }
+
+    #[tokio::test]
+    async fn prepared_capture_receipt_blocks_date_changes_but_allows_addition_and_recovery() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let created = DateTime::from_timestamp_millis(1_700_000_000_123).unwrap();
+        let added = DateTime::from_timestamp_millis(1_700_000_000_789).unwrap();
+        let metadata = AssetMetadata::default();
+        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
+            let record = TestAssetRecord::new("DATE_RECEIPT")
+                .version_size(version)
+                .created_at(created)
+                .added_at(added)
+                .build();
+            db.import_adopt(
+                &record,
+                Path::new("/photos/date.jpg"),
+                "local-v1",
+                1024,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            "DATE_RECEIPT",
+            (&metadata, created, Some(added)),
+            true,
+            true,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap();
+        let mut pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|row| row.asset.version_size == VersionSizeKey::Original)
+            .unwrap();
+        pending.capture_repair_receipt = db
+            .record_capture_repair_prepared(&pending, "prepared", 2048)
+            .await
+            .unwrap();
+
+        let changed = created + chrono::Duration::milliseconds(1);
+        for version in [
+            VersionSizeKey::Original,
+            VersionSizeKey::LiveOriginal,
+            VersionSizeKey::Thumb,
+        ] {
+            let record = TestAssetRecord::new("DATE_RECEIPT")
+                .version_size(version)
+                .created_at(changed)
+                .added_at(added)
+                .build();
+            assert!(
+                db.upsert_seen(&record).await.is_err(),
+                "capture change on {version:?}"
+            );
+            assert!(
+                db.import_adopt(
+                    &record,
+                    Path::new("/photos/date.jpg"),
+                    "local-v1",
+                    1024,
+                    None
+                )
+                .await
+                .is_err()
+            );
+        }
+        assert!(
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "DATE_RECEIPT",
+                (&metadata, changed, Some(added)),
+                false,
+                false,
+                METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .is_err()
+        );
+        let before = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(before.len(), 2);
+        assert!(
+            before
+                .iter()
+                .all(|row| row.created_at == created && row.added_at == Some(added))
+        );
+
+        let new_added = added + chrono::Duration::milliseconds(1);
+        for version in [VersionSizeKey::Original, VersionSizeKey::LiveOriginal] {
+            let record = TestAssetRecord::new("DATE_RECEIPT")
+                .version_size(version)
+                .created_at(created)
+                .added_at(new_added)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+        }
+        assert_eq!(
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "DATE_RECEIPT",
+                (&metadata, created, None),
+                false,
+                false,
+                METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .unwrap(),
+            2
+        );
+        let recovered = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        let original = recovered
+            .iter()
+            .find(|row| row.asset.version_size == VersionSizeKey::Original)
+            .unwrap();
+        assert_eq!(
+            original.capture_repair_receipt,
+            pending.capture_repair_receipt
+        );
+        assert_eq!(original.asset.created_at, created);
+        assert_eq!(original.asset.added_at, None);
+        assert!(
+            db.finish_metadata_rewrite(
+                original,
+                MetadataRewriteQueue::CaptureRepair,
+                Some("prepared"),
+                Some("local-v1"),
+                MetadataRewriteCompletion::CaptureRepair,
+            )
+            .await
+            .unwrap()
+        );
+        let rows = db.get_downloaded_page(0, 10).await.unwrap();
+        assert!(
+            rows.iter()
+                .all(|row| row.created_at == created && row.added_at.is_none())
+        );
+        assert_eq!(
+            rows.iter()
+                .find(|row| row.version_size == VersionSizeKey::Original)
+                .unwrap()
+                .local_checksum
+                .as_deref(),
+            Some("prepared")
+        );
+    }
+
+    #[tokio::test]
+    async fn prepared_capture_receipt_allows_only_its_own_provider_replacement() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("REPLACED_CAPTURE")
+            .created_at(DateTime::UNIX_EPOCH)
+            .build();
+        db.import_adopt(&record, Path::new("/photos/old.jpg"), "local", 1024, None)
+            .await
+            .unwrap();
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            &record.id,
+            (&record.metadata, record.created_at, None),
+            false,
+            true,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap()
+            .remove(0);
+        db.record_capture_repair_prepared(&pending, "prepared", 2048)
+            .await
+            .unwrap();
+        let mut replacement = record.clone();
+        replacement.created_at += chrono::Duration::milliseconds(1);
+        assert!(db.upsert_seen(&replacement).await.is_err());
+        replacement.checksum = "provider-v2".into();
+        replacement.version_size = VersionSizeKey::LiveOriginal;
+        assert!(
+            db.upsert_seen(&replacement).await.is_err(),
+            "a replacement sibling cannot invalidate the original receipt"
+        );
+        replacement.version_size = VersionSizeKey::Original;
+        db.upsert_seen(&replacement).await.unwrap();
+        let rows = db.get_pending().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].created_at, replacement.created_at);
+        assert_eq!(rows[0].checksum, replacement.checksum);
+        let receipt: (Option<String>, Option<String>, Option<i64>) = db.acquire_lock("replacement receipt").unwrap().query_row(
+            "SELECT capture_repair_metadata_hash, capture_repair_output_checksum, capture_repair_output_size FROM assets",
+            [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        ).unwrap();
+        assert_eq!(receipt, (None, None, None));
     }
 
     async fn seed_downloaded_capture_asset(
@@ -11209,7 +11680,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "CAPTURE",
-            &metadata,
+            (&metadata, DateTime::UNIX_EPOCH, None),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11336,7 +11807,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "CAPTURE",
-            &metadata,
+            (&metadata, DateTime::UNIX_EPOCH, None),
             false,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11396,7 +11867,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "CAPTURE",
-            &metadata,
+            (&metadata, DateTime::UNIX_EPOCH, None),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11455,7 +11926,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "REFRESH",
-            &unchanged,
+            (&unchanged, DateTime::UNIX_EPOCH, None),
             true,
             false,
             METADATA_CAPTURE_REVISION,
@@ -11478,7 +11949,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "REFRESH",
-            &unchanged,
+            (&unchanged, DateTime::UNIX_EPOCH, None),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11505,7 +11976,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "REFRESH",
-            &unchanged,
+            (&unchanged, DateTime::UNIX_EPOCH, None),
             false,
             false,
             METADATA_CAPTURE_REVISION,
@@ -11607,18 +12078,17 @@ mod tests {
             rating: Some(5),
             ..AssetMetadata::default()
         };
-        assert_eq!(
+        assert!(
             db.refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "REFRESH",
-                &changed,
+                (&changed, DateTime::UNIX_EPOCH, None),
                 false,
                 false,
                 METADATA_CAPTURE_REVISION,
             )
             .await
-            .unwrap(),
-            0,
+            .is_err(),
             "new provider metadata must wait until published repair bytes are finalised"
         );
         let preserved_after_change = db
@@ -11709,7 +12179,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "MULTI_REFRESH",
-            &current,
+            (&current, DateTime::UNIX_EPOCH, None),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11764,18 +12234,17 @@ mod tests {
                 ..
             })
         ));
-        assert_eq!(
+        assert!(
             db.refresh_downloaded_asset_metadata(
                 "PrimarySync",
                 "MULTI_REFRESH",
-                &changed,
+                (&changed, DateTime::UNIX_EPOCH, None),
                 false,
                 false,
                 METADATA_CAPTURE_REVISION,
             )
             .await
-            .unwrap(),
-            0
+            .is_err()
         );
 
         let downloaded = db.get_downloaded_page(0, 10).await.unwrap();
@@ -11810,7 +12279,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "CAPTURE_DELETE",
-            &metadata,
+            (&metadata, DateTime::UNIX_EPOCH, None),
             true,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11903,7 +12372,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "ADOPT_CAPTURE",
-            &record.metadata,
+            (&record.metadata, record.created_at, record.added_at),
             false,
             true,
             METADATA_CAPTURE_REVISION,
@@ -11974,7 +12443,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "ADOPT_CAPTURE",
-            &record.metadata,
+            (&record.metadata, record.created_at, record.added_at),
             false,
             true,
             METADATA_CAPTURE_REVISION,
@@ -12020,7 +12489,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "MALFORMED",
-            &changed,
+            (&changed, DateTime::UNIX_EPOCH, None),
             false,
             true,
             METADATA_CAPTURE_REVISION,
@@ -12119,7 +12588,7 @@ mod tests {
         db.refresh_downloaded_asset_metadata(
             "PrimarySync",
             "ASSET_CHILD",
-            &metadata,
+            (&metadata, record.created_at, record.added_at),
             true,
             false,
             METADATA_CAPTURE_REVISION,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -4372,9 +4372,9 @@ mod tests {
             &checksum,
         );
         page["records"][1]["fields"]["assetDate"]["value"] =
-            serde_json::json!(1_769_898_719_000_i64);
+            serde_json::json!(1_769_898_719_629_i64);
         page["records"][1]["fields"]["addedDate"]["value"] =
-            serde_json::json!(1_769_898_719_000_i64);
+            serde_json::json!(1_769_898_719_789_i64);
         page["records"][1]["fields"]["timeZoneOffset"] =
             serde_json::json!({"value": 39_600, "type": "INT64"});
 
@@ -4419,6 +4419,14 @@ mod tests {
 
         assert_eq!(result.stats.downloaded, 1);
         let downloaded = db.get_downloaded_page(0, 1).await.expect("downloaded row");
+        assert_eq!(
+            downloaded[0].created_at.timestamp_millis(),
+            1_769_898_719_629
+        );
+        assert_eq!(
+            downloaded[0].added_at.map(|date| date.timestamp_millis()),
+            Some(1_769_898_719_789)
+        );
         let media_path = downloaded[0].local_path.as_ref().expect("downloaded path");
         assert!(
             media_path
@@ -4436,13 +4444,20 @@ mod tests {
         )))
         .expect("capture-offset sidecar");
         let metadata = sidecar.parse::<XmpMeta>().expect("valid XMP sidecar");
-        assert_eq!(
-            metadata
-                .property(xmp_ns::EXIF, "DateTimeOriginal")
-                .expect("DateTimeOriginal")
-                .value,
-            "2026-02-01T09:31:59+11:00"
-        );
+        for (namespace, property) in [
+            (xmp_ns::XMP, "CreateDate"),
+            (xmp_ns::XMP, "ModifyDate"),
+            (xmp_ns::EXIF, "DateTimeOriginal"),
+            (xmp_ns::PHOTOSHOP, "DateCreated"),
+        ] {
+            assert_eq!(
+                metadata
+                    .property(namespace, property)
+                    .expect(property)
+                    .value,
+                "2026-02-01T09:31:59.629+11:00"
+            );
+        }
         assert_eq!(
             metadata
                 .property("http://cipa.jp/exif/1.0/", "OffsetTimeOriginal")

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -5180,11 +5180,22 @@ mod tests {
                 return Err(state::error::StateError::LockPoisoned(self.message.into()));
             }
             if let Some(newer) = &self.refresh_on_mark_downloaded {
+                let record = self
+                    .inner
+                    .get_downloaded_page(0, u32::MAX)
+                    .await?
+                    .into_iter()
+                    .find(|row| {
+                        row.library.as_ref() == library
+                            && row.id.as_ref() == id
+                            && row.version_size.as_str() == version_size
+                    })
+                    .expect("refresh target");
                 self.inner
                     .refresh_downloaded_asset_metadata(
                         library,
                         id,
-                        newer,
+                        (newer, record.created_at, record.added_at),
                         true,
                         false,
                         state::METADATA_CAPTURE_REVISION,
@@ -5784,7 +5795,11 @@ mod tests {
             &self,
             library: &str,
             asset_id: &str,
-            metadata: &state::AssetMetadata,
+            metadata: (
+                &state::AssetMetadata,
+                chrono::DateTime<chrono::Utc>,
+                Option<chrono::DateTime<chrono::Utc>>,
+            ),
             mark_for_rewrite: bool,
             mark_capture_repair: bool,
             capture_revision: i64,
@@ -8207,7 +8222,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/expired.jpg"))
             .respond_with(ResponseTemplate::new(410))
-            .expect(1)
+            .expect(0)
             .mount(&server)
             .await;
 
@@ -8253,7 +8268,7 @@ mod tests {
         .await
         .expect("expired URL cycle with failed pending-row write");
 
-        assert_eq!(result.failed_count, 2);
+        assert_eq!(result.failed_count, 1);
         assert_eq!(result.stats.state_write_failures, 1);
         assert!(!result.db_sync_token_advance_safe);
         assert_eq!(


### PR DESCRIPTION
## Summary
Mitigates the demonstrated catalogue and XMP precision loss in #803.

- Preserve capture/addition milliseconds as fractional Unix seconds in existing SQLite columns; update asset and manifest readers without changing schema or timestamp units.
- Extend `sync --refresh-metadata` to persist capture/addition dates with metadata, rewrite markers, and capture revision atomically. Existing rows and sidecars can be repaired without downloading media.
- Emit fractional ISO capture dates in sidecars. Preserve current native embedded output precision and accept its whole-second representation without accepting incorrect nonzero fractions.
- Protect prepared repair receipts against capture-date changes and stop dispatch when pending-state writes are rejected. Preserve the existing own-rendition provider-replacement exception.

## Compatibility and scope
No schema migration, revision bump, new flag, or automatic precision-backfill sweep. Legacy integer-second rows remain readable. Older binaries cannot read newly written fractional timestamps; downgrade is unsupported after those writes.

Enable `metadata.xmp_sidecar` for sidecar correction. Disable embedded output options when media bytes must stay untouched. Native subsecond writing, modification/deletion timestamp precision and hash changes, and ordinary capture-only drift detection are intentionally deferred; this PR does not claim to resolve every precision path mentioned in #803.

## Evidence
Ponytail complexity review, independent adversarial correctness review, and `kei-pr-ready` completed with all blockers addressed. Reviewed all eight changed files; no unrelated changes, dependencies, or unsafe edits. Tests account for most of the diff.

Pre-seeded HEIC/MOV media, integer dates, and whole-second sidecars are refreshed through production owners with an unchanged metadata hash. Both catalogue rows and sidecars gain fractions; media bytes, paths, and checksums stay unchanged; rewrite markers retire. An ordinary incremental follow-up performs no download or additional full query. Additional tests cover codec limits and legacy values, atomic rollback, rejected streaming/collecting dispatch, prepared-receipt recovery after interrupted finalization, and checkpoint retention.

Applicable contracts: `METADATA_WRITES_REQUIRE_OPT_IN`, `METADATA_EMBED_REWRITE_REQUIRES_STABLE_INPUT`, `HEIF_EMBED_REWRITE_REQUIRES_STABLE_INPUT`, `XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT`, `SOURCE_CHECKPOINT_REQUIRES_DURABLE_RECOVERY`, `SYNC_TOKEN_ADVANCE_REQUIRES_CLEAN_CYCLE`, and `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE`.

## Validation
All passed on commit `89f2b800a1e97195bfdf9a434e2c68c571aebffc` with a clean worktree:

- `just gate` via installed mise tool versions; all-feature and no-default-feature tests, integration tests, formatting, clippy, docs, audit, script/workflow lint, contracts, typos, and round-trip gate.
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused state, metadata, refresh, manifest, checkpoint, and capture-repair tests.
- `just test scenario pending-recovery` and `just test scenario config-reconciliation`.
- `cargo run --quiet -- sync --refresh-metadata --help`; Docker, systemd and Homebrew surfaces inspected, unchanged.

Live authenticated tests were not needed and were not run. No user media was modified.