### PR TITLE
Require native GPS accuracy provenance in XMP sidecars

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,8 +435,28 @@ counts are streamed without allocating from provider-controlled lengths.
 CloudKit is authoritative for the currently decoded coordinates, altitude, and
 capture timestamps. The location decoder currently maps only `lat`, `lon`, and
 `alt` from `locationEnc`, so source EXIF supplies GPS receiver time, speed,
-speed units, and horizontal positioning error. No coordinate matching or
-tolerance is applied for minor Photos location edits.
+speed units, and horizontal positioning error. Native horizontal accuracy is
+emitted only when both validated native coordinates equal the provider latitude
+and longitude after decoding to decimal degrees. There is no geographic
+proximity tolerance: rounding differences can omit accuracy, but nearby or
+edited locations do not establish that accuracy describes the same fix.
+Matching coordinates alone are insufficient after GPS embedding: kei may have
+inserted them beside an older native accuracy value. Sidecar planning also
+requires the current file to match its recorded pre-embed SHA-256 checksum.
+Normal downloads pass that baseline to the sidecar phase and retain it even
+when embedding is disabled. Queued rewrites use the path's `download_checksum`.
+They never substitute `local_checksum`, which can describe already-rewritten
+bytes after a failed state update. The baseline predates the current rewrite.
+Embedding, state-write failure, restart, and later sidecar-only retries cannot
+manufacture a match. Missing checksum evidence omits accuracy. This conservative rule can
+also omit valid accuracy after unrelated embedded edits; it does not delete
+native metadata or add a schema or output-revision mechanism.
+
+Missing, invalid, or different coordinates omit accuracy. A supported rewrite
+removes the obsolete value only if the existing property marker proves kei
+ownership. Unowned values remain unchanged. This rule applies to new sidecars
+and already-supported rewrites; automatic catch-up for untouched sidecars is
+separate work in #799. GPS receiver time and speed keep their existing policy.
 Source I/O failures still publish current CloudKit metadata, preserve prior
 kei-owned source GPS fields as unknown, and retain the metadata retry marker.
 Readable unsupported or malformed metadata permits a CloudKit-only sidecar.
@@ -510,6 +530,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 | `METADATA_EMBED_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/metadata.rs`, `src/download/file.rs`, `src/download/metadata_rewrite.rs` | Every embedded metadata rewrite prepares a uniquely owned sibling and replaces the media only while both the destination and prepared bytes match their approved fingerprints. Failure preserves concurrent edits and durable retry evidence. |
 | `HEIF_EMBED_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/heif.rs`, `src/download/metadata.rs`, `src/download/file.rs`, `src/download/metadata_rewrite.rs` | A HEIF-family embedded rewrite accepts tone-map insertion only when `dimg` and primary Exif `cdsc` relationships prove the exact target and no existing XMP owns that tone map, prepares a uniquely owned sibling, and replaces the media only while both the destination and prepared bytes match their approved fingerprints. Failure preserves concurrent edits and durable retry evidence. |
 | `XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs` | An existing XMP sidecar is replaced only when it parses and its bytes still match the writer's initial read. Failure preserves the sidecar and durable rewrite marker. |
+| `XMP_GPS_ACCURACY_REQUIRES_MATCHING_LOCATION` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs` | Native horizontal accuracy requires valid native latitude and longitude equal to the exported provider coordinates, plus a matching pre-embed file checksum. Rewritten or unrecorded media cannot establish native provenance. Readable missing, invalid, or mismatched evidence omits accuracy and clears only obsolete kei-owned values. Source I/O failure preserves unknown fields and durable retry evidence. |
 | `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE` | `src/download/mod.rs`, `src/state/db.rs` | Revision repair updates catalogue metadata and configured rewrite evidence before promotion, stays library-scoped, and preserves the provider checkpoint on unresolved work. |
 
 ## Change-impact checklist

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -442,15 +442,22 @@ proximity tolerance: rounding differences can omit accuracy, but nearby or
 edited locations do not establish that accuracy describes the same fix.
 Matching coordinates alone are insufficient after GPS embedding: kei may have
 inserted them beside an older native accuracy value. Sidecar planning also
-requires the current file to match its recorded pre-embed SHA-256 checksum.
-Normal downloads pass that baseline to the sidecar phase and retain it even
-when embedding is disabled. Queued rewrites use the path's `download_checksum`.
-They never substitute `local_checksum`, which can describe already-rewritten
-bytes after a failed state update. The baseline predates the current rewrite.
-Embedding, state-write failure, restart, and later sidecar-only retries cannot
-manufacture a match. Missing checksum evidence omits accuracy. This conservative rule can
-also omit valid accuracy after unrelated embedded edits; it does not delete
-native metadata or add a schema or output-revision mechanism.
+requires the current file to match SHA-256 evidence from a verified download,
+captured before any kei metadata write. Normal downloads pass that baseline to
+the sidecar phase, even when embedding is disabled. Download finalization
+atomically stores it in the path's `asset_metadata_paths.source_checksum`.
+Queued rewrites use only that source checksum, never `local_checksum` or
+`download_checksum`. Those older columns also support size validation and can
+be populated from already-rewritten bytes during checksum recovery.
+
+Schema v23 adds the nullable source checksum without backfilling historical
+rows. Missing evidence stays unknown across embedded writes, failed state
+updates, restart, and later retries. Adoption and local reconciliation do not
+establish new source evidence. Existing evidence remains scoped to its path
+and provider rendition; a different rendition invalidates it. Metadata-only
+finalization preserves source evidence without changing it. This conservative
+rule can omit valid accuracy from older downloads or after unrelated embedded
+edits. It does not delete native metadata or add an output-revision sweep.
 
 Missing, invalid, or different coordinates omit accuracy. A supported rewrite
 removes the obsolete value only if the existing property marker proves kei
@@ -530,7 +537,7 @@ Stable IDs connect safety rules to production owners and focused tests.
 | `METADATA_EMBED_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/metadata.rs`, `src/download/file.rs`, `src/download/metadata_rewrite.rs` | Every embedded metadata rewrite prepares a uniquely owned sibling and replaces the media only while both the destination and prepared bytes match their approved fingerprints. Failure preserves concurrent edits and durable retry evidence. |
 | `HEIF_EMBED_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/heif.rs`, `src/download/metadata.rs`, `src/download/file.rs`, `src/download/metadata_rewrite.rs` | A HEIF-family embedded rewrite accepts tone-map insertion only when `dimg` and primary Exif `cdsc` relationships prove the exact target and no existing XMP owns that tone map, prepares a uniquely owned sibling, and replaces the media only while both the destination and prepared bytes match their approved fingerprints. Failure preserves concurrent edits and durable retry evidence. |
 | `XMP_SIDECAR_REWRITE_REQUIRES_STABLE_INPUT` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs` | An existing XMP sidecar is replaced only when it parses and its bytes still match the writer's initial read. Failure preserves the sidecar and durable rewrite marker. |
-| `XMP_GPS_ACCURACY_REQUIRES_MATCHING_LOCATION` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs` | Native horizontal accuracy requires valid native latitude and longitude equal to the exported provider coordinates, plus a matching pre-embed file checksum. Rewritten or unrecorded media cannot establish native provenance. Readable missing, invalid, or mismatched evidence omits accuracy and clears only obsolete kei-owned values. Source I/O failure preserves unknown fields and durable retry evidence. |
+| `XMP_GPS_ACCURACY_REQUIRES_MATCHING_LOCATION` | `src/download/metadata.rs`, `src/download/metadata_rewrite.rs`, `src/state/db.rs` | Native horizontal accuracy requires valid native latitude and longitude equal to the exported provider coordinates, plus a matching verified-download source checksum. Recovered local or download checksums cannot establish native provenance. Readable missing, invalid, or mismatched evidence omits accuracy and clears only obsolete kei-owned values. Source I/O failure preserves unknown fields and durable retry evidence. |
 | `METADATA_CAPTURE_REVISION_REPAIR_IS_DURABLE` | `src/download/mod.rs`, `src/state/db.rs` | Revision repair updates catalogue metadata and configured rewrite evidence before promotion, stays library-scoped, and preserves the provider checkpoint on unresolved work. |
 
 ## Change-impact checklist

--- a/src/download/finalize.rs
+++ b/src/download/finalize.rs
@@ -68,7 +68,7 @@ where
     D: DownloadFinalizationStore + ?Sized,
 {
     match db
-        .mark_downloaded_with_capture_repair(
+        .mark_verified_download(
             library,
             &task.asset_id,
             task.version_size.as_str(),
@@ -174,7 +174,7 @@ where
 
     for attempt in 1..=STATE_WRITE_MAX_RETRIES {
         match db
-            .mark_downloaded_with_capture_repair(
+            .mark_verified_download(
                 &write.library,
                 &write.asset_id,
                 write.version_size.as_str(),
@@ -440,6 +440,57 @@ mod tests {
         assert_eq!(
             pending[0].asset.local_checksum.as_deref(),
             Some("replacement_checksum")
+        );
+    }
+
+    #[tokio::test]
+    async fn deferred_verified_download_preserves_source_checksum_after_reopen() {
+        use crate::state::db::MetadataRewriteQueue;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("source.jpg");
+        let db_path = dir.path().join("state.db");
+        write_file(&path).await;
+        let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let result = finalize_downloaded(
+            &db,
+            &Arc::from(LIBRARY),
+            &task("SOURCE_DEFER", path.clone()),
+            checksum.clone(),
+            Some(checksum.clone()),
+            true,
+            false,
+        )
+        .await;
+        let DownloadedFinalization::Deferred { write, .. } = result else {
+            panic!("missing catalogue row must defer source provenance too");
+        };
+        seed_pending(&db, "SOURCE_DEFER", "source.jpg").await;
+        assert_eq!(flush_pending_state_writes(&db, &[write]).await, 0);
+        db.record_metadata_write_failure(LIBRARY, "SOURCE_DEFER", "original")
+            .await
+            .unwrap();
+        drop(db);
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].asset.local_path.as_deref(), Some(path.as_path()));
+        assert_eq!(
+            pending[0].source_checksum.as_deref(),
+            Some(checksum.as_str())
+        );
+        assert_eq!(
+            pending[0].asset.local_checksum.as_deref(),
+            Some(checksum.as_str())
         );
     }
 

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -793,9 +793,29 @@ fn read_tiff_source_gps<R: std::io::Read + std::io::Seek>(
     let mut speed = None;
     let mut speed_ref = None;
     let mut horizontal_positioning_error = None;
+    let mut latitude = None;
+    let mut latitude_ref = None;
+    let mut longitude = None;
+    let mut longitude_ref = None;
     for index in 0..gps_count {
         let entry = reader.read_ifd_entry(gps_ifd_offset, index)?;
         match tiff_u16(reader.endian, [entry[0], entry[1]]) {
+            0x0001 => {
+                latitude_ref = reader.entry_value::<2>(&entry, "GPSLatitudeRef", 2, 2)?;
+            }
+            0x0002 => {
+                latitude = reader
+                    .entry_value::<24>(&entry, "GPSLatitude", 5, 3)?
+                    .and_then(|value| tiff_rational_triplet(reader.endian, &value));
+            }
+            0x0003 => {
+                longitude_ref = reader.entry_value::<2>(&entry, "GPSLongitudeRef", 2, 2)?;
+            }
+            0x0004 => {
+                longitude = reader
+                    .entry_value::<24>(&entry, "GPSLongitude", 5, 3)?
+                    .and_then(|value| tiff_rational_triplet(reader.endian, &value));
+            }
             0x0007 if time.is_none() => {
                 if let Some(value) = reader.entry_value::<24>(&entry, "GPSTimeStamp", 5, 3)? {
                     time = tiff_rational_triplet(reader.endian, &value);
@@ -846,10 +866,48 @@ fn read_tiff_source_gps<R: std::io::Read + std::io::Seek>(
     };
     let speed_ref = speed.as_ref().and(speed_ref);
     Ok(SourceGpsMetadata {
+        latitude: latitude.zip(latitude_ref).and_then(|(value, reference)| {
+            source_gps_degrees(&value, reference, GpsAxis::Latitude)
+        }),
+        longitude: longitude.zip(longitude_ref).and_then(|(value, reference)| {
+            source_gps_degrees(&value, reference, GpsAxis::Longitude)
+        }),
         datetime,
         speed,
         speed_ref,
         horizontal_positioning_error,
+    })
+}
+
+#[cfg(feature = "xmp")]
+enum GpsAxis {
+    Latitude,
+    Longitude,
+}
+
+#[cfg(feature = "xmp")]
+fn source_gps_degrees(values: &[XmpRational; 3], reference: [u8; 2], axis: GpsAxis) -> Option<f64> {
+    const MINUTES_PER_DEGREE: f64 = 60.0;
+    const SECONDS_PER_DEGREE: f64 = 3600.0;
+    let (positive, negative, maximum) = match axis {
+        GpsAxis::Latitude => (b'N', b'S', 90.0),
+        GpsAxis::Longitude => (b'E', b'W', 180.0),
+    };
+    if reference[1] != 0 || ![positive, negative].contains(&reference[0]) {
+        return None;
+    }
+    let [degrees, minutes, seconds] = values.each_ref().map(XmpRational::as_f64);
+    if minutes >= MINUTES_PER_DEGREE || seconds >= MINUTES_PER_DEGREE {
+        return None;
+    }
+    let decimal = degrees + minutes / MINUTES_PER_DEGREE + seconds / SECONDS_PER_DEGREE;
+    if decimal > maximum {
+        return None;
+    }
+    Some(if reference[0] == negative {
+        -decimal
+    } else {
+        decimal
     })
 }
 
@@ -1054,6 +1112,8 @@ impl XmpRational {
 #[cfg(feature = "xmp")]
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct SourceGpsMetadata {
+    pub(crate) latitude: Option<f64>,
+    pub(crate) longitude: Option<f64>,
     pub(crate) datetime: Option<String>,
     pub(crate) speed: Option<XmpRational>,
     pub(crate) speed_ref: Option<String>,

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -126,6 +126,13 @@ pub(super) struct MetadataWriteRequest<'a> {
     pub(super) final_path: &'a Path,
     pub(super) embed_path: Option<&'a Path>,
     pub(super) expected_embed_fingerprint: Option<super::file::ExistingFileFingerprint>,
+    /// SHA-256 of the bytes before any kei metadata rewrite. Missing evidence
+    /// permits provider metadata, but not a native horizontal accuracy claim.
+    #[cfg_attr(
+        not(feature = "xmp"),
+        allow(dead_code, reason = "native-only builds do not write sidecars")
+    )]
+    pub(super) source_checksum: Option<&'a str>,
     #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     pub(super) sidecar_path: Option<&'a Path>,
     pub(super) payload: Arc<MetadataPayload>,
@@ -183,6 +190,7 @@ pub(super) async fn write_download_metadata(
             sidecar_path,
             Arc::clone(&request.payload),
             request.created_local,
+            request.source_checksum,
             request.temp_suffix,
         )
         .await;
@@ -374,12 +382,19 @@ async fn write_sidecar_metadata(
     path: &Path,
     payload: Arc<MetadataPayload>,
     created_local: DateTime<FixedOffset>,
+    source_checksum: Option<&str>,
     temp_suffix: &str,
 ) -> bool {
+    let source_checksum = source_checksum.map(str::to_owned);
     let sidecar_path = path.to_path_buf();
     let log_path = sidecar_path.clone();
     let planned = tokio::task::spawn_blocking(move || {
-        plan_sidecar_write(&sidecar_path, &payload, &created_local)
+        plan_sidecar_write(
+            &sidecar_path,
+            &payload,
+            &created_local,
+            source_checksum.as_deref(),
+        )
     })
     .await;
     let (write, source_error) = match planned {
@@ -442,10 +457,40 @@ fn plan_sidecar_write(
     path: &Path,
     payload: &MetadataPayload,
     created_local: &DateTime<FixedOffset>,
+    source_checksum: Option<&str>,
 ) -> (super::metadata::MetadataWrite, Option<anyhow::Error>) {
-    let (source_gps, source_error) = match super::metadata::read_source_gps(path) {
+    let (source_gps, mut source_error) = match super::metadata::read_source_gps(path) {
         Ok(metadata) => (metadata, None),
         Err(error) => (super::metadata::SourceGpsMetadata::default(), Some(error)),
+    };
+    // CONTRACT: XMP_GPS_ACCURACY_REQUIRES_MATCHING_LOCATION
+    // Exact decoded-coordinate equality is conservative: rounding differences
+    // omit accuracy rather than using proximity as evidence of the same fix.
+    // I/O failures remain unknown under the shared sidecar ownership policy.
+    let accuracy_matches_location =
+        source_gps
+            .latitude
+            .zip(source_gps.longitude)
+            .is_some_and(|(latitude, longitude)| {
+                payload.latitude == Some(latitude) && payload.longitude == Some(longitude)
+            });
+    // Current native coordinates may have been inserted by an earlier embed.
+    // Reuse the pre-embed checksum, including on retries after a state reopen.
+    // A changed or unrecorded source cannot establish native provenance. This
+    // conservatively omits accuracy after unrelated embedded edits as well.
+    let original_source = if accuracy_matches_location
+        && source_gps.horizontal_positioning_error.is_some()
+        && let Some(expected) = source_checksum
+    {
+        match super::file::fingerprint_regular_file_snapshot_blocking(path) {
+            Ok(actual) => fingerprint_checksum(actual.fingerprint) == expected,
+            Err(error) => {
+                source_error = Some(error);
+                false
+            }
+        }
+    } else {
+        false
     };
     let mut write = super::metadata::MetadataWrite {
         datetime: Some(created_local.format("%Y:%m:%d %H:%M:%S").to_string()),
@@ -453,7 +498,9 @@ fn plan_sidecar_write(
         gps_datetime: source_gps.datetime,
         gps_speed: source_gps.speed,
         gps_speed_ref: source_gps.speed_ref,
-        gps_h_positioning_error: source_gps.horizontal_positioning_error,
+        gps_h_positioning_error: source_gps
+            .horizontal_positioning_error
+            .filter(|_| original_source),
         preserve_source_gps: source_error.is_some(),
         rating: payload.rating,
         gps: gps_from_payload(payload),
@@ -1034,9 +1081,14 @@ where
 
         #[cfg(feature = "xmp")]
         if metadata_flags.contains(MetadataFlags::XMP_SIDECAR) {
-            outcome.sidecar_failed =
-                !write_sidecar_metadata(&path, Arc::clone(&payload), created_local, &temp_suffix)
-                    .await;
+            outcome.sidecar_failed = !write_sidecar_metadata(
+                &path,
+                Arc::clone(&payload),
+                created_local,
+                record.download_checksum.as_deref(),
+                &temp_suffix,
+            )
+            .await;
         }
 
         if drifted {
@@ -1578,7 +1630,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("photo.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
-        let (w, source_error) = plan_sidecar_write(&path, &payload, &now_local());
+        let (w, source_error) = plan_sidecar_write(&path, &payload, &now_local(), None);
         assert!(source_error.is_none());
         // Every payload field should land in the sidecar write, no flag gating.
         assert!(w.datetime.is_some());
@@ -1603,7 +1655,7 @@ mod tests {
         let path = dir.path().join("photo.jpg");
         std::fs::write(&path, minimal_jpeg_bytes()).unwrap();
         let (w, source_error) =
-            plan_sidecar_write(&path, &MetadataPayload::default(), &now_local());
+            plan_sidecar_write(&path, &MetadataPayload::default(), &now_local(), None);
         assert!(source_error.is_none());
         assert!(w.datetime.is_some());
         assert!(w.gps_datetime.is_none());
@@ -1641,6 +1693,7 @@ mod tests {
             final_path: &photo_path,
             embed_path: Some(&photo_path),
             expected_embed_fingerprint: None,
+            source_checksum: None,
             sidecar_path: Some(&photo_path),
             payload: Arc::new(MetadataPayload::default()),
             created_local: now_local(),
@@ -1678,6 +1731,7 @@ mod tests {
             final_path: &photo_path,
             embed_path: Some(&photo_path),
             expected_embed_fingerprint: None,
+            source_checksum: None,
             sidecar_path: None,
             payload: Arc::new(MetadataPayload {
                 rating: Some(5),
@@ -1726,6 +1780,7 @@ mod tests {
             final_path: &photo_path,
             embed_path: Some(&photo_path),
             expected_embed_fingerprint: Some(approved),
+            source_checksum: None,
             sidecar_path: None,
             payload: Arc::new(MetadataPayload {
                 rating: Some(5),
@@ -1760,6 +1815,7 @@ mod tests {
             final_path: &photo_path,
             embed_path: Some(&photo_path),
             expected_embed_fingerprint: Some(approved),
+            source_checksum: None,
             sidecar_path: None,
             payload: Arc::new(MetadataPayload {
                 rating: Some(5),
@@ -2821,6 +2877,644 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_new_writes() {
+        use crate::test_helpers::ur64;
+        use little_exif::exif_tag::ExifTag;
+        use little_exif::filetype::FileExtension;
+        use little_exif::metadata::Metadata;
+
+        let source = crate::test_helpers::minimal_jpeg_with_source_gps_and_location();
+        let dir = tempfile::tempdir().unwrap();
+        // Even a one-ULP edit does not establish provenance. Invalid provider
+        // evidence must not authorize accuracy, whether or not it is rendered.
+        let provider_cases = [
+            ("matching", Some(1.5), Some(2.5), true),
+            ("edited-latitude", Some(12.3456), Some(2.5), false),
+            ("edited-longitude", Some(1.5), Some(-78.9012), false),
+            (
+                "adjacent-float",
+                Some(f64::from_bits(1.5_f64.to_bits() + 1)),
+                Some(2.5),
+                false,
+            ),
+            ("missing-latitude", None, Some(2.5), false),
+            ("missing-longitude", Some(1.5), None, false),
+            ("invalid-latitude", Some(91.0), Some(2.5), false),
+            ("invalid-longitude", Some(1.5), Some(181.0), false),
+            ("nan", Some(f64::NAN), Some(2.5), false),
+            ("infinite", Some(1.5), Some(f64::INFINITY), false),
+        ];
+        for (name, latitude, longitude, expected) in provider_cases {
+            let path = dir.path().join(format!("{name}.jpg"));
+            std::fs::write(&path, &source).unwrap();
+            let payload = Arc::new(MetadataPayload {
+                latitude,
+                longitude,
+                ..MetadataPayload::default()
+            });
+            let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+            assert!(
+                write_sidecar_metadata(&path, payload, now_local(), Some(&checksum), ".gps-test")
+                    .await
+            );
+            let xmp: XmpMeta = std::fs::read_to_string(path.with_extension("jpg.xmp"))
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+                expected,
+                "{name}"
+            );
+            if expected {
+                assert_eq!(
+                    xmp.property(xmp_ns::EXIF, "GPSHPositioningError")
+                        .unwrap()
+                        .value,
+                    "3/2"
+                );
+            }
+            assert_eq!(std::fs::read(&path).unwrap(), source, "{name}");
+        }
+
+        // Neither an absent legacy baseline nor a different recorded source
+        // can certify matching coordinates in the current file.
+        let path = dir.path().join("unproven.jpg");
+        std::fs::write(&path, &source).unwrap();
+        for checksum in [None, Some("different-source-checksum")] {
+            assert!(
+                write_sidecar_metadata(
+                    &path,
+                    Arc::new(MetadataPayload {
+                        latitude: Some(1.5),
+                        longitude: Some(2.5),
+                        ..MetadataPayload::default()
+                    }),
+                    now_local(),
+                    checksum,
+                    ".gps-test"
+                )
+                .await
+            );
+            let xmp: XmpMeta = std::fs::read_to_string(path.with_extension("jpg.xmp"))
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert!(!xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"));
+            assert_eq!(std::fs::read(&path).unwrap(), source);
+        }
+
+        // Remove a tag, or replace it with invalid readable EXIF. Both are
+        // known absence, not retryable I/O failures.
+        let native_cases = [
+            (
+                "missing-native-latitude",
+                ExifTag::GPSLatitude(vec![]),
+                None,
+            ),
+            (
+                "missing-native-longitude",
+                ExifTag::GPSLongitude(vec![]),
+                None,
+            ),
+            (
+                "missing-native-reference",
+                ExifTag::GPSLatitudeRef(String::new()),
+                None,
+            ),
+            (
+                "missing-accuracy",
+                ExifTag::GPSHPositioningError(vec![]),
+                None,
+            ),
+            (
+                "invalid-native-latitude",
+                ExifTag::GPSLatitude(vec![]),
+                Some(ExifTag::GPSLatitude(vec![
+                    ur64(91, 1),
+                    ur64(0, 1),
+                    ur64(0, 1),
+                ])),
+            ),
+            (
+                "invalid-native-longitude",
+                ExifTag::GPSLongitude(vec![]),
+                Some(ExifTag::GPSLongitude(vec![
+                    ur64(181, 1),
+                    ur64(0, 1),
+                    ur64(0, 1),
+                ])),
+            ),
+            (
+                "invalid-minutes",
+                ExifTag::GPSLatitude(vec![]),
+                Some(ExifTag::GPSLatitude(vec![
+                    ur64(0, 1),
+                    ur64(90, 1),
+                    ur64(0, 1),
+                ])),
+            ),
+            (
+                "invalid-seconds",
+                ExifTag::GPSLatitude(vec![]),
+                Some(ExifTag::GPSLatitude(vec![
+                    ur64(1, 1),
+                    ur64(29, 1),
+                    ur64(60, 1),
+                ])),
+            ),
+            (
+                "invalid-reference",
+                ExifTag::GPSLatitudeRef(String::new()),
+                Some(ExifTag::GPSLatitudeRef("E".into())),
+            ),
+            (
+                "zero-coordinate-denominator",
+                ExifTag::GPSLatitude(vec![]),
+                Some(ExifTag::GPSLatitude(vec![
+                    ur64(1, 0),
+                    ur64(30, 1),
+                    ur64(0, 1),
+                ])),
+            ),
+            (
+                "zero-accuracy-denominator",
+                ExifTag::GPSHPositioningError(vec![]),
+                Some(ExifTag::GPSHPositioningError(vec![ur64(3, 0)])),
+            ),
+        ];
+        for (name, removed, replacement) in native_cases {
+            let mut metadata = Metadata::new_from_vec(&source, FileExtension::JPEG).unwrap();
+            assert!(metadata.remove_tag(removed) > 0);
+            if let Some(tag) = replacement {
+                metadata.set_tag(tag);
+            }
+            let mut bytes = minimal_jpeg_bytes();
+            metadata
+                .write_to_vec(&mut bytes, FileExtension::JPEG)
+                .unwrap();
+            let path = dir.path().join(format!("{name}.jpg"));
+            std::fs::write(&path, &bytes).unwrap();
+            let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+            // Out-of-range native values deliberately match the provider so
+            // coordinate validation, not mere inequality, must reject them.
+            let (latitude, longitude, rendered_latitude) = match name {
+                "invalid-native-latitude" => (91.0, 2.5, "91,0.0000N"),
+                "invalid-native-longitude" => (1.5, 181.0, "1,30.0000N"),
+                _ => (1.5, 2.5, "1,30.0000N"),
+            };
+            assert!(
+                write_sidecar_metadata(
+                    &path,
+                    Arc::new(MetadataPayload {
+                        latitude: Some(latitude),
+                        longitude: Some(longitude),
+                        ..MetadataPayload::default()
+                    }),
+                    now_local(),
+                    Some(&checksum),
+                    ".gps-test"
+                )
+                .await,
+                "{name}"
+            );
+            let xmp: XmpMeta = std::fs::read_to_string(path.with_extension("jpg.xmp"))
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert!(
+                !xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+                "{name}"
+            );
+            assert_eq!(
+                xmp.property(xmp_ns::EXIF, "GPSLatitude").unwrap().value,
+                rendered_latitude,
+                "{name}"
+            );
+            assert_eq!(std::fs::read(&path).unwrap(), bytes, "{name}");
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_after_embed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.jpg");
+        std::fs::write(&path, crate::test_helpers::minimal_jpeg_with_source_gps()).unwrap();
+        let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+        let native = super::super::metadata::read_source_gps(&path).unwrap();
+        assert!(native.latitude.is_none());
+        assert!(native.longitude.is_none());
+        assert!(native.horizontal_positioning_error.is_some());
+        // Match the download path: embed before publication, then write the
+        // sidecar from the published media in a separate call.
+        for (embed_path, sidecar_path) in
+            [(Some(path.as_path()), None), (None, Some(path.as_path()))]
+        {
+            let outcome = write_download_metadata(MetadataWriteRequest {
+                final_path: &path,
+                embed_path,
+                expected_embed_fingerprint: None,
+                source_checksum: Some(&checksum),
+                sidecar_path,
+                payload: Arc::new(MetadataPayload {
+                    latitude: Some(1.5),
+                    longitude: Some(2.5),
+                    ..MetadataPayload::default()
+                }),
+                created_local: now_local(),
+                flags: MetadataFlags::GPS | MetadataFlags::XMP_SIDECAR,
+                capture_timestamp_repair: CaptureTimestampRepair::Preserve,
+                temp_suffix: ".gps-test",
+            })
+            .await;
+            assert!(!outcome.any_failed());
+        }
+        let rewritten = super::super::metadata::read_source_gps(&path).unwrap();
+        assert_eq!(rewritten.latitude, Some(1.5));
+        assert_eq!(rewritten.longitude, Some(2.5));
+        let xmp: XmpMeta = std::fs::read_to_string(path.with_extension("jpg.xmp"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(!xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"));
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_embed_retry() {
+        use crate::state::{AssetMetadata, SqliteStateDb};
+
+        for fail_state_write in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("source.jpg");
+            let sidecar = path.with_extension("jpg.xmp");
+            let source = crate::test_helpers::minimal_jpeg_with_source_gps();
+            std::fs::write(&path, &source).unwrap();
+            let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+            let db_path = dir.path().join("state.db");
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            seed_downloaded_marker(
+                &db,
+                "GPS_EMBED_RETRY",
+                "source.jpg",
+                &path,
+                &checksum,
+                AssetMetadata {
+                    latitude: Some(1.5),
+                    longitude: Some(2.5),
+                    ..AssetMetadata::default()
+                },
+                None,
+            )
+            .await;
+            // The native coordinate mutation succeeds, then publication and,
+            // in the second case, checksum finalization fail.
+            std::fs::create_dir(&sidecar).unwrap();
+            if fail_state_write {
+                db.fail_metadata_checksum_write_for_test();
+            }
+            let pass = run_pending(
+                &db,
+                MetadataFlags::GPS | MetadataFlags::XMP_SIDECAR,
+                Arc::from(".gps-test"),
+                &CancellationToken::new(),
+            )
+            .await;
+            assert_eq!(pass.failed, 1);
+            assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+            let rewritten = std::fs::read(&path).unwrap();
+            assert_ne!(rewritten, source);
+            let native = super::super::metadata::read_source_gps(&path).unwrap();
+            assert_eq!((native.latitude, native.longitude), (Some(1.5), Some(2.5)));
+            assert!(
+                native.horizontal_positioning_error.is_some(),
+                "native accuracy must not be deleted"
+            );
+            let checksums = stored_checksums(&db).await;
+            if fail_state_write {
+                assert_eq!(checksums, (None, None));
+            } else {
+                assert_eq!(checksums.1.as_deref(), Some(checksum.as_str()));
+            }
+            drop(db);
+            std::fs::remove_dir(&sidecar).unwrap();
+            let db = SqliteStateDb::open(&db_path).await.unwrap();
+            let pass = run_pending(
+                &db,
+                MetadataFlags::XMP_SIDECAR,
+                Arc::from(".gps-test"),
+                &CancellationToken::new(),
+            )
+            .await;
+            assert_eq!((pass.applied, pass.failed), (1, 0));
+            let xmp: XmpMeta = std::fs::read_to_string(&sidecar).unwrap().parse().unwrap();
+            assert!(!xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"));
+            assert_eq!(
+                xmp.property(xmp_ns::EXIF, "GPSLatitude").unwrap().value,
+                "1,30.0000N"
+            );
+            assert_eq!(std::fs::read(&path).unwrap(), rewritten);
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            // A later no-op embed may establish a local checksum after failed
+            // finalization. It must not promote those rewritten bytes into
+            // original-source evidence for the next sidecar-only retry.
+            for flags in [
+                MetadataFlags::GPS | MetadataFlags::XMP_SIDECAR,
+                MetadataFlags::XMP_SIDECAR,
+            ] {
+                db.record_metadata_write_failure("PrimarySync", "GPS_EMBED_RETRY", "original")
+                    .await
+                    .unwrap();
+                let pass = run_pending(
+                    &db,
+                    flags,
+                    Arc::from(".gps-test"),
+                    &CancellationToken::new(),
+                )
+                .await;
+                assert_eq!((pass.applied, pass.failed), (1, 0));
+                let xmp: XmpMeta = std::fs::read_to_string(&sidecar).unwrap().parse().unwrap();
+                assert!(!xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"));
+                assert_eq!(std::fs::read(&path).unwrap(), rewritten);
+            }
+            let before = std::fs::read(&sidecar).unwrap();
+            let steady = run_pending(
+                &db,
+                MetadataFlags::XMP_SIDECAR,
+                Arc::from(".gps-test"),
+                &CancellationToken::new(),
+            )
+            .await;
+            assert_eq!((steady.applied, steady.failed), (0, 0));
+            assert_eq!(std::fs::read(&sidecar).unwrap(), before);
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_native_boundaries() {
+        use crate::test_helpers::ur64;
+        use little_exif::exif_tag::ExifTag;
+
+        let dir = tempfile::tempdir().unwrap();
+        for (name, latitude, longitude, lat_ref, lon_ref) in [
+            ("south-west", 1, 2, "S", "W"),
+            ("north-east-limits", 90, 180, "N", "E"),
+            ("south-west-limits", 90, 180, "S", "W"),
+            ("zero", 0, 0, "N", "E"),
+        ] {
+            let mut metadata = crate::test_helpers::exif_with_source_gps();
+            metadata.set_tag(ExifTag::GPSLatitude(vec![
+                ur64(latitude, 1),
+                ur64(0, 1),
+                ur64(0, 1),
+            ]));
+            metadata.set_tag(ExifTag::GPSLongitude(vec![
+                ur64(longitude, 1),
+                ur64(0, 1),
+                ur64(0, 1),
+            ]));
+            metadata.set_tag(ExifTag::GPSLatitudeRef(lat_ref.into()));
+            metadata.set_tag(ExifTag::GPSLongitudeRef(lon_ref.into()));
+            metadata.set_tag(ExifTag::GPSHPositioningError(vec![ur64(0, 1)]));
+            let tiff = metadata.encode().unwrap();
+            let heic = crate::download::heif::apple_tmap_insertion_heic(&tiff, b"");
+            for (extension, bytes) in [("dng", &tiff), ("heic", &heic)] {
+                let path = dir.path().join(format!("{name}.{extension}"));
+                std::fs::write(&path, bytes).unwrap();
+                let payload = Arc::new(MetadataPayload {
+                    latitude: Some(f64::from(latitude) * if lat_ref == "S" { -1.0 } else { 1.0 }),
+                    longitude: Some(f64::from(longitude) * if lon_ref == "W" { -1.0 } else { 1.0 }),
+                    ..MetadataPayload::default()
+                });
+                let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+                assert!(
+                    write_sidecar_metadata(
+                        &path,
+                        payload,
+                        now_local(),
+                        Some(&checksum),
+                        ".gps-test"
+                    )
+                    .await
+                );
+                let xmp: XmpMeta =
+                    std::fs::read_to_string(path.with_extension(format!("{extension}.xmp")))
+                        .unwrap()
+                        .parse()
+                        .unwrap();
+                assert_eq!(
+                    xmp.property(xmp_ns::EXIF, "GPSHPositioningError")
+                        .unwrap()
+                        .value,
+                    "0/1",
+                    "{name}.{extension}"
+                );
+                assert_eq!(std::fs::read(&path).unwrap(), *bytes);
+            }
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_rewrite_and_retry() {
+        use crate::state::{AssetMetadata, SqliteStateDb};
+        use xmp_toolkit::XmpValue;
+
+        for owned in [true, false] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("source.jpg");
+            let sidecar_path = path.with_extension("jpg.xmp");
+            let source = crate::test_helpers::minimal_jpeg_with_source_gps_and_location();
+            std::fs::write(&path, &source).unwrap();
+            let checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+            let db = SqliteStateDb::open(&dir.path().join("state.db"))
+                .await
+                .unwrap();
+            let mut metadata = AssetMetadata {
+                latitude: Some(1.5),
+                longitude: Some(2.5),
+                ..AssetMetadata::default()
+            };
+            seed_downloaded_marker(
+                &db,
+                "GPS_PROVENANCE",
+                "source.jpg",
+                &path,
+                &checksum,
+                metadata.clone(),
+                None,
+            )
+            .await;
+            db.mark_downloaded(
+                "PrimarySync",
+                "GPS_PROVENANCE",
+                "original",
+                &path,
+                &checksum,
+                Some(&checksum),
+            )
+            .await
+            .unwrap();
+            db.record_metadata_write_failure("PrimarySync", "GPS_PROVENANCE", "original")
+                .await
+                .unwrap();
+            let token = CancellationToken::new();
+            let drain = || {
+                run_pending(
+                    &db,
+                    MetadataFlags::XMP_SIDECAR,
+                    Arc::from(".gps-test"),
+                    &token,
+                )
+            };
+            assert_eq!(drain().await.applied, 1);
+            let mut initial: XmpMeta = std::fs::read_to_string(&sidecar_path)
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                initial
+                    .property(xmp_ns::EXIF, "GPSHPositioningError")
+                    .unwrap()
+                    .value,
+                "3/2"
+            );
+            if !owned {
+                initial
+                    .delete_property("https://github.com/rhoopr/kei/ns/1.0/", "managedFields")
+                    .unwrap();
+            }
+            initial
+                .set_property(xmp_ns::XMP, "Label", &XmpValue::new("keep me".to_owned()))
+                .unwrap();
+            std::fs::write(&sidecar_path, initial.to_string()).unwrap();
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            metadata.latitude = Some(12.3456);
+            metadata.longitude = Some(-78.9012);
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "GPS_PROVENANCE",
+                &metadata,
+                true,
+                false,
+                crate::state::METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .unwrap();
+
+            // A source read failure is unknown: preserve the old accuracy and
+            // its ownership while publishing current provider coordinates.
+            let saved_media = dir.path().join("saved.jpg");
+            std::fs::rename(&path, &saved_media).unwrap();
+            std::fs::create_dir(&path).unwrap();
+            assert_eq!(drain().await.failed, 1);
+            let unknown: XmpMeta = std::fs::read_to_string(&sidecar_path)
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                unknown
+                    .property(xmp_ns::EXIF, "GPSHPositioningError")
+                    .unwrap()
+                    .value,
+                "3/2"
+            );
+            assert_eq!(
+                unknown.property(xmp_ns::EXIF, "GPSLatitude").unwrap().value,
+                "12,20.7360N"
+            );
+            assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+            std::fs::remove_dir(&path).unwrap();
+            std::fs::rename(&saved_media, &path).unwrap();
+
+            // Publication failure must not consume the pending correction.
+            let saved_sidecar = dir.path().join("saved.xmp");
+            let before_failure = std::fs::read(&sidecar_path).unwrap();
+            std::fs::rename(&sidecar_path, &saved_sidecar).unwrap();
+            std::fs::create_dir(&sidecar_path).unwrap();
+            assert_eq!(drain().await.failed, 1);
+            assert!(sidecar_path.is_dir());
+            assert_eq!(std::fs::read(&saved_sidecar).unwrap(), before_failure);
+            assert_eq!(db.get_pending_metadata_rewrites(10).await.unwrap().len(), 1);
+            std::fs::remove_dir(&sidecar_path).unwrap();
+            std::fs::rename(&saved_sidecar, &sidecar_path).unwrap();
+
+            assert_eq!(drain().await.applied, 1);
+            let corrected_bytes = std::fs::read(&sidecar_path).unwrap();
+            let corrected: XmpMeta = std::str::from_utf8(&corrected_bytes)
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                corrected.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+                !owned
+            );
+            if !owned {
+                assert_eq!(
+                    corrected
+                        .property(xmp_ns::EXIF, "GPSHPositioningError")
+                        .unwrap()
+                        .value,
+                    "3/2"
+                );
+            }
+            assert_eq!(
+                corrected
+                    .property(xmp_ns::EXIF, "GPSLatitude")
+                    .unwrap()
+                    .value,
+                "12,20.7360N"
+            );
+            assert_eq!(
+                corrected
+                    .property(xmp_ns::EXIF, "GPSLongitude")
+                    .unwrap()
+                    .value,
+                "78,54.0720W"
+            );
+            assert_eq!(
+                corrected.property(xmp_ns::XMP, "Label").unwrap().value,
+                "keep me"
+            );
+            assert!(
+                db.get_pending_metadata_rewrites(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            let steady = drain().await;
+            assert_eq!((steady.applied, steady.failed), (0, 0));
+            assert_eq!(std::fs::read(&sidecar_path).unwrap(), corrected_bytes);
+            assert_eq!(std::fs::read(&path).unwrap(), source);
+            assert_eq!(
+                stored_checksums(&db).await.0.as_deref(),
+                Some(checksum.as_str())
+            );
+        }
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
     async fn sidecar_write_carries_source_gps_and_corrected_coordinates() {
         let dir = tempfile::tempdir().expect("metadata temp dir");
         let media_path = dir.path().join("source.jpg");
@@ -2838,6 +3532,7 @@ mod tests {
             final_path: &media_path,
             embed_path: None,
             expected_embed_fingerprint: None,
+            source_checksum: None,
             sidecar_path: Some(&media_path),
             payload: Arc::new(payload.clone()),
             created_local: cloudkit_created,
@@ -2930,6 +3625,7 @@ mod tests {
             final_path: &media_path,
             embed_path: None,
             expected_embed_fingerprint: None,
+            source_checksum: None,
             sidecar_path: Some(&media_path),
             payload: Arc::new(payload),
             created_local: now_local(),
@@ -3271,6 +3967,7 @@ mod tests {
             final_path: &normal_path,
             embed_path: Some(&normal_path),
             expected_embed_fingerprint: None,
+            source_checksum: None,
             sidecar_path: Some(&normal_path),
             payload: Arc::new(normal_payload),
             created_local: record.metadata.capture_local(record.created_at),

--- a/src/download/metadata_rewrite.rs
+++ b/src/download/metadata_rewrite.rs
@@ -1085,7 +1085,7 @@ where
                 &path,
                 Arc::clone(&payload),
                 created_local,
-                record.download_checksum.as_deref(),
+                pending_rewrite.source_checksum.as_deref(),
                 &temp_suffix,
             )
             .await;
@@ -3265,6 +3265,139 @@ mod tests {
 
     #[cfg(feature = "xmp")]
     #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_checksum_recovery() {
+        use crate::state::{AssetMetadata, SqliteStateDb};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.jpg");
+        let sidecar = path.with_extension("jpg.xmp");
+        std::fs::write(&path, crate::test_helpers::minimal_jpeg_with_source_gps()).unwrap();
+        let original_checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+        let original_gps = super::super::metadata::read_source_gps(&path).unwrap();
+        assert!(original_gps.latitude.is_none() && original_gps.longitude.is_none());
+        assert!(original_gps.horizontal_positioning_error.is_some());
+        let db_path = dir.path().join("state.db");
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let mut metadata = AssetMetadata {
+            rating: Some(1),
+            latitude: Some(1.5),
+            longitude: Some(2.5),
+            ..AssetMetadata::default()
+        };
+        seed_downloaded_marker(
+            &db,
+            "PROVENANCE",
+            "source.jpg",
+            &path,
+            &original_checksum,
+            metadata.clone(),
+            None,
+        )
+        .await;
+        db.fail_metadata_checksum_write_for_test();
+        let first = run_pending(
+            &db,
+            MetadataFlags::GPS | MetadataFlags::RATING | MetadataFlags::XMP_SIDECAR,
+            Arc::from(".review"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(first.failed, 1);
+        assert_eq!(stored_checksums(&db).await, (None, None));
+        let gps = super::super::metadata::read_source_gps(&path).unwrap();
+        assert_eq!((gps.latitude, gps.longitude), (Some(1.5), Some(2.5)));
+        drop(db);
+
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let retry = run_pending(
+            &db,
+            MetadataFlags::RATING | MetadataFlags::XMP_SIDECAR,
+            Arc::from(".review"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert_eq!((retry.applied, retry.failed), (1, 0));
+        let rewritten_checksum = crate::download::file::compute_sha256(&path).await.unwrap();
+        assert_ne!(rewritten_checksum, original_checksum);
+        assert_eq!(
+            stored_checksums(&db).await,
+            (Some(rewritten_checksum.clone()), None)
+        );
+        for rating in [2, 1] {
+            metadata.rating = Some(rating);
+            db.refresh_downloaded_asset_metadata(
+                "PrimarySync",
+                "PROVENANCE",
+                &metadata,
+                true,
+                false,
+                crate::state::METADATA_CAPTURE_REVISION,
+            )
+            .await
+            .unwrap();
+            let pass = run_pending(
+                &db,
+                MetadataFlags::RATING | MetadataFlags::XMP_SIDECAR,
+                Arc::from(".review"),
+                &CancellationToken::new(),
+            )
+            .await;
+            assert_eq!((pass.applied, pass.failed), (1, 0));
+        }
+        assert_eq!(
+            stored_checksums(&db).await,
+            (Some(rewritten_checksum.clone()), Some(rewritten_checksum))
+        );
+        let xmp: XmpMeta = std::fs::read_to_string(&sidecar).unwrap().parse().unwrap();
+        assert!(
+            !xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+            "kei-inserted coordinates acquired fabricated original-byte provenance"
+        );
+        let media = std::fs::read(&path).unwrap();
+        let sidecar_bytes = std::fs::read(&sidecar).unwrap();
+        drop(db);
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        db.record_metadata_write_failure("PrimarySync", "PROVENANCE", "original")
+            .await
+            .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert!(pending[0].source_checksum.is_none());
+        let retry = run_pending(
+            &db,
+            MetadataFlags::XMP_SIDECAR,
+            Arc::from(".review"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert_eq!((retry.applied, retry.failed), (1, 0));
+        let steady = run_pending(
+            &db,
+            MetadataFlags::XMP_SIDECAR,
+            Arc::from(".review"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert_eq!((steady.applied, steady.failed), (0, 0));
+        assert_eq!(std::fs::read(&path).unwrap(), media);
+        assert_eq!(std::fs::read(&sidecar).unwrap(), sidecar_bytes);
+        assert!(
+            db.get_pending_metadata_rewrites(10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
     async fn contract_xmp_gps_accuracy_requires_matching_location_native_boundaries() {
         use crate::test_helpers::ur64;
         use little_exif::exif_tag::ExifTag;
@@ -3331,7 +3464,7 @@ mod tests {
     #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn contract_xmp_gps_accuracy_requires_matching_location_rewrite_and_retry() {
-        use crate::state::{AssetMetadata, SqliteStateDb};
+        use crate::state::{AssetMetadata, DownloadStateStore, SqliteStateDb};
         use xmp_toolkit::XmpValue;
 
         for owned in [true, false] {
@@ -3359,13 +3492,14 @@ mod tests {
                 None,
             )
             .await;
-            db.mark_downloaded(
+            db.mark_verified_download(
                 "PrimarySync",
                 "GPS_PROVENANCE",
                 "original",
                 &path,
                 &checksum,
                 Some(&checksum),
+                false,
             )
             .await
             .unwrap();

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -3347,6 +3347,7 @@ async fn download_single_task<C: super::file::DownloadClient>(
                     final_path: &task.download_path,
                     embed_path: Some(part),
                     expected_embed_fingerprint: None,
+                    source_checksum: download_checksum.as_deref(),
                     sidecar_path: None,
                     payload: Arc::clone(&task.metadata),
                     created_local: task.created_local,
@@ -3377,11 +3378,22 @@ async fn download_single_task<C: super::file::DownloadClient>(
             super::file::publish_part_to_final(part, &task.download_path, task.publication).await?;
         }
 
+        // Embed work already captured the original checksum. Otherwise take
+        // a baseline for the unchanged download before sidecar planning.
+        let unmodified_checksum = if download_checksum.is_none()
+            && metadata_flags.contains(metadata_rewrite::MetadataFlags::XMP_SIDECAR)
+        {
+            Some(super::file::compute_sha256(&task.download_path).await?)
+        } else {
+            None
+        };
+
         let outcome =
             metadata_rewrite::write_download_metadata(metadata_rewrite::MetadataWriteRequest {
                 final_path: &task.download_path,
                 embed_path: None,
                 expected_embed_fingerprint: None,
+                source_checksum: download_checksum.as_deref().or(unmodified_checksum.as_deref()),
                 sidecar_path: Some(&task.download_path),
                 payload: Arc::clone(&task.metadata),
                 created_local: task.created_local,
@@ -3402,7 +3414,8 @@ async fn download_single_task<C: super::file::DownloadClient>(
 
         tracing::debug!(path = %task.download_path.display(), "Downloaded");
 
-        // Compute SHA-256 of the final file for local storage and verification.
+        // Recheck after sidecar work before finalization, preserving the
+        // existing final-file checksum boundary.
         let local_checksum = super::file::compute_sha256(&task.download_path).await?;
 
         // Note: Apple's `fileChecksum` is an MMCS (MobileMe Chunked Storage)
@@ -3411,6 +3424,10 @@ async fn download_single_task<C: super::file::DownloadClient>(
         // is verified by size matching (Content-Length + API size field) and
         // magic-byte validation during download instead.
 
+        // Retain original-byte evidence even when no embedding was requested.
+        // Future sidecar-only retries must not infer provenance from a local
+        // checksum that may have been refreshed after an embedded rewrite.
+        let download_checksum = Some(download_checksum.or(unmodified_checksum).unwrap_or_else(|| local_checksum.clone()));
         Ok((
             exif_ok,
             local_checksum,
@@ -5827,6 +5844,159 @@ mod tests {
             err.to_string().contains("producer task crashed"),
             "Expected producer panic error, got: {err}"
         );
+    }
+
+    #[cfg(feature = "xmp")]
+    #[tokio::test]
+    async fn contract_xmp_gps_accuracy_requires_matching_location_download_and_reopen() {
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::SqliteStateDb;
+        use base64::Engine as _;
+        use futures_util::stream;
+        use serde_json::json;
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::method;
+        use wiremock::{Mock, ResponseTemplate};
+        use xmp_toolkit::{XmpMeta, xmp_ns};
+
+        for (native_location, embed) in [(false, true), (true, false), (true, true)] {
+            let source = if native_location {
+                crate::test_helpers::minimal_jpeg_with_source_gps_and_location()
+            } else {
+                crate::test_helpers::minimal_jpeg_with_source_gps()
+            };
+            let original_checksum = data_encoding::HEXLOWER.encode(&Sha256::digest(&source));
+            let server = crate::start_wiremock_or_skip!();
+            Mock::given(method("GET"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(source.clone())
+                        .insert_header("content-type", "image/jpeg"),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            let asset = PhotoAsset::new(
+                json!({
+                    "recordName": "GPS_MASTER",
+                    "fields": {
+                        "filenameEnc": {"value": "source.jpg", "type": "STRING"},
+                        "itemType": {"value": "public.jpeg"},
+                        "resOriginalRes": {"value": {
+                            "size": source.len(), "downloadURL": format!("{}/source.jpg", server.uri()),
+                            "fileChecksum": base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&source))
+                        }},
+                        "resOriginalFileType": {"value": "public.jpeg"}
+                    }
+                }),
+                json!({
+                    "recordName": "asset-GPS_CHILD",
+                    "fields": {
+                        "assetDate": {"value": 1736899200000.0},
+                        "locationLatitude": {"value": 1.5}, "locationLongitude": {"value": 2.5}
+                    }
+                }),
+            );
+            let dir = TempDir::new().unwrap();
+            let db_path = dir.path().join("state.db");
+            let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+            let download_dir = dir.path().join("downloads");
+            let mut config = DownloadConfig::test_default();
+            config.directory = Arc::from(download_dir.as_path());
+            config.metadata.set_exif_gps = embed;
+            config.metadata.xmp_sidecar = true;
+            config.state_db = Some(db.clone());
+            let config = Arc::new(config);
+            let result = stream_and_download_from_stream(
+                &Client::new(),
+                stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset.clone())]),
+                &config,
+                DownloadControls::download_hidden(),
+                1,
+                CancellationToken::new(),
+                StreamRuntime::new(None, None),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result.downloaded, 1);
+            assert!(result.failed.is_empty());
+            assert_eq!(result.exif_failures, 0);
+            let rows = db.get_downloaded_page(0, 10).await.unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(
+                rows[0].download_checksum.as_deref(),
+                Some(original_checksum.as_str())
+            );
+            let media = rows[0].local_path.as_ref().unwrap().clone();
+            let sidecar = sidecar_path_for(&media);
+            let xmp: XmpMeta = fs::read_to_string(&sidecar).unwrap().parse().unwrap();
+            assert_eq!(
+                xmp.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+                native_location
+            );
+            let media_bytes = fs::read(&media).unwrap();
+            if native_location {
+                assert_eq!(media_bytes, source);
+            } else {
+                assert_ne!(media_bytes, source);
+            }
+            let native = super::super::metadata::read_source_gps(&media).unwrap();
+            assert!(native.horizontal_positioning_error.is_some());
+            db.record_metadata_write_failure("PrimarySync", asset.state_id(), "original")
+                .await
+                .unwrap();
+            drop(config);
+            drop(db);
+
+            let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+            let mut config = DownloadConfig::test_default();
+            config.directory = Arc::from(download_dir.as_path());
+            config.metadata.xmp_sidecar = true;
+            config.state_db = Some(db.clone());
+            let config = Arc::new(config);
+            let mut previous_sidecar = None;
+            for _ in 0..2 {
+                let result = stream_and_download_from_stream(
+                    &Client::new(),
+                    stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset.clone())]),
+                    &config,
+                    DownloadControls::download_hidden(),
+                    1,
+                    CancellationToken::new(),
+                    StreamRuntime::new(None, None),
+                )
+                .await
+                .unwrap();
+                assert_eq!(result.downloaded, 0);
+                assert!(result.failed.is_empty());
+                assert_eq!(result.exif_failures, 0);
+                assert_eq!(fs::read(&media).unwrap(), media_bytes);
+                let sidecar_bytes = fs::read(&sidecar).unwrap();
+                if let Some(previous) = previous_sidecar.replace(sidecar_bytes.clone()) {
+                    assert_eq!(
+                        sidecar_bytes, previous,
+                        "steady state must not repeat sidecar work"
+                    );
+                }
+                let rows = db.get_downloaded_page(0, 10).await.unwrap();
+                assert_eq!(
+                    rows[0].download_checksum.as_deref(),
+                    Some(original_checksum.as_str())
+                );
+                let current: XmpMeta = fs::read_to_string(&sidecar).unwrap().parse().unwrap();
+                assert_eq!(
+                    current.contains_property(xmp_ns::EXIF, "GPSHPositioningError"),
+                    native_location
+                );
+                assert!(
+                    db.get_pending_metadata_rewrites(10)
+                        .await
+                        .unwrap()
+                        .is_empty()
+                );
+            }
+            server.verify().await;
+        }
     }
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -291,6 +291,16 @@ impl CaptureRepairReceipt {
 pub struct PendingMetadataRewrite {
     pub asset: AssetRecord,
     pub capture_repair_receipt: Option<CaptureRepairReceipt>,
+    /// SHA-256 captured from a verified download before embedding, for this
+    /// exact path and provider rendition. Never inferred from local checksums.
+    #[cfg_attr(
+        not(feature = "xmp"),
+        allow(
+            dead_code,
+            reason = "native-only builds retain provenance for later sidecar writes"
+        )
+    )]
+    pub source_checksum: Option<String>,
 }
 
 /// Debt retired by one atomic metadata-rewrite completion.
@@ -462,6 +472,36 @@ pub trait DownloadStateStore: Send + Sync {
             local_path,
             local_checksum,
             download_checksum,
+        )
+        .await
+    }
+    /// Finalize bytes received by the verified download pipeline.
+    ///
+    /// `download_checksum`, when present, must hash the received bytes before
+    /// any kei metadata write. Adoption and local reconciliation must instead
+    /// use `mark_downloaded` or `mark_downloaded_with_capture_repair`.
+    /// Stores without source-provenance support retain unknown evidence.
+    ///
+    /// # Errors
+    /// Returns a state error if downloaded-state finalization fails.
+    async fn mark_verified_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+        mark_capture_repair: bool,
+    ) -> Result<(), StateError> {
+        self.mark_downloaded_with_capture_repair(
+            library,
+            id,
+            version_size,
+            local_path,
+            local_checksum,
+            download_checksum,
+            mark_capture_repair,
         )
         .await
     }
@@ -1553,6 +1593,13 @@ fn metadata_rewrite_target(
     })
 }
 
+/// Checksum roles supplied by one file-finalization route.
+struct DownloadChecksums<'a> {
+    local: &'a str,
+    downloaded: Option<&'a str>,
+    source: Option<&'a str>,
+}
+
 /// Copy the catalogue path's exact publication evidence in the same transaction.
 /// Other paths retain their own fingerprints and independent retry receipts.
 fn record_metadata_path(
@@ -1577,6 +1624,8 @@ fn record_metadata_path(
              provider_checksum = excluded.provider_checksum, \
              local_checksum = excluded.local_checksum, \
              download_checksum = excluded.download_checksum, \
+             source_checksum = CASE WHEN asset_metadata_paths.provider_checksum = excluded.provider_checksum \
+                 THEN asset_metadata_paths.source_checksum ELSE NULL END, \
              metadata_write_failed_at = CASE WHEN ?4 = 1 THEN \
                  COALESCE(excluded.metadata_write_failed_at, asset_metadata_paths.metadata_write_failed_at) \
                  ELSE excluded.metadata_write_failed_at END, \
@@ -2006,13 +2055,38 @@ impl SqliteStateDb {
         download_checksum: Option<&str>,
         mark_capture_repair: bool,
     ) -> Result<(), StateError> {
+        self.mark_downloaded_with_checksums(
+            library,
+            id,
+            version_size,
+            local_path,
+            DownloadChecksums {
+                local: local_checksum,
+                downloaded: download_checksum,
+                source: None,
+            },
+            mark_capture_repair,
+        )
+        .await
+    }
+
+    async fn mark_downloaded_with_checksums(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        checksums: DownloadChecksums<'_>,
+        mark_capture_repair: bool,
+    ) -> Result<(), StateError> {
         let downloaded_at = Utc::now().timestamp();
         let library = library.to_owned();
         let id = id.to_owned();
         let version_size = version_size.to_owned();
         let local_path = local_path.to_path_buf();
-        let local_checksum = local_checksum.to_owned();
-        let download_checksum = download_checksum.map(str::to_owned);
+        let local_checksum = checksums.local.to_owned();
+        let download_checksum = checksums.downloaded.map(str::to_owned);
+        let source_checksum = checksums.source.map(str::to_owned);
 
         self.with_conn_mut("mark_downloaded", move |conn| {
             let tx = conn
@@ -2036,6 +2110,23 @@ impl SqliteStateDb {
                     asset_id: id,
                     version_size,
                 });
+            }
+
+            if let Some(source_checksum) = &source_checksum {
+                // CONTRACT: XMP_GPS_ACCURACY_REQUIRES_MATCHING_LOCATION
+                // Source provenance and downloaded state commit together.
+                tx.execute(
+                    "UPDATE asset_metadata_paths SET source_checksum = ?5 \
+                     WHERE library = ?1 AND id = ?2 AND version_size = ?3 AND local_path = ?4",
+                    rusqlite::params![
+                        library,
+                        id,
+                        version_size,
+                        local_path.to_string_lossy(),
+                        source_checksum
+                    ],
+                )
+                .map_err(|e| StateError::query("mark_downloaded::source_checksum", e))?;
             }
 
             record_metadata_capture_revision(
@@ -5606,6 +5697,31 @@ impl DownloadStateStore for SqliteStateDb {
         .await
     }
 
+    async fn mark_verified_download(
+        &self,
+        library: &str,
+        id: &str,
+        version_size: &str,
+        local_path: &Path,
+        local_checksum: &str,
+        download_checksum: Option<&str>,
+        mark_capture_repair: bool,
+    ) -> Result<(), StateError> {
+        self.mark_downloaded_with_checksums(
+            library,
+            id,
+            version_size,
+            local_path,
+            DownloadChecksums {
+                local: local_checksum,
+                downloaded: download_checksum,
+                source: download_checksum,
+            },
+            mark_capture_repair,
+        )
+        .await
+    }
+
     async fn mark_failed(
         &self,
         library: &str,
@@ -6485,9 +6601,13 @@ fn metadata_rewrite_source_sql() -> String {
         .join(", ");
     format!(
         "SELECT {ASSET_COLUMNS}, metadata_write_failed_at, capture_repair_metadata_hash, \
-             capture_repair_output_checksum, capture_repair_output_size FROM assets \
+             capture_repair_output_checksum, capture_repair_output_size, \
+             (SELECT p.source_checksum FROM asset_metadata_paths p \
+              WHERE p.library = assets.library AND p.id = assets.id \
+                AND p.version_size = assets.version_size AND p.local_path = assets.local_path \
+                AND p.provider_checksum = assets.checksum) AS source_checksum FROM assets \
          UNION ALL SELECT {path_columns}, p.metadata_write_failed_at, p.capture_repair_metadata_hash, \
-             p.capture_repair_output_checksum, p.capture_repair_output_size \
+             p.capture_repair_output_checksum, p.capture_repair_output_size, p.source_checksum \
          FROM asset_metadata_paths p JOIN assets a \
            ON a.library = p.library AND a.id = p.id AND a.version_size = p.version_size \
          WHERE p.local_path IS NOT a.local_path AND p.provider_checksum = a.checksum"
@@ -6519,7 +6639,7 @@ fn query_pending_metadata_rewrites(
     let source = metadata_rewrite_source_sql();
     let sql = format!(
         "SELECT {ASSET_COLUMNS}, capture_repair_metadata_hash, \
-            capture_repair_output_checksum, capture_repair_output_size \
+            capture_repair_output_checksum, capture_repair_output_size, source_checksum \
          FROM ({source}) WHERE {queue_predicate} \
            AND status = 'downloaded' AND is_deleted = 0 AND local_path IS NOT NULL \
            {scope} ORDER BY {order}, local_path LIMIT ? OFFSET ?"
@@ -6583,6 +6703,7 @@ fn row_to_pending_metadata_rewrite(
     Ok(PendingMetadataRewrite {
         asset: row_to_asset_record(row)?,
         capture_repair_receipt,
+        source_checksum: row.get(ASSET_COLUMN_COUNT + 3)?,
     })
 }
 
@@ -6747,6 +6868,218 @@ mod tests {
 
     fn test_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    #[tokio::test]
+    async fn verified_source_checksum_round_trip_is_path_and_rendition_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("state.db");
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let first = dir.path().join("first.jpg");
+        let second = dir.path().join("second.jpg");
+        let mut record = TestAssetRecord::new("PROVENANCE")
+            .checksum("provider-v1")
+            .metadata(AssetMetadata {
+                metadata_hash: Some("metadata".into()),
+                ..AssetMetadata::default()
+            })
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_verified_download(
+            "PrimarySync",
+            "PROVENANCE",
+            "original",
+            &first,
+            "local-first",
+            Some("source-first"),
+            false,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "PROVENANCE", "original")
+            .await
+            .unwrap();
+        // Import/reconciliation-style registration must not treat recovered
+        // download_checksum values as source provenance for a different path.
+        db.mark_downloaded(
+            "PrimarySync",
+            "PROVENANCE",
+            "original",
+            &second,
+            "local-second",
+            Some("recovered-second"),
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "PROVENANCE", "original")
+            .await
+            .unwrap();
+        drop(db);
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 2);
+        for work in &pending {
+            let expected = if work.asset.local_path.as_deref() == Some(first.as_path()) {
+                Some("source-first")
+            } else {
+                None
+            };
+            assert_eq!(work.source_checksum.as_deref(), expected);
+        }
+        // Metadata finalization must preserve the additional path's source
+        // evidence while updating the independent local/size checksum state.
+        let extra = pending
+            .iter()
+            .find(|work| work.asset.local_path.as_deref() == Some(first.as_path()))
+            .unwrap();
+        db.finish_metadata_rewrite(
+            extra,
+            MetadataRewriteQueue::Ordinary,
+            Some("local-rewritten"),
+            Some("local-first"),
+            MetadataRewriteCompletion::None,
+        )
+        .await
+        .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        let extra = pending
+            .iter()
+            .find(|work| work.asset.local_path.as_deref() == Some(first.as_path()))
+            .unwrap();
+        assert_eq!(extra.source_checksum.as_deref(), Some("source-first"));
+        assert_eq!(
+            extra.asset.local_checksum.as_deref(),
+            Some("local-rewritten")
+        );
+
+        db.mark_verified_download(
+            "PrimarySync",
+            "PROVENANCE",
+            "original",
+            &second,
+            "local-second",
+            Some("source-second"),
+            false,
+        )
+        .await
+        .unwrap();
+        record.checksum = "provider-v2".into();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded(
+            "PrimarySync",
+            "PROVENANCE",
+            "original",
+            &second,
+            "local-v2",
+            Some("recovered-v2"),
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "PROVENANCE", "original")
+            .await
+            .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "old provider paths cannot supply current metadata evidence"
+        );
+        assert_eq!(
+            pending[0].asset.local_path.as_deref(),
+            Some(second.as_path())
+        );
+        assert!(pending[0].source_checksum.is_none());
+    }
+
+    #[tokio::test]
+    async fn verified_source_checksum_failure_rolls_back_download_finalization() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("state.db");
+        let media = dir.path().join("source.jpg");
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        let record = TestAssetRecord::new("SOURCE_COMMIT").build();
+        db.upsert_seen(&record).await.unwrap();
+        {
+            let conn = db.acquire_lock("test_source_checksum_failure").unwrap();
+            conn.execute_batch(
+                "CREATE TEMP TRIGGER fail_source_checksum BEFORE UPDATE OF source_checksum \
+                 ON asset_metadata_paths BEGIN SELECT RAISE(ABORT, 'source checksum failure'); END;"
+            ).unwrap();
+        }
+        assert!(
+            db.mark_verified_download(
+                "PrimarySync",
+                "SOURCE_COMMIT",
+                "original",
+                &media,
+                "local",
+                Some("source"),
+                false
+            )
+            .await
+            .is_err()
+        );
+        assert!(db.get_downloaded_page(0, 10).await.unwrap().is_empty());
+        {
+            let conn = db.acquire_lock("test_source_checksum_rollback").unwrap();
+            let paths: i64 = conn
+                .query_row("SELECT COUNT(*) FROM asset_metadata_paths", [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(paths, 0);
+        }
+        drop(db);
+        let db = SqliteStateDb::open(&db_path).await.unwrap();
+        db.mark_verified_download(
+            "PrimarySync",
+            "SOURCE_COMMIT",
+            "original",
+            &media,
+            "local",
+            Some("source"),
+            false,
+        )
+        .await
+        .unwrap();
+        db.record_metadata_write_failure("PrimarySync", "SOURCE_COMMIT", "original")
+            .await
+            .unwrap();
+        let pending = db
+            .get_pending_metadata_rewrites_page_for_queue(
+                MetadataRewriteQueue::Ordinary,
+                None,
+                0,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].source_checksum.as_deref(), Some("source"));
     }
 
     #[tokio::test]

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 22;
+pub(crate) const SCHEMA_VERSION: i32 = 23;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -730,6 +730,15 @@ fn migrate_to_version(
         }
         21 => conn.execute_batch(SCHEMA_V21)?,
         22 => conn.execute_batch(SCHEMA_V22)?,
+        23 => {
+            // Historical download_checksum values may come from rewritten
+            // local bytes. Only new verified downloads establish provenance.
+            if !column_exists(conn, "asset_metadata_paths", "source_checksum")? {
+                conn.execute_batch(
+                    "ALTER TABLE asset_metadata_paths ADD COLUMN source_checksum TEXT;",
+                )?;
+            }
+        }
         other => {
             return Err(StateError::UnsupportedSchemaVersion {
                 found: other,
@@ -2131,6 +2140,88 @@ mod tests {
             })
             .unwrap();
         assert_eq!(rows, 0);
+        assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn v23_source_checksum_migration_keeps_historical_provenance_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.db");
+        let conn = Connection::open(&path).unwrap();
+        for version in 1..=22 {
+            migrate_to_version(&conn, 0, version).unwrap();
+        }
+        set_schema_version(&conn, 22).unwrap();
+        for (name, local, downloaded) in [
+            ("equal", Some("rewritten"), Some("rewritten")),
+            ("different", Some("local"), Some("downloaded")),
+            ("missing", None, None),
+        ] {
+            conn.execute(
+                "INSERT INTO asset_metadata_paths \
+                    (library, id, version_size, local_path, provider_checksum, \
+                     local_checksum, download_checksum, metadata_write_failed_at) \
+                 VALUES ('PrimarySync', ?1, 'original', ?1, 'provider', ?2, ?3, 7)",
+                rusqlite::params![name, local, downloaded],
+            )
+            .unwrap();
+        }
+        migrate(&conn).unwrap();
+        drop(conn);
+        let conn = Connection::open(&path).unwrap();
+        migrate(&conn).unwrap();
+        let known: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM asset_metadata_paths WHERE source_checksum IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(known, 0);
+        // Re-entry cannot overwrite subsequently established source evidence.
+        conn.execute(
+            "UPDATE asset_metadata_paths SET source_checksum = 'verified' WHERE id = 'equal'",
+            [],
+        )
+        .unwrap();
+        migrate_to_version(&conn, 22, 23).unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, local_checksum, download_checksum, source_checksum, metadata_write_failed_at \
+             FROM asset_metadata_paths ORDER BY id"
+        ).unwrap();
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "different".into(),
+                    Some("local".into()),
+                    Some("downloaded".into()),
+                    None,
+                    7
+                ),
+                (
+                    "equal".into(),
+                    Some("rewritten".into()),
+                    Some("rewritten".into()),
+                    Some("verified".into()),
+                    7
+                ),
+                ("missing".into(), None, None, None, 7),
+            ]
+        );
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
     }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1193,8 +1193,8 @@ pub fn heif_ftyp_without_meta_bytes() -> Vec<u8> {
     ]
 }
 
-/// Asserts an XMP packet carries the standard source GPS facts with the values
-/// `exif_with_source_gps` yields.
+/// Asserts the standard source GPS time and speed, without accuracy when
+/// native coordinates are absent or differ from the provider location.
 #[cfg(feature = "xmp")]
 pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
     use xmp_toolkit::xmp_ns;
@@ -1203,7 +1203,7 @@ pub fn assert_source_gps_in_xmp(meta: &xmp_toolkit::XmpMeta) {
     assert_eq!(text("GPSTimeStamp"), SOURCE_GPS_DATETIME);
     assert_eq!(text("GPSSpeedRef"), SOURCE_GPS_SPEED_REF);
     assert_eq!(text("GPSSpeed"), SOURCE_GPS_SPEED);
-    assert_eq!(text("GPSHPositioningError"), SOURCE_GPS_H_POSITIONING_ERROR);
+    assert!(!meta.contains_property(xmp_ns::EXIF, "GPSHPositioningError"));
     assert!(
         !meta.contains_property("http://cipa.jp/exif/1.0/", "GPSHPositioningError"),
         "Apple-compatible sidecars must not duplicate GPSHPositioningError in exifEX"

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -82,7 +82,7 @@ fn sanitize_username(username: &str) -> String {
 /// any schema bump in `src/state/schema.rs` fails the suite until this
 /// helper is updated to match, preventing silent drift between the
 /// helper's "fresh DB" shape and what the binary expects.
-const HELPER_SCHEMA_VERSION: i32 = 22;
+const HELPER_SCHEMA_VERSION: i32 = 23;
 
 /// Create a state DB at the expected path for the given username inside
 /// `data_dir`. Mirrors the current schema from `src/state/schema.rs`
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS asset_metadata_paths (
     provider_checksum TEXT NOT NULL,
     local_checksum TEXT,
     download_checksum TEXT,
+    source_checksum TEXT,
     metadata_write_failed_at INTEGER,
     capture_repair_metadata_hash TEXT,
     capture_repair_output_checksum TEXT,
@@ -360,7 +361,7 @@ fn insert_asset(
 
 /// Pin the helper schema version against the binary's
 /// production constant. The binary writes a fresh DB at
-/// `state::schema::SCHEMA_VERSION` (currently 22). The helper above
+/// `state::schema::SCHEMA_VERSION` (currently 23). The helper above
 /// claims to "Mirror the latest schema" and must therefore land on the
 /// same version. Otherwise existing tests rely on the binary's
 /// migrate() loop to fill in columns and we lose end-to-end coverage of
@@ -378,7 +379,7 @@ fn behavioral_helper_schema_matches_production() {
     // update the DDL in `create_state_db` above to match the new
     // shape. The fresh-DB DDL emitted by a real binary run can be
     // dumped via `sqlite3 <db> '.schema'` for reference.
-    const PRODUCTION_SCHEMA_VERSION: i32 = 22;
+    const PRODUCTION_SCHEMA_VERSION: i32 = 23;
     assert_eq!(
         HELPER_SCHEMA_VERSION, PRODUCTION_SCHEMA_VERSION,
         "behavioral.rs::create_state_db schema is out of sync with \


### PR DESCRIPTION
## Summary
- Emit native GPS horizontal accuracy only when validated native coordinates exactly match the exported provider coordinates and the source bytes match the recorded original-download checksum.
- Keep original-byte evidence for downloads with or without embedding. Prevent embedded coordinates from manufacturing accuracy provenance, including after restart, partial failure, and sidecar-only retries.
- Clear obsolete kei-owned accuracy while preserving native metadata, unowned XMP, and durable retries. Document the provenance contract and add production-path regression tests.

## Tests
- `just gate`: passed, including 3,533 all-feature tests and 3,309 no-default-feature tests.
- `cargo test --all-features --lib contract_xmp_gps_accuracy_requires_matching_location -- --nocapture`: 6 passed, including HTTP download, SQLite reopen, embedding, ownership, and retry cases.
- `cargo fmt --all --check` and `git diff --check`: passed.

## Scope
Rewritten source files or missing original checksums conservatively omit accuracy, even when the value might still be valid. This change does not remove native metadata, add a schema migration, or introduce automatic sidecar catch-up. Catch-up remains in #799.

Fixes #800.
