### PR TITLE
Fix album XMP membership and track metadata retries per path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -390,10 +390,13 @@ leaves the affected markers pending. A completed download writes the snapshot
 it was planned from, so it records a marker on failure but never retires one.
 
 The first task payload includes its concrete pass album, even when the cycle's
-grouping preload is empty. Provider membership changes update the `asset_albums`
-read model and metadata retry markers in one transaction. The projection uses
-child identity or the recorded legacy state owner, never a sibling's master
-reference alone. Completed snapshots can remove missing memberships; interrupted
+grouping preload is empty. Provider membership changes update the
+`asset_albums` read model and metadata retry markers in one transaction. The
+projection uses child identity or the recorded legacy state owner, never a
+sibling's master reference alone. Individual membership changes use indexed
+identity lookups; container refreshes enumerate only that container. Schema v22
+adds a reverse index for legacy owners without changing their recorded
+identities. Completed snapshots can remove missing memberships; interrupted
 snapshots preserve the prior live memberships. External grouping sources remain
 unchanged. The end-of-cycle writer uses the accumulated memberships for each
 tracked media path. Retry markers do not authorize writes when metadata outputs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,6 +389,32 @@ album and people rows for its library-scoped asset IDs. A grouping-read failure
 leaves the affected markers pending. A completed download writes the snapshot
 it was planned from, so it records a marker on failure but never retires one.
 
+The first task payload includes its concrete pass album, even when the cycle's
+grouping preload is empty. Provider membership changes update the `asset_albums`
+read model and metadata retry markers in one transaction. The projection uses
+child identity or the recorded legacy state owner, never a sibling's master
+reference alone. Completed snapshots can remove missing memberships; interrupted
+snapshots preserve the prior live memberships. External grouping sources remain
+unchanged. The end-of-cycle writer uses the accumulated memberships for each
+tracked media path. Retry markers do not authorize writes when metadata outputs
+are disabled.
+
+`asset_metadata_paths` records each successfully finalized media path, its
+provider rendition checksum, local fingerprints, and metadata retry receipts.
+Registration and downloaded-state finalization share one transaction. The
+catalogue still owns sync selection and keeps one path per rendition. Metadata
+rewrites also visit the additional recorded paths that match the current
+provider rendition. Each completion checks the selected path and fingerprints,
+then clears only that path's debt. A failed copy does not block successful
+copies or lose its retry evidence. Capture-repair receipts remain path-specific.
+Missing paths retain retry evidence; old provider renditions remain recorded
+but do not receive current-rendition metadata.
+
+Schema migration seeds only the path already recorded in each catalogue row.
+It does not scan for, infer ownership of, or authorize writes to older copies
+that were never recorded. Additional paths enter the registry through verified
+download finalization or explicit import adoption.
+
 XMP sidecars record the exact properties that kei writes in the kei namespace.
 A later rewrite deletes a cleared property only when that marker proves kei
 owned the prior value. Unmarked standard properties and unrelated third-party

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -522,11 +522,16 @@ fn build_payload(
     asset: &crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> Arc<MetadataPayload> {
-    Arc::new(
-        config
-            .asset_groupings
-            .metadata_payload(asset.state_id(), asset.metadata()),
-    )
+    let mut payload = config
+        .asset_groupings
+        .metadata_payload(asset.state_id(), asset.metadata());
+    // The current pass is newer evidence than the cycle's grouping preload.
+    if let Some(album) = config.album_name.as_deref().filter(|name| !name.is_empty())
+        && !payload.keywords.iter().any(|keyword| keyword == album)
+    {
+        payload.keywords.push(album.to_owned());
+    }
+    Arc::new(payload)
 }
 
 /// A unit of work produced by the filter phase and consumed by the download phase.

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2927,18 +2927,20 @@ impl AlbumSnapshotRecorder {
         db: Option<Arc<dyn DownloadStore>>,
         pass: &crate::commands::AlbumPass,
         enum_config_hash: Option<&str>,
-    ) -> Option<Self> {
+    ) -> Result<Option<Self>> {
         if pass.kind != crate::commands::PassKind::Album {
-            return None;
+            return Ok(None);
         }
-        let db = db?;
+        let Some(db) = db else {
+            return Ok(None);
+        };
         let Some(container_id) = pass.album.container_id() else {
             tracing::debug!(
                 album = %pass.album.name,
                 library = %pass.album.zone_name(),
                 "Album pass has no container ID; skipping membership snapshot"
             );
-            return None;
+            return Ok(None);
         };
         let library = pass.album.zone_name();
         if let Err(e) = db
@@ -2952,7 +2954,7 @@ impl AlbumSnapshotRecorder {
                 error = %e,
                 "Failed to upsert album container; skipping membership snapshot"
             );
-            return None;
+            return Err(e.into());
         }
         let generation = match db
             .start_album_membership_snapshot(library, container_id, enum_config_hash)
@@ -2967,16 +2969,16 @@ impl AlbumSnapshotRecorder {
                     error = %e,
                     "Failed to start album membership snapshot"
                 );
-                return None;
+                return Err(e.into());
             }
         };
-        Some(Self {
+        Ok(Some(Self {
             db,
             library: Arc::from(library),
             container_id: Arc::from(container_id),
             generation,
             write_failed: Arc::new(AtomicBool::new(false)),
-        })
+        }))
     }
 
     async fn record_asset(&self, asset: &PhotoAsset) {
@@ -3005,11 +3007,12 @@ impl AlbumSnapshotRecorder {
         }
     }
 
-    async fn complete_if_clean(&self, result: &StreamingResult) {
-        if self.write_failed.load(Ordering::Relaxed)
-            || result.enumeration_errors > 0
-            || !result.enumeration_complete
-        {
+    async fn complete_if_clean(&self, result: &mut StreamingResult) {
+        if self.write_failed.load(Ordering::Relaxed) {
+            result.state_write_failures += 1;
+            return;
+        }
+        if result.enumeration_errors > 0 || !result.enumeration_complete {
             tracing::debug!(
                 library = %self.library,
                 container_id = %self.container_id,
@@ -3026,6 +3029,7 @@ impl AlbumSnapshotRecorder {
             .complete_album_membership_snapshot(&self.library, &self.container_id, self.generation)
             .await
         {
+            result.state_write_failures += 1;
             tracing::warn!(
                 library = %self.library,
                 container_id = %self.container_id,
@@ -3246,7 +3250,7 @@ where
         None => Box::pin(stream),
     };
 
-    let result = stream_and_download_from_stream(
+    let mut result = stream_and_download_from_stream(
         &download_client,
         stream,
         &pass_config,
@@ -3262,7 +3266,7 @@ where
     )
     .await?;
     if let Some(snapshot) = &options.album_snapshot {
-        snapshot.complete_if_clean(&result).await;
+        snapshot.complete_if_clean(&mut result).await;
     }
 
     let elapsed = pass_start.elapsed();
@@ -6011,7 +6015,7 @@ async fn download_photos_full_with_token_policy(
                             pass,
                             config.enum_config_hash.as_deref(),
                         )
-                        .await
+                        .await?
                     } else {
                         None
                     };
@@ -16071,6 +16075,443 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn album_membership_rewrites_every_finalized_path_after_restart() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        use xmp_toolkit::{OpenFileOptions, XmpFile, XmpMeta, xmp_ns};
+
+        for embed_xmp in [false, true] {
+            let server = crate::start_wiremock_or_skip!();
+            let body = vec![
+                0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+                0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+            ];
+            Mock::given(method("GET"))
+                .and(path("/copies.jpg"))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+                .expect(2)
+                .mount(&server)
+                .await;
+            let mut records = incremental_photo_records_with_url(
+                "COPIES",
+                "copies.jpg",
+                &format!("{}/copies.jpg", server.uri()),
+                body.len() as u64,
+            );
+            records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] =
+                json!(base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&body)));
+            let passes: Vec<_> = [("Family", "family"), ("Trip", "trip")]
+                .into_iter()
+                .map(|(name, id)| AlbumPass {
+                    kind: PassKind::Album,
+                    album: mock_album_with_container(
+                        name,
+                        id,
+                        MockPhotosFlow::new()
+                            .album_count(1)
+                            .query_page(records.clone(), Some("token-full"))
+                            .build(),
+                    ),
+                    exclude_ids: Arc::new(FxHashSet::default()),
+                })
+                .collect();
+            let dir = TempDir::new().unwrap();
+            let db_path = dir.path().join("state.db");
+            let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+            let mut config = test_config();
+            config.directory = Arc::from(dir.path().join("media"));
+            config.metadata.xmp_sidecar = true;
+            config.metadata.embed_xmp = embed_xmp;
+            config.state_db = Some(db.clone());
+            let initial = download_photos_with_sync(
+                &Client::new(),
+                &passes,
+                Arc::new(config.clone()),
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(initial.outcome, DownloadOutcome::Success),
+                "{initial:?}"
+            );
+            assert_eq!(initial.stats.downloaded, 2);
+            let paths: Vec<PathBuf> = {
+                let conn = db.acquire_lock("test_finalized_paths").unwrap();
+                let mut stmt = conn
+                    .prepare("SELECT local_path FROM asset_metadata_paths ORDER BY local_path")
+                    .unwrap();
+                stmt.query_map([], |row| row.get::<_, String>(0))
+                    .unwrap()
+                    .map(|row| PathBuf::from(row.unwrap()))
+                    .collect()
+            };
+            assert_eq!(paths.len(), 2);
+            assert_eq!(
+                paths
+                    .iter()
+                    .map(|path| path
+                        .parent()
+                        .unwrap()
+                        .file_name()
+                        .unwrap()
+                        .to_str()
+                        .unwrap())
+                    .collect::<Vec<_>>(),
+                ["Family", "Trip"]
+            );
+            let sidecars: Vec<_> = paths
+                .iter()
+                .map(|path| {
+                    let mut name = path.file_name().unwrap().to_os_string();
+                    name.push(".xmp");
+                    path.with_file_name(name)
+                })
+                .collect();
+            let subjects = |contents: &str| {
+                let meta: XmpMeta = contents.parse().unwrap();
+                let mut values: Vec<_> = meta
+                    .property_array(xmp_ns::DC, "subject")
+                    .map(|item| item.value)
+                    .collect();
+                values.sort();
+                values
+            };
+            let embedded_subjects = |path: &Path| {
+                let mut file = XmpFile::new().unwrap();
+                file.open_file(path, OpenFileOptions::default().for_read())
+                    .unwrap();
+                let meta = file.xmp().unwrap();
+                let mut values: Vec<_> = meta
+                    .property_array(xmp_ns::DC, "subject")
+                    .map(|item| item.value)
+                    .collect();
+                values.sort();
+                values
+            };
+            if embed_xmp {
+                for path in &paths {
+                    assert_eq!(embedded_subjects(path), ["Family", "Trip"]);
+                }
+            }
+            for path in &sidecars {
+                assert_eq!(
+                    subjects(&tokio::fs::read_to_string(path).await.unwrap()),
+                    ["Family", "Trip"]
+                );
+            }
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            assert_eq!(
+                db.acquire_lock("test_registered_paths")
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM asset_metadata_paths", [], |row| row
+                        .get::<_, i64>(
+                        0
+                    ))
+                    .unwrap(),
+                2
+            );
+            config.state_db = None;
+            drop(db);
+            let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+            config.state_db = Some(db.clone());
+            config.recent = Some(10);
+            let pass = AlbumPass {
+                kind: PassKind::Unfiled,
+                album: changes_album(
+                    "",
+                    changes_zone_session(
+                        Arc::new(AtomicUsize::new(0)),
+                        vec![relation_delete_record("trip", "asset-COPIES")],
+                    ),
+                ),
+                exclude_ids: Arc::new(FxHashSet::default()),
+            };
+            // One independently damaged sidecar must not prevent the other copy's
+            // rewrite, or clear the damaged copy's durable retry marker.
+            let original_sidecar = tokio::fs::read(&sidecars[0]).await.unwrap();
+            tokio::fs::write(&sidecars[0], b"not parseable XMP")
+                .await
+                .unwrap();
+            let failed = download_photos_incremental(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                &Arc::new(config.clone()),
+                "token-full",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(failed.outcome, DownloadOutcome::PartialFailure { .. }),
+                "{failed:?}"
+            );
+            assert_eq!(failed.stats.downloaded, 0);
+            assert_eq!(
+                tokio::fs::read(&sidecars[0]).await.unwrap(),
+                b"not parseable XMP"
+            );
+            assert_eq!(
+                subjects(&tokio::fs::read_to_string(&sidecars[1]).await.unwrap()),
+                ["Family"]
+            );
+            let pending = db.get_pending_metadata_rewrites(10).await.unwrap();
+            assert_eq!(pending.len(), 1);
+            assert_eq!(pending[0].local_path.as_ref(), Some(&paths[0]));
+            tokio::fs::write(&sidecars[0], original_sidecar)
+                .await
+                .unwrap();
+            let repaired = download_photos_incremental(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                &Arc::new(config.clone()),
+                "token-full",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(repaired.outcome, DownloadOutcome::Success),
+                "{repaired:?}"
+            );
+            assert_eq!(repaired.stats.downloaded, 0);
+            let mut mtimes = Vec::new();
+            for (media, sidecar) in paths.iter().zip(&sidecars) {
+                if embed_xmp {
+                    assert_eq!(embedded_subjects(media), ["Family"]);
+                } else {
+                    assert_eq!(tokio::fs::read(media).await.unwrap(), body);
+                }
+                let checksum = file::compute_sha256(media).await.unwrap();
+                let recorded: String = db
+                    .acquire_lock("test_path_fingerprints")
+                    .unwrap()
+                    .query_row(
+                        "SELECT local_checksum FROM asset_metadata_paths WHERE local_path = ?1",
+                        [media.to_string_lossy()],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(recorded, checksum);
+                assert_eq!(
+                    subjects(&tokio::fs::read_to_string(sidecar).await.unwrap()),
+                    ["Family"]
+                );
+                mtimes.push(
+                    tokio::fs::metadata(sidecar)
+                        .await
+                        .unwrap()
+                        .modified()
+                        .unwrap(),
+                );
+            }
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            let steady = download_photos_incremental(
+                &Client::new(),
+                &[pass],
+                &Arc::new(config),
+                "token-full",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(steady.outcome, DownloadOutcome::Success),
+                "{steady:?}"
+            );
+            assert_eq!(steady.stats.downloaded, 0);
+            for (sidecar, before) in sidecars.iter().zip(mtimes) {
+                assert_eq!(
+                    tokio::fs::metadata(sidecar)
+                        .await
+                        .unwrap()
+                        .modified()
+                        .unwrap(),
+                    before
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn album_membership_first_xmp_and_tracked_path_removal() {
+        use base64::Engine as _;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        use xmp_toolkit::{XmpMeta, xmp_ns};
+
+        let server = crate::start_wiremock_or_skip!();
+        let body = vec![
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+        ];
+        Mock::given(method("GET"))
+            .and(path("/album.jpg"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut records = incremental_photo_records_with_url(
+            "FIRST_ALBUM",
+            "album.jpg",
+            &format!("{}/album.jpg", server.uri()),
+            body.len() as u64,
+        );
+        records[0]["fields"]["resOriginalRes"]["value"]["fileChecksum"] =
+            json!(base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&body)));
+        let asset = PhotoAsset::new(records[0].clone(), records[1].clone());
+        let dir = TempDir::new().unwrap();
+        let db = Arc::new(
+            SqliteStateDb::open(&dir.path().join("state.db"))
+                .await
+                .unwrap(),
+        );
+        let mut config = test_config();
+        config.directory = Arc::from(dir.path().join("media"));
+        config.album_name = Some(Arc::from("Trip"));
+        config.metadata.xmp_sidecar = true;
+        config.state_db = Some(db.clone());
+        assert!(
+            db.get_all_asset_albums("PrimarySync")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let first = stream_and_download_from_stream(
+            &Client::new(),
+            futures_util::stream::iter(vec![Ok(asset.clone())]),
+            &Arc::new(config.clone()),
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None).deferring_metadata_drain(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.downloaded, 1);
+        assert_eq!(first.exif_failures, 0);
+        let row = db.get_downloaded_page(0, 10).await.unwrap().remove(0);
+        let media_path = row.local_path.as_ref().unwrap();
+        let mut sidecar_name = media_path.file_name().unwrap().to_os_string();
+        sidecar_name.push(".xmp");
+        let sidecar_path = media_path.with_file_name(sidecar_name);
+        let subjects = |contents: &str| {
+            let xmp: XmpMeta = contents.parse().expect("parse actual sidecar");
+            let mut names: Vec<_> = xmp
+                .property_array(xmp_ns::DC, "subject")
+                .map(|value| value.value)
+                .collect();
+            names.sort();
+            names
+        };
+        let first_xmp = tokio::fs::read_to_string(&sidecar_path).await.unwrap();
+        assert_eq!(
+            subjects(&first_xmp),
+            ["Trip"],
+            "inspect before any rewrite drain"
+        );
+        assert_eq!(tokio::fs::read(media_path).await.unwrap(), body);
+
+        seed_complete_album_snapshot(&db, "trip", "Trip", &[("asset-FIRST_ALBUM", "FIRST_ALBUM")])
+            .await;
+        seed_complete_album_snapshot(
+            &db,
+            "family",
+            "Family",
+            &[("asset-FIRST_ALBUM", "FIRST_ALBUM")],
+        )
+        .await;
+        config.album_name = Some(Arc::from("Family"));
+        let second = stream_and_download_from_stream(
+            &Client::new(),
+            futures_util::stream::iter(vec![Ok(asset)]),
+            &Arc::new(config.clone()),
+            DownloadControls::download_hidden(),
+            1,
+            CancellationToken::new(),
+            StreamRuntime::new(None, None),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.downloaded, 0);
+        assert_eq!(second.exif_failures, 0);
+        assert_eq!(
+            subjects(&tokio::fs::read_to_string(&sidecar_path).await.unwrap()),
+            ["Family", "Trip"]
+        );
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        config.album_name = None;
+        config.recent = Some(10);
+        let pass = AlbumPass {
+            kind: PassKind::Unfiled,
+            album: changes_album(
+                "",
+                changes_zone_session(
+                    Arc::new(AtomicUsize::new(0)),
+                    vec![relation_delete_record("trip", "asset-FIRST_ALBUM")],
+                ),
+            ),
+            exclude_ids: Arc::new(FxHashSet::default()),
+        };
+        for _ in 0..2 {
+            let removed = download_photos_incremental(
+                &Client::new(),
+                std::slice::from_ref(&pass),
+                &Arc::new(config.clone()),
+                "zone-token-prev",
+                DownloadControls::download_hidden(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+            assert!(
+                matches!(removed.outcome, DownloadOutcome::Success),
+                "{removed:?}"
+            );
+            assert_eq!(removed.stats.downloaded, 0);
+            assert_eq!(
+                subjects(&tokio::fs::read_to_string(&sidecar_path).await.unwrap()),
+                ["Family"]
+            );
+            assert_eq!(tokio::fs::read(media_path).await.unwrap(), body);
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            let rows = db.get_downloaded_page(0, 10).await.unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].local_path, row.local_path);
+        }
+    }
+
     #[tokio::test]
     async fn collecting_album_membership_failure_replays_without_redownloading() {
         let db = Arc::new(SqliteStateDb::open_in_memory().expect("state db"));
@@ -16311,7 +16752,7 @@ mod tests {
 
         assert!(matches!(
             result.outcome,
-            DownloadOutcome::PartialFailure { failed_count: 1 }
+            DownloadOutcome::PartialFailure { failed_count: 2 }
         ));
         assert_eq!(result.stats.downloaded, 0);
         assert_eq!(result.sync_token, None);
@@ -16326,12 +16767,24 @@ mod tests {
             .expect("read unchanged row")
             .remove(0);
         assert!(!unchanged.metadata.is_favorite);
+        let pending = db
+            .get_pending_metadata_rewrites(10)
+            .await
+            .expect("read rewrite queue");
+        assert_eq!(
+            pending.len(),
+            1,
+            "the independent album removal must retain retry evidence"
+        );
         assert!(
-            db.get_pending_metadata_rewrites(10)
+            !pending[0].metadata.is_favorite,
+            "failed provider metadata must not leak into the rewrite"
+        );
+        assert!(
+            db.get_all_asset_albums("PrimarySync")
                 .await
-                .expect("read rewrite queue")
-                .is_empty(),
-            "the catalogue and rewrite marker must fail atomically"
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1771,6 +1771,23 @@ where
                         }
                     }
 
+                    // Persist membership even when planning skips already-landed media.
+                    if let Some(db) = &producer_state_db
+                        && let Err(e) =
+                            planner::record_album_membership_if_named(db.as_ref(), config, &asset)
+                                .await
+                        && let Some(album) = config.album_name.as_deref()
+                    {
+                        state_write_failures_producer
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(
+                            asset_id = %asset.id(),
+                            album = %album,
+                            error = %e,
+                            "Failed to record album membership after retries"
+                        );
+                    }
+
                     let plan = task_planner.plan_asset(&asset, config).await;
                     if let Some(reason) = plan.filter_reason {
                         skips.record_filter_reason(reason);
@@ -1874,28 +1891,6 @@ where
                             }
 
                             if let Some(db) = &producer_state_db {
-                                // Per-album config (set when {album} is in folder_structure)
-                                // carries the album name so we can record membership.
-                                // In merged-stream mode album is unknown at this point;
-                                // the next incremental sync fills it in.
-                                if let Err(e) = planner::record_album_membership_if_named(
-                                    db.as_ref(),
-                                    config,
-                                    &asset,
-                                )
-                                .await
-                                    && let Some(album) = config.album_name.as_deref()
-                                {
-                                    state_write_failures_producer
-                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    tracing::warn!(
-                                        asset_id = %asset.id(),
-                                        album = %album,
-                                        error = %e,
-                                        "Failed to record album membership after retries"
-                                    );
-                                }
-
                                 if let Some(adoption) = adopt_pending_on_disk_task(
                                     producer_state_db.as_deref(),
                                     config,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -1,6 +1,6 @@
 //! State database trait and `SQLite` implementation.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -24,6 +24,122 @@ use super::types::{
 /// CloudKit parsing sets `source` explicitly; this fallback is a safety net,
 /// not the intended write path.
 const DEFAULT_SOURCE: &str = "icloud";
+
+/// Project provider relations into the compatibility grouping table. Only
+/// explicit relation/container tombstones remove names; an unfinished snapshot
+/// retains its prior live rows. External grouping sources are never removed.
+fn refresh_asset_album_groupings_tx(
+    tx: &Transaction<'_>,
+    library: &str,
+    asset_id: &str,
+    previous_name: Option<&str>,
+) -> Result<(), StateError> {
+    let operation = "refresh_asset_album_groupings";
+    let mut stmt = tx
+        .prepare_cached(
+            "SELECT c.album_name, m.is_deleted OR c.is_deleted \
+         FROM asset_album_memberships m JOIN album_containers c \
+           ON c.library = m.library AND c.container_id = m.container_id \
+         WHERE m.library = ?1 AND m.asset_record_name IN ( \
+             SELECT ?2 UNION SELECT asset_record_name FROM legacy_master_state_owners \
+             WHERE library = ?1 AND master_record_name = ?2)",
+        )
+        .map_err(|e| StateError::query(operation, e))?;
+    let rows = stmt
+        .query_map(rusqlite::params![library, asset_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?))
+        })
+        .map_err(|e| StateError::query(operation, e))?;
+    let mut known = BTreeSet::new();
+    let mut live = BTreeSet::new();
+    for row in rows {
+        let (name, deleted) = row.map_err(|e| StateError::query(operation, e))?;
+        known.insert(name.clone());
+        if !deleted {
+            live.insert(name);
+        }
+    }
+    if let Some(name) = previous_name {
+        known.insert(name.to_owned());
+    }
+    let mut changed = 0;
+    for name in known.difference(&live) {
+        changed += tx
+            .execute(
+                "DELETE FROM asset_albums WHERE library = ?1 AND asset_id = ?2 \
+             AND album_name = ?3 AND source = 'icloud'",
+                rusqlite::params![library, asset_id, name],
+            )
+            .map_err(|e| StateError::query(operation, e))?;
+    }
+    for name in live {
+        changed += tx
+            .execute(
+                "INSERT INTO asset_albums (library, asset_id, album_name, source) \
+             SELECT ?1, ?2, ?3, 'icloud' WHERE NOT EXISTS ( \
+                 SELECT 1 FROM asset_albums WHERE library = ?1 AND asset_id = ?2 \
+                 AND album_name = ?3 AND source = 'icloud')",
+                rusqlite::params![library, asset_id, name],
+            )
+            .map_err(|e| StateError::query(operation, e))?;
+    }
+    if changed > 0 {
+        mark_album_groupings_dirty_tx(tx, library, asset_id)?;
+    }
+    Ok(())
+}
+
+fn mark_album_groupings_dirty_tx(
+    tx: &Transaction<'_>,
+    library: &str,
+    asset_id: &str,
+) -> Result<(), StateError> {
+    tx.execute(
+        "UPDATE assets SET metadata_write_failed_at = COALESCE(metadata_write_failed_at, ?3) \
+         WHERE library = ?1 AND id = ?2 AND is_deleted = 0",
+        rusqlite::params![library, asset_id, Utc::now().timestamp()],
+    )
+    .map_err(|e| StateError::query("mark_album_groupings_dirty", e))?;
+    tx.execute(
+        "UPDATE asset_metadata_paths SET metadata_write_failed_at = COALESCE(metadata_write_failed_at, ?3) \
+         WHERE library = ?1 AND id = ?2",
+        rusqlite::params![library, asset_id, Utc::now().timestamp()],
+    ).map_err(|e| StateError::query("mark_album_metadata_paths_dirty", e))?;
+    Ok(())
+}
+
+fn refresh_container_groupings_tx(
+    tx: &Transaction<'_>,
+    library: &str,
+    container_id: &str,
+    asset_record_name: Option<&str>,
+    previous_name: Option<&str>,
+) -> Result<(), StateError> {
+    let operation = "refresh_container_groupings";
+    let mut stmt = tx
+        .prepare_cached(
+            "SELECT DISTINCT a.id FROM asset_album_memberships m \
+         LEFT JOIN legacy_master_state_owners o \
+           ON o.library = m.library AND o.asset_record_name = m.asset_record_name \
+         JOIN assets a ON a.library = m.library \
+           AND (a.id = m.asset_record_name OR a.id = o.master_record_name) \
+         WHERE m.library = ?1 AND m.container_id = ?2 \
+           AND (?3 IS NULL OR m.asset_record_name = ?3)",
+        )
+        .map_err(|e| StateError::query(operation, e))?;
+    let ids = stmt
+        .query_map(
+            rusqlite::params![library, container_id, asset_record_name],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|e| StateError::query(operation, e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| StateError::query(operation, e))?;
+    for id in ids {
+        refresh_asset_album_groupings_tx(tx, library, &id, previous_name)?;
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone)]
 struct OwnedTempPathKey(Vec<u8>);
@@ -1137,10 +1253,12 @@ fn upsert_asset_row(
         None
     };
     let metadata_hash: Option<&str> = meta.metadata_hash.as_deref().or(computed_hash.as_deref());
+    let source = metadata_rewrite_source_sql();
     let blocked_capture_repair: i64 = conn
         .query_row(
-            "SELECT EXISTS( \
-                SELECT 1 FROM assets \
+            &format!(
+                "SELECT EXISTS( \
+                SELECT 1 FROM ({source}) \
                 WHERE library = ?1 AND id = ?2 \
                   AND status = 'downloaded' AND is_deleted = 0 \
                   AND capture_repair_metadata_hash IS NOT NULL \
@@ -1151,7 +1269,8 @@ fn upsert_asset_row(
                   AND capture_repair_output_size >= 0 \
                   AND capture_repair_metadata_hash IS NOT ?3 \
                   AND (version_size <> ?4 OR checksum = ?5) \
-            )",
+            )"
+            ),
             rusqlite::params![
                 &record.library,
                 &record.id,
@@ -1377,6 +1496,124 @@ fn record_metadata_capture_revision(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum MetadataPathWrite {
+    Published,
+    Rewritten,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MetadataRewriteTarget {
+    Catalogue,
+    AdditionalPath,
+}
+
+impl MetadataRewriteTarget {
+    fn sql(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Catalogue => (
+                "assets",
+                "status = 'downloaded' AND is_deleted = 0 AND metadata_hash IS ?4",
+            ),
+            Self::AdditionalPath => (
+                "asset_metadata_paths",
+                "EXISTS (SELECT 1 FROM assets a \
+                WHERE a.library = asset_metadata_paths.library AND a.id = asset_metadata_paths.id \
+                  AND a.version_size = asset_metadata_paths.version_size \
+                  AND a.checksum = asset_metadata_paths.provider_checksum \
+                  AND a.status = 'downloaded' AND a.is_deleted = 0 AND a.metadata_hash IS ?4)",
+            ),
+        }
+    }
+}
+
+/// Select a path-specific compare-and-swap target without changing sync ownership.
+fn metadata_rewrite_target(
+    conn: &Connection,
+    library: &str,
+    id: &str,
+    version_size: &str,
+    path: &Path,
+) -> Result<MetadataRewriteTarget, StateError> {
+    let primary = conn.query_row(
+        "SELECT local_path IS ?4 FROM assets WHERE library = ?1 AND id = ?2 AND version_size = ?3",
+        rusqlite::params![library, id, version_size, path.to_string_lossy()], |row| row.get::<_, bool>(0),
+    ).optional().map_err(|e| StateError::query("metadata_rewrite_target", e))?.unwrap_or(false);
+    Ok(if primary {
+        MetadataRewriteTarget::Catalogue
+    } else {
+        MetadataRewriteTarget::AdditionalPath
+    })
+}
+
+/// Copy the catalogue path's exact publication evidence in the same transaction.
+/// Other paths retain their own fingerprints and independent retry receipts.
+fn record_metadata_path(
+    conn: &Connection,
+    library: &str,
+    id: &str,
+    version_size: &str,
+    write: MetadataPathWrite,
+) -> Result<(), StateError> {
+    let preserve_debt = i64::from(matches!(write, MetadataPathWrite::Published));
+    conn.execute(
+        "INSERT INTO asset_metadata_paths \
+            (library, id, version_size, local_path, provider_checksum, local_checksum, \
+             download_checksum, metadata_write_failed_at, capture_repair_metadata_hash, \
+             capture_repair_output_checksum, capture_repair_output_size) \
+         SELECT library, id, version_size, local_path, checksum, local_checksum, \
+                download_checksum, metadata_write_failed_at, capture_repair_metadata_hash, \
+                capture_repair_output_checksum, capture_repair_output_size \
+         FROM assets WHERE library = ?1 AND id = ?2 AND version_size = ?3 \
+             AND status = 'downloaded' AND local_path IS NOT NULL \
+         ON CONFLICT(library, id, version_size, local_path) DO UPDATE SET \
+             provider_checksum = excluded.provider_checksum, \
+             local_checksum = excluded.local_checksum, \
+             download_checksum = excluded.download_checksum, \
+             metadata_write_failed_at = CASE WHEN ?4 = 1 THEN \
+                 COALESCE(excluded.metadata_write_failed_at, asset_metadata_paths.metadata_write_failed_at) \
+                 ELSE excluded.metadata_write_failed_at END, \
+             capture_repair_metadata_hash = CASE WHEN ?4 = 1 \
+                 AND asset_metadata_paths.provider_checksum = excluded.provider_checksum \
+                 AND asset_metadata_paths.local_checksum IS excluded.local_checksum \
+                 THEN COALESCE(excluded.capture_repair_metadata_hash, asset_metadata_paths.capture_repair_metadata_hash) \
+                 ELSE excluded.capture_repair_metadata_hash END, \
+             capture_repair_output_checksum = CASE WHEN ?4 = 1 \
+                 AND asset_metadata_paths.provider_checksum = excluded.provider_checksum \
+                 AND asset_metadata_paths.local_checksum IS excluded.local_checksum \
+                 THEN COALESCE(excluded.capture_repair_output_checksum, asset_metadata_paths.capture_repair_output_checksum) \
+                 ELSE excluded.capture_repair_output_checksum END, \
+             capture_repair_output_size = CASE WHEN ?4 = 1 \
+                 AND asset_metadata_paths.provider_checksum = excluded.provider_checksum \
+                 AND asset_metadata_paths.local_checksum IS excluded.local_checksum \
+                 THEN COALESCE(excluded.capture_repair_output_size, asset_metadata_paths.capture_repair_output_size) \
+                 ELSE excluded.capture_repair_output_size END",
+        rusqlite::params![library, id, version_size, preserve_debt],
+    )
+    .map_err(|e| StateError::query("record_metadata_path", e))?;
+    if matches!(write, MetadataPathWrite::Published) {
+        // A previously additional path can become the catalogue path again.
+        // Keep its own preserved debt visible in the catalogue projection.
+        conn.execute(
+            "UPDATE assets SET (metadata_write_failed_at, capture_repair_metadata_hash, \
+                 capture_repair_output_checksum, capture_repair_output_size) = ( \
+                 SELECT p.metadata_write_failed_at, p.capture_repair_metadata_hash, \
+                        p.capture_repair_output_checksum, p.capture_repair_output_size \
+                 FROM asset_metadata_paths p WHERE p.library = assets.library AND p.id = assets.id \
+                   AND p.version_size = assets.version_size AND p.local_path = assets.local_path) \
+             WHERE library = ?1 AND id = ?2 AND version_size = ?3 AND EXISTS ( \
+                 SELECT 1 FROM asset_metadata_paths p WHERE p.library = assets.library AND p.id = assets.id \
+                   AND p.version_size = assets.version_size AND p.local_path = assets.local_path \
+                   AND (p.metadata_write_failed_at IS NOT assets.metadata_write_failed_at \
+                     OR p.capture_repair_metadata_hash IS NOT assets.capture_repair_metadata_hash \
+                     OR p.capture_repair_output_checksum IS NOT assets.capture_repair_output_checksum \
+                     OR p.capture_repair_output_size IS NOT assets.capture_repair_output_size))",
+            rusqlite::params![library, id, version_size],
+        ).map_err(|e| StateError::query("record_metadata_path::restore_debt", e))?;
+    }
+    Ok(())
+}
+
 /// Execute the `mark_downloaded` UPDATE on `conn`. Returns rows affected;
 /// callers decide what zero rows means in their context.
 #[expect(
@@ -1400,27 +1637,36 @@ fn update_status_to_downloaded(
              local_checksum = ?3, download_checksum = COALESCE(?4, download_checksum), last_error = NULL, \
              capture_repair_metadata_hash = CASE \
                  WHEN ?5 = 1 THEN metadata_hash \
-                 WHEN local_checksum IS ?3 THEN capture_repair_metadata_hash ELSE NULL END, \
+                 WHEN local_checksum IS ?3 AND local_path IS ?2 THEN capture_repair_metadata_hash ELSE NULL END, \
              capture_repair_output_checksum = CASE \
                  WHEN ?5 = 1 THEN NULL \
-                 WHEN local_checksum IS ?3 THEN capture_repair_output_checksum ELSE NULL END, \
+                 WHEN local_checksum IS ?3 AND local_path IS ?2 THEN capture_repair_output_checksum ELSE NULL END, \
              capture_repair_output_size = CASE \
                  WHEN ?5 = 1 THEN NULL \
-                 WHEN local_checksum IS ?3 THEN capture_repair_output_size ELSE NULL END \
+                 WHEN local_checksum IS ?3 AND local_path IS ?2 THEN capture_repair_output_size ELSE NULL END \
              WHERE library = ?6 AND id = ?7 AND version_size = ?8",
         )
         .map_err(|e| StateError::query("mark_downloaded::prepare", e))?;
-    stmt.execute(rusqlite::params![
-        downloaded_at,
-        local_path.to_string_lossy(),
-        local_checksum,
-        download_checksum,
-        i64::from(mark_capture_repair),
+    let updated = stmt
+        .execute(rusqlite::params![
+            downloaded_at,
+            local_path.to_string_lossy(),
+            local_checksum,
+            download_checksum,
+            i64::from(mark_capture_repair),
+            library,
+            id,
+            version_size
+        ])
+        .map_err(|e| StateError::query("mark_downloaded", e))?;
+    record_metadata_path(
+        conn,
         library,
         id,
-        version_size
-    ])
-    .map_err(|e| StateError::query("mark_downloaded", e))
+        version_size,
+        MetadataPathWrite::Published,
+    )?;
+    Ok(updated)
 }
 
 fn ensure_asset_has_no_prepared_capture_repair(
@@ -1429,10 +1675,12 @@ fn ensure_asset_has_no_prepared_capture_repair(
     asset_id: &str,
     operation: &'static str,
 ) -> Result<(), StateError> {
+    let source = metadata_rewrite_source_sql();
     let prepared: i64 = conn
         .query_row(
-            "SELECT EXISTS( \
-                SELECT 1 FROM assets \
+            &format!(
+                "SELECT EXISTS( \
+                SELECT 1 FROM ({source}) \
                 WHERE library = ?1 AND id = ?2 \
                   AND capture_repair_metadata_hash IS NOT NULL \
                   AND capture_repair_metadata_hash <> '' \
@@ -1440,7 +1688,8 @@ fn ensure_asset_has_no_prepared_capture_repair(
                   AND capture_repair_output_checksum <> '' \
                   AND capture_repair_output_size IS NOT NULL \
                   AND capture_repair_output_size >= 0 \
-            )",
+            )"
+            ),
             rusqlite::params![library, asset_id],
             |row| row.get(0),
         )
@@ -1460,10 +1709,12 @@ fn ensure_master_family_has_no_prepared_capture_repair(
     master_record_name: &str,
     operation: &'static str,
 ) -> Result<(), StateError> {
+    let source = metadata_rewrite_source_sql();
     let prepared: i64 = conn
         .query_row(
-            "SELECT EXISTS( \
-                SELECT 1 FROM assets \
+            &format!(
+                "SELECT EXISTS( \
+                SELECT 1 FROM ({source}) \
                 WHERE library = ?1 \
                   AND (id = ?2 OR id IN ( \
                       SELECT asset_record_name FROM asset_master_mappings \
@@ -1475,7 +1726,8 @@ fn ensure_master_family_has_no_prepared_capture_repair(
                   AND capture_repair_output_checksum <> '' \
                   AND capture_repair_output_size IS NOT NULL \
                   AND capture_repair_output_size >= 0 \
-            )",
+            )"
+            ),
             rusqlite::params![library, master_record_name],
             |row| row.get(0),
         )
@@ -1699,8 +1951,19 @@ impl SqliteStateDb {
 
     pub(crate) async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
         let record = record.clone();
-        self.with_conn("upsert_seen", move |conn| {
-            upsert_asset_row(conn, &record, Utc::now().timestamp())
+        self.with_conn_mut("upsert_seen", move |conn| {
+            let tx = conn.transaction().map_err(|e| StateError::query("upsert_seen::begin", e))?;
+            upsert_asset_row(&tx, &record, Utc::now().timestamp())?;
+            refresh_asset_album_groupings_tx(&tx, &record.library, &record.id, None)?;
+            // Membership may precede the first state row. Keep a retry marker
+            // until the end-of-cycle writer sees all selected album producers.
+            tx.execute(
+                "UPDATE assets SET metadata_write_failed_at = COALESCE(metadata_write_failed_at, ?3) \
+                 WHERE library = ?1 AND id = ?2 AND status = 'pending' AND EXISTS ( \
+                     SELECT 1 FROM asset_albums WHERE library = ?1 AND asset_id = ?2)",
+                rusqlite::params![&record.library, &record.id, Utc::now().timestamp()],
+            ).map_err(|e| StateError::query("upsert_seen::album_marker", e))?;
+            tx.commit().map_err(|e| StateError::query("upsert_seen::commit", e))
         })
         .await
     }
@@ -1744,9 +2007,12 @@ impl SqliteStateDb {
         let local_checksum = local_checksum.to_owned();
         let download_checksum = download_checksum.map(str::to_owned);
 
-        self.with_conn("mark_downloaded", move |conn| {
+        self.with_conn_mut("mark_downloaded", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("mark_downloaded::begin", e))?;
             let rows = update_status_to_downloaded(
-                conn,
+                &tx,
                 &library,
                 &id,
                 &version_size,
@@ -1766,13 +2032,15 @@ impl SqliteStateDb {
             }
 
             record_metadata_capture_revision(
-                conn,
+                &tx,
                 &library,
                 &id,
                 METADATA_CAPTURE_REVISION,
                 downloaded_at,
             )?;
 
+            tx.commit()
+                .map_err(|e| StateError::query("mark_downloaded::commit", e))?;
             Ok(())
         })
         .await
@@ -3237,13 +3505,22 @@ impl SqliteStateDb {
         let asset_id = asset_id.to_owned();
         let album_name = album_name.to_owned();
         let source = source.to_owned();
-        self.with_conn("add_asset_album", move |conn| {
-            conn.execute(
-                "INSERT OR IGNORE INTO asset_albums (library, asset_id, album_name, source) \
+        self.with_conn_mut("add_asset_album", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("add_asset_album::begin", e))?;
+            let changed = tx
+                .execute(
+                    "INSERT OR IGNORE INTO asset_albums (library, asset_id, album_name, source) \
                  VALUES (?1, ?2, ?3, ?4)",
-                rusqlite::params![library, asset_id, album_name, source],
-            )
-            .map_err(|e| StateError::query("add_asset_album", e))?;
+                    rusqlite::params![&library, &asset_id, album_name, source],
+                )
+                .map_err(|e| StateError::query("add_asset_album", e))?;
+            if changed > 0 {
+                mark_album_groupings_dirty_tx(&tx, &library, &asset_id)?;
+            }
+            tx.commit()
+                .map_err(|e| StateError::query("add_asset_album::commit", e))?;
             Ok(())
         })
         .await
@@ -3353,9 +3630,16 @@ impl SqliteStateDb {
         let container_id = container_id.to_owned();
         let album_name = album_name.to_owned();
         let pass_kind = pass_kind.to_owned();
-        self.with_conn("upsert_album_container", move |conn| {
+        self.with_conn_mut("upsert_album_container", move |conn| {
             let now = Utc::now().timestamp();
-            conn.execute(
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("upsert_album_container::begin", e))?;
+            let previous_name: Option<String> = tx.query_row(
+                "SELECT album_name FROM album_containers WHERE library = ?1 AND container_id = ?2",
+                rusqlite::params![&library, &container_id], |row| row.get(0),
+            ).optional().map_err(|e| StateError::query("upsert_album_container::name", e))?;
+            tx.execute(
                 "INSERT INTO album_containers \
                     (library, container_id, album_name, pass_kind, is_deleted, updated_at) \
                  VALUES (?1, ?2, ?3, ?4, 0, ?5) \
@@ -3364,9 +3648,18 @@ impl SqliteStateDb {
                     pass_kind = excluded.pass_kind, \
                     is_deleted = 0, \
                     updated_at = excluded.updated_at",
-                rusqlite::params![library, container_id, album_name, pass_kind, now],
+                rusqlite::params![&library, &container_id, album_name, pass_kind, now],
             )
             .map_err(|e| StateError::query("upsert_album_container", e))?;
+            refresh_container_groupings_tx(
+                &tx,
+                &library,
+                &container_id,
+                None,
+                previous_name.as_deref(),
+            )?;
+            tx.commit()
+                .map_err(|e| StateError::query("upsert_album_container::commit", e))?;
             Ok(())
         })
         .await
@@ -3379,15 +3672,31 @@ impl SqliteStateDb {
     ) -> Result<(), StateError> {
         let library = library.to_owned();
         let container_id = container_id.to_owned();
-        self.with_conn("mark_album_container_deleted", move |conn| {
+        self.with_conn_mut("mark_album_container_deleted", move |conn| {
             let now = Utc::now().timestamp();
-            conn.execute(
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("mark_album_container_deleted::begin", e))?;
+            let previous_name: Option<String> = tx.query_row(
+                "SELECT album_name FROM album_containers WHERE library = ?1 AND container_id = ?2",
+                rusqlite::params![&library, &container_id], |row| row.get(0),
+            ).optional().map_err(|e| StateError::query("mark_album_container_deleted::name", e))?;
+            tx.execute(
                 "UPDATE album_containers \
                  SET is_deleted = 1, updated_at = ?1 \
                  WHERE library = ?2 AND container_id = ?3",
-                rusqlite::params![now, library, container_id],
+                rusqlite::params![now, &library, &container_id],
             )
             .map_err(|e| StateError::query("mark_album_container_deleted", e))?;
+            refresh_container_groupings_tx(
+                &tx,
+                &library,
+                &container_id,
+                None,
+                previous_name.as_deref(),
+            )?;
+            tx.commit()
+                .map_err(|e| StateError::query("mark_album_container_deleted::commit", e))?;
             Ok(())
         })
         .await
@@ -3498,6 +3807,7 @@ impl SqliteStateDb {
                 ],
             )
             .map_err(|e| StateError::query("add_album_membership_to_snapshot::upsert", e))?;
+            refresh_container_groupings_tx(&tx, &library, &container_id, Some(&asset_record_name), None)?;
             tx.commit()
                 .map_err(|e| StateError::query("add_album_membership_to_snapshot::commit", e))?;
             Ok(())
@@ -3549,6 +3859,7 @@ impl SqliteStateDb {
                 ],
             )
             .map_err(|e| StateError::query("upsert_album_membership_delta::upsert", e))?;
+            refresh_container_groupings_tx(&tx, &library, &container_id, Some(&asset_record_name), None)?;
             tx.commit()
                 .map_err(|e| StateError::query("upsert_album_membership_delta::commit", e))?;
             Ok(container_known)
@@ -3583,6 +3894,13 @@ impl SqliteStateDb {
                 rusqlite::params![now, &library, &container_id, &asset_record_name],
             )
             .map_err(|e| StateError::query("mark_album_membership_deleted::update", e))?;
+            refresh_container_groupings_tx(
+                &tx,
+                &library,
+                &container_id,
+                Some(&asset_record_name),
+                None,
+            )?;
             tx.commit()
                 .map_err(|e| StateError::query("mark_album_membership_deleted::commit", e))?;
             Ok(container_known)
@@ -3630,6 +3948,7 @@ impl SqliteStateDb {
                 rusqlite::params![now, &library, &container_id, generation],
             )
             .map_err(|e| StateError::query("complete_album_membership_snapshot::prune", e))?;
+            refresh_container_groupings_tx(&tx, &library, &container_id, None, None)?;
             tx.commit()
                 .map_err(|e| StateError::query("complete_album_membership_snapshot::commit", e))?;
             Ok(())
@@ -4252,13 +4571,24 @@ impl SqliteStateDb {
         let library = library.to_owned();
         let asset_id = asset_id.to_owned();
         let version_size = version_size.to_owned();
-        self.with_conn("record_metadata_write_failure", move |conn| {
-            conn.execute(
+        self.with_conn_mut("record_metadata_write_failure", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("record_metadata_write_failure::begin", e))?;
+            tx.execute(
                 "UPDATE assets SET metadata_write_failed_at = ?1 \
+                 WHERE library = ?2 AND id = ?3 AND version_size = ?4",
+                rusqlite::params![ts, &library, &asset_id, &version_size],
+            )
+            .map_err(|e| StateError::query("record_metadata_write_failure", e))?;
+            tx.execute(
+                "UPDATE asset_metadata_paths SET metadata_write_failed_at = ?1 \
                  WHERE library = ?2 AND id = ?3 AND version_size = ?4",
                 rusqlite::params![ts, library, asset_id, version_size],
             )
-            .map_err(|e| StateError::query("record_metadata_write_failure", e))?;
+            .map_err(|e| StateError::query("record_metadata_write_failure::paths", e))?;
+            tx.commit()
+                .map_err(|e| StateError::query("record_metadata_write_failure::commit", e))?;
             Ok(())
         })
         .await
@@ -4316,30 +4646,52 @@ impl SqliteStateDb {
                 operation: "record_capture_repair_prepared",
                 detail: "capture-repair output size exceeds SQLite INTEGER".into(),
             })?;
-        self.with_conn("record_capture_repair_prepared", move |conn| {
-            let updated = conn
+        let Some(path) = pending.asset.local_path.clone() else {
+            return Ok(None);
+        };
+        self.with_conn_mut("record_capture_repair_prepared", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("record_capture_repair_prepared::begin", e))?;
+            let target = metadata_rewrite_target(&tx, &library, &asset_id, &version_size, &path)?;
+            let (table, evidence) = target.sql();
+
+            let updated = tx
                 .execute(
-                    "UPDATE assets SET capture_repair_output_checksum = ?8, \
+                    &format!(
+                        "UPDATE {table} SET capture_repair_output_checksum = ?8, \
                         capture_repair_output_size = ?9 \
                      WHERE library = ?1 AND id = ?2 AND version_size = ?3 \
-                       AND status = 'downloaded' AND is_deleted = 0 \
-                       AND metadata_hash IS ?4 AND local_checksum IS ?5 \
+                       AND {evidence} AND local_checksum IS ?5 \
                        AND capture_repair_metadata_hash IS ?4 \
                        AND capture_repair_output_checksum IS ?6 \
-                       AND capture_repair_output_size IS ?7",
+                       AND capture_repair_output_size IS ?7 AND local_path IS ?10"
+                    ),
                     rusqlite::params![
-                        library,
-                        asset_id,
-                        version_size,
+                        &library,
+                        &asset_id,
+                        &version_size,
                         metadata_hash,
                         input_checksum,
                         selected_output_checksum,
                         selected_output_size,
                         output_checksum,
-                        output_size_sql
+                        output_size_sql,
+                        path.to_string_lossy()
                     ],
                 )
                 .map_err(|e| StateError::query("record_capture_repair_prepared", e))?;
+            if updated > 0 && target == MetadataRewriteTarget::Catalogue {
+                record_metadata_path(
+                    &tx,
+                    &library,
+                    &asset_id,
+                    &version_size,
+                    MetadataPathWrite::Rewritten,
+                )?;
+            }
+            tx.commit()
+                .map_err(|e| StateError::query("record_capture_repair_prepared::commit", e))?;
             Ok((updated > 0).then_some(CaptureRepairReceipt::Prepared {
                 metadata_hash,
                 output_checksum,
@@ -4365,10 +4717,13 @@ impl SqliteStateDb {
             metadata.refresh_hash();
         }
         let rewrite_at = Utc::now().timestamp();
-        self.with_conn("refresh_downloaded_asset_metadata", move |conn| {
+        self.with_conn_mut("refresh_downloaded_asset_metadata", move |connection| {
+            let tx = connection.transaction().map_err(|e| StateError::query("refresh_downloaded_asset_metadata::begin", e))?;
+            let conn = &tx;
+            let source = metadata_rewrite_source_sql();
             let updated = conn
                 .execute(
-                    r"
+                    &format!(r"
                     UPDATE assets SET
                         source = COALESCE(?1, source),
                         is_favorite = ?2,
@@ -4446,7 +4801,7 @@ impl SqliteStateDb {
                     WHERE library = ?27 AND id = ?28
                       AND status = 'downloaded' AND is_deleted = 0
                       AND NOT EXISTS (
-                          SELECT 1 FROM assets AS blocked
+                          SELECT 1 FROM ({source}) AS blocked
                           WHERE blocked.library = ?27 AND blocked.id = ?28
                             AND blocked.status = 'downloaded' AND blocked.is_deleted = 0
                             AND blocked.capture_repair_metadata_hash IS NOT NULL
@@ -4457,7 +4812,7 @@ impl SqliteStateDb {
                             AND blocked.capture_repair_output_size >= 0
                             AND blocked.capture_repair_metadata_hash IS NOT ?23
                       )
-                    ",
+                    "),
                     rusqlite::params![
                         metadata.source.as_deref(),
                         i64::from(metadata.is_favorite),
@@ -4500,11 +4855,11 @@ impl SqliteStateDb {
                 // write. A missing or still-stale row stays a failure.
                 let durable: i64 = conn
                     .query_row(
-                        "SELECT COUNT(*) FROM assets \
+                        &format!("SELECT COUNT(*) FROM assets \
                          WHERE library = ?1 AND id = ?2 AND is_deleted = 0 \
                            AND metadata_hash IS NOT NULL AND metadata_hash = ?3 \
                            AND NOT EXISTS ( \
-                               SELECT 1 FROM assets AS blocked \
+                               SELECT 1 FROM ({source}) AS blocked \
                                WHERE blocked.library = ?1 AND blocked.id = ?2 \
                                  AND blocked.status = 'downloaded' \
                                  AND blocked.is_deleted = 0 \
@@ -4515,7 +4870,7 @@ impl SqliteStateDb {
                                  AND blocked.capture_repair_output_size IS NOT NULL \
                                  AND blocked.capture_repair_output_size >= 0 \
                                  AND blocked.capture_repair_metadata_hash IS NOT ?3 \
-                           )",
+                           )"),
                         rusqlite::params![library, asset_id, metadata.metadata_hash.as_deref()],
                         |row| row.get(0),
                     )
@@ -4523,6 +4878,20 @@ impl SqliteStateDb {
                 usize::try_from(durable).unwrap_or(0)
             };
             if durable > 0 {
+                conn.execute(
+                    "UPDATE asset_metadata_paths SET \
+                        metadata_write_failed_at = CASE WHEN ?3 = 1 THEN ?5 ELSE metadata_write_failed_at END, \
+                        capture_repair_metadata_hash = CASE WHEN ?4 = 1 AND ( \
+                            (capture_repair_metadata_hash IS NULL AND capture_repair_output_checksum IS NULL AND capture_repair_output_size IS NULL) \
+                            OR (capture_repair_metadata_hash <> '' AND capture_repair_output_checksum IS NULL AND capture_repair_output_size IS NULL)) \
+                            THEN ?6 ELSE capture_repair_metadata_hash END \
+                     WHERE library = ?1 AND id = ?2 AND EXISTS ( \
+                         SELECT 1 FROM assets a WHERE a.library = ?1 AND a.id = ?2 \
+                           AND a.version_size = asset_metadata_paths.version_size \
+                           AND a.checksum = asset_metadata_paths.provider_checksum \
+                           AND a.status = 'downloaded' AND a.is_deleted = 0)",
+                    rusqlite::params![&library, &asset_id, i64::from(mark_for_rewrite), i64::from(mark_capture_repair), rewrite_at, metadata.metadata_hash.as_deref()],
+                ).map_err(|e| StateError::query("refresh_downloaded_asset_metadata::paths", e))?;
                 record_metadata_capture_revision(
                     conn,
                     &library,
@@ -4531,6 +4900,7 @@ impl SqliteStateDb {
                     rewrite_at,
                 )?;
             }
+            tx.commit().map_err(|e| StateError::query("refresh_downloaded_asset_metadata::commit", e))?;
             Ok(durable)
         })
         .await
@@ -4720,10 +5090,20 @@ impl SqliteStateDb {
         let selected_capture = i64::from(selected_queue == MetadataRewriteQueue::CaptureRepair);
         let clear_ordinary = i64::from(completion.clears(MetadataRewriteQueue::Ordinary));
         let clear_capture = i64::from(completion.clears(MetadataRewriteQueue::CaptureRepair));
-        self.with_conn("finish_metadata_rewrite", move |conn| {
-            let updated = conn
+        let Some(path) = pending.asset.local_path.clone() else {
+            return Ok(false);
+        };
+        self.with_conn_mut("finish_metadata_rewrite", move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| StateError::query("finish_metadata_rewrite::begin", e))?;
+            let target = metadata_rewrite_target(&tx, &library, &asset_id, &version_size, &path)?;
+            let (table, evidence) = target.sql();
+
+            let updated = tx
                 .execute(
-                    "UPDATE assets SET \
+                    &format!(
+                        "UPDATE {table} SET \
                         local_checksum = ?6, \
                         download_checksum = COALESCE(download_checksum, ?7), \
                         metadata_write_failed_at = CASE WHEN ?8 = 1 \
@@ -4738,8 +5118,7 @@ impl SqliteStateDb {
                             WHEN ?9 = 1 OR local_checksum IS NOT ?6 \
                                 THEN NULL ELSE capture_repair_output_size END \
                      WHERE library = ?1 AND id = ?2 AND version_size = ?3 \
-                       AND status = 'downloaded' AND is_deleted = 0 \
-                       AND metadata_hash IS ?4 AND local_checksum IS ?5 \
+                       AND {evidence} AND local_checksum IS ?5 \
                        AND ((?10 = 0 AND metadata_write_failed_at IS NOT NULL) \
                          OR (?10 = 1 \
                            AND capture_repair_metadata_hash IS ?11 \
@@ -4748,11 +5127,12 @@ impl SqliteStateDb {
                        AND (?9 = 0 OR ( \
                            capture_repair_metadata_hash IS ?11 \
                            AND capture_repair_output_checksum IS ?12 \
-                           AND capture_repair_output_size IS ?13))",
+                           AND capture_repair_output_size IS ?13)) AND local_path IS ?14"
+                    ),
                     rusqlite::params![
-                        library,
-                        asset_id,
-                        version_size,
+                        &library,
+                        &asset_id,
+                        &version_size,
                         metadata_hash,
                         input_checksum,
                         local_checksum,
@@ -4762,10 +5142,22 @@ impl SqliteStateDb {
                         selected_capture,
                         capture_metadata_hash,
                         capture_output_checksum,
-                        capture_output_size
+                        capture_output_size,
+                        path.to_string_lossy()
                     ],
                 )
                 .map_err(|e| StateError::query("finish_metadata_rewrite", e))?;
+            if updated > 0 && target == MetadataRewriteTarget::Catalogue {
+                record_metadata_path(
+                    &tx,
+                    &library,
+                    &asset_id,
+                    &version_size,
+                    MetadataPathWrite::Rewritten,
+                )?;
+            }
+            tx.commit()
+                .map_err(|e| StateError::query("finish_metadata_rewrite::commit", e))?;
             Ok(updated > 0 && completion.clears(selected_queue))
         })
         .await
@@ -4775,11 +5167,9 @@ impl SqliteStateDb {
         &self,
     ) -> Result<HashSet<(String, String, String)>, StateError> {
         self.with_conn("get_metadata_retry_markers", move |conn| {
+            let source = metadata_rewrite_source_sql();
             let mut stmt = conn
-                .prepare_cached(
-                    "SELECT library, id, version_size FROM assets \
-                     WHERE metadata_write_failed_at IS NOT NULL",
-                )
+                .prepare(&format!("SELECT library, id, version_size FROM ({source}) WHERE metadata_write_failed_at IS NOT NULL"))
                 .map_err(|e| StateError::query("get_metadata_retry_markers", e))?;
             let mut markers: HashSet<(String, String, String)> = HashSet::new();
             let rows = stmt
@@ -6073,6 +6463,30 @@ const ASSET_COLUMNS: &str = "id, version_size, checksum, filename, created_at, \
 /// asserts `row_to_asset_record` reads exactly this many indices (0..N).
 const ASSET_COLUMN_COUNT: usize = 40;
 
+fn metadata_rewrite_source_sql() -> String {
+    let path_columns = ASSET_COLUMNS
+        .split(',')
+        .map(str::trim)
+        .map(|column| {
+            let owner = match column {
+                "local_path" | "local_checksum" | "download_checksum" => "p",
+                _ => "a",
+            };
+            format!("{owner}.{column}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT {ASSET_COLUMNS}, metadata_write_failed_at, capture_repair_metadata_hash, \
+             capture_repair_output_checksum, capture_repair_output_size FROM assets \
+         UNION ALL SELECT {path_columns}, p.metadata_write_failed_at, p.capture_repair_metadata_hash, \
+             p.capture_repair_output_checksum, p.capture_repair_output_size \
+         FROM asset_metadata_paths p JOIN assets a \
+           ON a.library = p.library AND a.id = p.id AND a.version_size = p.version_size \
+         WHERE p.local_path IS NOT a.local_path AND p.provider_checksum = a.checksum"
+    )
+}
+
 fn query_pending_metadata_rewrites(
     conn: &Connection,
     queue: MetadataRewriteQueue,
@@ -6095,12 +6509,13 @@ fn query_pending_metadata_rewrites(
     let scope = libraries
         .map(|libraries| format!(" AND library IN ({})", sqlite_placeholders(libraries.len())))
         .unwrap_or_default();
+    let source = metadata_rewrite_source_sql();
     let sql = format!(
         "SELECT {ASSET_COLUMNS}, capture_repair_metadata_hash, \
             capture_repair_output_checksum, capture_repair_output_size \
-         FROM assets WHERE {queue_predicate} \
+         FROM ({source}) WHERE {queue_predicate} \
            AND status = 'downloaded' AND is_deleted = 0 AND local_path IS NOT NULL \
-           {scope} ORDER BY {order} LIMIT ? OFFSET ?"
+           {scope} ORDER BY {order}, local_path LIMIT ? OFFSET ?"
     );
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
     let offset = i64::try_from(offset).unwrap_or(i64::MAX);
@@ -10119,6 +10534,498 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_paths_finalize_atomically_and_complete_independently() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("copies").checksum("provider").build();
+        db.upsert_seen(&record).await.unwrap();
+        db.acquire_lock("test_path_registration_failure")
+            .unwrap()
+            .execute_batch(
+                "CREATE TEMP TRIGGER fail_path_registration BEFORE INSERT ON asset_metadata_paths \
+             BEGIN SELECT RAISE(ABORT, 'path registration failure'); END;",
+            )
+            .unwrap();
+        assert!(
+            db.mark_downloaded(
+                "PrimarySync",
+                "copies",
+                "original",
+                Path::new("/photos/a.jpg"),
+                "local-a",
+                None
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(
+            db.acquire_lock("test_atomic_finalize")
+                .unwrap()
+                .query_row(
+                    "SELECT status, local_path FROM assets WHERE id = 'copies'",
+                    [],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                )
+                .unwrap(),
+            ("pending".into(), None)
+        );
+        db.acquire_lock("test_allow_path_registration")
+            .unwrap()
+            .execute_batch("DROP TRIGGER fail_path_registration")
+            .unwrap();
+        for (path, checksum) in [("/photos/a.jpg", "local-a"), ("/photos/b.jpg", "local-b")] {
+            db.mark_downloaded(
+                "PrimarySync",
+                "copies",
+                "original",
+                Path::new(path),
+                checksum,
+                Some("download"),
+            )
+            .await
+            .unwrap();
+        }
+        db.record_metadata_write_failure("PrimarySync", "copies", "original")
+            .await
+            .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                Some(&["PrimarySync"]),
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].asset.local_checksum.as_deref(), Some("local-a"));
+        assert_eq!(pending[1].asset.local_checksum.as_deref(), Some("local-b"));
+        assert!(
+            db.finish_metadata_rewrite(
+                &pending[0],
+                MetadataRewriteQueue::Ordinary,
+                Some("rewritten-a"),
+                Some("local-a"),
+                MetadataRewriteCompletion::Ordinary
+            )
+            .await
+            .unwrap()
+        );
+        let remaining = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(
+            remaining[0].local_path.as_deref(),
+            Some(Path::new("/photos/b.jpg"))
+        );
+        assert_eq!(remaining[0].local_checksum.as_deref(), Some("local-b"));
+        db.record_metadata_write_failure("PrimarySync", "copies", "original")
+            .await
+            .unwrap();
+        assert!(
+            !db.finish_metadata_rewrite(
+                &pending[0],
+                MetadataRewriteQueue::Ordinary,
+                Some("stale-a"),
+                Some("local-a"),
+                MetadataRewriteCompletion::Ordinary
+            )
+            .await
+            .unwrap()
+        );
+        let copies = db.get_pending_metadata_rewrites(10).await.unwrap();
+        assert_eq!(copies.len(), 2);
+        assert_eq!(copies[0].local_checksum.as_deref(), Some("rewritten-a"));
+        assert_eq!(copies[1].local_checksum.as_deref(), Some("local-b"));
+        assert!(
+            db.finish_metadata_rewrite(
+                &pending[1],
+                MetadataRewriteQueue::Ordinary,
+                Some("local-b"),
+                None,
+                MetadataRewriteCompletion::Ordinary
+            )
+            .await
+            .unwrap()
+        );
+        let only_additional = db.get_pending_metadata_rewrites(1).await.unwrap();
+        assert_eq!(only_additional.len(), 1);
+        assert_eq!(
+            only_additional[0].local_path.as_deref(),
+            Some(Path::new("/photos/a.jpg"))
+        );
+        assert!(
+            db.get_metadata_retry_markers().await.unwrap().contains(&(
+                "PrimarySync".into(),
+                "copies".into(),
+                "original".into()
+            )),
+            "an additional copy must remain visible after the catalogue copy completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn additional_path_prepared_capture_receipt_blocks_stale_metadata() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("copies")
+            .checksum("provider")
+            .metadata(AssetMetadata {
+                metadata_hash: Some("metadata-v1".into()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        for path in ["/photos/a.jpg", "/photos/b.jpg"] {
+            db.mark_downloaded(
+                "PrimarySync",
+                "copies",
+                "original",
+                Path::new(path),
+                "local",
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        db.refresh_downloaded_asset_metadata(
+            "PrimarySync",
+            "copies",
+            &record.metadata,
+            true,
+            true,
+            METADATA_CAPTURE_REVISION,
+        )
+        .await
+        .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 2);
+        assert!(
+            db.record_capture_repair_prepared(&pending[0], "prepared", 42)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        db.mark_downloaded(
+            "PrimarySync",
+            "copies",
+            "original",
+            Path::new("/photos/a.jpg"),
+            "local",
+            None,
+        )
+        .await
+        .unwrap();
+        let switched = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            switched.len(),
+            2,
+            "changing the catalogue path must not hide either copy's debt"
+        );
+        assert!(matches!(
+            switched[0].capture_repair_receipt,
+            Some(CaptureRepairReceipt::Prepared { .. })
+        ));
+        let mut changed = (*record.metadata).clone();
+        changed.metadata_hash = Some("metadata-v2".into());
+        assert_eq!(
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "copies",
+                &changed,
+                true,
+                true,
+                METADATA_CAPTURE_REVISION
+            )
+            .await
+            .unwrap(),
+            0
+        );
+        let changed_record = TestAssetRecord::new("copies")
+            .checksum("provider")
+            .metadata(changed)
+            .build();
+        assert!(db.upsert_seen(&changed_record).await.is_err());
+        let preserved = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            preserved[0].capture_repair_receipt,
+            Some(CaptureRepairReceipt::Prepared {
+                metadata_hash: "metadata-v1".into(),
+                output_checksum: "prepared".into(),
+                output_size: 42
+            })
+        );
+        assert_eq!(
+            preserved[1].capture_repair_receipt,
+            Some(CaptureRepairReceipt::Pending {
+                metadata_hash: "metadata-v1".into()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn album_grouping_projection_respects_legacy_state_ownership() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for id in ["master", "child-b"] {
+            db.upsert_seen(&TestAssetRecord::new(id).build())
+                .await
+                .unwrap();
+        }
+        assert!(
+            db.claim_legacy_master_state_owner("PrimarySync", "master", "child-a")
+                .await
+                .unwrap()
+        );
+        db.upsert_album_container("PrimarySync", "trip", "Trip", "album")
+            .await
+            .unwrap();
+        db.upsert_album_membership_delta(
+            "PrimarySync",
+            "trip",
+            "child-b",
+            Some("master"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        assert!(
+            db.get_asset_groupings("PrimarySync", &["master"])
+                .await
+                .unwrap()
+                .albums
+                .is_empty()
+        );
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["child-b"])
+                .await
+                .unwrap()
+                .albums,
+            [("child-b".into(), "Trip".into())]
+        );
+        db.upsert_album_membership_delta(
+            "PrimarySync",
+            "trip",
+            "child-a",
+            Some("master"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["master"])
+                .await
+                .unwrap()
+                .albums,
+            [("master".into(), "Trip".into())]
+        );
+        db.mark_album_membership_deleted("PrimarySync", "trip", "child-b")
+            .await
+            .unwrap();
+        assert!(
+            db.get_asset_groupings("PrimarySync", &["child-b"])
+                .await
+                .unwrap()
+                .albums
+                .is_empty()
+        );
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["master"])
+                .await
+                .unwrap()
+                .albums,
+            [("master".into(), "Trip".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn album_grouping_mutations_keep_atomic_retry_evidence() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        for (library, id) in [
+            ("PrimarySync", "child"),
+            ("PrimarySync", "sibling"),
+            ("SharedSync", "child"),
+        ] {
+            db.upsert_seen(&TestAssetRecord::new(id).library(library).build())
+                .await
+                .unwrap();
+        }
+        db.add_asset_album("PrimarySync", "child", "External", "external-import")
+            .await
+            .unwrap();
+        db.upsert_album_container("PrimarySync", "trip", "Trip", "album")
+            .await
+            .unwrap();
+        let generation = db
+            .start_album_membership_snapshot("PrimarySync", "trip", None)
+            .await
+            .unwrap();
+        db.add_album_membership_to_snapshot(
+            "PrimarySync",
+            "trip",
+            generation,
+            "child",
+            Some("master"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        let groups = db
+            .get_asset_groupings("PrimarySync", &["child"])
+            .await
+            .unwrap();
+        assert_eq!(
+            groups.albums,
+            [
+                ("child".into(), "External".into()),
+                ("child".into(), "Trip".into())
+            ]
+        );
+        db.clear_metadata_write_failure("PrimarySync", "child", "original")
+            .await
+            .unwrap();
+        db.add_album_membership_to_snapshot(
+            "PrimarySync",
+            "trip",
+            generation,
+            "child",
+            Some("master"),
+            "icloud",
+        )
+        .await
+        .unwrap();
+        db.complete_album_membership_snapshot("PrimarySync", "trip", generation)
+            .await
+            .unwrap();
+        let dirty = || {
+            db.acquire_lock("test_grouping_markers")
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM assets WHERE metadata_write_failed_at IS NOT NULL",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(dirty(), 0, "replayed membership must not queue a rewrite");
+        db.acquire_lock("test_grouping_marker_failure").unwrap().execute_batch(
+            "CREATE TEMP TRIGGER fail_grouping_marker BEFORE UPDATE OF metadata_write_failed_at ON assets \
+             BEGIN SELECT RAISE(ABORT, 'grouping marker failure'); END;",
+        ).unwrap();
+        assert!(
+            db.mark_album_membership_deleted("PrimarySync", "trip", "child")
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["child"])
+                .await
+                .unwrap()
+                .albums,
+            groups.albums
+        );
+        assert_eq!(
+            db.get_live_selected_album_memberships_for_asset("PrimarySync", "child", &["trip"])
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        db.acquire_lock("test_grouping_marker_recovery")
+            .unwrap()
+            .execute_batch("DROP TRIGGER fail_grouping_marker")
+            .unwrap();
+        db.mark_album_membership_deleted("PrimarySync", "trip", "child")
+            .await
+            .unwrap();
+        assert_eq!(
+            dirty(),
+            1,
+            "only the changed child in this library is dirty"
+        );
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["child"])
+                .await
+                .unwrap()
+                .albums,
+            [("child".into(), "External".into())]
+        );
+        db.clear_metadata_write_failure("PrimarySync", "child", "original")
+            .await
+            .unwrap();
+        db.mark_album_membership_deleted("PrimarySync", "trip", "child")
+            .await
+            .unwrap();
+        assert_eq!(dirty(), 0, "replayed tombstones are a no-op");
+
+        db.upsert_album_membership_delta("PrimarySync", "trip", "child", Some("master"), "icloud")
+            .await
+            .unwrap();
+        db.clear_metadata_write_failure("PrimarySync", "child", "original")
+            .await
+            .unwrap();
+        let next = db
+            .start_album_membership_snapshot("PrimarySync", "trip", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["child"])
+                .await
+                .unwrap()
+                .albums,
+            groups.albums,
+            "an interrupted empty snapshot cannot remove the prior membership"
+        );
+        assert_eq!(dirty(), 0);
+        db.complete_album_membership_snapshot("PrimarySync", "trip", next)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_asset_groupings("PrimarySync", &["child"])
+                .await
+                .unwrap()
+                .albums,
+            [("child".into(), "External".into())]
+        );
+        assert_eq!(
+            dirty(),
+            1,
+            "completed snapshot removal must queue a rewrite"
+        );
+        db.clear_metadata_write_failure("PrimarySync", "child", "original")
+            .await
+            .unwrap();
+        let steady = db
+            .start_album_membership_snapshot("PrimarySync", "trip", None)
+            .await
+            .unwrap();
+        db.complete_album_membership_snapshot("PrimarySync", "trip", steady)
+            .await
+            .unwrap();
+        assert_eq!(dirty(), 0);
+    }
+
+    #[tokio::test]
     async fn add_asset_album_is_idempotent() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         db.add_asset_album("PrimarySync", "A1", "Favorites", "icloud")
@@ -10596,7 +11503,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn old_asset_album_reader_ignores_trusted_membership_tables() {
+    async fn unmaterialized_relations_do_not_create_compatibility_groupings() {
         let db = SqliteStateDb::open_in_memory().unwrap();
         db.add_asset_album("PrimarySync", "master-old", "Legacy Album", "icloud")
             .await
@@ -10626,7 +11533,7 @@ mod tests {
         assert_eq!(
             legacy_rows,
             vec![("master-old".to_string(), "Legacy Album".to_string())],
-            "trusted membership rows must not change the old asset_albums read model",
+            "relations without a catalogued state identity must not create compatibility groupings",
         );
     }
 
@@ -11958,6 +12865,30 @@ mod tests {
         )
         .await
         .unwrap();
+        let preserved = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::CaptureRepair,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(preserved.len(), 1);
+        assert_eq!(
+            preserved[0].asset.local_path.as_deref(),
+            Some(Path::new("/photos/adopted.jpg")),
+            "changing one copy must not erase another path's prepared receipt"
+        );
+        db.import_adopt(
+            &record,
+            Path::new("/photos/adopted.jpg"),
+            "local-changed",
+            2048,
+            Some(4),
+        )
+        .await
+        .unwrap();
         assert!(
             db.get_pending_metadata_rewrites_page_for_queue(
                 MetadataRewriteQueue::CaptureRepair,
@@ -11968,7 +12899,7 @@ mod tests {
             .await
             .unwrap()
             .is_empty(),
-            "changed installed bytes must invalidate capture evidence"
+            "changed bytes at the same path invalidate capture evidence"
         );
 
         db.refresh_downloaded_asset_metadata(

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -108,6 +108,21 @@ fn mark_album_groupings_dirty_tx(
     Ok(())
 }
 
+// Keep the optional member filter in separate branches so both scopes use
+// indexed lookups. IN deduplicates child and legacy-owner identities.
+const ALBUM_GROUPING_STATE_IDS_SQL: &str = "WITH members AS MATERIALIZED ( \
+    SELECT asset_record_name FROM asset_album_memberships \
+    WHERE library = ?1 AND container_id = ?2 AND asset_record_name = ?3 \
+    UNION ALL \
+    SELECT asset_record_name FROM asset_album_memberships \
+    INDEXED BY idx_asset_album_memberships_container \
+    WHERE library = ?1 AND container_id = ?2 AND ?3 IS NULL \
+) SELECT DISTINCT id FROM assets WHERE library = ?1 AND id IN ( \
+    SELECT asset_record_name FROM members \
+    UNION ALL \
+    SELECT master_record_name FROM legacy_master_state_owners \
+    WHERE library = ?1 AND asset_record_name IN (SELECT asset_record_name FROM members))";
+
 fn refresh_container_groupings_tx(
     tx: &Transaction<'_>,
     library: &str,
@@ -117,15 +132,7 @@ fn refresh_container_groupings_tx(
 ) -> Result<(), StateError> {
     let operation = "refresh_container_groupings";
     let mut stmt = tx
-        .prepare_cached(
-            "SELECT DISTINCT a.id FROM asset_album_memberships m \
-         LEFT JOIN legacy_master_state_owners o \
-           ON o.library = m.library AND o.asset_record_name = m.asset_record_name \
-         JOIN assets a ON a.library = m.library \
-           AND (a.id = m.asset_record_name OR a.id = o.master_record_name) \
-         WHERE m.library = ?1 AND m.container_id = ?2 \
-           AND (?3 IS NULL OR m.asset_record_name = ?3)",
-        )
+        .prepare_cached(ALBUM_GROUPING_STATE_IDS_SQL)
         .map_err(|e| StateError::query(operation, e))?;
     let ids = stmt
         .query_map(
@@ -10782,6 +10789,108 @@ mod tests {
                 metadata_hash: "metadata-v1".into()
             })
         );
+    }
+
+    #[tokio::test]
+    async fn album_grouping_projection_has_bounded_sql_work() {
+        use rusqlite::StatementStatus;
+
+        const SINGLE_MEMBER_STEP_LIMIT: i32 = 300;
+        const STEPS_PER_MEMBER_LIMIT: i32 = 150;
+        for members in [128, 512] {
+            let db = SqliteStateDb::open_in_memory().unwrap();
+            db.upsert_album_container("PrimarySync", "trip", "Trip", "album")
+                .await
+                .unwrap();
+            {
+                let mut conn = db.acquire_lock("seed_populated_album").unwrap();
+                let tx = conn.transaction().unwrap();
+                for index in 0..members {
+                    let child = format!("child-{index}");
+                    let master = format!("master-{index}");
+                    for id in [&child, &master] {
+                        tx.execute(
+                            "INSERT INTO assets (library, id, version_size, checksum, filename, created_at, size_bytes, media_type, status, last_seen_at) VALUES ('PrimarySync', ?1, 'original', 'provider', 'image.jpg', 0, 10, 'photo', 'downloaded', 0)",
+                            [id],
+                        ).unwrap();
+                    }
+                    tx.execute(
+                        "INSERT INTO legacy_master_state_owners VALUES ('PrimarySync', ?1, ?2, 0)",
+                        [&master, &child],
+                    )
+                    .unwrap();
+                    // Missing master hints must not hide the durable legacy owner.
+                    tx.execute("INSERT INTO asset_album_memberships VALUES ('PrimarySync', ?1, NULL, 'trip', 1, 0, 'icloud', 0)", [&child]).unwrap();
+                }
+                tx.commit().unwrap();
+            }
+            let steps = || {
+                db.acquire_lock("projection_sql_work")
+                    .unwrap()
+                    .prepare_cached(ALBUM_GROUPING_STATE_IDS_SQL)
+                    .unwrap()
+                    .reset_status(StatementStatus::VmStep)
+            };
+            let dirty = || {
+                let conn = db.acquire_lock("projection_dirty_rows").unwrap();
+                conn.query_row(
+                    "SELECT COUNT(*) FROM assets WHERE metadata_write_failed_at IS NOT NULL",
+                    [],
+                    |row| row.get::<_, i32>(0),
+                )
+                .unwrap()
+            };
+            steps();
+            for expected_dirty in [2, 0] {
+                db.upsert_album_membership_delta("PrimarySync", "trip", "child-0", None, "icloud")
+                    .await
+                    .unwrap();
+                let work = steps();
+                assert!(
+                    work > 0 && work <= SINGLE_MEMBER_STEP_LIMIT,
+                    "{members} members: {work} single-member VM steps"
+                );
+                assert_eq!(
+                    db.get_asset_groupings("PrimarySync", &["child-0", "master-0"])
+                        .await
+                        .unwrap()
+                        .albums,
+                    [
+                        ("child-0".into(), "Trip".into()),
+                        ("master-0".into(), "Trip".into())
+                    ]
+                );
+                assert_eq!(dirty(), expected_dirty);
+                for id in ["child-0", "master-0"] {
+                    db.clear_metadata_write_failure("PrimarySync", id, "original")
+                        .await
+                        .unwrap();
+                }
+            }
+            for expected_dirty in [members * 2, 0] {
+                db.upsert_album_container("PrimarySync", "trip", "Renamed", "album")
+                    .await
+                    .unwrap();
+                let work = steps();
+                assert!(
+                    work > 0 && work <= members * STEPS_PER_MEMBER_LIMIT,
+                    "{members} members: {work} container VM steps"
+                );
+                let groups = db.get_all_asset_albums("PrimarySync").await.unwrap();
+                assert_eq!(groups.len(), usize::try_from(members * 2).unwrap());
+                assert!(groups.iter().all(|(_, name)| name == "Renamed"));
+                assert_eq!(
+                    dirty(),
+                    expected_dirty,
+                    "unchanged projection must not queue work"
+                );
+                db.acquire_lock("clear_projection_debt")
+                    .unwrap()
+                    .execute("UPDATE assets SET metadata_write_failed_at = NULL", [])
+                    .unwrap();
+            }
+            assert_eq!(dirty(), 0);
+        }
     }
 
     #[tokio::test]

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 21;
+pub(crate) const SCHEMA_VERSION: i32 = 22;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -559,6 +559,10 @@ SELECT library, id, version_size, local_path, checksum, local_checksum,
 FROM assets WHERE status = 'downloaded' AND local_path IS NOT NULL;
 ";
 
+/// Reverse lookup for the authoritative legacy owner of a child identity.
+const SCHEMA_V22: &str = "CREATE INDEX IF NOT EXISTS idx_legacy_master_state_owners_asset \
+    ON legacy_master_state_owners (library, asset_record_name, master_record_name);";
+
 /// Apply migration for a specific version.
 ///
 /// `start_version` is the schema version the DB carried when `migrate()`
@@ -725,6 +729,7 @@ fn migrate_to_version(
             }
         }
         21 => conn.execute_batch(SCHEMA_V21)?,
+        22 => conn.execute_batch(SCHEMA_V22)?,
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -740,6 +745,32 @@ fn migrate_to_version(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn v22_indexes_existing_legacy_owners_without_changing_them() {
+        let conn = Connection::open_in_memory().unwrap();
+        for version in 1..=21 {
+            migrate_to_version(&conn, 0, version).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO legacy_master_state_owners VALUES ('PrimarySync', 'master', 'child', 123)",
+            [],
+        )
+        .unwrap();
+        migrate(&conn).unwrap();
+        migrate(&conn).unwrap();
+        let columns: Vec<String> = conn.prepare("SELECT name FROM pragma_index_info('idx_legacy_master_state_owners_asset') ORDER BY seqno").unwrap()
+            .query_map([], |row| row.get(0)).unwrap().collect::<Result<_, _>>().unwrap();
+        assert_eq!(
+            columns,
+            ["library", "asset_record_name", "master_record_name"]
+        );
+        let owner = conn.query_row("SELECT master_record_name, asset_record_name, claimed_at FROM legacy_master_state_owners WHERE library = 'PrimarySync'", [], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+        }).unwrap();
+        assert_eq!(owner, ("master".into(), "child".into(), 123));
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
 
     #[test]
     fn v21_migrates_only_recorded_paths_with_independent_retry_evidence() {

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 20;
+pub(crate) const SCHEMA_VERSION: i32 = 21;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -529,6 +529,36 @@ const V20_ASSET_COLUMNS: &[(&str, &str)] = &[
     ("capture_repair_output_size", "INTEGER"),
 ];
 
+/// Metadata evidence for every successfully finalized path. The catalogue still
+/// owns sync selection; this table does not authorize adoption or media deletion.
+const SCHEMA_V21: &str = r"
+CREATE TABLE IF NOT EXISTS asset_metadata_paths (
+    library TEXT NOT NULL,
+    id TEXT NOT NULL,
+    version_size TEXT NOT NULL,
+    local_path TEXT NOT NULL,
+    provider_checksum TEXT NOT NULL,
+    local_checksum TEXT,
+    download_checksum TEXT,
+    metadata_write_failed_at INTEGER,
+    capture_repair_metadata_hash TEXT,
+    capture_repair_output_checksum TEXT,
+    capture_repair_output_size INTEGER,
+    PRIMARY KEY (library, id, version_size, local_path)
+);
+CREATE INDEX IF NOT EXISTS idx_asset_metadata_paths_retry
+    ON asset_metadata_paths(metadata_write_failed_at, library, id, version_size, local_path)
+    WHERE metadata_write_failed_at IS NOT NULL;
+INSERT OR IGNORE INTO asset_metadata_paths
+    (library, id, version_size, local_path, provider_checksum, local_checksum,
+     download_checksum, metadata_write_failed_at, capture_repair_metadata_hash,
+     capture_repair_output_checksum, capture_repair_output_size)
+SELECT library, id, version_size, local_path, checksum, local_checksum,
+       download_checksum, metadata_write_failed_at, capture_repair_metadata_hash,
+       capture_repair_output_checksum, capture_repair_output_size
+FROM assets WHERE status = 'downloaded' AND local_path IS NOT NULL;
+";
+
 /// Apply migration for a specific version.
 ///
 /// `start_version` is the schema version the DB carried when `migrate()`
@@ -694,6 +724,7 @@ fn migrate_to_version(
                 }
             }
         }
+        21 => conn.execute_batch(SCHEMA_V21)?,
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -709,6 +740,42 @@ fn migrate_to_version(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn v21_migrates_only_recorded_paths_with_independent_retry_evidence() {
+        let conn = Connection::open_in_memory().unwrap();
+        for version in 1..=20 {
+            migrate_to_version(&conn, 0, version).unwrap();
+        }
+        let path = "/photos/Trip's été/image.jpg";
+        conn.execute(
+            "INSERT INTO assets (library, id, version_size, checksum, filename, created_at, size_bytes, media_type, status, last_seen_at, local_path, local_checksum, metadata_write_failed_at, capture_repair_metadata_hash, capture_repair_output_checksum, capture_repair_output_size) VALUES ('PrimarySync', 'child', 'original', 'provider', 'image.jpg', 1, 10, 'photo', 'downloaded', 1, ?1, 'local', 123, 'metadata', 'prepared', 12)",
+            [path],
+        ).unwrap();
+        migrate(&conn).unwrap();
+        migrate(&conn).unwrap();
+        let row = conn.query_row("SELECT local_path, local_checksum, metadata_write_failed_at, capture_repair_output_checksum FROM asset_metadata_paths", [], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?, row.get::<_, String>(3)?))
+        }).unwrap();
+        assert_eq!(row, (path.into(), "local".into(), 123, "prepared".into()));
+        conn.execute("INSERT INTO asset_metadata_paths (library, id, version_size, local_path, provider_checksum) VALUES ('PrimarySync', 'child', 'original', '/photos/Family/image.jpg', 'provider')", []).unwrap();
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM asset_metadata_paths", [], |row| row
+                .get::<_, i64>(
+                0
+            ))
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM assets", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1,
+            "path metadata tracking must not duplicate the sync catalogue"
+        );
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
 
     #[test]
     fn test_fresh_db_migration() {

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -82,7 +82,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 21;
+const HELPER_SCHEMA_VERSION: i32 = 22;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -286,6 +286,9 @@ CREATE INDEX IF NOT EXISTS idx_asset_metadata_paths_retry
             PRIMARY KEY (library, master_record_name)
         );
 
+        CREATE INDEX IF NOT EXISTS idx_legacy_master_state_owners_asset
+            ON legacy_master_state_owners (library, asset_record_name, master_record_name);
+
         CREATE TABLE IF NOT EXISTS asset_metadata_capture_revisions (
             library TEXT NOT NULL,
             asset_id TEXT NOT NULL,
@@ -357,7 +360,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 21). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 22). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -375,7 +378,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 21;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 22;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -82,7 +82,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 20;
+const HELPER_SCHEMA_VERSION: i32 = 21;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -97,6 +97,24 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
     let conn = rusqlite::Connection::open(&db_path).unwrap();
     conn.execute_batch(
         r"
+
+CREATE TABLE IF NOT EXISTS asset_metadata_paths (
+    library TEXT NOT NULL,
+    id TEXT NOT NULL,
+    version_size TEXT NOT NULL,
+    local_path TEXT NOT NULL,
+    provider_checksum TEXT NOT NULL,
+    local_checksum TEXT,
+    download_checksum TEXT,
+    metadata_write_failed_at INTEGER,
+    capture_repair_metadata_hash TEXT,
+    capture_repair_output_checksum TEXT,
+    capture_repair_output_size INTEGER,
+    PRIMARY KEY (library, id, version_size, local_path)
+);
+CREATE INDEX IF NOT EXISTS idx_asset_metadata_paths_retry
+    ON asset_metadata_paths(metadata_write_failed_at, library, id, version_size, local_path)
+    WHERE metadata_write_failed_at IS NOT NULL;
         CREATE TABLE IF NOT EXISTS assets (
             library TEXT NOT NULL,
             id TEXT NOT NULL,
@@ -339,7 +357,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 20). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 21). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -357,7 +375,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 20;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 21;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \
@@ -3941,6 +3959,16 @@ fn behavioral_helper_carries_every_migrated_column() {
             "v20 column assets.{column} must exist in the behavioral helper's DDL"
         );
     }
+    let path_key: Vec<String> = conn
+        .prepare(
+            "SELECT name FROM pragma_table_info('asset_metadata_paths') WHERE pk > 0 ORDER BY pk",
+        )
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(path_key, ["library", "id", "version_size", "local_path"]);
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Include the current album in the first XMP payload.
- Queue membership additions and removals for every recorded copy, with independent fingerprints and retry receipts.
- Add regressions covering multiple albums, embedded XMP, sidecars, restart, partial failure, atomic rollback, and unchanged follow-up cycles.

Fixes #760.

## Tests
- `just gate`: passed, including 3,525 all-feature and 3,307 no-default-feature tests.
- Formatting and clippy: passed.
- Optional actionlint, shellcheck, shfmt, and ruff checks were skipped because those tools are unavailable.

## Migration
Schema 21 seeds existing catalogued paths. It does not infer ownership of previously unrecorded copies.
